### PR TITLE
refactor: remove unused React import

### DIFF
--- a/apps/ligo-virgo/src/pages/ui/index.tsx
+++ b/apps/ligo-virgo/src/pages/ui/index.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 export const UIPage = () => {
     return (
         <div className="">

--- a/apps/ligo-virgo/src/pages/workspace/docs/collapsible-page-tree.tsx
+++ b/apps/ligo-virgo/src/pages/workspace/docs/collapsible-page-tree.tsx
@@ -14,7 +14,12 @@ import {
     styled,
 } from '@toeverything/components/ui';
 import { services } from '@toeverything/datasource/db-service';
-import React, { useCallback, useState } from 'react';
+import {
+    type CSSProperties,
+    type ReactNode,
+    useCallback,
+    useState,
+} from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 const StyledBtn = styled('div')({
@@ -34,9 +39,9 @@ const StyledBtn = styled('div')({
 export type CollapsiblePageTreeProps = {
     title?: string;
     initialOpen?: boolean;
-    children?: React.ReactNode;
+    children?: ReactNode;
     className?: string;
-    style?: React.CSSProperties;
+    style?: CSSProperties;
 };
 
 export function CollapsiblePageTree(props: CollapsiblePageTreeProps) {

--- a/apps/ligo-virgo/src/pages/workspace/docs/workspace-name.tsx
+++ b/apps/ligo-virgo/src/pages/workspace/docs/workspace-name.tsx
@@ -4,7 +4,7 @@ import {
     useUserAndSpaces,
     useShowSpaceSidebar,
 } from '@toeverything/datasource/state';
-import React, {
+import {
     ChangeEvent,
     KeyboardEvent,
     useCallback,

--- a/libs/components/board-draw/src/components/error-fallback/error-fallback.tsx
+++ b/libs/components/board-draw/src/components/error-fallback/error-fallback.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { FallbackProps } from 'react-error-boundary';
 import { useTldrawApp } from '../../hooks';
 import { styled } from '@toeverything/components/ui';

--- a/libs/components/board-draw/src/components/loading/loading.tsx
+++ b/libs/components/board-draw/src/components/loading/loading.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useTldrawApp } from '../../hooks';
 import { styled } from '@toeverything/components/ui';
 import type { TDSnapshot } from '@toeverything/components/board-types';

--- a/libs/components/board-draw/src/hooks/use-file-system-handlers.ts
+++ b/libs/components/board-draw/src/hooks/use-file-system-handlers.ts
@@ -1,43 +1,47 @@
-import * as React from 'react';
 import { useTldrawApp } from './use-tldraw-app';
+import {
+    type MouseEvent as ReactMouseEvent,
+    type KeyboardEvent as ReactKeyboardEvent,
+    useCallback,
+} from 'react';
 
 export function useFileSystemHandlers() {
     const app = useTldrawApp();
 
-    const onNewProject = React.useCallback(
-        async (e?: React.MouseEvent | React.KeyboardEvent | KeyboardEvent) => {
+    const onNewProject = useCallback(
+        async (e?: ReactMouseEvent | ReactKeyboardEvent | KeyboardEvent) => {
             if (e && app.callbacks.onOpenProject) e.preventDefault();
             app.callbacks.onNewProject?.(app);
         },
         [app]
     );
 
-    const onSaveProject = React.useCallback(
-        (e?: React.MouseEvent | React.KeyboardEvent | KeyboardEvent) => {
+    const onSaveProject = useCallback(
+        (e?: ReactMouseEvent | ReactKeyboardEvent | KeyboardEvent) => {
             if (e && app.callbacks.onOpenProject) e.preventDefault();
             app.callbacks.onSaveProject?.(app);
         },
         [app]
     );
 
-    const onSaveProjectAs = React.useCallback(
-        (e?: React.MouseEvent | React.KeyboardEvent | KeyboardEvent) => {
+    const onSaveProjectAs = useCallback(
+        (e?: ReactMouseEvent | ReactKeyboardEvent | KeyboardEvent) => {
             if (e && app.callbacks.onOpenProject) e.preventDefault();
             app.callbacks.onSaveProjectAs?.(app);
         },
         [app]
     );
 
-    const onOpenProject = React.useCallback(
-        async (e?: React.MouseEvent | React.KeyboardEvent | KeyboardEvent) => {
+    const onOpenProject = useCallback(
+        async (e?: ReactMouseEvent | ReactKeyboardEvent | KeyboardEvent) => {
             if (e && app.callbacks.onOpenProject) e.preventDefault();
             app.callbacks.onOpenProject?.(app);
         },
         [app]
     );
 
-    const onOpenMedia = React.useCallback(
-        async (e?: React.MouseEvent | React.KeyboardEvent | KeyboardEvent) => {
+    const onOpenMedia = useCallback(
+        async (e?: ReactMouseEvent | ReactKeyboardEvent | KeyboardEvent) => {
             if (e && app.callbacks.onOpenMedia) e.preventDefault();
             app.callbacks.onOpenMedia?.(app);
         },

--- a/libs/components/board-draw/src/hooks/use-keyboard-shortcuts.tsx
+++ b/libs/components/board-draw/src/hooks/use-keyboard-shortcuts.tsx
@@ -1,13 +1,13 @@
-import * as React from 'react';
 import { useHotkeys } from 'react-hotkeys-hook';
 import { AlignStyle, TDShapeType } from '@toeverything/components/board-types';
 import { useTldrawApp } from './use-tldraw-app';
 import { useFileSystemHandlers } from './use-file-system-handlers';
+import { type RefObject, useCallback, useEffect } from 'react';
 
-export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
+export function useKeyboardShortcuts(ref: RefObject<HTMLDivElement>) {
     const app = useTldrawApp();
 
-    const canHandleEvent = React.useCallback(
+    const canHandleEvent = useCallback(
         (ignoreMenus = false) => {
             const elm = ref.current;
             if (
@@ -24,7 +24,7 @@ export function useKeyboardShortcuts(ref: React.RefObject<HTMLDivElement>) {
         [ref]
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (!app) return;
 
         const handleCut = (e: ClipboardEvent) => {

--- a/libs/components/board-draw/src/hooks/use-stylesheet.ts
+++ b/libs/components/board-draw/src/hooks/use-stylesheet.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useLayoutEffect } from 'react';
 
 const styles = new Map<string, HTMLStyleElement>();
 
@@ -42,7 +42,7 @@ const CSS = `
 `;
 
 export function useStylesheet() {
-    React.useLayoutEffect(() => {
+    useLayoutEffect(() => {
         if (styles.get(UID)) return;
         const style = document.createElement('style');
         style.innerHTML = CSS;

--- a/libs/components/board-draw/src/hooks/use-tldraw-app.ts
+++ b/libs/components/board-draw/src/hooks/use-tldraw-app.ts
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import { createContext, useContext } from 'react';
 import type { TldrawApp } from '@toeverything/components/board-state';
 
-export const TldrawContext = React.createContext<TldrawApp>({} as TldrawApp);
+export const TldrawContext = createContext<TldrawApp>({} as TldrawApp);
 
 export function useTldrawApp() {
-    const context = React.useContext(TldrawContext);
+    const context = useContext(TldrawContext);
     return context;
 }

--- a/libs/components/board-shapes/src/arrow-util/arrow-util.tsx
+++ b/libs/components/board-shapes/src/arrow-util/arrow-util.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo, useCallback } from 'react';
 import { Utils, TLBounds, SVGContainer } from '@tldraw/core';
 import { Vec } from '@tldraw/vec';
 import { defaultStyle } from '../shared/shape-styles';
@@ -125,7 +125,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
             const labelSize =
                 label || isEditing ? getTextLabelSize(label, font) : [0, 0];
             const bounds = this.getBounds(shape);
-            const dist = React.useMemo(() => {
+            const dist = useMemo(() => {
                 const { start, bend, end } = shape.handles;
                 if (isStraightLine) return Vec.dist(start.point, end.point);
                 const circle = getCtp(start.point, bend.point, end.point);
@@ -149,7 +149,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
                     )
                 )
             );
-            const offset = React.useMemo(() => {
+            const offset = useMemo(() => {
                 const bounds = this.getBounds(shape);
                 const offset = Vec.sub(
                     shape.handles.bend.point,
@@ -157,7 +157,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
                 );
                 return offset;
             }, [shape, scale]);
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => {
                     onShapeChange?.({ id, label });
                 },
@@ -247,7 +247,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
         const isStraightLine =
             Vec.dist(bend.point, Vec.toFixed(Vec.med(start.point, end.point))) <
             1;
-        const dist = React.useMemo(() => {
+        const dist = useMemo(() => {
             const { start, bend, end } = shape.handles;
             if (isStraightLine) return Vec.dist(start.point, end.point);
             const circle = getCtp(start.point, bend.point, end.point);
@@ -266,7 +266,7 @@ export class ArrowUtil extends TDShapeUtil<T, E> {
                 )
             )
         );
-        const offset = React.useMemo(() => {
+        const offset = useMemo(() => {
             const bounds = this.getBounds(shape);
             const offset = Vec.sub(shape.handles.bend.point, [
                 bounds.width / 2,

--- a/libs/components/board-shapes/src/arrow-util/components/arrow-head.tsx
+++ b/libs/components/board-shapes/src/arrow-util/components/arrow-head.tsx
@@ -1,5 +1,3 @@
-import * as React from 'react';
-
 export interface ArrowheadProps {
     left: number[];
     middle: number[];

--- a/libs/components/board-shapes/src/arrow-util/components/curved-arrow.tsx
+++ b/libs/components/board-shapes/src/arrow-util/components/curved-arrow.tsx
@@ -1,6 +1,6 @@
 import { Utils } from '@tldraw/core';
 import Vec from '@tldraw/vec';
-import * as React from 'react';
+import { memo } from 'react';
 import { EASINGS } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
 import type {
@@ -29,7 +29,7 @@ interface ArrowSvgProps {
     isDraw: boolean;
 }
 
-export const CurvedArrow = React.memo(function CurvedArrow({
+export const CurvedArrow = memo(function CurvedArrow({
     id,
     style,
     start,

--- a/libs/components/board-shapes/src/arrow-util/components/straight-arrow.tsx
+++ b/libs/components/board-shapes/src/arrow-util/components/straight-arrow.tsx
@@ -1,6 +1,6 @@
 import { Utils } from '@tldraw/core';
 import Vec from '@tldraw/vec';
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type {
     Decoration,
@@ -25,7 +25,7 @@ interface ArrowSvgProps {
     isDraw: boolean;
 }
 
-export const StraightArrow = React.memo(function StraightArrow({
+export const StraightArrow = memo(function StraightArrow({
     id,
     style,
     start,

--- a/libs/components/board-shapes/src/draw-util/DrawUtil.tsx
+++ b/libs/components/board-shapes/src/draw-util/DrawUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useMemo } from 'react';
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core';
 import { Vec } from '@tldraw/vec';
 import { defaultStyle, getShapeStyle } from '../shared/shape-styles';
@@ -62,11 +62,11 @@ export class DrawUtil extends TDShapeUtil<T, E> {
         ({ shape, meta, isSelected, isGhost, events }, ref) => {
             const { points, style, isComplete } = shape;
 
-            const polygon_path_td_snapshot = React.useMemo(() => {
+            const polygon_path_td_snapshot = useMemo(() => {
                 return getFillPath(shape);
             }, [points, style.strokeWidth]);
 
-            const path_td_snapshot = React.useMemo(() => {
+            const path_td_snapshot = useMemo(() => {
                 return style.dash === DashStyle.Draw
                     ? getDrawStrokePathTDSnapshot(shape)
                     : getSolidStrokePathTDSnapshot(shape);
@@ -200,7 +200,7 @@ export class DrawUtil extends TDShapeUtil<T, E> {
     Indicator = TDShapeUtil.Indicator<T>(({ shape }) => {
         const { points } = shape;
 
-        const path_td_snapshot = React.useMemo(() => {
+        const path_td_snapshot = useMemo(() => {
             return getSolidStrokePathTDSnapshot(shape);
         }, [points]);
 

--- a/libs/components/board-shapes/src/ellipse-util/EllipseUtil.tsx
+++ b/libs/components/board-shapes/src/ellipse-util/EllipseUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core';
 import { Vec } from '@tldraw/vec';
 import {
@@ -92,7 +92,7 @@ export class EllipseUtil extends TDShapeUtil<T, E> {
             const ry = Math.max(0, radius[1] - sw / 2);
             const Component =
                 style.dash === DashStyle.Draw ? DrawEllipse : DashedEllipse;
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => onShapeChange?.({ id, label }),
                 [onShapeChange]
             );

--- a/libs/components/board-shapes/src/ellipse-util/components/DashedEllipse.tsx
+++ b/libs/components/board-shapes/src/ellipse-util/components/DashedEllipse.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { Utils } from '@tldraw/core';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
@@ -10,7 +10,7 @@ interface EllipseSvgProps {
     isDarkMode: boolean;
 }
 
-export const DashedEllipse = React.memo(function DashedEllipse({
+export const DashedEllipse = memo(function DashedEllipse({
     radius,
     style,
     isSelected,

--- a/libs/components/board-shapes/src/ellipse-util/components/DrawEllipse.tsx
+++ b/libs/components/board-shapes/src/ellipse-util/components/DrawEllipse.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getEllipseIndicatorPath, getEllipsePath } from '../ellipse-helpers';
@@ -11,7 +11,7 @@ interface EllipseSvgProps {
     isDarkMode: boolean;
 }
 
-export const DrawEllipse = React.memo(function DrawEllipse({
+export const DrawEllipse = memo(function DrawEllipse({
     id,
     radius,
     style,

--- a/libs/components/board-shapes/src/frame-util/components/Frame.tsx
+++ b/libs/components/board-shapes/src/frame-util/components/Frame.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
@@ -11,7 +11,7 @@ interface RectangleSvgProps {
     isDarkMode: boolean;
 }
 
-export const Frame = React.memo(function DashedRectangle({
+export const Frame = memo(function DashedRectangle({
     id,
     style,
     size,

--- a/libs/components/board-shapes/src/frame-util/components/frame-binding-indicator.tsx
+++ b/libs/components/board-shapes/src/frame-util/components/frame-binding-indicator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 
 interface BindingIndicatorProps {

--- a/libs/components/board-shapes/src/group-util/group-util.tsx
+++ b/libs/components/board-shapes/src/group-util/group-util.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { styled } from '@toeverything/components/ui';
 import { Utils, SVGContainer } from '@tldraw/core';
 import { defaultStyle } from '../shared/shape-styles';

--- a/libs/components/board-shapes/src/hexagon-util/HexagonUtil.tsx
+++ b/libs/components/board-shapes/src/hexagon-util/HexagonUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core';
 import {
     HexagonShape,
@@ -91,11 +91,11 @@ export class HexagonUtil extends TDShapeUtil<T, E> {
             const styles = getShapeStyle(style, meta.isDarkMode);
             const Component =
                 style.dash === DashStyle.Draw ? DrawHexagon : DashedHexagon;
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => onShapeChange?.({ id, label }),
                 [onShapeChange]
             );
-            const offsetY = React.useMemo(() => {
+            const offsetY = useMemo(() => {
                 const center = Vec.div(size, 2);
                 const centroid = getHexagonCentroid(size);
                 return (centroid[1] - center[1]) * 0.72;

--- a/libs/components/board-shapes/src/hexagon-util/components/DashedHexagon.tsx
+++ b/libs/components/board-shapes/src/hexagon-util/components/DashedHexagon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { Utils } from '@tldraw/core';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
@@ -13,7 +13,7 @@ interface HexagonSvgProps {
     isDarkMode: boolean;
 }
 
-export const DashedHexagon = React.memo(function DashedHexagon({
+export const DashedHexagon = memo(function DashedHexagon({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/hexagon-util/components/DrawHexagon.tsx
+++ b/libs/components/board-shapes/src/hexagon-util/components/DrawHexagon.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import {
@@ -14,7 +14,7 @@ interface HexagonSvgProps {
     isDarkMode: boolean;
 }
 
-export const DrawHexagon = React.memo(function DrawTriangle({
+export const DrawHexagon = memo(function DrawTriangle({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/hexagon-util/components/HexagonBindingIndicator.tsx
+++ b/libs/components/board-shapes/src/hexagon-util/components/HexagonBindingIndicator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 import { getHexagonPoints } from '../hexagon-helpers';
 

--- a/libs/components/board-shapes/src/image-util/image-util.tsx
+++ b/libs/components/board-shapes/src/image-util/image-util.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useLayoutEffect } from 'react';
 import { Utils, HTMLContainer } from '@tldraw/core';
 import {
     TDShapeType,
@@ -64,10 +64,10 @@ export class ImageUtil extends TDShapeUtil<T, E> {
         ) => {
             const { size, style } = shape;
 
-            const rImage = React.useRef<HTMLImageElement>(null);
-            const rWrapper = React.useRef<HTMLDivElement>(null);
+            const rImage = useRef<HTMLImageElement>(null);
+            const rWrapper = useRef<HTMLDivElement>(null);
 
-            React.useLayoutEffect(() => {
+            useLayoutEffect(() => {
                 const wrapper = rWrapper.current;
                 if (!wrapper) return;
                 const [width, height] = size;

--- a/libs/components/board-shapes/src/pentagram-util/PentagramUtil.tsx
+++ b/libs/components/board-shapes/src/pentagram-util/PentagramUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core';
 import {
     PentagramShape,
@@ -91,11 +91,11 @@ export class PentagramUtil extends TDShapeUtil<T, E> {
             const styles = getShapeStyle(style, meta.isDarkMode);
             const Component =
                 style.dash === DashStyle.Draw ? DrawPentagram : DashedPentagram;
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => onShapeChange?.({ id, label }),
                 [onShapeChange]
             );
-            const offsetY = React.useMemo(() => {
+            const offsetY = useMemo(() => {
                 const center = Vec.div(size, 2);
                 const centroid = getPentagramCentroid(size);
                 return (centroid[1] - center[1]) * 0.72;

--- a/libs/components/board-shapes/src/pentagram-util/components/DashedPentagram.tsx
+++ b/libs/components/board-shapes/src/pentagram-util/components/DashedPentagram.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { Utils } from '@tldraw/core';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
@@ -13,7 +13,7 @@ interface PentagramSvgProps {
     isDarkMode: boolean;
 }
 
-export const DashedPentagram = React.memo(function DashedPentagram({
+export const DashedPentagram = memo(function DashedPentagram({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/pentagram-util/components/DrawPentagram.tsx
+++ b/libs/components/board-shapes/src/pentagram-util/components/DrawPentagram.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import {
@@ -14,7 +14,7 @@ interface PentagramSvgProps {
     isDarkMode: boolean;
 }
 
-export const DrawPentagram = React.memo(function DrawTriangle({
+export const DrawPentagram = memo(function DrawTriangle({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/pentagram-util/components/PentagramBindingIndicator.tsx
+++ b/libs/components/board-shapes/src/pentagram-util/components/PentagramBindingIndicator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 import { getPentagramPoints } from '../pentagram-helpers';
 

--- a/libs/components/board-shapes/src/rectangle-util/RectangleUtil.tsx
+++ b/libs/components/board-shapes/src/rectangle-util/RectangleUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback } from 'react';
 import { Utils, SVGContainer } from '@tldraw/core';
 import {
     RectangleShape,
@@ -83,7 +83,7 @@ export class RectangleUtil extends TDShapeUtil<T, E> {
             const styles = getShapeStyle(style, meta.isDarkMode);
             const Component =
                 style.dash === DashStyle.Draw ? DrawRectangle : DashedRectangle;
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => onShapeChange?.({ id, label }),
                 [onShapeChange]
             );

--- a/libs/components/board-shapes/src/rectangle-util/components/BindingIndicator.tsx
+++ b/libs/components/board-shapes/src/rectangle-util/components/BindingIndicator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 
 interface BindingIndicatorProps {

--- a/libs/components/board-shapes/src/rectangle-util/components/DashedRectangle.tsx
+++ b/libs/components/board-shapes/src/rectangle-util/components/DashedRectangle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { Utils } from '@tldraw/core';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 import type { ShapeStyles } from '@toeverything/components/board-types';
@@ -12,7 +12,7 @@ interface RectangleSvgProps {
     isDarkMode: boolean;
 }
 
-export const DashedRectangle = React.memo(function DashedRectangle({
+export const DashedRectangle = memo(function DashedRectangle({
     id,
     style,
     size,

--- a/libs/components/board-shapes/src/rectangle-util/components/DrawRectangle.tsx
+++ b/libs/components/board-shapes/src/rectangle-util/components/DrawRectangle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import {
@@ -14,7 +14,7 @@ interface RectangleSvgProps {
     size: number[];
 }
 
-export const DrawRectangle = React.memo(function DrawRectangle({
+export const DrawRectangle = memo(function DrawRectangle({
     id,
     style,
     size,

--- a/libs/components/board-shapes/src/shared/label-mask.tsx
+++ b/libs/components/board-shapes/src/shared/label-mask.tsx
@@ -1,5 +1,4 @@
 import type { TLBounds } from '@tldraw/core';
-import * as React from 'react';
 
 interface WithLabelMaskProps {
     id: string;

--- a/libs/components/board-shapes/src/shared/stop-propagation.ts
+++ b/libs/components/board-shapes/src/shared/stop-propagation.ts
@@ -1,5 +1,5 @@
-import type React from 'react';
+import { SyntheticEvent } from 'react';
 
 export const stopPropagation = (
-    e: KeyboardEvent | React.SyntheticEvent<any, Event>
+    e: KeyboardEvent | SyntheticEvent<any, Event>
 ) => e.stopPropagation();

--- a/libs/components/board-shapes/src/shared/text-label.tsx
+++ b/libs/components/board-shapes/src/shared/text-label.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { stopPropagation } from './stop-propagation';
 import {
     GHOSTED_OPACITY,
@@ -8,6 +7,17 @@ import { normalizeText } from './normalize-text';
 import { styled } from '@toeverything/components/ui';
 import { getTextLabelSize } from './get-text-size';
 import { TextAreaUtils } from './text-area-utils';
+import {
+    type KeyboardEvent,
+    type PointerEventHandler,
+    type FocusEvent,
+    type ChangeEvent,
+    memo,
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+} from 'react';
 
 export interface TextLabelProps {
     font: string;
@@ -21,7 +31,7 @@ export interface TextLabelProps {
     isEditing?: boolean;
 }
 
-export const TextLabel = React.memo(function TextLabel({
+export const TextLabel = memo(function TextLabel({
     font,
     text,
     color,
@@ -32,17 +42,17 @@ export const TextLabel = React.memo(function TextLabel({
     onBlur,
     onChange,
 }: TextLabelProps) {
-    const rInput = React.useRef<HTMLTextAreaElement>(null);
-    const rIsMounted = React.useRef(false);
+    const rInput = useRef<HTMLTextAreaElement>(null);
+    const rIsMounted = useRef(false);
 
-    const handleChange = React.useCallback(
-        (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = useCallback(
+        (e: ChangeEvent<HTMLTextAreaElement>) => {
             onChange(normalizeText(e.currentTarget.value));
         },
         [onChange]
     );
-    const handleKeyDown = React.useCallback(
-        (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent<HTMLTextAreaElement>) => {
             if (e.key === 'Escape') return;
 
             if (e.key === 'Tab' && text.length === 0) {
@@ -77,16 +87,16 @@ export const TextLabel = React.memo(function TextLabel({
         [onChange]
     );
 
-    const handleBlur = React.useCallback(
-        (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const handleBlur = useCallback(
+        (e: FocusEvent<HTMLTextAreaElement>) => {
             e.currentTarget.setSelectionRange(0, 0);
             onBlur?.();
         },
         [onBlur]
     );
 
-    const handleFocus = React.useCallback(
-        (e: React.FocusEvent<HTMLTextAreaElement>) => {
+    const handleFocus = useCallback(
+        (e: FocusEvent<HTMLTextAreaElement>) => {
             if (!isEditing) return;
             if (!rIsMounted.current) return;
 
@@ -97,8 +107,8 @@ export const TextLabel = React.memo(function TextLabel({
         [isEditing]
     );
 
-    const handlePointerDown = React.useCallback<
-        React.PointerEventHandler<HTMLTextAreaElement>
+    const handlePointerDown = useCallback<
+        PointerEventHandler<HTMLTextAreaElement>
     >(
         e => {
             if (isEditing) {
@@ -108,7 +118,7 @@ export const TextLabel = React.memo(function TextLabel({
         [isEditing]
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
         if (isEditing) {
             requestAnimationFrame(() => {
                 rIsMounted.current = true;
@@ -123,9 +133,9 @@ export const TextLabel = React.memo(function TextLabel({
         }
     }, [isEditing, onBlur]);
 
-    const rInnerWrapper = React.useRef<HTMLDivElement>(null);
+    const rInnerWrapper = useRef<HTMLDivElement>(null);
 
-    React.useLayoutEffect(() => {
+    useLayoutEffect(() => {
         const elm = rInnerWrapper.current;
         if (!elm) return;
         const size = getTextLabelSize(text, font);

--- a/libs/components/board-shapes/src/triangle-util/TriangleUtil.tsx
+++ b/libs/components/board-shapes/src/triangle-util/TriangleUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core';
 import {
     TriangleShape,
@@ -91,11 +91,11 @@ export class TriangleUtil extends TDShapeUtil<T, E> {
             const styles = getShapeStyle(style, meta.isDarkMode);
             const Component =
                 style.dash === DashStyle.Draw ? DrawTriangle : DashedTriangle;
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => onShapeChange?.({ id, label }),
                 [onShapeChange]
             );
-            const offsetY = React.useMemo(() => {
+            const offsetY = useMemo(() => {
                 const center = Vec.div(size, 2);
                 const centroid = getTriangleCentroid(size);
                 return (centroid[1] - center[1]) * 0.72;

--- a/libs/components/board-shapes/src/triangle-util/components/DashedTriangle.tsx
+++ b/libs/components/board-shapes/src/triangle-util/components/DashedTriangle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { Utils } from '@tldraw/core';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
@@ -13,7 +13,7 @@ interface TriangleSvgProps {
     isDarkMode: boolean;
 }
 
-export const DashedTriangle = React.memo(function DashedTriangle({
+export const DashedTriangle = memo(function DashedTriangle({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/triangle-util/components/DrawTriangle.tsx
+++ b/libs/components/board-shapes/src/triangle-util/components/DrawTriangle.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import {
@@ -14,7 +14,7 @@ interface TriangleSvgProps {
     isDarkMode: boolean;
 }
 
-export const DrawTriangle = React.memo(function DrawTriangle({
+export const DrawTriangle = memo(function DrawTriangle({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/triangle-util/components/TriangleBindingIndicator.tsx
+++ b/libs/components/board-shapes/src/triangle-util/components/TriangleBindingIndicator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 import { getTrianglePoints } from '../triangle-helpers';
 

--- a/libs/components/board-shapes/src/video-util/video-util.tsx
+++ b/libs/components/board-shapes/src/video-util/video-util.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useRef, useLayoutEffect, useCallback } from 'react';
 import { Utils, HTMLContainer } from '@tldraw/core';
 import {
     TDShapeType,
@@ -63,12 +63,12 @@ export class VideoUtil extends TDShapeUtil<T, E> {
             },
             ref
         ) => {
-            const rVideo = React.useRef<HTMLVideoElement>(null);
-            const rWrapper = React.useRef<HTMLDivElement>(null);
+            const rVideo = useRef<HTMLVideoElement>(null);
+            const rWrapper = useRef<HTMLDivElement>(null);
 
             const { currentTime = 0, size, isPlaying, style } = shape;
 
-            React.useLayoutEffect(() => {
+            useLayoutEffect(() => {
                 const wrapper = rWrapper.current;
                 if (!wrapper) return;
                 const [width, height] = size;
@@ -76,7 +76,7 @@ export class VideoUtil extends TDShapeUtil<T, E> {
                 wrapper.style.height = `${height}px`;
             }, [size]);
 
-            React.useLayoutEffect(() => {
+            useLayoutEffect(() => {
                 const video = rVideo.current;
                 if (!video) return;
                 if (isPlaying) video.play();
@@ -84,7 +84,7 @@ export class VideoUtil extends TDShapeUtil<T, E> {
                 else video.pause();
             }, [isPlaying]);
 
-            React.useLayoutEffect(() => {
+            useLayoutEffect(() => {
                 const video = rVideo.current;
                 if (!video) return;
                 if (currentTime !== video.currentTime) {
@@ -92,15 +92,15 @@ export class VideoUtil extends TDShapeUtil<T, E> {
                 }
             }, [currentTime]);
 
-            const handlePlay = React.useCallback(() => {
+            const handlePlay = useCallback(() => {
                 onShapeChange?.({ id: shape.id, isPlaying: true });
             }, []);
 
-            const handlePause = React.useCallback(() => {
+            const handlePause = useCallback(() => {
                 onShapeChange?.({ id: shape.id, isPlaying: false });
             }, []);
 
-            const handleSetCurrentTime = React.useCallback(() => {
+            const handleSetCurrentTime = useCallback(() => {
                 const video = rVideo.current;
                 if (!video) return;
                 if (!isEditing) return;

--- a/libs/components/board-shapes/src/white-arrow-util/WhiteArrowUtil.tsx
+++ b/libs/components/board-shapes/src/white-arrow-util/WhiteArrowUtil.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { useCallback, useMemo } from 'react';
 import { Utils, SVGContainer, TLBounds } from '@tldraw/core';
 import {
     WhiteArrowShape,
@@ -96,11 +96,11 @@ export class WhiteArrowUtil extends TDShapeUtil<T, E> {
                 style.dash === DashStyle.Draw
                     ? DrawWhiteArrow
                     : DashedWhiteArrow;
-            const handleLabelChange = React.useCallback(
+            const handleLabelChange = useCallback(
                 (label: string) => onShapeChange?.({ id, label }),
                 [onShapeChange]
             );
-            const offsetY = React.useMemo(() => {
+            const offsetY = useMemo(() => {
                 const center = Vec.div(size, 2);
                 const centroid = getWhiteArrowCentroid(size);
                 return (centroid[1] - center[1]) * 0.72;

--- a/libs/components/board-shapes/src/white-arrow-util/components/DashedWhiteArrow.tsx
+++ b/libs/components/board-shapes/src/white-arrow-util/components/DashedWhiteArrow.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { Utils } from '@tldraw/core';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import { getShapeStyle } from '../../shared';
@@ -13,7 +13,7 @@ interface WhiteArrowSvgProps {
     isDarkMode: boolean;
 }
 
-export const DashedWhiteArrow = React.memo(function DashedWhiteArrow({
+export const DashedWhiteArrow = memo(function DashedWhiteArrow({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/white-arrow-util/components/DrawWhiteArrow.tsx
+++ b/libs/components/board-shapes/src/white-arrow-util/components/DrawWhiteArrow.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { memo } from 'react';
 import { getShapeStyle } from '../../shared';
 import type { ShapeStyles } from '@toeverything/components/board-types';
 import {
@@ -14,7 +14,7 @@ interface WhiteArrowSvgProps {
     isDarkMode: boolean;
 }
 
-export const DrawWhiteArrow = React.memo(function DrawTriangle({
+export const DrawWhiteArrow = memo(function DrawTriangle({
     id,
     size,
     style,

--- a/libs/components/board-shapes/src/white-arrow-util/components/WhiteArrowBindingIndicator.tsx
+++ b/libs/components/board-shapes/src/white-arrow-util/components/WhiteArrowBindingIndicator.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { BINDING_DISTANCE } from '@toeverything/components/board-types';
 import { getWhiteArrowPoints } from '../white-arrow-helpers';
 

--- a/libs/components/board-state/src/tldraw-app.ts
+++ b/libs/components/board-state/src/tldraw-app.ts
@@ -4,6 +4,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 /* eslint-disable no-restricted-syntax */
 import { Vec } from '@tldraw/vec';
+import { type PointerEvent } from 'react';
 import {
     TLBoundsEventHandler,
     TLBoundsHandleEventHandler,
@@ -3889,7 +3890,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
                             pointerId: 0,
                             clientX: info.point[0],
                             clientY: info.point[1],
-                        } as unknown as React.PointerEvent<HTMLDivElement>
+                        } as unknown as PointerEvent<HTMLDivElement>
                     );
                 }
                 break;
@@ -3961,7 +3962,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
                         pointerId: 0,
                         clientX: currentPoint[0],
                         clientY: currentPoint[1],
-                    } as unknown as React.PointerEvent<HTMLDivElement>
+                    } as unknown as PointerEvent<HTMLDivElement>
                 );
                 break;
             }
@@ -4077,7 +4078,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
 
         // When panning, we also want to call onPointerMove, except when "force panning" via spacebar / middle wheel button (it's called elsewhere in that case)
         if (!this.useStore.getState().settings.forcePanning)
-            this.onPointerMove(info, e as unknown as React.PointerEvent);
+            this.onPointerMove(info, e as unknown as PointerEvent);
     };
 
     onZoom: TLWheelEventHandler = (info, e) => {
@@ -4089,7 +4090,7 @@ export class TldrawApp extends StateManager<TDSnapshot> {
                 ? 0.2 * Math.sign(info.delta[2])
                 : info.delta[2] / 50;
         this.zoomBy(delta, info.point);
-        this.onPointerMove(info, e as unknown as React.PointerEvent);
+        this.onPointerMove(info, e as unknown as PointerEvent);
     };
 
     /* ----------------- Pointer Events ----------------- */

--- a/libs/components/board-state/src/types/tool.ts
+++ b/libs/components/board-state/src/types/tool.ts
@@ -4,6 +4,7 @@ import {
     TLPointerEventHandler,
     Utils,
 } from '@tldraw/core';
+import type { PointerEvent } from 'react';
 import type { TldrawApp } from '../tldraw-app';
 import {
     TDEventHandler,
@@ -83,7 +84,7 @@ export abstract class BaseTool<T extends string = any> extends TDEventHandler {
         if (this.status !== 'pinching') return;
         if (isNaN(info.delta[0]) || isNaN(info.delta[1])) return;
         this.app.pinchZoom(info.point, info.delta, info.delta[2]);
-        this.onPointerMove?.(info, e as unknown as React.PointerEvent);
+        this.onPointerMove?.(info, e as unknown as PointerEvent);
     };
 
     /* ---------------------- Keys ---------------------- */

--- a/libs/components/common/src/lib/Logo/LogoImg.tsx
+++ b/libs/components/common/src/lib/Logo/LogoImg.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { CSSProperties } from 'react';
 
 export const LogoImg = ({ style = {} }: { style: CSSProperties }) => {

--- a/libs/components/common/src/lib/button/index.tsx
+++ b/libs/components/common/src/lib/button/index.tsx
@@ -1,4 +1,10 @@
 import clsx from 'clsx';
+import type {
+    ReactNode,
+    MouseEventHandler,
+    CSSProperties,
+    MouseEvent as ReactMouseEvent,
+} from 'react';
 import style9 from 'style9';
 
 const styles = style9.create({
@@ -26,11 +32,11 @@ export type SizeType = 'small' | 'medium' | 'large';
 export type ButtonProps = {
     type?: ButtonType;
     size?: SizeType;
-    icon?: React.ReactNode;
+    icon?: ReactNode;
     className?: string;
-    children?: React.ReactNode;
-    onClick?: React.MouseEventHandler<HTMLElement>;
-    style?: React.CSSProperties;
+    children?: ReactNode;
+    onClick?: MouseEventHandler<HTMLElement>;
+    style?: CSSProperties;
 };
 
 export default function Button(props: ButtonProps) {
@@ -44,14 +50,12 @@ export default function Button(props: ButtonProps) {
         className
     );
     const handleClick = (
-        e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>
+        e: ReactMouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>
     ) => {
         const { onClick } = props;
-        (
-            onClick as React.MouseEventHandler<
-                HTMLButtonElement | HTMLAnchorElement
-            >
-        )?.(e);
+        (onClick as MouseEventHandler<HTMLButtonElement | HTMLAnchorElement>)?.(
+            e
+        );
     };
     return (
         <button className={classes} style={style || {}} onClick={handleClick}>

--- a/libs/components/common/src/lib/collapsible-title/index.tsx
+++ b/libs/components/common/src/lib/collapsible-title/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { type CSSProperties, type ReactNode, useState } from 'react';
 import {
     MuiButton as Button,
     MuiCollapse as Collapse,
@@ -23,10 +23,10 @@ const StyledContainer = styled('div')({
 export type CollapsibleTitleProps = {
     title?: string;
     initialOpen?: boolean;
-    icon?: React.ReactNode;
-    children?: React.ReactNode;
+    icon?: ReactNode;
+    children?: ReactNode;
     className?: string;
-    style?: React.CSSProperties;
+    style?: CSSProperties;
 };
 
 export function CollapsibleTitle(props: CollapsibleTitleProps) {

--- a/libs/components/common/src/lib/text/EditableText.tsx
+++ b/libs/components/common/src/lib/text/EditableText.tsx
@@ -1,19 +1,20 @@
 /* eslint-disable max-lines */
-import React, {
-    KeyboardEvent,
-    KeyboardEventHandler,
+import {
     useCallback,
     useEffect,
     useMemo,
     useRef,
     useState,
     forwardRef,
-    MouseEventHandler,
     useLayoutEffect,
-    CSSProperties,
-    MouseEvent,
-    DragEvent,
+    type KeyboardEvent,
+    type KeyboardEventHandler,
+    type MouseEventHandler,
+    type CSSProperties,
+    type MouseEvent,
+    type DragEvent,
 } from 'react';
+
 import isHotkey from 'is-hotkey';
 import {
     createEditor,
@@ -735,7 +736,7 @@ const EditorElement = (props: any) => {
     } = props;
     const defaultElementStyles = {
         textAlign: element['textAlign'],
-    } as React.CSSProperties;
+    } as CSSProperties;
 
     switch (element.type) {
         case 'link': {
@@ -781,7 +782,7 @@ const EditorLeaf = ({ attributes, children, leaf }: any) => {
         if (leaf.fontBgColor) {
             styles.backgroundColor = leaf.fontBgColor as string;
         }
-        return styles as React.CSSProperties;
+        return styles as CSSProperties;
     }, [leaf.fontBgColor, leaf.fontColor]);
 
     const commentsIds = useMemo(

--- a/libs/components/common/src/lib/text/plugins/link.tsx
+++ b/libs/components/common/src/lib/text/plugins/link.tsx
@@ -1,13 +1,14 @@
-import React, {
+import {
     useEffect,
     useMemo,
     useRef,
     useState,
     useCallback,
-    KeyboardEvent,
-    MouseEvent,
     memo,
+    type KeyboardEvent,
+    type MouseEvent,
 } from 'react';
+
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
@@ -156,7 +157,7 @@ export const LinkComponent = ({
     );
 
     const handle_click_link_text = useCallback(
-        (event: React.MouseEvent<HTMLAnchorElement>) => {
+        (event: MouseEvent<HTMLAnchorElement>) => {
             // prevent route to href url
             event.preventDefault();
             event.stopPropagation();

--- a/libs/components/editor-blocks/src/blocks/code/CodeMirror.tsx
+++ b/libs/components/editor-blocks/src/blocks/code/CodeMirror.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useRef, useImperativeHandle } from 'react';
+import {
+    useEffect,
+    useRef,
+    useImperativeHandle,
+    forwardRef,
+    type HTMLAttributes,
+} from 'react';
 import { EditorState, EditorStateConfig, Extension } from '@codemirror/state';
 import { EditorView, ViewUpdate } from '@codemirror/view';
 import { useCodeMirror } from './use-code-mirror';
@@ -7,7 +13,7 @@ export * from './use-code-mirror';
 
 export interface ReactCodeMirrorProps
     extends Omit<EditorStateConfig, 'doc' | 'extensions'>,
-        Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'placeholder'> {
+        Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'placeholder'> {
     /** value of the auto created model in the editor. */
     value?: string;
     height?: string;
@@ -67,87 +73,88 @@ export interface ReactCodeMirrorRef {
     view?: EditorView;
 }
 
-const ReactCodeMirror = React.forwardRef<
-    ReactCodeMirrorRef,
-    ReactCodeMirrorProps
->((props, ref) => {
-    const {
-        className,
-        value = '',
-        selection,
-        extensions = [],
-        onChange,
-        onUpdate,
-        handleKeyArrowUp,
-        handleKeyArrowDown,
-        autoFocus,
-        theme = 'light',
-        height,
-        minHeight,
-        maxHeight,
-        width,
-        minWidth,
-        maxWidth,
-        basicSetup,
-        placeholder,
-        indentWithTab,
-        editable,
-        readOnly,
-        root,
-        ...other
-    } = props;
-    const editor = useRef<HTMLDivElement>(null);
-    const { state, view, container, setContainer } = useCodeMirror({
-        container: editor.current,
-        root,
-        value,
-        autoFocus,
-        theme,
-        height,
-        minHeight,
-        maxHeight,
-        width,
-        minWidth,
-        maxWidth,
-        basicSetup,
-        placeholder,
-        indentWithTab,
-        editable,
-        readOnly,
-        selection,
-        onChange,
-        onUpdate,
-        extensions,
-        handleKeyArrowUp,
-        handleKeyArrowDown,
-    });
-    useImperativeHandle(ref, () => ({ editor: container, state, view }), [
-        container,
-        state,
-        view,
-    ]);
-    useEffect(() => {
-        setContainer(editor.current);
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+const ReactCodeMirror = forwardRef<ReactCodeMirrorRef, ReactCodeMirrorProps>(
+    (props, ref) => {
+        const {
+            className,
+            value = '',
+            selection,
+            extensions = [],
+            onChange,
+            onUpdate,
+            handleKeyArrowUp,
+            handleKeyArrowDown,
+            autoFocus,
+            theme = 'light',
+            height,
+            minHeight,
+            maxHeight,
+            width,
+            minWidth,
+            maxWidth,
+            basicSetup,
+            placeholder,
+            indentWithTab,
+            editable,
+            readOnly,
+            root,
+            ...other
+        } = props;
+        const editor = useRef<HTMLDivElement>(null);
+        const { state, view, container, setContainer } = useCodeMirror({
+            container: editor.current,
+            root,
+            value,
+            autoFocus,
+            theme,
+            height,
+            minHeight,
+            maxHeight,
+            width,
+            minWidth,
+            maxWidth,
+            basicSetup,
+            placeholder,
+            indentWithTab,
+            editable,
+            readOnly,
+            selection,
+            onChange,
+            onUpdate,
+            extensions,
+            handleKeyArrowUp,
+            handleKeyArrowDown,
+        });
+        useImperativeHandle(ref, () => ({ editor: container, state, view }), [
+            container,
+            state,
+            view,
+        ]);
+        useEffect(() => {
+            setContainer(editor.current);
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+        }, []);
 
-    // check type of value
-    if (typeof value !== 'string') {
-        throw new Error(`value must be typeof string but got ${typeof value}`);
+        // check type of value
+        if (typeof value !== 'string') {
+            throw new Error(
+                `value must be typeof string but got ${typeof value}`
+            );
+        }
+
+        const defaultClassNames =
+            typeof theme === 'string' ? `cm-theme-${theme}` : 'cm-theme';
+        return (
+            <div
+                ref={editor}
+                className={`${defaultClassNames}${
+                    className ? ` ${className}` : ''
+                }`}
+                {...other}
+            />
+        );
     }
-
-    const defaultClassNames =
-        typeof theme === 'string' ? `cm-theme-${theme}` : 'cm-theme';
-    return (
-        <div
-            ref={editor}
-            className={`${defaultClassNames}${
-                className ? ` ${className}` : ''
-            }`}
-            {...other}
-        />
-    );
-});
+);
 
 ReactCodeMirror.displayName = 'CodeMirror';
 

--- a/libs/components/editor-blocks/src/blocks/code/CodeView.tsx
+++ b/libs/components/editor-blocks/src/blocks/code/CodeView.tsx
@@ -3,7 +3,7 @@ import { StyleWithAtRules } from 'style9';
 
 import { CreateView } from '@toeverything/framework/virgo';
 import CodeMirror, { ReactCodeMirrorRef } from './CodeMirror';
-import { styled } from '@toeverything/components/ui';
+import { styled, Option, Select } from '@toeverything/components/ui';
 
 import { javascript } from '@codemirror/lang-javascript';
 import { html } from '@codemirror/lang-html';
@@ -45,7 +45,6 @@ import { dockerFile } from '@codemirror/legacy-modes/mode/dockerfile';
 import { julia } from '@codemirror/legacy-modes/mode/julia';
 import { r } from '@codemirror/legacy-modes/mode/r';
 import { Extension } from '@codemirror/state';
-import { Option, Select } from '@toeverything/components/ui';
 
 import {
     useOnSelect,
@@ -200,7 +199,8 @@ export const CodeView = ({ block, editor }: CreateCodeView) => {
                     </div>
                     <div>
                         <div className="copy-block" onClick={copyCode}>
-                            <DuplicateIcon></DuplicateIcon>Copy
+                            <DuplicateIcon />
+                            Copy
                         </div>
                     </div>
                 </div>

--- a/libs/components/editor-blocks/src/blocks/divider/divider-view.tsx
+++ b/libs/components/editor-blocks/src/blocks/divider/divider-view.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type MouseEvent } from 'react';
 import { CreateView } from '@toeverything/framework/virgo';
 import { styled } from '@toeverything/components/ui';
 import { useOnSelect } from '@toeverything/components/editor-core';
@@ -25,7 +25,7 @@ export const DividerView = ({ block, editor }: CreateView) => {
         setIsSelected(isSelect);
     });
 
-    const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const handleClick = (e: MouseEvent<HTMLDivElement>) => {
         editor.selectionManager.setSelectedNodesIds([block.id]);
     };
 

--- a/libs/components/editor-blocks/src/blocks/grid/GirdHandle.tsx
+++ b/libs/components/editor-blocks/src/blocks/grid/GirdHandle.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type MouseEventHandler } from 'react';
 import { styled } from '@toeverything/components/ui';
 import { BlockEditor } from '@toeverything/framework/virgo';
 
@@ -7,12 +7,12 @@ const GRID_ADD_HANDLE_NAME = 'grid-add-handle';
 type GridHandleProps = {
     editor: BlockEditor;
     onDrag?: (e: MouseEvent) => void;
-    onMouseDown?: React.MouseEventHandler<HTMLDivElement>;
+    onMouseDown?: MouseEventHandler<HTMLDivElement>;
     blockId: string;
     enabledAddItem: boolean;
     draggable: boolean;
     alertHandleId: string;
-    onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
+    onMouseEnter?: MouseEventHandler<HTMLDivElement>;
 };
 
 export const GridHandle = function ({
@@ -26,7 +26,7 @@ export const GridHandle = function ({
     onMouseEnter,
 }: GridHandleProps) {
     const [isMouseDown, setIsMouseDown] = useState<boolean>(false);
-    const handleMouseDown: React.MouseEventHandler<HTMLDivElement> = e => {
+    const handleMouseDown: MouseEventHandler<HTMLDivElement> = e => {
         if (draggable) {
             const cb = (e: MouseEvent) => {
                 onDrag && onDrag(e);
@@ -48,7 +48,7 @@ export const GridHandle = function ({
         }
     };
 
-    const handleMouseEnter: React.MouseEventHandler<HTMLDivElement> = e => {
+    const handleMouseEnter: MouseEventHandler<HTMLDivElement> = e => {
         onMouseEnter && onMouseEnter(e);
     };
 

--- a/libs/components/editor-blocks/src/blocks/grid/Grid.tsx
+++ b/libs/components/editor-blocks/src/blocks/grid/Grid.tsx
@@ -1,6 +1,11 @@
 import { RenderBlock } from '@toeverything/components/editor-core';
 import { CreateView } from '@toeverything/framework/virgo';
-import React, { useEffect, useRef, useState } from 'react';
+import {
+    useEffect,
+    useRef,
+    useState,
+    type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { GridHandle } from './GirdHandle';
 import { styled } from '@toeverything/components/ui';
 import ReactDOM from 'react-dom';
@@ -87,7 +92,7 @@ export const Grid = function (props: CreateView) {
     };
 
     const handleMouseDown = (
-        e: React.MouseEvent<HTMLDivElement>,
+        e: ReactMouseEvent<HTMLDivElement>,
         index: number
     ) => {
         mouseStartPoint.current = new Point(e.clientX, e.clientY);
@@ -193,7 +198,7 @@ export const Grid = function (props: CreateView) {
     };
 
     const handleHandleMouseEnter = (
-        e: React.MouseEvent<HTMLDivElement>,
+        e: ReactMouseEvent<HTMLDivElement>,
         index: number
     ) => {
         const leftBlockId = block.childrenIds[index];

--- a/libs/components/editor-blocks/src/blocks/group/components/filter/MultipleChipInput.tsx
+++ b/libs/components/editor-blocks/src/blocks/group/components/filter/MultipleChipInput.tsx
@@ -5,9 +5,8 @@ import {
     autocompleteClasses,
     useAutocomplete,
 } from '@toeverything/components/ui';
-import type { MouseEvent } from 'react';
+import type { MouseEvent, SyntheticEvent } from 'react';
 import type { ValueOption } from './types';
-import * as React from 'react';
 
 const ListBox = styled('ul')`
     width: 300px;
@@ -154,7 +153,7 @@ const MultipleChipInput = (props: Props) => {
         options,
         value: initValue,
         getOptionLabel: option => (option as ValueOption).title,
-        onChange: (event: React.SyntheticEvent, data) => {
+        onChange: (event: SyntheticEvent, data) => {
             onChange(data as ValueOption[]);
         },
     });

--- a/libs/components/editor-blocks/src/blocks/image/ImageView.tsx
+++ b/libs/components/editor-blocks/src/blocks/image/ImageView.tsx
@@ -6,7 +6,7 @@ import {
 import { styled } from '@toeverything/components/ui';
 import { services } from '@toeverything/datasource/db-service';
 import { CreateView } from '@toeverything/framework/virgo';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
 import { Image as SourceView } from '../../components/ImageView';
 import { Upload } from '../../components/upload/upload';
 import { SCENE_CONFIG } from '../group/config';
@@ -143,7 +143,7 @@ export const ImageView = ({ block, editor }: ImageView) => {
             type: 'link',
         });
     };
-    const handle_click = async (e: React.MouseEvent<HTMLDivElement>) => {
+    const handle_click = async (e: MouseEvent<HTMLDivElement>) => {
         //TODO clear active selection
         // document.getElementsByTagName('body')[0].click();
         e.stopPropagation();

--- a/libs/components/editor-blocks/src/components/select/index.tsx
+++ b/libs/components/editor-blocks/src/components/select/index.tsx
@@ -1,8 +1,10 @@
+import type { ChangeEvent, OptionHTMLAttributes } from 'react';
+
 interface SelectProps {
     label?: string;
     value?: string;
     options?: string[];
-    onChange?(evn: React.ChangeEvent<HTMLSelectElement>): void;
+    onChange?(evn: ChangeEvent<HTMLSelectElement>): void;
 }
 
 export const Select = ({
@@ -17,7 +19,7 @@ export const Select = ({
             <span>
                 <select value={value} onChange={onChange}>
                     {options.map((item, key) => {
-                        const optionProps: React.OptionHTMLAttributes<HTMLOptionElement> =
+                        const optionProps: OptionHTMLAttributes<HTMLOptionElement> =
                             {};
                         if (value === item) {
                             optionProps.value = item;

--- a/libs/components/editor-blocks/src/components/source-view/SourceView.tsx
+++ b/libs/components/editor-blocks/src/components/source-view/SourceView.tsx
@@ -161,10 +161,7 @@ export const SourceView = (props: Props) => {
                 <SourceViewContainer isSelected={isSelected} scene={type}>
                     <MouseMaskContainer />
 
-                    <LazyIframe
-                        src={src}
-                        fallback={LoadingContiner()}
-                    ></LazyIframe>
+                    <LazyIframe src={src} fallback={LoadingContiner()} />
                 </SourceViewContainer>
             </div>
         );

--- a/libs/components/editor-blocks/src/components/text-manage/TextManage.tsx
+++ b/libs/components/editor-blocks/src/components/text-manage/TextManage.tsx
@@ -23,6 +23,7 @@ import {
     useEffect,
     useRef,
     type MutableRefObject,
+    type KeyboardEvent,
 } from 'react';
 import { Range } from 'slate';
 import { ReactEditor } from 'slate-react';
@@ -289,7 +290,7 @@ export const TextManage = forwardRef<ExtendedTextUtils, CreateTextView>(
             return { nowPosition: nowPosition, prePosition: prePosition };
         };
 
-        const onKeyboardUp = (event: React.KeyboardEvent<Element>) => {
+        const onKeyboardUp = (event: KeyboardEvent<Element>) => {
             // if default event is prevented do noting
             // if U want to disable up/down/enter use capture event for preventing
             if (!event.isDefaultPrevented()) {
@@ -328,7 +329,7 @@ export const TextManage = forwardRef<ExtendedTextUtils, CreateTextView>(
             return false;
         };
 
-        const onKeyboardDown = (event: React.KeyboardEvent<Element>) => {
+        const onKeyboardDown = (event: KeyboardEvent<Element>) => {
             // if default event is prevented do noting
             // if U want to disable up/down/enter use capture event for preventing
             // editor.selectionManager.activeNextNode(block.id, 'start');

--- a/libs/components/editor-core/src/RenderRoot.tsx
+++ b/libs/components/editor-core/src/RenderRoot.tsx
@@ -1,7 +1,15 @@
 import type { BlockEditor } from './editor';
 import { styled, usePatchNodes } from '@toeverything/components/ui';
 import type { PropsWithChildren } from 'react';
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import {
+    useEffect,
+    useRef,
+    useState,
+    useCallback,
+    type MouseEvent as ReactMouseEvent,
+    type KeyboardEventHandler,
+    type DragEvent,
+} from 'react';
 import { EditorProvider } from './Contexts';
 import { SelectionRect, SelectionRef } from './Selection';
 import {
@@ -71,60 +79,56 @@ export const RenderRoot = ({
     }, [rootId, editor, fetchPageBlockWidth]);
 
     const onMouseMove = async (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
+        event: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => {
         selectionRef.current?.onMouseMove(event);
         editor.getHooks().onRootNodeMouseMove(event);
     };
 
     const onMouseDown = (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
+        event: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => {
         triggeredBySelect.current = true;
         selectionRef.current?.onMouseDown(event);
         editor.getHooks().onRootNodeMouseDown(event);
     };
 
-    const onMouseUp = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const onMouseUp = (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {
         selectionRef.current?.onMouseUp(event);
         editor.getHooks().onRootNodeMouseUp(event);
     };
 
-    const onMouseOut = (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
-    ) => {
+    const onMouseOut = (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => {
         editor.getHooks().onRootNodeMouseOut(event);
     };
 
     const onMouseLeave = (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
+        event: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => {
         editor.getHooks().onRootNodeMouseLeave(event);
     };
 
     const onContextmenu = (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
+        event: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => {
         selectionRef.current?.onContextmenu(event);
     };
 
-    const onKeyDown: React.KeyboardEventHandler<HTMLDivElement> = event => {
+    const onKeyDown: KeyboardEventHandler<HTMLDivElement> = event => {
         // IMP move into keyboard managers?
         editor.getHooks().onRootNodeKeyDown(event);
     };
 
-    const onKeyUp: React.KeyboardEventHandler<HTMLDivElement> = event => {
+    const onKeyUp: KeyboardEventHandler<HTMLDivElement> = event => {
         // IMP move into keyboard managers?
         editor.getHooks().onRootNodeKeyUp(event);
     };
 
-    const onKeyDownCapture: React.KeyboardEventHandler<
-        HTMLDivElement
-    > = event => {
+    const onKeyDownCapture: KeyboardEventHandler<HTMLDivElement> = event => {
         editor.getHooks().onRootNodeKeyDownCapture(event);
     };
 
-    const onDragOver = (event: React.DragEvent<Element>) => {
+    const onDragOver = (event: DragEvent<Element>) => {
         event.dataTransfer.dropEffect = 'move';
         event.preventDefault();
         editor.dragDropManager.handlerEditorDragOver(event);
@@ -133,25 +137,25 @@ export const RenderRoot = ({
         }
     };
 
-    const onDragLeave = (event: React.DragEvent<Element>) => {
+    const onDragLeave = (event: DragEvent<Element>) => {
         if (editor.dragDropManager.isEnabled()) {
             editor.getHooks().onRootNodeDragLeave(event);
         }
     };
 
-    const onDragOverCapture = (event: React.DragEvent<Element>) => {
+    const onDragOverCapture = (event: DragEvent<Element>) => {
         event.preventDefault();
         if (editor.dragDropManager.isEnabled()) {
             editor.getHooks().onRootNodeDragOver(event);
         }
     };
 
-    const onDragEnd = (event: React.DragEvent<Element>) => {
+    const onDragEnd = (event: DragEvent<Element>) => {
         editor.dragDropManager.handlerEditorDragEnd(event);
         editor.getHooks().onRootNodeDragEnd(event);
     };
 
-    const onDrop = (event: React.DragEvent<Element>) => {
+    const onDrop = (event: DragEvent<Element>) => {
         event.preventDefault();
         editor.dragDropManager.handlerEditorDrop(event);
         editor.getHooks().onRootNodeDrop(event);
@@ -202,7 +206,7 @@ function ScrollBlank({ editor }: { editor: BlockEditor }) {
     const onMouseDown = useCallback(() => (mouseMoved.current = false), []);
     const onMouseMove = useCallback(() => (mouseMoved.current = true), []);
     const onClick = useCallback(
-        async (e: React.MouseEvent) => {
+        async (e: ReactMouseEvent) => {
             if (mouseMoved.current) {
                 mouseMoved.current = false;
                 return;

--- a/libs/components/editor-core/src/Selection.tsx
+++ b/libs/components/editor-core/src/Selection.tsx
@@ -1,9 +1,10 @@
-import React, {
+import {
     forwardRef,
     useImperativeHandle,
     useEffect,
     useRef,
     useState,
+    type MouseEvent as ReactMouseEvent,
 } from 'react';
 import { domToRect, Point, Rect } from '@toeverything/utils';
 // TODO: optimize
@@ -26,12 +27,10 @@ const DIRECTION_VALUE_MAP = {
 type VerticalTypes = 'up' | 'down' | null;
 type HorizontalTypes = 'left' | 'right' | null;
 export type SelectionRef = {
-    onMouseDown: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-    onMouseMove: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-    onMouseUp: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-    onContextmenu: (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
-    ) => void;
+    onMouseDown: (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onMouseMove: (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onMouseUp: (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onContextmenu: (event: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
 };
 
 const getFixedPoint = (
@@ -116,7 +115,7 @@ export const SelectionRect = forwardRef<SelectionRef, SelectionProps>(
         const scrollContainerRect = useRef<Rect>();
 
         const onMouseDown = async (
-            event: React.MouseEvent<HTMLDivElement, MouseEvent>
+            event: ReactMouseEvent<HTMLDivElement, MouseEvent>
         ) => {
             await selectionManager.setSelectedNodesIds([]);
             startPointRef.current = new Point(event.clientX, event.clientY);
@@ -133,7 +132,7 @@ export const SelectionRect = forwardRef<SelectionRef, SelectionProps>(
         };
 
         const onMouseMove = async (
-            event: React.MouseEvent<HTMLDivElement, MouseEvent>
+            event: ReactMouseEvent<HTMLDivElement, MouseEvent>
         ) => {
             if (mouseType.current === 'down') {
                 endPointRef.current = new Point(event.clientX, event.clientY);

--- a/libs/components/editor-core/src/block-pendant/AddPendantPopover.tsx
+++ b/libs/components/editor-core/src/block-pendant/AddPendantPopover.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useRef } from 'react';
+import { CSSProperties, useRef } from 'react';
 import { Add } from '@mui/icons-material';
 import {
     Popover,

--- a/libs/components/editor-core/src/block-pendant/PendantTag.tsx
+++ b/libs/components/editor-core/src/block-pendant/PendantTag.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Tag, type TagProps } from '@toeverything/components/ui';
 import {
     DateValue,

--- a/libs/components/editor-core/src/block-pendant/StyledComponent.tsx
+++ b/libs/components/editor-core/src/block-pendant/StyledComponent.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { styled } from '@toeverything/components/ui';
 
 export const IconButton = styled('button')`

--- a/libs/components/editor-core/src/block-pendant/pendant-history-panel/PendantHistoryPanel.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-history-panel/PendantHistoryPanel.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef, useEffect, useState } from 'react';
+import { ReactNode, useRef, useEffect, useState } from 'react';
 import {
     getRecastItemValue,
     RecastMetaProperty,

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Date.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Date.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import { ModifyPanelContentProps } from './types';
 import {

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/IconInput.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/IconInput.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, type CSSProperties, useState } from 'react';
+import { forwardRef, ReactNode, useState, type CSSProperties } from 'react';
 import { Input, styled, InputProps } from '@toeverything/components/ui';
 import { StyledHighLightWrapper } from '../StyledComponent';
 import { IconNames } from '../types';
@@ -53,8 +53,8 @@ export const IconInput = forwardRef<HTMLInputElement, IconInputProps>(
 );
 
 type HighLightIconInputProps = {
-    startElement?: React.ReactNode;
-    endElement?: React.ReactNode;
+    startElement?: ReactNode;
+    endElement?: ReactNode;
     tabIndex?: number;
 } & IconInputProps;
 

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Information.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Information.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { ModifyPanelContentProps } from './types';
 import { StyledDivider, StyledPopoverSubTitle } from '../StyledComponent';

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Mention.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Mention.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useState } from 'react';
+import { CSSProperties, useState } from 'react';
 import { useUserAndSpaces } from '@toeverything/datasource/state';
 import {
     Option,

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/PendantModifyPanel.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/PendantModifyPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PendantTypes } from '../types';
 import { ModifyPanelContentProps, ModifyPanelProps } from './types';
 import { MuiButton as Button, styled } from '@toeverything/components/ui';

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/PendantTypeSelect.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/PendantTypeSelect.tsx
@@ -1,6 +1,5 @@
 import { PendantTypes } from '../types';
 import { MuiRadio as Radio, styled } from '@toeverything/components/ui';
-import React from 'react';
 
 export const PendantSelect = ({
     currentType,

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Select.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Select.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
     CSSProperties,
     useEffect,
     useState,

--- a/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Text.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-modify-panel/Text.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useState } from 'react';
+import { CSSProperties, useState } from 'react';
 
 import { ModifyPanelContentProps } from './types';
 import { HighLightIconInput } from './IconInput';

--- a/libs/components/editor-core/src/block-pendant/pendant-operation-panel/CreatePendantPanel.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-operation-panel/CreatePendantPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { message, Option, Select } from '@toeverything/components/ui';
 import { AsyncBlock } from '../../editor';
 

--- a/libs/components/editor-core/src/block-pendant/pendant-operation-panel/FieldTitleInput.tsx
+++ b/libs/components/editor-core/src/block-pendant/pendant-operation-panel/FieldTitleInput.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Input, Tooltip, InputProps } from '@toeverything/components/ui';
 import { StyledInputEndAdornment } from '../StyledComponent';
 import { HelpCenterIcon } from '@toeverything/components/icons';

--- a/libs/components/editor-core/src/editor/drag-drop/drag-drop.ts
+++ b/libs/components/editor-core/src/editor/drag-drop/drag-drop.ts
@@ -7,6 +7,7 @@ import { BlockDropPlacement, GroupDirection } from '../types';
 // TODO: Evaluate implementing custom events with Rxjs
 import EventEmitter from 'eventemitter3';
 import { Protocol } from '@toeverything/datasource/db-service';
+import type { DragEvent } from 'react';
 
 enum DragType {
     dragBlock = 'dragBlock',
@@ -79,7 +80,7 @@ export class DragDropManager {
         this._blockDragTargetId = id;
     }
 
-    private async _canBeDrop(event: React.DragEvent<Element>) {
+    private async _canBeDrop(event: DragEvent<Element>) {
         const blockId = event.dataTransfer.getData(this._blockIdKey);
         if (blockId === undefined || this._blockDragTargetId === undefined) {
             return false;
@@ -94,7 +95,7 @@ export class DragDropManager {
         return true;
     }
 
-    private async _handleDropBlock(event: React.DragEvent<Element>) {
+    private async _handleDropBlock(event: DragEvent<Element>) {
         const targetBlock = await this._editor.getBlockById(
             this._blockDragTargetId
         );
@@ -170,7 +171,7 @@ export class DragDropManager {
         }
     }
 
-    private async _handleDropGroup(event: React.DragEvent<Element>) {
+    private async _handleDropGroup(event: DragEvent<Element>) {
         const blockId = event.dataTransfer.getData(this._blockIdKey);
         const toGroup = await this._editor.getGroupBlockByPoint(
             new Point(event.clientX, event.clientY)
@@ -208,7 +209,7 @@ export class DragDropManager {
         this._enabled = false;
     }
 
-    public setDragBlockInfo(event: React.DragEvent<Element>, blockId: string) {
+    public setDragBlockInfo(event: DragEvent<Element>, blockId: string) {
         this.dragType = this.dragActions.dragBlock;
         event.dataTransfer.setData(
             this._dragActions.dragBlock,
@@ -225,17 +226,17 @@ export class DragDropManager {
      *
      *  Drag data store's dragover event is Protected mode.
      * Drag over can not get dataTransfer value by event.dataTransfer.
-     * @param {React.DragEvent<Element>} [event]
+     * @param {DragEvent<Element>} [event]
      * @return {*}
      * @memberof DragDropManager
      */
-    public isDragBlock(event: React.DragEvent<Element>) {
+    public isDragBlock(event: DragEvent<Element>) {
         return event.dataTransfer.types.includes(
             this.dragActions.dragBlock.toLowerCase()
         );
     }
 
-    public setDragGroupInfo(event: React.DragEvent<Element>, blockId: string) {
+    public setDragGroupInfo(event: DragEvent<Element>, blockId: string) {
         this.dragType = this.dragActions.dragGroup;
         event.dataTransfer.setData(
             this._dragActions.dragGroup,
@@ -252,11 +253,11 @@ export class DragDropManager {
      *
      *  Drag data store's dragover event is Protected mode.
      * Drag over can not get dataTransfer value by event.dataTransfer.
-     * @param {React.DragEvent<Element>} [event]
+     * @param {DragEvent<Element>} [event]
      * @return {*}
      * @memberof DragDropManager
      */
-    public isDragGroup(event: React.DragEvent<Element>) {
+    public isDragGroup(event: DragEvent<Element>) {
         return event.dataTransfer.types.includes(
             this.dragActions.dragGroup.toLowerCase()
         );
@@ -265,7 +266,7 @@ export class DragDropManager {
     /**
      *
      * check if drag block is out of blocks and return direction
-     * @param {React.DragEvent<Element>} event
+     * @param {DragEvent<Element>} event
      * @return {
      *      direction: BlockDropPlacement.none, // none, outerLeft, outerRight
      *      block: undefined, // the block in the same clientY
@@ -274,7 +275,7 @@ export class DragDropManager {
      *
      * @memberof DragDropManager
      */
-    public async checkOuterBlockDragTypes(event: React.DragEvent<Element>) {
+    public async checkOuterBlockDragTypes(event: DragEvent<Element>) {
         const { clientX, clientY } = event;
         const mousePoint = new Point(clientX, clientY);
         const rootBlock = await this._editor.getBlockById(
@@ -350,7 +351,7 @@ export class DragDropManager {
     }
 
     public async checkBlockDragTypes(
-        event: React.DragEvent<Element>,
+        event: DragEvent<Element>,
         blockDom: HTMLElement,
         blockId: string
     ) {
@@ -420,7 +421,7 @@ export class DragDropManager {
         return { direction, block: targetBlock };
     }
 
-    public handlerEditorDrop(event: React.DragEvent<Element>) {
+    public handlerEditorDrop(event: DragEvent<Element>) {
         // IMP: can not use Decorators now may use decorators is right
         if (this.isEnabled()) {
             if (this.isDragBlock(event)) {
@@ -433,11 +434,11 @@ export class DragDropManager {
         this.dragType = undefined;
     }
 
-    public handlerEditorDragOver(event: React.DragEvent<Element>) {
+    public handlerEditorDragOver(event: DragEvent<Element>) {
         // IMP: can not use Decorators now
     }
 
-    public handlerEditorDragEnd(event: React.DragEvent<Element>) {
+    public handlerEditorDragEnd(event: DragEvent<Element>) {
         this._resetDragDropData();
         if (this.isOnDrag) {
             this.isOnDrag = false;

--- a/libs/components/editor-core/src/editor/keyboard/keyboard.ts
+++ b/libs/components/editor-core/src/editor/keyboard/keyboard.ts
@@ -228,20 +228,20 @@ export class KeyboardManager {
                 );
             } else {
                 // suspend(true)
-                let textBlock = await this._editor.createBlock('text');
+                const textBlock = await this._editor.createBlock('text');
                 await selectedNode.after(textBlock);
                 this._editor.selectionManager.setActivatedNodeId(textBlock.id);
             }
         }
     };
     private mergeGroup = async (event: Event) => {
-        let selectedGroup = await this.getSelectedGroups();
+        const selectedGroup = await this.getSelectedGroups();
         this._editor.commands.blockCommands.mergeGroup(...selectedGroup);
     };
     private mergeGroupDown = async (event: Event) => {
-        let selectedGroup = await this.getSelectedGroups();
+        const selectedGroup = await this.getSelectedGroups();
         if (selectedGroup.length) {
-            let nextGroup = await selectedGroup[
+            const nextGroup = await selectedGroup[
                 selectedGroup.length - 1
             ].nextSibling();
             if (nextGroup?.type === Protocol.Block.Type.group) {
@@ -253,9 +253,9 @@ export class KeyboardManager {
         }
     };
     private mergeGroupUp = async (event: Event) => {
-        let selectedGroup = await this.getSelectedGroups();
+        const selectedGroup = await this.getSelectedGroups();
         if (selectedGroup.length) {
-            let preGroup = await selectedGroup[0].previousSibling();
+            const preGroup = await selectedGroup[0].previousSibling();
             if (preGroup?.type === Protocol.Block.Type.group) {
                 this._editor.commands.blockCommands.mergeGroup(
                     preGroup,

--- a/libs/components/editor-core/src/editor/plugin/hooks.ts
+++ b/libs/components/editor-core/src/editor/plugin/hooks.ts
@@ -1,5 +1,11 @@
 import { Observable, Subject } from 'rxjs';
 import { HooksRunner, HookType, PluginHooks } from '../types';
+import type {
+    KeyboardEvent,
+    MouseEvent as ReactMouseEvent,
+    DragEvent,
+    UIEvent,
+} from 'react';
 
 export class Hooks implements HooksRunner, PluginHooks {
     private _subject: Record<string, Subject<unknown>> = {};
@@ -42,73 +48,69 @@ export class Hooks implements HooksRunner, PluginHooks {
         this._runHook(HookType.RENDER);
     }
 
-    public onRootNodeKeyDown(e: React.KeyboardEvent<HTMLDivElement>): void {
+    public onRootNodeKeyDown(e: KeyboardEvent<HTMLDivElement>): void {
         this._runHook(HookType.ON_ROOT_NODE_KEYDOWN, e);
     }
 
-    public onRootNodeKeyDownCapture(
-        e: React.KeyboardEvent<HTMLDivElement>
-    ): void {
+    public onRootNodeKeyDownCapture(e: KeyboardEvent<HTMLDivElement>): void {
         this._runHook(HookType.ON_ROOT_NODE_KEYDOWN_CAPTURE, e);
     }
 
-    public onRootNodeKeyUp(e: React.KeyboardEvent<HTMLDivElement>): void {
+    public onRootNodeKeyUp(e: KeyboardEvent<HTMLDivElement>): void {
         this._runHook(HookType.ON_ROOT_NODE_KEYUP, e);
     }
 
     public onRootNodeMouseDown(
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ): void {
         this._runHook(HookType.ON_ROOTNODE_MOUSE_DOWN, e);
     }
 
     public onRootNodeMouseMove(
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ): void {
         this._runHook(HookType.ON_ROOTNODE_MOUSE_MOVE, e);
     }
 
     public onRootNodeMouseUp(
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ): void {
         this._runHook(HookType.ON_ROOTNODE_MOUSE_UP, e);
     }
 
     public onRootNodeMouseOut(
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ): void {
         this._runHook(HookType.ON_ROOTNODE_MOUSE_OUT, e);
     }
 
     public onRootNodeMouseLeave(
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ): void {
         this._runHook(HookType.ON_ROOTNODE_MOUSE_LEAVE, e);
     }
 
-    public afterOnResize(
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
-    ): void {
+    public afterOnResize(e: ReactMouseEvent<HTMLDivElement, MouseEvent>): void {
         this._runHook(HookType.AFTER_ON_RESIZE, e);
     }
 
-    public onRootNodeDragOver(e: React.DragEvent<Element>): void {
+    public onRootNodeDragOver(e: DragEvent<Element>): void {
         this._runHook(HookType.ON_ROOTNODE_DRAG_OVER, e);
     }
 
-    public onRootNodeDragLeave(e: React.DragEvent<Element>): void {
+    public onRootNodeDragLeave(e: DragEvent<Element>): void {
         this._runHook(HookType.ON_ROOTNODE_DRAG_LEAVE, e);
     }
 
-    public onRootNodeDragEnd(e: React.DragEvent<Element>): void {
+    public onRootNodeDragEnd(e: DragEvent<Element>): void {
         this._runHook(HookType.ON_ROOTNODE_DRAG_END, e);
     }
 
-    public onRootNodeDrop(e: React.DragEvent<Element>): void {
+    public onRootNodeDrop(e: DragEvent<Element>): void {
         this._runHook(HookType.ON_ROOTNODE_DROP, e);
     }
 
-    public onRootNodeDragOverCapture(e: React.DragEvent<Element>): void {
+    public onRootNodeDragOverCapture(e: DragEvent<Element>): void {
         this._runHook(HookType.ON_ROOTNODE_DRAG_OVER_CAPTURE, e);
     }
 
@@ -124,7 +126,7 @@ export class Hooks implements HooksRunner, PluginHooks {
         this._runHook(HookType.BEFORE_CUT, e);
     }
 
-    public onRootNodeScroll(e: React.UIEvent): void {
+    public onRootNodeScroll(e: UIEvent): void {
         this._runHook(HookType.ON_ROOTNODE_SCROLL, e);
     }
 }

--- a/libs/components/editor-core/src/editor/selection/selection.ts
+++ b/libs/components/editor-core/src/editor/selection/selection.ts
@@ -1063,10 +1063,10 @@ export class SelectionManager implements VirgoSelection {
         index: number,
         blockId: string
     ): Promise<void> {
-        let preRang = document.createRange();
+        const preRang = document.createRange();
         preRang.setStart(nowRange.startContainer, index);
         preRang.setEnd(nowRange.endContainer, index);
-        let prePosition = preRang.getClientRects().item(0);
+        const prePosition = preRang.getClientRects().item(0);
         this.activeNodeByNodeId(
             blockId,
             new Point(prePosition.left, prePosition.bottom)

--- a/libs/components/editor-core/src/editor/types.ts
+++ b/libs/components/editor-core/src/editor/types.ts
@@ -24,6 +24,12 @@ import { MouseManager } from './mouse';
 import { Observable } from 'rxjs';
 import { Point } from '@toeverything/utils';
 import { ScrollManager } from './scroll';
+import type {
+    KeyboardEvent,
+    MouseEvent as ReactMouseEvent,
+    DragEvent,
+    UIEvent,
+} from 'react';
 
 // import { BrowserClipboard } from './clipboard/browser-clipboard';
 
@@ -187,33 +193,31 @@ export enum HookType {
 export interface HooksRunner {
     init: () => void;
     render: () => void;
-    onRootNodeKeyUp: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-    onRootNodeKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
-    onRootNodeKeyDownCapture: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+    onRootNodeKeyUp: (e: KeyboardEvent<HTMLDivElement>) => void;
+    onRootNodeKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void;
+    onRootNodeKeyDownCapture: (e: KeyboardEvent<HTMLDivElement>) => void;
     onRootNodeMouseDown: (
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => void;
     onRootNodeMouseMove: (
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => void;
-    onRootNodeMouseUp: (
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
-    ) => void;
+    onRootNodeMouseUp: (e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
     onRootNodeMouseOut: (
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => void;
     onRootNodeMouseLeave: (
-        e: React.MouseEvent<HTMLDivElement, MouseEvent>
+        e: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => void;
     onSearch: () => void;
-    afterOnResize: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
-    onRootNodeDragOver: (e: React.DragEvent<Element>) => void;
-    onRootNodeDragEnd: (e: React.DragEvent<Element>) => void;
-    onRootNodeDragLeave: (e: React.DragEvent<Element>) => void;
-    onRootNodeDrop: (e: React.DragEvent<Element>) => void;
+    afterOnResize: (e: ReactMouseEvent<HTMLDivElement, MouseEvent>) => void;
+    onRootNodeDragOver: (e: DragEvent<Element>) => void;
+    onRootNodeDragEnd: (e: DragEvent<Element>) => void;
+    onRootNodeDragLeave: (e: DragEvent<Element>) => void;
+    onRootNodeDrop: (e: DragEvent<Element>) => void;
     beforeCopy: (e: ClipboardEvent) => void;
     beforeCut: (e: ClipboardEvent) => void;
-    onRootNodeScroll: (e: React.UIEvent) => void;
+    onRootNodeScroll: (e: UIEvent) => void;
 }
 
 export type PayloadType<T extends Array<any>> = T extends []

--- a/libs/components/editor-plugins/src/comment/AddCommentInput.tsx
+++ b/libs/components/editor-plugins/src/comment/AddCommentInput.tsx
@@ -1,11 +1,17 @@
-import { useCallback, ChangeEvent, KeyboardEvent } from 'react';
+import {
+    useCallback,
+    type ChangeEvent,
+    type KeyboardEvent,
+    type Dispatch,
+    type SetStateAction,
+} from 'react';
 import { styled } from '@toeverything/components/ui';
 import { useAddComment } from './use-add-comment';
 import { WithEditorSelectionType } from '../menu/inline-menu/types';
 
 type AddCommentInputProps = {
     comment: string;
-    setComment: React.Dispatch<React.SetStateAction<string>>;
+    setComment: Dispatch<SetStateAction<string>>;
     createComment: () => Promise<{ commentsId: string }>;
     handleSubmitCurrentComment: () => Promise<void>;
 };

--- a/libs/components/editor-plugins/src/menu/command-menu/Container.tsx
+++ b/libs/components/editor-plugins/src/menu/command-menu/Container.tsx
@@ -1,9 +1,11 @@
-import React, {
+import {
     useEffect,
     useState,
     useMemo,
     useCallback,
     useRef,
+    type KeyboardEvent,
+    type CSSProperties,
 } from 'react';
 import style9 from 'style9';
 
@@ -46,7 +48,7 @@ const ContentContainer = styled('div')(({ theme }) => {
 export type CommandMenuContainerProps = {
     editor: Virgo;
     hooks: PluginHooks;
-    style?: React.CSSProperties;
+    style?: CSSProperties;
     isShow?: boolean;
     blockId: string;
     onSelected?: (item: BlockFlavorKeys | string) => void;
@@ -133,7 +135,7 @@ export const CommandMenuContainer = ({
     }, [isShow, types, currentItem]);
 
     const handleClickUp = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (isShow && types && event.code === 'ArrowUp') {
                 event.preventDefault();
                 if (!currentItem && types.length) {
@@ -152,7 +154,7 @@ export const CommandMenuContainer = ({
     );
 
     const handleClickDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (isShow && types && event.code === 'ArrowDown') {
                 event.preventDefault();
                 if (!currentItem && types.length) {
@@ -171,7 +173,7 @@ export const CommandMenuContainer = ({
     );
 
     const handleClickEnter = useCallback(
-        async (event: React.KeyboardEvent<HTMLDivElement>) => {
+        async (event: KeyboardEvent<HTMLDivElement>) => {
             if (isShow && event.code === 'Enter' && currentItem) {
                 event.preventDefault();
                 onSelected && onSelected(currentItem);
@@ -181,7 +183,7 @@ export const CommandMenuContainer = ({
     );
 
     const handleKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             handleClickUp(event);
             handleClickDown(event);
             handleClickEnter(event);

--- a/libs/components/editor-plugins/src/menu/command-menu/Menu.tsx
+++ b/libs/components/editor-plugins/src/menu/command-menu/Menu.tsx
@@ -1,10 +1,11 @@
 import { BlockFlavorKeys, Protocol } from '@toeverything/datasource/db-service';
-import React, {
+import {
     useCallback,
     useEffect,
     useMemo,
     useRef,
     useState,
+    type KeyboardEvent,
 } from 'react';
 
 import { MuiClickAwayListener } from '@toeverything/components/ui';
@@ -79,7 +80,7 @@ export const CommandMenu = ({ editor, hooks, style }: CommandMenuProps) => {
     }, [searchBlocks, searchText]);
 
     const checkIfShowCommandMenu = useCallback(
-        async (event: React.KeyboardEvent<HTMLDivElement>) => {
+        async (event: KeyboardEvent<HTMLDivElement>) => {
             const { type, anchorNode } = editor.selection.currentSelectInfo;
             if (!anchorNode?.id) {
                 return;
@@ -119,7 +120,7 @@ export const CommandMenu = ({ editor, hooks, style }: CommandMenuProps) => {
                                 ?.getRangeAt(0)
                                 ?.getBoundingClientRect();
                         if (rect) {
-                            let rectTop = rect.top;
+                            const rectTop = rect.top;
                             const clientHeight =
                                 document.documentElement.clientHeight;
 
@@ -149,7 +150,7 @@ export const CommandMenu = ({ editor, hooks, style }: CommandMenuProps) => {
     );
 
     const handleClickOthers = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (show) {
                 const { anchorNode } = editor.selection.currentSelectInfo;
                 if (anchorNode.id !== blockId) {
@@ -175,7 +176,7 @@ export const CommandMenu = ({ editor, hooks, style }: CommandMenuProps) => {
     );
 
     const handleKeyup = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             checkIfShowCommandMenu(event);
             handleClickOthers(event);
         },
@@ -183,7 +184,7 @@ export const CommandMenu = ({ editor, hooks, style }: CommandMenuProps) => {
     );
 
     const handleKeyDown = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (event.code === 'Escape') {
                 hideMenu();
             }

--- a/libs/components/editor-plugins/src/menu/group-menu/DragItem.tsx
+++ b/libs/components/editor-plugins/src/menu/group-menu/DragItem.tsx
@@ -3,6 +3,7 @@ import { AsyncBlock, Virgo } from '@toeverything/components/editor-core';
 import { HandleParentIcon } from '@toeverything/components/icons';
 import { styled } from '@toeverything/components/ui';
 import { Point } from '@toeverything/utils';
+import type { MutableRefObject, HTMLAttributes } from 'react';
 
 export const ICON_WIDTH = 16;
 
@@ -10,9 +11,9 @@ type DragItemProps = {
     isShow: boolean;
     groupBlock: AsyncBlock;
     editor: Virgo;
-    item: React.MutableRefObject<HTMLDivElement>;
+    item: MutableRefObject<HTMLDivElement>;
     onPositionChange?: (position: Point) => void;
-} & React.HTMLAttributes<HTMLDivElement>;
+} & HTMLAttributes<HTMLDivElement>;
 
 export const DragItem = function ({
     isShow,

--- a/libs/components/editor-plugins/src/menu/group-menu/GropuMenu.tsx
+++ b/libs/components/editor-plugins/src/menu/group-menu/GropuMenu.tsx
@@ -6,7 +6,14 @@ import {
 } from '@toeverything/components/editor-core';
 import { Point } from '@toeverything/utils';
 import { GroupDirection } from '@toeverything/framework/virgo';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+    type MouseEvent as ReactMouseEvent,
+    type DragEvent,
+} from 'react';
 import { DragItem } from './DragItem';
 import { Line } from './Line';
 import { Menu } from './Menu';
@@ -27,7 +34,7 @@ export const GroupMenu = function ({ editor, hooks }: GroupMenuProps) {
     const menuRef = useRef<HTMLUListElement>(null);
 
     const handleRootMouseMove = useCallback(
-        async (e: React.MouseEvent<HTMLDivElement>) => {
+        async (e: ReactMouseEvent<HTMLDivElement>) => {
             const groupBlockNew = await editor.getGroupBlockByPoint(
                 new Point(e.clientX, e.clientY)
             );
@@ -39,7 +46,7 @@ export const GroupMenu = function ({ editor, hooks }: GroupMenuProps) {
     );
 
     const handleRootMouseDown = useCallback(
-        (e: React.MouseEvent<HTMLDivElement>) => {
+        (e: ReactMouseEvent<HTMLDivElement>) => {
             if (
                 menuRef.current &&
                 !menuRef.current.contains(e.target as Node)
@@ -51,7 +58,7 @@ export const GroupMenu = function ({ editor, hooks }: GroupMenuProps) {
     );
 
     const handleRootDragOver = useCallback(
-        async (e: React.DragEvent<Element>) => {
+        async (e: DragEvent<Element>) => {
             e.preventDefault();
             let groupBlockOnDragOver = null;
             const mousePoint = new Point(e.clientX, e.clientY);
@@ -76,7 +83,7 @@ export const GroupMenu = function ({ editor, hooks }: GroupMenuProps) {
     );
 
     const handleRootDrop = useCallback(
-        async (e: React.DragEvent<Element>) => {
+        async (e: DragEvent<Element>) => {
             let groupBlockOnDrop = null;
             if (editor.dragDropManager.isDragGroup(e)) {
                 groupBlockOnDrop = await editor.getGroupBlockByPoint(
@@ -149,7 +156,7 @@ export const GroupMenu = function ({ editor, hooks }: GroupMenuProps) {
         setShowMenu(!showMenu);
     };
 
-    const handleDragStart = async (e: React.DragEvent<HTMLDivElement>) => {
+    const handleDragStart = async (e: DragEvent<HTMLDivElement>) => {
         editor.dragDropManager.isOnDrag = true;
         const dragImage = await editor.blockHelper.getBlockDragImg(
             groupBlock.id
@@ -162,7 +169,7 @@ export const GroupMenu = function ({ editor, hooks }: GroupMenuProps) {
         e.dataTransfer.setData('text/plain', groupBlock.id);
     };
 
-    const handleMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    const handleMouseDown = (e: ReactMouseEvent<HTMLDivElement>) => {
         e.stopPropagation();
     };
 

--- a/libs/components/editor-plugins/src/menu/group-menu/Line.tsx
+++ b/libs/components/editor-plugins/src/menu/group-menu/Line.tsx
@@ -5,7 +5,7 @@ import {
 } from '@toeverything/components/editor-core';
 import { Rect } from '@toeverything/utils';
 import { styled } from '@toeverything/components/ui';
-import { useEffect, useState } from 'react';
+import { type CSSProperties, useEffect, useState } from 'react';
 
 type LineProps = {
     groupBlock: AsyncBlock | null;
@@ -34,7 +34,7 @@ export const Line = function ({ direction, editor, groupBlock }: LineProps) {
         }
     }, [groupBlock, editor.container]);
 
-    const computeLineStyle = (): React.CSSProperties => {
+    const computeLineStyle = (): CSSProperties => {
         if (!rect) {
             return {};
         }

--- a/libs/components/editor-plugins/src/menu/group-menu/Menu.tsx
+++ b/libs/components/editor-plugins/src/menu/group-menu/Menu.tsx
@@ -2,7 +2,7 @@ import { AsyncBlock, Virgo } from '@toeverything/components/editor-core';
 import { DeleteCashBinIcon } from '@toeverything/components/icons';
 import { Popover, styled } from '@toeverything/components/ui';
 import { Point } from '@toeverything/utils';
-import { PropsWithChildren } from 'react';
+import type { PropsWithChildren, RefObject } from 'react';
 import { ICON_WIDTH } from './DragItem';
 
 type MenuProps = {
@@ -12,7 +12,7 @@ type MenuProps = {
     position: Point;
     editor: Virgo;
     groupBlock: AsyncBlock;
-    menuRef: React.RefObject<HTMLUListElement>;
+    menuRef: RefObject<HTMLUListElement>;
 };
 
 export const Menu = ({

--- a/libs/components/editor-plugins/src/menu/inline-menu/menu-item/DropdownItem.tsx
+++ b/libs/components/editor-plugins/src/menu/inline-menu/menu-item/DropdownItem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import style9 from 'style9';
 import {
     Popover,
@@ -40,98 +40,93 @@ export const MenuDropdownItem = ({
     const shortcut = inlineMenuShortcuts[nameKey];
 
     return (
-        <>
-            <Popover
-                trigger="click"
-                placement="bottom-start"
+        <Popover
+            trigger="click"
+            placement="bottom-start"
+            content={
+                <div className={styles('dropdownContainer')}>
+                    {children.map(item => {
+                        const {
+                            name,
+                            icon: ItemIcon,
+                            onClick,
+                            nameKey: itemNameKey,
+                        } = item;
+
+                        const StyledIcon = withStylesForIcon(ItemIcon);
+
+                        return (
+                            <button
+                                className={styles('dropdownItem')}
+                                key={name}
+                                onClick={() => {
+                                    if (
+                                        onClick &&
+                                        selectionInfo?.anchorNode?.id
+                                    ) {
+                                        onClick({
+                                            editor,
+                                            type: itemNameKey,
+                                            anchorNodeId:
+                                                selectionInfo?.anchorNode?.id,
+                                        });
+                                    }
+                                    handle_close_dropdown_menu();
+                                }}
+                            >
+                                <StyledIcon
+                                    fontColor={
+                                        nameKey ===
+                                        inlineMenuNamesKeys.currentFontColor
+                                            ? fontColorPalette[
+                                                  inlineMenuNamesForFontColor[
+                                                      itemNameKey as keyof typeof inlineMenuNamesForFontColor
+                                                  ]
+                                              ]
+                                            : nameKey ===
+                                              inlineMenuNamesKeys.currentFontBackground
+                                            ? fontBgColorPalette[
+                                                  inlineMenuNamesForFontColor[
+                                                      itemNameKey as keyof typeof inlineMenuNamesForFontColor
+                                                  ]
+                                              ]
+                                            : ''
+                                    }
+                                    // fontBgColor={
+                                    //     nameKey=== inlineMenuNamesKeys.currentFontBackground ?  fontBgColorPalette[
+                                    //         inlineMenuNamesForFontColor[itemNameKey] as keyof typeof fontBgColorPalette
+                                    //     ]:''
+                                    // }
+                                />
+                                {/* <ItemIcon sx={{ width: 20, height: 20 }} /> */}
+                                <span className={styles('dropdownItemItext')}>
+                                    {name}
+                                </span>
+                            </button>
+                        );
+                    })}
+                </div>
+            }
+        >
+            <Tooltip
                 content={
-                    <div className={styles('dropdownContainer')}>
-                        {children.map(item => {
-                            const {
-                                name,
-                                icon: ItemIcon,
-                                onClick,
-                                nameKey: itemNameKey,
-                            } = item;
-
-                            const StyledIcon = withStylesForIcon(ItemIcon);
-
-                            return (
-                                <button
-                                    className={styles('dropdownItem')}
-                                    key={name}
-                                    onClick={() => {
-                                        if (
-                                            onClick &&
-                                            selectionInfo?.anchorNode?.id
-                                        ) {
-                                            onClick({
-                                                editor,
-                                                type: itemNameKey,
-                                                anchorNodeId:
-                                                    selectionInfo?.anchorNode
-                                                        ?.id,
-                                            });
-                                        }
-                                        handle_close_dropdown_menu();
-                                    }}
-                                >
-                                    <StyledIcon
-                                        fontColor={
-                                            nameKey ===
-                                            inlineMenuNamesKeys.currentFontColor
-                                                ? fontColorPalette[
-                                                      inlineMenuNamesForFontColor[
-                                                          itemNameKey as keyof typeof inlineMenuNamesForFontColor
-                                                      ]
-                                                  ]
-                                                : nameKey ===
-                                                  inlineMenuNamesKeys.currentFontBackground
-                                                ? fontBgColorPalette[
-                                                      inlineMenuNamesForFontColor[
-                                                          itemNameKey as keyof typeof inlineMenuNamesForFontColor
-                                                      ]
-                                                  ]
-                                                : ''
-                                        }
-                                        // fontBgColor={
-                                        //     nameKey=== inlineMenuNamesKeys.currentFontBackground ?  fontBgColorPalette[
-                                        //         inlineMenuNamesForFontColor[itemNameKey] as keyof typeof fontBgColorPalette
-                                        //     ]:''
-                                        // }
-                                    />
-                                    {/* <ItemIcon sx={{ width: 20, height: 20 }} /> */}
-                                    <span
-                                        className={styles('dropdownItemItext')}
-                                    >
-                                        {name}
-                                    </span>
-                                </button>
-                            );
-                        })}
+                    <div style={{ padding: '2px 4px' }}>
+                        <p>{name}</p>
+                        {shortcut && <p>{shortcut}</p>}
                     </div>
                 }
+                placement="top"
+                trigger="hover"
             >
-                <Tooltip
-                    content={
-                        <div style={{ padding: '2px 4px' }}>
-                            <p>{name}</p>
-                            {shortcut && <p>{shortcut}</p>}
-                        </div>
-                    }
-                    placement="top"
-                    trigger="hover"
+                <button
+                    className={styles('currentDropdownButton')}
+                    aria-label={name}
                 >
-                    <button
-                        className={styles('currentDropdownButton')}
-                        aria-label={name}
-                    >
-                        <MenuIcon sx={{ width: 20, height: 20 }} />
-                        <ArrowDropDownIcon sx={{ width: 20, height: 20 }} />
-                    </button>
-                </Tooltip>
-            </Popover>
-        </>
+                    <MenuIcon sx={{ width: 20, height: 20 }} />
+                    <ArrowDropDownIcon sx={{ width: 20, height: 20 }} />
+                </button>
+            </Tooltip>
+        </Popover>
     );
 };
 

--- a/libs/components/editor-plugins/src/menu/inline-menu/menu-item/IconItem.tsx
+++ b/libs/components/editor-plugins/src/menu/inline-menu/menu-item/IconItem.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import { useCallback, type MouseEvent } from 'react';
 import style9 from 'style9';
 
 import type { IconItemType, WithEditorSelectionType } from '../types';
@@ -16,7 +16,7 @@ export const MenuIconItem = ({
     setShow,
 }: MenuIconItemProps) => {
     const handleToolbarItemClick = useCallback(
-        (event: React.MouseEvent<HTMLButtonElement>) => {
+        (event: MouseEvent<HTMLButtonElement>) => {
             if (onClick && selectionInfo?.anchorNode?.id) {
                 onClick({
                     editor,

--- a/libs/components/editor-plugins/src/menu/inline-menu/types.ts
+++ b/libs/components/editor-plugins/src/menu/inline-menu/types.ts
@@ -1,11 +1,12 @@
 import type { SvgIconProps } from '@toeverything/components/ui';
 import type { Virgo, SelectionInfo } from '@toeverything/framework/virgo';
 import { inlineMenuNames, INLINE_MENU_UI_TYPES } from './config';
+import type { Dispatch, SetStateAction } from 'react';
 
 export type WithEditorSelectionType = {
     editor: Virgo;
     selectionInfo: SelectionInfo;
-    setShow?: React.Dispatch<React.SetStateAction<boolean>>;
+    setShow?: Dispatch<SetStateAction<boolean>>;
 };
 
 export type InlineMenuNamesType = keyof typeof inlineMenuNames;

--- a/libs/components/editor-plugins/src/menu/left-menu/LeftMenu.tsx
+++ b/libs/components/editor-plugins/src/menu/left-menu/LeftMenu.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type ReactElement } from 'react';
 import { Virgo, PluginHooks } from '@toeverything/framework/virgo';
 import { Cascader, CascaderItemProps } from '@toeverything/components/ui';
 import { TurnIntoMenu } from './TurnIntoMenu';
@@ -10,7 +10,7 @@ import {
 
 interface LeftMenuProps {
     anchorEl?: Element;
-    children?: React.ReactElement;
+    children?: ReactElement;
     onClose: () => void;
     editor?: Virgo;
     hooks: PluginHooks;
@@ -73,7 +73,7 @@ export function LeftMenu(props: LeftMenuProps) {
     // };
 
     // const on_filter = (
-    //     e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+    //     e: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
     // ) => {
     //     const value = e.currentTarget.value;
     //     if (!value) {

--- a/libs/components/editor-plugins/src/menu/left-menu/LeftMenuPlugin.tsx
+++ b/libs/components/editor-plugins/src/menu/left-menu/LeftMenuPlugin.tsx
@@ -1,5 +1,9 @@
 import { HookType, BlockDropPlacement } from '@toeverything/framework/virgo';
-import { StrictMode } from 'react';
+import {
+    StrictMode,
+    type DragEvent,
+    type MouseEvent as ReactMouseEvent,
+} from 'react';
 import { BasePlugin } from '../../base-plugin';
 import { ignoreBlockTypes } from './menu-config';
 import {
@@ -68,9 +72,7 @@ export class LeftMenuPlugin extends BasePlugin {
         );
     }
 
-    private _handleRootNodeDragover = async (
-        event: React.DragEvent<Element>
-    ) => {
+    private _handleRootNodeDragover = async (event: DragEvent<Element>) => {
         event.preventDefault();
         if (this.editor.dragDropManager.isDragBlock(event)) {
             const { direction, block, isOuter } =
@@ -93,12 +95,10 @@ export class LeftMenuPlugin extends BasePlugin {
         }
     };
 
-    private _onDrop = (e: React.DragEvent<Element>) => {
+    private _onDrop = (e: DragEvent<Element>) => {
         this._lineInfo.next(undefined);
     };
-    private _handleDragOverBlockNode = async (
-        event: React.DragEvent<Element>
-    ) => {
+    private _handleDragOverBlockNode = async (event: DragEvent<Element>) => {
         event.preventDefault();
         if (!this.editor.dragDropManager.isDragBlock(event)) return;
         const block = await this.editor.getBlockByPoint(
@@ -121,7 +121,7 @@ export class LeftMenuPlugin extends BasePlugin {
     };
 
     private _handleMouseMove = async (
-        event: React.MouseEvent<HTMLDivElement, MouseEvent>
+        event: ReactMouseEvent<HTMLDivElement, MouseEvent>
     ) => {
         if (!this._hideTimer) {
             this._hideTimer = window.setTimeout(() => {

--- a/libs/components/editor-plugins/src/menu/left-menu/TurnIntoMenu.tsx
+++ b/libs/components/editor-plugins/src/menu/left-menu/TurnIntoMenu.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BlockFlavorKeys, Protocol } from '@toeverything/datasource/db-service';
 import { Virgo, PluginHooks } from '@toeverything/framework/virgo';
 import { CommandMenuContainer } from '../command-menu/Container';

--- a/libs/components/editor-plugins/src/menu/reference-menu/Container.tsx
+++ b/libs/components/editor-plugins/src/menu/reference-menu/Container.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import {
+    useEffect,
+    useState,
+    useCallback,
+    useRef,
+    type CSSProperties,
+    type KeyboardEvent,
+} from 'react';
 
 import { Virgo, PluginHooks, HookType } from '@toeverything/framework/virgo';
 import {
@@ -14,7 +21,7 @@ import { QueryResult } from '../../search';
 export type ReferenceMenuContainerProps = {
     editor: Virgo;
     hooks: PluginHooks;
-    style?: React.CSSProperties;
+    style?: CSSProperties;
     isShow?: boolean;
     blockId: string;
     onSelected?: (item: string) => void;
@@ -85,7 +92,7 @@ export const ReferenceMenuContainer = ({
     }, [isShow, types, current_item]);
 
     const handle_click_up = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (isShow && types && event.code === 'ArrowUp') {
                 event.preventDefault();
                 if (!current_item && types.length) {
@@ -104,7 +111,7 @@ export const ReferenceMenuContainer = ({
     );
 
     const handle_click_down = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (isShow && types && event.code === 'ArrowDown') {
                 event.preventDefault();
                 if (!current_item && types.length) {
@@ -123,7 +130,7 @@ export const ReferenceMenuContainer = ({
     );
 
     const handle_click_enter = useCallback(
-        async (event: React.KeyboardEvent<HTMLDivElement>) => {
+        async (event: KeyboardEvent<HTMLDivElement>) => {
             if (isShow && event.code === 'Enter' && current_item) {
                 event.preventDefault();
                 onSelected && onSelected(current_item);
@@ -133,7 +140,7 @@ export const ReferenceMenuContainer = ({
     );
 
     const handle_key_down = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             handle_click_up(event);
             handle_click_down(event);
             handle_click_enter(event);

--- a/libs/components/editor-plugins/src/menu/reference-menu/ReferenceMenu.tsx
+++ b/libs/components/editor-plugins/src/menu/reference-menu/ReferenceMenu.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    type KeyboardEvent,
+} from 'react';
 
 import { MuiClickAwayListener, styled } from '@toeverything/components/ui';
 import { Virgo, HookType, PluginHooks } from '@toeverything/framework/virgo';
@@ -38,7 +44,7 @@ export const ReferenceMenu = ({ editor, hooks, style }: ReferenceMenuProps) => {
     );
 
     const handle_search = useCallback(
-        async (event: React.KeyboardEvent<HTMLDivElement>) => {
+        async (event: KeyboardEvent<HTMLDivElement>) => {
             const { type, anchorNode } = editor.selection.currentSelectInfo;
             if (
                 type === 'Range' &&
@@ -72,12 +78,12 @@ export const ReferenceMenu = ({ editor, hooks, style }: ReferenceMenuProps) => {
     );
 
     const handle_keyup = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => handle_search(event),
+        (event: KeyboardEvent<HTMLDivElement>) => handle_search(event),
         [handle_search]
     );
 
     const handle_key_down = useCallback(
-        (event: React.KeyboardEvent<HTMLDivElement>) => {
+        (event: KeyboardEvent<HTMLDivElement>) => {
             if (event.code === 'Escape') {
                 set_is_show(false);
             }

--- a/libs/components/layout/src/header/PageSettingPortal.tsx
+++ b/libs/components/layout/src/header/PageSettingPortal.tsx
@@ -1,4 +1,4 @@
-import { useState, MouseEvent, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, type ChangeEvent } from 'react';
 import { services } from '@toeverything/datasource/db-service';
 import { useParams, useNavigate } from 'react-router-dom';
 
@@ -135,7 +135,7 @@ function PageSettingPortal() {
     };
 
     const handleFullWidthCheckedChange = async (
-        event: React.ChangeEvent<HTMLInputElement>
+        event: ChangeEvent<HTMLInputElement>
     ) => {
         const checked = event.target.checked;
         setPageBlock({

--- a/libs/components/layout/src/workspace-sidebar/activities/activities.tsx
+++ b/libs/components/layout/src/workspace-sidebar/activities/activities.tsx
@@ -1,8 +1,8 @@
 import { services } from '@toeverything/datasource/db-service';
 import { useUserAndSpaces } from '@toeverything/datasource/state';
 import { useCallback, useEffect, useState } from 'react';
-import { styled } from '@toeverything/components/ui';
 import {
+    styled,
     MuiList as List,
     MuiListItem as ListItem,
     MuiListItemText as ListItemText,

--- a/libs/components/layout/src/workspace-sidebar/page-tree/DndTree.tsx
+++ b/libs/components/layout/src/workspace-sidebar/page-tree/DndTree.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 
 import {
     DndContext,

--- a/libs/components/layout/src/workspace-sidebar/page-tree/tree-item/DndTreeItem.tsx
+++ b/libs/components/layout/src/workspace-sidebar/page-tree/tree-item/DndTreeItem.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties } from 'react';
+import { CSSProperties } from 'react';
 
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';

--- a/libs/components/layout/src/workspace-sidebar/page-tree/tree-item/MoreActions.tsx
+++ b/libs/components/layout/src/workspace-sidebar/page-tree/tree-item/MoreActions.tsx
@@ -10,7 +10,7 @@ import {
 import { services, TemplateFactory } from '@toeverything/datasource/db-service';
 import { useFlag } from '@toeverything/datasource/feature-flags';
 import { copyToClipboard } from '@toeverything/utils';
-import React from 'react';
+import { useState, MouseEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { TreeItemMoreActions } from './styles';
 
@@ -29,8 +29,8 @@ const StyledAction = styled('div')({
 });
 
 function DndTreeItemMoreActions(props: ActionsProps) {
-    const [alert_open, set_alert_open] = React.useState(false);
-    const [anchorEl, setAnchorEl] = React.useState<HTMLDivElement | null>(null);
+    const [alert_open, set_alert_open] = useState(false);
+    const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
     const navigate = useNavigate();
     const workspaceId = props.workspaceId;
@@ -44,7 +44,7 @@ function DndTreeItemMoreActions(props: ActionsProps) {
     const handle_alert_close = () => {
         set_alert_open(false);
     };
-    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const handleClick = (event: MouseEvent<HTMLDivElement>) => {
         if (anchorEl) {
             setAnchorEl(null);
             return;

--- a/libs/components/layout/src/workspace-sidebar/page-tree/tree-item/NewFromTemplatePortal.tsx
+++ b/libs/components/layout/src/workspace-sidebar/page-tree/tree-item/NewFromTemplatePortal.tsx
@@ -1,10 +1,4 @@
-import React, {
-    useState,
-    MouseEvent,
-    useCallback,
-    useEffect,
-    useRef,
-} from 'react';
+import { useState, MouseEvent, useRef } from 'react';
 import { services, TemplateFactory } from '@toeverything/datasource/db-service';
 import { useParams, useNavigate } from 'react-router-dom';
 
@@ -58,7 +52,7 @@ interface NewFromTemplatePortalProps {
 }
 function NewFromTemplatePortal(props: NewFromTemplatePortalProps) {
     const [alertOpen, setAlertOpen] = useState(false);
-    const [anchorEl, setAnchorEl] = React.useState<HTMLDivElement | null>(null);
+    const [anchorEl, setAnchorEl] = useState<HTMLDivElement | null>(null);
 
     const params = useParams();
     const navigate = useNavigate();
@@ -102,7 +96,7 @@ function NewFromTemplatePortal(props: NewFromTemplatePortalProps) {
         setAnchorEl(null);
     };
     const open = Boolean(anchorEl);
-    const handleClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    const handleClick = (event: MouseEvent<HTMLDivElement>) => {
         setAnchorEl(event.currentTarget);
     };
     const newFromTemplateRef = useRef();

--- a/libs/components/ui/src/button/ListButton.tsx
+++ b/libs/components/ui/src/button/ListButton.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import style9 from 'style9';
 

--- a/libs/components/ui/src/cascader/Cascader.tsx
+++ b/libs/components/ui/src/cascader/Cascader.tsx
@@ -39,7 +39,7 @@ function CascaderItem(props: ItemProps) {
     const [open, setOpen] = useState(false);
 
     if (isDivide) {
-        return <Divider></Divider>;
+        return <Divider />;
     }
 
     const on_click_item = () => {

--- a/libs/components/ui/src/checkbox/Checkbox.tsx
+++ b/libs/components/ui/src/checkbox/Checkbox.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import MuiCheckbox, { type CheckboxProps } from '@mui/material/Checkbox';
 import {
     CheckBoxUncheckIcon,

--- a/libs/components/ui/src/date/Calendar.tsx
+++ b/libs/components/ui/src/date/Calendar.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
     Calendar as ReactCalendar,
     type CalendarProps,

--- a/libs/components/ui/src/input/Input.tsx
+++ b/libs/components/ui/src/input/Input.tsx
@@ -1,14 +1,15 @@
-import React, {
-    forwardRef,
-    type ForwardedRef,
-    type InputHTMLAttributes,
-    type CSSProperties,
+import type {
+    ForwardedRef,
+    InputHTMLAttributes,
+    CSSProperties,
+    ReactNode,
 } from 'react';
+import { forwardRef } from 'react';
 import { styled } from '../styled';
 
 export type InputProps = {
-    startAdornment?: React.ReactNode;
-    endAdornment?: React.ReactNode;
+    startAdornment?: ReactNode;
+    endAdornment?: ReactNode;
     style?: CSSProperties;
     noBorder?: boolean;
 } & InputHTMLAttributes<HTMLInputElement>;

--- a/libs/components/ui/src/notification/Notification.tsx
+++ b/libs/components/ui/src/notification/Notification.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useImperativeHandle } from 'react';
+import { forwardRef, useImperativeHandle } from 'react';
 
 import {
     SnackbarProvider,

--- a/libs/components/ui/src/popover/Popover.tsx
+++ b/libs/components/ui/src/popover/Popover.tsx
@@ -1,5 +1,5 @@
 import type { MuiPopperPlacementType as PopperPlacementType } from '../mui';
-import React, { type PropsWithChildren } from 'react';
+import type { PropsWithChildren } from 'react';
 import { Popper } from '../popper';
 import { PopoverContainer } from './Container';
 import type { PopoverProps, PopoverDirection } from './interface';

--- a/libs/components/ui/src/popper/PopoverArrow.tsx
+++ b/libs/components/ui/src/popper/PopoverArrow.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 import { PopperArrowProps } from './interface';
 import { styled } from '../styled';
 

--- a/libs/components/ui/src/popper/Popper.tsx
+++ b/libs/components/ui/src/popper/Popper.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
     useEffect,
     useImperativeHandle,
     useMemo,

--- a/libs/components/ui/src/radio/Radio.tsx
+++ b/libs/components/ui/src/radio/Radio.tsx
@@ -1,5 +1,4 @@
-import * as React from 'react';
-/* eslint-disable no-restricted-imports */
+// eslint-disable-next-line no-restricted-imports
 import MuiRadio, { type RadioProps } from '@mui/material/Radio';
 import { styled } from '../styled';
 

--- a/libs/utils/src/error-boundary.tsx
+++ b/libs/utils/src/error-boundary.tsx
@@ -1,4 +1,13 @@
-import * as React from 'react';
+import {
+    ComponentType,
+    ReactElement,
+    Component,
+    PropsWithRef,
+    PropsWithChildren,
+    ErrorInfo,
+    isValidElement,
+    useState,
+} from 'react';
 
 const changedArray = (a: Array<unknown> = [], b: Array<unknown> = []) =>
     a.length !== b.length ||
@@ -18,13 +27,13 @@ interface ErrorBoundaryPropsWithComponent {
     onError?: (error: Error, info: { componentStack: string }) => void;
     resetKeys?: Array<unknown>;
     fallback?: never;
-    FallbackComponent: React.ComponentType<FallbackProps>;
+    FallbackComponent: ComponentType<FallbackProps>;
     fallbackRender?: never;
 }
 
 declare function FallbackRender(
     props: FallbackProps
-): React.ReactElement<unknown, string | typeof React.Component> | null;
+): ReactElement<unknown, string | typeof Component> | null;
 
 interface ErrorBoundaryPropsWithRender {
     onResetKeysChange?: (
@@ -47,10 +56,7 @@ interface ErrorBoundaryPropsWithFallback {
     onReset?: (...args: Array<unknown>) => void;
     onError?: (error: Error, info: { componentStack: string }) => void;
     resetKeys?: Array<unknown>;
-    fallback: React.ReactElement<
-        unknown,
-        string | typeof React.Component
-    > | null;
+    fallback: ReactElement<unknown, string | typeof Component> | null;
     FallbackComponent?: never;
     fallbackRender?: never;
 }
@@ -64,8 +70,8 @@ type ErrorBoundaryState = { error: Error | null };
 
 const initialState: ErrorBoundaryState = { error: null };
 
-class ErrorBoundary extends React.Component<
-    React.PropsWithRef<React.PropsWithChildren<ErrorBoundaryProps>>,
+class ErrorBoundary extends Component<
+    PropsWithRef<PropsWithChildren<ErrorBoundaryProps>>,
     ErrorBoundaryState
 > {
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -83,7 +89,7 @@ class ErrorBoundary extends React.Component<
         this.setState(initialState);
     }
 
-    override componentDidCatch(error: Error, info: React.ErrorInfo) {
+    override componentDidCatch(error: Error, info: ErrorInfo) {
         this.props.onError?.(error, info);
     }
 
@@ -121,7 +127,7 @@ class ErrorBoundary extends React.Component<
                 error,
                 resetErrorBoundary: this.resetErrorBoundary,
             };
-            if (React.isValidElement(fallback)) {
+            if (isValidElement(fallback)) {
                 return fallback;
             } else if (typeof fallbackRender === 'function') {
                 return fallbackRender(props);
@@ -139,10 +145,10 @@ class ErrorBoundary extends React.Component<
 }
 
 function withErrorBoundary<P>(
-    Component: React.ComponentType<P>,
+    Component: ComponentType<P>,
     errorBoundaryProps: ErrorBoundaryProps
-): React.ComponentType<P> {
-    const Wrapped: React.ComponentType<P> = props => {
+): ComponentType<P> {
+    const Wrapped: ComponentType<P> = props => {
         return (
             <ErrorBoundary {...errorBoundaryProps}>
                 <Component {...props} />
@@ -158,7 +164,7 @@ function withErrorBoundary<P>(
 }
 
 function useErrorHandler(givenError?: unknown): (error: unknown) => void {
-    const [error, setError] = React.useState<unknown>(null);
+    const [error, setError] = useState<unknown>(null);
     if (givenError != null) throw givenError;
     if (error != null) throw error;
     return setError;


### PR DESCRIPTION
## Motivation

[As of Babel 7.9.0](https://babeljs.io/blog/2020/03/16/7.9.0#a-new-jsx-transform-11154-https-githubcom-babel-babel-pull-11154), when using runtime: automatic in `@babel/preset-react` or `@babel/plugin-transform-react-jsx`, you will not need to explicitly import React for compiling jsx.


This PR removes the redundant import statements. It also converts default imports (`import React from 'react'`) to named imports (e.g. `import { useState } from 'react'`).

[React codemod scripts](https://github.com/reactjs/react-codemod).
