### PR TITLE
build: experimental vite support

### DIFF
--- a/apps/ligo-virgo/index.html
+++ b/apps/ligo-virgo/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <!-- local dev index.html -->
+        <!-- Vite local dev index.html -->
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
@@ -13,4 +13,5 @@
     <body>
         <div id="root"></div>
     </body>
+    <script src="./src/index.tsx" lang="ts" type="module"></script>
 </html>

--- a/apps/ligo-virgo/package.json
+++ b/apps/ligo-virgo/package.json
@@ -13,8 +13,10 @@
         "@mui/icons-material": "^5.8.4"
     },
     "devDependencies": {
+        "@vitejs/plugin-react": "^2.0.1",
         "firebase": "^9.9.2",
         "mini-css-extract-plugin": "^2.6.1",
+        "vite": "^3",
         "webpack": "^5.74.0"
     }
 }

--- a/apps/ligo-virgo/src/index.html
+++ b/apps/ligo-virgo/src/index.html
@@ -13,4 +13,5 @@
     <body>
         <div id="root"></div>
     </body>
+    <script src="./index.tsx" lang="ts"></script>
 </html>

--- a/apps/ligo-virgo/src/pages/AppRoutes.tsx
+++ b/apps/ligo-virgo/src/pages/AppRoutes.tsx
@@ -41,7 +41,7 @@ export function LigoVirgoRoutes() {
                         </RoutePrivate>
                     }
                 />
-                <Route path="/" element={<Navigate to="/login" replace />} />
+                {/* <Route path="/" element={<Navigate to="/login" replace />} /> */}
             </Route>
 
             {/* put public routes here; header and sidebar are disabled here */}

--- a/apps/ligo-virgo/src/pages/agenda/container/index.tsx
+++ b/apps/ligo-virgo/src/pages/agenda/container/index.tsx
@@ -1,17 +1,10 @@
 import { Outlet } from 'react-router-dom';
-import style9 from 'style9';
 
 import { MuiBox as Box } from '@toeverything/components/ui';
 
-const styles = style9.create({
-    container: {
-        display: 'flex',
-    },
-});
-
 export default function AgendaRootContainer() {
     return (
-        <Box className={styles('container')}>
+        <Box style={{ display: 'flex' }}>
             <Outlet />
         </Box>
     );

--- a/apps/ligo-virgo/src/pages/workspace/Container.tsx
+++ b/apps/ligo-virgo/src/pages/workspace/Container.tsx
@@ -1,18 +1,15 @@
 import { Outlet } from 'react-router-dom';
-import style9 from 'style9';
 
 import { MuiBox as Box } from '@toeverything/components/ui';
 
-const styles = style9.create({
-    container: {
-        display: 'flex',
-        overflow: 'hidden',
-    },
-});
-
 export function WorkspaceRootContainer() {
     return (
-        <Box className={styles('container')}>
+        <Box
+            style={{
+                display: 'flex',
+                overflow: 'hidden',
+            }}
+        >
             <Outlet />
         </Box>
     );

--- a/apps/ligo-virgo/vite.config.ts
+++ b/apps/ligo-virgo/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import path from 'path';
+import reactPlugin from '@vitejs/plugin-react';
+
+export default defineConfig({
+    plugins: [reactPlugin()],
+    resolve: {
+        alias: {
+            '@toeverything': path.resolve(__dirname, '../../libs/'),
+        },
+    },
+});

--- a/apps/ligo-virgo/vite.config.ts
+++ b/apps/ligo-virgo/vite.config.ts
@@ -4,6 +4,12 @@ import reactPlugin from '@vitejs/plugin-react';
 
 export default defineConfig({
     plugins: [reactPlugin()],
+    define: {
+        'process.env': {
+            NODE_ENV: '"development"',
+        },
+        JWT_DEV: false,
+    },
     resolve: {
         alias: {
             '@toeverything': path.resolve(__dirname, '../../libs/'),

--- a/libs/components/account/package.json
+++ b/libs/components/account/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/account",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@authing/react-ui-components": "^3.1.39",
         "@emotion/styled": "^11.9.3"

--- a/libs/components/account/src/error.tsx
+++ b/libs/components/account/src/error.tsx
@@ -1,20 +1,9 @@
 import { Link } from 'react-router-dom';
-import style9 from 'style9';
 import { getAuth, signOut } from 'firebase/auth';
 
 import { MuiBox as Box } from '@toeverything/components/ui';
 import { keyframes } from '@emotion/react';
 import { LOGOUT_LOCAL_STORAGE, LOGOUT_COOKIES } from '@toeverything/utils';
-
-const styles = style9.create({
-    container: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-        height: 'calc( 100vh - 64px )',
-    },
-});
 
 type ErrorProps = {
     title?: string;

--- a/libs/components/account/src/loading.tsx
+++ b/libs/components/account/src/loading.tsx
@@ -1,22 +1,19 @@
-import style9 from 'style9';
 import { MuiCircularProgress as CircularProgress } from '@toeverything/components/ui';
-
-const styles = style9.create({
-    container: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-        height: 'calc( 100vh - 64px )',
-    },
-});
 
 /**
  * Loading components occupy the entire page
  */
 export function PageLoading() {
     return (
-        <div className={styles('container')}>
+        <div
+            style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100%',
+                height: 'calc( 100vh - 64px )',
+            }}
+        >
             <CircularProgress />
         </div>
     );

--- a/libs/components/account/src/login/authing.tsx
+++ b/libs/components/account/src/login/authing.tsx
@@ -42,7 +42,7 @@ export function Authing() {
     }, [currentSpaceId, navigate]);
 
     return (
-        <div className={styles('loginContainer')}>
+        <div style={loginContainerStyle}>
             <Box
                 sx={{
                     '.g2-view-header': {
@@ -67,12 +67,10 @@ export function Authing() {
     );
 }
 
-const styles = style9.create({
-    loginContainer: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '100%',
-        height: 'calc( 100vh - 64px )',
-    },
-});
+const loginContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '100%',
+    height: 'calc( 100vh - 64px )',
+};

--- a/libs/components/affine-board/package.json
+++ b/libs/components/affine-board/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@toeverything/components/affine-board",
     "version": "0.0.1",
+    "main": "src/index.ts",
     "license": "MIT"
 }

--- a/libs/components/affine-editor/package.json
+++ b/libs/components/affine-editor/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@toeverything/components/affine-editor",
     "version": "0.0.1",
+    "main": "src/index.ts",
     "license": "MIT"
 }

--- a/libs/components/board-commands/package.json
+++ b/libs/components/board-commands/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-commands",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@tldraw/core": "^1.12.0",
         "@tldraw/intersect": "^1.7.1",

--- a/libs/components/board-draw/package.json
+++ b/libs/components/board-draw/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-draw",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@mui/icons-material": "^5.8.0",
         "@tldraw/core": "^1.12.0",

--- a/libs/components/board-draw/src/components/tools-panel/ToolsPanel.tsx
+++ b/libs/components/board-draw/src/components/tools-panel/ToolsPanel.tsx
@@ -1,4 +1,3 @@
-import style9 from 'style9';
 import {
     // MuiIconButton as IconButton,
     // MuiTooltip as Tooltip,
@@ -90,8 +89,8 @@ export const ToolsPanel = ({ app }: { app: TldrawApp }) => {
             }}
             direction="none"
         >
-            <div className={styles('container')}>
-                <div className={styles('toolBar')}>
+            <div style={containerStyle}>
+                <div style={toolBarStyle}>
                     {tools.map(
                         ({
                             type,
@@ -133,18 +132,17 @@ export const ToolsPanel = ({ app }: { app: TldrawApp }) => {
     );
 };
 
-const styles = style9.create({
-    container: {
-        display: 'flex',
-        flexDirection: 'column',
-        justifyContent: 'center',
-        height: '100%',
-    },
-    toolBar: {
-        display: 'flex',
-        flexDirection: 'column',
-        backgroundColor: '#ffffff',
-        borderRadius: '10px',
-        padding: '4px 4px',
-    },
-});
+const containerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    height: '100%',
+};
+
+const toolBarStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: '#ffffff',
+    borderRadius: '10px',
+    padding: '4px 4px',
+};

--- a/libs/components/board-sessions/package.json
+++ b/libs/components/board-sessions/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-sessions",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@tldraw/core": "^1.12.0",
         "@tldraw/intersect": "^1.7.1",

--- a/libs/components/board-shapes/package.json
+++ b/libs/components/board-shapes/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-shapes",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@tldraw/core": "^1.12.0",
         "@tldraw/intersect": "^1.7.1",

--- a/libs/components/board-state/package.json
+++ b/libs/components/board-state/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-state",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@tldraw/core": "^1.12.0",
         "@tldraw/intersect": "^1.7.1",

--- a/libs/components/board-tools/package.json
+++ b/libs/components/board-tools/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-tools",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@tldraw/core": "^1.12.0",
         "@tldraw/intersect": "^1.7.1",

--- a/libs/components/board-types/package.json
+++ b/libs/components/board-types/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/board-types",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@tldraw/core": "^1.12.0",
         "@tldraw/intersect": "^1.7.1",

--- a/libs/components/common/package.json
+++ b/libs/components/common/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/common",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",

--- a/libs/components/common/src/lib/block-preview/BlockPreview.tsx
+++ b/libs/components/common/src/lib/block-preview/BlockPreview.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { PagesIcon } from '@toeverything/components/icons';
 // eslint-disable-next-line @nrwl/nx/enforce-module-boundaries
 import { BlockSearchItem } from '@toeverything/datasource/jwt';
@@ -5,6 +6,7 @@ import { ListButton } from '@toeverything/components/ui';
 
 type BlockPreviewProps = {
     block: BlockSearchItem;
+    style?: React.CSSProperties;
     className?: string;
     onClick?: () => void;
     onMouseOver?: () => void;
@@ -16,6 +18,7 @@ export const BlockPreview = (props: BlockPreviewProps) => {
 
     return (
         <ListButton
+            style={props.style}
             className={props.className}
             onClick={props.onClick}
             onMouseOver={props.onMouseOver}

--- a/libs/components/common/src/lib/button/index.tsx
+++ b/libs/components/common/src/lib/button/index.tsx
@@ -1,31 +1,7 @@
-import clsx from 'clsx';
-import style9 from 'style9';
-
-const styles = style9.create({
-    ligoButton: {
-        border: 'none',
-        outline: 'none',
-        // backgroundColor: 'white',
-        cursor: 'pointer',
-        ':hover': {
-            backgroundColor: '#edeef0',
-        },
-    },
-});
-
-export type ButtonType =
-    | 'default'
-    | 'primary'
-    | 'ghost'
-    | 'dashed'
-    | 'link'
-    | 'text';
-
-export type SizeType = 'small' | 'medium' | 'large';
+import React from 'react';
+import { styled } from '@toeverything/components/ui';
 
 export type ButtonProps = {
-    type?: ButtonType;
-    size?: SizeType;
     icon?: React.ReactNode;
     className?: string;
     children?: React.ReactNode;
@@ -33,16 +9,18 @@ export type ButtonProps = {
     style?: React.CSSProperties;
 };
 
+const StyledButton = styled('button')({
+    border: 'none',
+    outline: 'none',
+    // backgroundColor: 'white',
+    cursor: 'pointer',
+    '&:hover': {
+        backgroundColor: '#edeef0',
+    },
+});
+
 export default function Button(props: ButtonProps) {
-    const { className, type, style, size, children } = props;
-    const classes = clsx(
-        styles('ligoButton'),
-        {
-            [`${styles('ligoButton')}-${type}`]: type,
-            [`${styles('ligoButton')}-icon-only`]: !children && children !== 0,
-        },
-        className
-    );
+    const { className, style, children } = props;
     const handleClick = (
         e: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement, MouseEvent>
     ) => {
@@ -54,8 +32,8 @@ export default function Button(props: ButtonProps) {
         )?.(e);
     };
     return (
-        <button className={classes} style={style || {}} onClick={handleClick}>
+        <StyledButton className={className} style={style} onClick={handleClick}>
             {children}
-        </button>
+        </StyledButton>
     );
 }

--- a/libs/components/common/src/lib/list/index.tsx
+++ b/libs/components/common/src/lib/list/index.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router';
-import clsx from 'clsx';
-import style9 from 'style9';
 
 import {
     BaseButton,
@@ -49,22 +47,15 @@ export const CommonList = (props: MenuItemsProps) => {
         return !JSONUnsupportedBlockTypes.includes(item?.content?.id);
     });
     return (
-        <div className={clsx(styles('root_container'), props.className)}>
-            <div
-                className={clsx([
-                    styles('scroll_container'),
-                    commonListContainer,
-                ])}
-            >
+        <div style={rootContainerStyle} className={props.className}>
+            <div style={scrollContainerStyle} className={commonListContainer}>
                 {usedItems?.length ? (
                     usedItems.map((item, idx) => {
                         if (item.block) {
                             return (
                                 <BlockPreview
-                                    className={clsx(
-                                        styles('button'),
-                                        `item-${item.block.id}`
-                                    )}
+                                    style={buttonStyle}
+                                    className={`item-${item.block.id}`}
                                     key={item.block.id}
                                     block={item.block}
                                     onClick={() => onSelected?.(item.block.id)}
@@ -79,10 +70,8 @@ export const CommonList = (props: MenuItemsProps) => {
                             return (
                                 <ListButton
                                     key={id}
-                                    className={clsx(
-                                        styles('button'),
-                                        `item-${id}`
-                                    )}
+                                    style={buttonStyle}
+                                    className={`item-${id}`}
                                     onClick={() => onSelected?.(id)}
                                     onMouseOver={() => setCurrentItem?.(id)}
                                     hover={currentItem === id}
@@ -93,7 +82,7 @@ export const CommonList = (props: MenuItemsProps) => {
                         } else if (item.divider) {
                             return (
                                 <hr
-                                    className={styles('separator')}
+                                    style={separatorStyle}
                                     key={`${item.divider}${idx}-separator`}
                                     tabIndex={-1}
                                 />
@@ -103,7 +92,7 @@ export const CommonList = (props: MenuItemsProps) => {
                         }
                     })
                 ) : (
-                    <span className={styles('empty')}>no search result</span>
+                    <span style={emptyStyle}>no search result</span>
                 )}
             </div>
         </div>
@@ -140,7 +129,7 @@ export const BackLink = (props: BackLinkProps) => {
                 }
             >
                 <BaseButton
-                    className={styles('backlinks_button')}
+                    style={backlinksButtonStyle}
                     onClick={() => set_visible(bool => !bool)}
                 >
                     <BackwardUndoIcon sx={{ width: 20, height: 20 }} />
@@ -151,51 +140,49 @@ export const BackLink = (props: BackLinkProps) => {
     ) : null;
 };
 
-const styles = style9.create({
-    root_container: {
-        width: '228px',
-        overflowX: 'hidden',
-        overflowY: 'hidden',
-        marginTop: '6px',
-        marginLeft: '5px',
-    },
-    scroll_container: {
-        width: 'calc(100% + 25px)',
-        height: '100%',
-        overflowY: 'scroll',
-    },
-    button: {
-        width: '220px',
-        borderRadius: '5px!important',
-        marginTop: '0px!important',
-    },
-    empty: {
-        display: 'inline-flex',
-        width: '220px',
-        height: '100%',
-        justifyContent: 'center',
-        alignItems: 'center',
-        fontSize: '15px',
-        lineHeight: '17px',
-        textAlign: 'justify',
-        letterSpacing: '1.5px',
-        color: '#4C6275',
-    },
-    separator: {
-        height: '1px',
-        border: 0,
-        marginTop: '8px',
-        marginBottom: '8px',
-        backgroundColor: 'rgba(152, 172, 189, 0.6)',
-        borderColor: 'rgba(152, 172, 189, 0.6)',
-    },
-    backlinks_container: {
-        borderRadius: '10px',
-        boxShadow: '0px 1px 10px rgba(152, 172, 189, 0.6)',
-        backgroundColor: '#fff',
-    },
-    backlinks_button: {
-        display: 'flex',
-        alignItems: 'center',
-    },
-});
+const rootContainerStyle: React.CSSProperties = {
+    width: '228px',
+    overflowX: 'hidden',
+    overflowY: 'hidden',
+    marginTop: '6px',
+    marginLeft: '5px',
+};
+const scrollContainerStyle: React.CSSProperties = {
+    width: 'calc(100% + 25px)',
+    height: '100%',
+    overflowY: 'scroll',
+};
+const buttonStyle: React.CSSProperties = {
+    width: '220px',
+    borderRadius: '5px!important',
+    marginTop: '0px!important',
+};
+const emptyStyle: React.CSSProperties = {
+    display: 'inline-flex',
+    width: '220px',
+    height: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    fontSize: '15px',
+    lineHeight: '17px',
+    textAlign: 'justify',
+    letterSpacing: '1.5px',
+    color: '#4C6275',
+};
+const separatorStyle: React.CSSProperties = {
+    height: '1px',
+    border: 0,
+    marginTop: '8px',
+    marginBottom: '8px',
+    backgroundColor: 'rgba(152, 172, 189, 0.6)',
+    borderColor: 'rgba(152, 172, 189, 0.6)',
+};
+const backlinksContainerStyle: React.CSSProperties = {
+    borderRadius: '10px',
+    boxShadow: '0px 1px 10px rgba(152, 172, 189, 0.6)',
+    backgroundColor: '#fff',
+};
+const backlinksButtonStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+};

--- a/libs/components/common/src/lib/text/plugins/link.tsx
+++ b/libs/components/common/src/lib/text/plugins/link.tsx
@@ -12,7 +12,6 @@ import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 
 import isUrl from 'is-url';
-import style9 from 'style9';
 import {
     Editor,
     Transforms,
@@ -194,10 +193,10 @@ export const LinkComponent = ({
         >
             <a
                 {...attributes}
-                className={styles({
-                    linkWrapper: true,
-                    linkWrapperHover: tooltip_visible,
-                })}
+                style={{
+                    ...linkWrapperStyle,
+                    ...(tooltip_visible ? linkWrapperHoverStyle : {}),
+                }}
                 href={element.url}
             >
                 {/* <InlineChromiumBugfix /> */}
@@ -304,21 +303,18 @@ const LinkTooltips = (props: LinkTooltipsProps) => {
     }, [editor, select_link]);
 
     return (
-        <div className={styles('linkTooltipContainer')}>
-            <span className={styles('linkModalIcon')}>
+        <div style={linkTooltipContainerStyle}>
+            <span style={linkModalIconStyle}>
                 <OpenInNewIcon style={{ fontSize: 15 }} />
             </span>
-            <span className={styles('linkModalUrl')}>{url}</span>
-            <div className={styles('linkModalStick')} />
-            <div
-                onClick={handle_edit_link_url}
-                className={styles('linkModalBtn')}
-            >
+            <span style={linkModalUrlStyle}>{url}</span>
+            <div style={linkModalStickStyle} />
+            <LinkModalBtn onClick={handle_edit_link_url}>
                 <EditIcon style={{ fontSize: 16 }} />
-            </div>
-            <div onClick={handle_unlink} className={styles('linkModalBtn')}>
+            </LinkModalBtn>
+            <LinkModalBtn onClick={handle_unlink}>
                 <LinkOffIcon style={{ fontSize: 16 }} />
-            </div>
+            </LinkModalBtn>
         </div>
     );
 };
@@ -417,13 +413,12 @@ export const LinkModal = memo((props: LinkModalProps) => {
                         left,
                     }}
                 >
-                    <div className={styles('linkModalContainerIcon')}>
+                    <div style={linkModalContainerIconStyle}>
                         <LinkIcon
                             style={{ fontSize: '16px', marginTop: '2px' }}
                         />
                     </div>
-                    <input
-                        className={styles('linkModalContainerInput')}
+                    <LinkModalContainerInput
                         onKeyDown={handle_key_down}
                         placeholder="Paste link url, like https://affine.pro"
                         autoComplete="off"
@@ -467,8 +462,13 @@ const LinkBehavior = (props: {
                 return (
                     <div
                         key={`fake-selection-${i}`}
-                        className={styles('fakeSelection')}
-                        style={{ top, left, width, height }}
+                        style={{
+                            top,
+                            left,
+                            width,
+                            height,
+                            ...fakeSelectionStyle,
+                        }}
                     />
                 );
             });
@@ -479,11 +479,7 @@ const LinkBehavior = (props: {
 
     return (
         <>
-            <div
-                ref={ref}
-                className={styles('linkMask')}
-                onMouseDown={onMousedown}
-            />
+            <div ref={ref} style={linkMaskStyle} onMouseDown={onMousedown} />
             {renderFakeSelection()}
         </>
     );
@@ -502,73 +498,81 @@ const LinkModalContainer = styled('div')(({ theme }) => ({
     zIndex: '1',
 }));
 
-const styles = style9.create({
-    linkModalContainerIcon: {
-        display: 'flex',
-        width: '16px',
-        margin: '0 16px 0 4px',
-        color: '#4C6275',
+const linkModalContainerIconStyle: React.CSSProperties = {
+    display: 'flex',
+    width: '16px',
+    margin: '0 16px 0 4px',
+    color: '#4C6275',
+};
+
+const LinkModalContainerInput = styled('input')(() => ({
+    flex: '1',
+    outline: 'none',
+    border: 'none',
+    padding: '0',
+    fontFamily: 'Helvetica,Arial,"Microsoft Yahei",SimHei,sans-serif',
+    '::-webkit-input-placeholder': {
+        color: '#98acbd',
     },
-    linkModalContainerInput: {
-        flex: '1',
-        outline: 'none',
-        border: 'none',
-        padding: '0',
-        fontFamily: 'Helvetica,Arial,"Microsoft Yahei",SimHei,sans-serif',
-        '::-webkit-input-placeholder': {
-            color: '#98acbd',
-        },
-        color: '#4C6275',
-    },
-    linkMask: {
-        position: 'fixed',
-        top: '0',
-        left: '0',
-        width: '100vw',
-        height: '100vh',
-        zIndex: '1',
-    },
-    fakeSelection: {
-        pointerEvents: 'none',
-        position: 'fixed',
-        // backgroundColor: 'rgba(80, 46, 196, 0.1)',
-        zIndex: '1',
-    },
-    linkWrapper: {
+    color: '#4C6275',
+}));
+
+const linkMaskStyle: React.CSSProperties = {
+    position: 'fixed',
+    top: '0',
+    left: '0',
+    width: '100vw',
+    height: '100vh',
+    zIndex: '1',
+};
+
+const fakeSelectionStyle: React.CSSProperties = {
+    pointerEvents: 'none',
+    position: 'fixed',
+    // backgroundColor: 'rgba(80, 46, 196, 0.1)',
+    zIndex: '1',
+};
+
+const linkWrapperStyle: React.CSSProperties = {
+    cursor: 'pointer',
+    textDecorationLine: 'none',
+};
+
+const linkWrapperHoverStyle: React.CSSProperties = {};
+
+const linkTooltipContainerStyle: React.CSSProperties = {
+    // color: 'var(--ligo-Gray04)',
+    display: 'flex',
+    alignItems: 'center',
+};
+
+const linkModalIconStyle: React.CSSProperties = {};
+
+const linkModalStickStyle: React.CSSProperties = {
+    width: '1px',
+    height: '20px',
+    margin: '0 10px 0 16px',
+};
+
+const linkModalUrlStyle: React.CSSProperties = {
+    marginLeft: '8px',
+    maxWidth: '261px',
+    textOverflow: 'ellipsis',
+    overflowX: 'hidden',
+    overflowY: 'hidden',
+    whiteSpace: 'nowrap',
+};
+
+const LinkModalBtn = styled('div')(() => ({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    width: '28px',
+    height: '28px',
+    transitionProperty: 'background-color',
+    transitionDuration: '0.3s',
+    borderRadius: '4px',
+    ':hover': {
         cursor: 'pointer',
-        textDecorationLine: 'none',
     },
-    linkWrapperHover: {},
-    linkTooltipContainer: {
-        // color: 'var(--ligo-Gray04)',
-        display: 'flex',
-        alignItems: 'center',
-    },
-    linkModalIcon: {},
-    linkModalStick: {
-        width: '1px',
-        height: '20px',
-        margin: '0 10px 0 16px',
-    },
-    linkModalUrl: {
-        marginLeft: '8px',
-        maxWidth: '261px',
-        textOverflow: 'ellipsis',
-        overflowX: 'hidden',
-        overflowY: 'hidden',
-        whiteSpace: 'nowrap',
-    },
-    linkModalBtn: {
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        width: '28px',
-        height: '28px',
-        transitionProperty: 'background-color',
-        transitionDuration: '0.3s',
-        borderRadius: '4px',
-        ':hover': {
-            cursor: 'pointer',
-        },
-    },
-});
+}));

--- a/libs/components/common/src/lib/toolbar/index.tsx
+++ b/libs/components/common/src/lib/toolbar/index.tsx
@@ -1,38 +1,37 @@
 import { MuiTooltip as Tooltip } from '@toeverything/components/ui';
+import { styled } from '@toeverything/components/ui';
 
-import style9 from 'style9';
+const toolbarContainerStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'row',
+    lineHeight: 1,
+    zIndex: 1,
+    padding: '0 8px',
+    backgroundColor: '#ffffff',
+    border: '1px solid #e1e1e1',
+    boxShadow: '0px 14px 24px rgba(51, 51, 51, 0.08)',
+    borderRadius: '4px',
+    color: '#333',
+    fontSize: '16px',
+    cursor: 'pointer',
+};
 
-const styles = style9.create({
-    toolbarContainer: {
-        display: 'flex',
-        flexDirection: 'row',
-        lineHeight: 1,
-        zIndex: 1,
-        padding: '0 8px',
-        backgroundColor: '#ffffff',
-        border: '1px solid #e1e1e1',
-        boxShadow: '0px 14px 24px rgba(51, 51, 51, 0.08)',
-        borderRadius: '4px',
-        color: '#333',
-        fontSize: '16px',
-        cursor: 'pointer',
-    },
-    toolbarItem: {
+const lineStyle: React.CSSProperties = {
+    margin: '0 8px',
+    width: '1px',
+    backgroundColor: '#e1e1e1',
+};
+
+const StyledToolbarItem = styled('span')<{ active: boolean }>(({ active }) => {
+    return {
         padding: '6px',
         margin: '6px 2px',
-        ':hover': {
+        '&:hover': {
             backgroundColor: '#f4f4f4',
             borderRadius: '4px',
         },
-    },
-    toolbarItemActive: {
-        color: '#502ec4',
-    },
-    line: {
-        margin: '0 8px',
-        width: '1px',
-        backgroundColor: '#e1e1e1',
-    },
+        ...(active ? { color: '#502ec4' } : {}),
+    };
 });
 
 interface Props {
@@ -41,27 +40,24 @@ interface Props {
 
 export default function Toolbar({ data }: Props) {
     return (
-        <div className={styles('toolbarContainer')}>
+        <div style={toolbarContainerStyle}>
             {data.map((item, index) => {
                 const { icon: Icon } = item;
                 return item.child ? (
-                    <span key={item.key} className={styles('toolbarItem')}>
+                    <StyledToolbarItem active={false} key={item.key}>
                         {item.child}
-                    </span>
+                    </StyledToolbarItem>
                 ) : item.line ? (
-                    <div className={styles('line')} key={index}></div>
+                    <div style={lineStyle} key={index}></div>
                 ) : (
                     <Tooltip title={item.text} placement="top" key={item.key}>
-                        <span
+                        <StyledToolbarItem
+                            active={item.active}
                             key={item.key}
-                            className={styles({
-                                toolbarItem: true,
-                                toolbarItemActive: !!item?.active,
-                            })}
                             onClick={() => item?.action(item.key)}
                         >
                             <Icon />
-                        </span>
+                        </StyledToolbarItem>
                     </Tooltip>
                 );
             })}

--- a/libs/components/editor-blocks/package.json
+++ b/libs/components/editor-blocks/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/editor-blocks",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@codemirror/commands": "^6.0.1",
         "@codemirror/lang-cpp": "~6.0.1",

--- a/libs/components/editor-blocks/src/components/table/basic-table.tsx
+++ b/libs/components/editor-blocks/src/components/table/basic-table.tsx
@@ -75,15 +75,17 @@ const Cell = memo(
         const row = data.rows[rowIndex];
         const is_first_column = columnIndex === 0;
         const is_first_row = rowIndex === 0;
-        const class_name = styles({
-            cell: true,
-            cellLeftBorder: !is_first_column,
-            cellTopBorder: !is_first_row,
-        });
+
+        const mergedStyle = {
+            ...cellStyle,
+            ...(!is_first_column ? cellLeftBorderStyle : {}),
+            ...(!is_first_row ? cellTopBorderStyle : {}),
+            ...style,
+        };
 
         const CustomCell = data.CustomCell;
         return (
-            <div style={style} className={class_name}>
+            <div style={mergedStyle}>
                 <CustomCell
                     column={column}
                     row={row}
@@ -157,7 +159,7 @@ export const BasicTable = ({
     );
 
     return (
-        <div ref={container_ref} className={styles('containerBorder')}>
+        <div ref={container_ref} style={containerBorderStyle}>
             {table_width ? (
                 <VariableSizeGrid
                     className="v-basic-table-body"
@@ -181,22 +183,25 @@ export const BasicTable = ({
     );
 };
 
-const styles = style9.create({
-    containerBorder: {
-        borderTop: '1px solid #ECEFF3',
-        borderBottom: '1px solid #ECEFF3',
-        boxSizing: 'border-box',
-    },
-    cell: {
-        overflowX: 'hidden',
-        overflowY: 'hidden',
-        padding: '10px 4px',
-        boxSizing: 'border-box',
-    },
-    cellLeftBorder: {
-        // borderLeft: '1px solid #98ACBD'
-    },
-    cellTopBorder: {
-        borderTop: '1px solid #ECEFF3',
-    },
-});
+const containerBorderStyle: React.CSSProperties = {
+    borderTop: '1px solid #ECEFF3',
+    borderBottom: '1px solid #ECEFF3',
+    boxSizing: 'border-box',
+};
+
+const cellStyle: React.CSSProperties = {
+    overflowX: 'hidden',
+    overflowY: 'hidden',
+    padding: '10px 4px',
+    boxSizing: 'border-box',
+};
+
+const cellLeftBorderStyle: React.CSSProperties = {
+    // borderLeft: '1px solid #98ACBD'
+};
+
+const cellTopBorderStyle: React.CSSProperties = {
+    borderTop: '1px solid #ECEFF3',
+    borderBottom: '1px solid #ECEFF3',
+    boxSizing: 'border-box',
+};

--- a/libs/components/editor-core/package.json
+++ b/libs/components/editor-core/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/editor-core",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@mui/icons-material": "^5.8.4",
         "date-fns": "^2.28.0",

--- a/libs/components/editor-plugins/package.json
+++ b/libs/components/editor-plugins/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/editor-plugins",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@mui/icons-material": "^5.8.4",
         "date-fns": "^2.28.0",

--- a/libs/components/editor-plugins/src/menu/command-menu/Categories.tsx
+++ b/libs/components/editor-plugins/src/menu/command-menu/Categories.tsx
@@ -1,5 +1,4 @@
 import { useMemo } from 'react';
-import style9 from 'style9';
 
 import { CommandMenuCategories } from './config';
 
@@ -44,15 +43,17 @@ export const MenuCategories = ({
     };
 
     return (
-        <div className={styles('rootContainer')}>
+        <div style={rootContainerStyle}>
             {categories_data.map((menu_category, index) => {
                 const { type, text } = menu_category;
                 return categories.includes(type) ? (
                     <button
-                        className={styles({
-                            categoryItem: true,
-                            activeItem: currentCategories === type,
-                        })}
+                        style={{
+                            ...categoryItemStyle,
+                            ...(currentCategories === type
+                                ? activeItemStyle
+                                : {}),
+                        }}
                         key={type}
                         onClick={() => {
                             handle_click(type);
@@ -66,26 +67,27 @@ export const MenuCategories = ({
     );
 };
 
-const styles = style9.create({
-    rootContainer: {
-        minWidth: '120px',
-        marginTop: '6px',
-    },
-    categoryItem: {
-        display: 'flex',
-        width: '120px',
-        paddingLeft: '12px',
-        paddingTop: '6px',
-        paddingBottom: '6px',
-        borderRadius: '5px',
-        color: '#98ACBD',
-        fontSize: '12px',
-        lineHeight: '14px',
-        fontFamily: 'Helvetica,Arial,"Microsoft Yahei",SimHei,sans-serif',
-        textAlign: 'justify',
-        letterSpacing: '1.5px',
-    },
-    activeItem: {
-        backgroundColor: 'rgba(152, 172, 189, 0.1)',
-    },
-});
+const rootContainerStyle: React.CSSProperties = {
+    minWidth: '120px',
+    marginTop: '6px',
+};
+
+const categoryItemStyle: React.CSSProperties = {
+    display: 'flex',
+    width: '120px',
+    paddingLeft: '12px',
+    paddingTop: '6px',
+    paddingBottom: '6px',
+    borderRadius: '5px',
+    color: '#98ACBD',
+    fontSize: '12px',
+    lineHeight: '14px',
+    fontFamily: 'Helvetica,Arial,"Microsoft Yahei",SimHei,sans-serif',
+    textAlign: 'justify',
+    letterSpacing: '1.5px',
+};
+
+const activeItemStyle: React.CSSProperties = {
+    minWidth: '120px',
+    marginTop: '6px',
+};

--- a/libs/components/editor-plugins/src/menu/inline-menu/menu-item/DropdownItem.tsx
+++ b/libs/components/editor-plugins/src/menu/inline-menu/menu-item/DropdownItem.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react';
-import style9 from 'style9';
 import {
     Popover,
     styled,
@@ -45,7 +44,7 @@ export const MenuDropdownItem = ({
                 trigger="click"
                 placement="bottom-start"
                 content={
-                    <div className={styles('dropdownContainer')}>
+                    <div style={dropdownContainerStyle}>
                         {children.map(item => {
                             const {
                                 name,
@@ -57,8 +56,7 @@ export const MenuDropdownItem = ({
                             const StyledIcon = withStylesForIcon(ItemIcon);
 
                             return (
-                                <button
-                                    className={styles('dropdownItem')}
+                                <DropdownItem
                                     key={name}
                                     onClick={() => {
                                         if (
@@ -101,12 +99,10 @@ export const MenuDropdownItem = ({
                                         // }
                                     />
                                     {/* <ItemIcon sx={{ width: 20, height: 20 }} /> */}
-                                    <span
-                                        className={styles('dropdownItemItext')}
-                                    >
+                                    <span style={dropdownItemItextStyle}>
                                         {name}
                                     </span>
-                                </button>
+                                </DropdownItem>
                             );
                         })}
                     </div>
@@ -122,13 +118,10 @@ export const MenuDropdownItem = ({
                     placement="top"
                     trigger="hover"
                 >
-                    <button
-                        className={styles('currentDropdownButton')}
-                        aria-label={name}
-                    >
+                    <CurrentDropdownButton aria-label={name}>
                         <MenuIcon sx={{ width: 20, height: 20 }} />
                         <ArrowDropDownIcon sx={{ width: 20, height: 20 }} />
-                    </button>
+                    </CurrentDropdownButton>
                 </Tooltip>
             </Popover>
         </>
@@ -152,31 +145,32 @@ const withStylesForIcon = (
         }
     );
 
-const styles = style9.create({
-    currentDropdownButton: {
-        display: 'inline-flex',
-        padding: '0',
-        margin: '15px 6px',
-        color: '#98acbd',
-        ':hover': { backgroundColor: 'transparent' },
-    },
-    dropdownContainer: {
-        margin: '8px 4px',
-    },
-    dropdownItem: {
-        display: 'flex',
-        alignItems: 'center',
-        // @ts-ignore
-        gap: '12px',
-        // width: '120px',
-        height: '32px',
-        padding: '0px 12px',
-        borderRadius: '5px',
-        color: '#98acbd',
-        ':hover': { backgroundColor: '#F5F7F8' },
-    },
-    dropdownItemItext: {
-        color: '#4C6275',
-        fontFamily: 'Helvetica,Arial,"Microsoft Yahei",SimHei,sans-serif',
-    },
-});
+const CurrentDropdownButton = styled('button')(() => ({
+    display: 'inline-flex',
+    padding: '0',
+    margin: '15px 6px',
+    color: '#98acbd',
+    ':hover': { backgroundColor: 'transparent' },
+}));
+
+const dropdownContainerStyle: React.CSSProperties = {
+    margin: '8px 4px',
+};
+
+const DropdownItem = styled('button')(() => ({
+    display: 'flex',
+    alignItems: 'center',
+    // @ts-ignore
+    gap: '12px',
+    // width: '120px',
+    height: '32px',
+    padding: '0px 12px',
+    borderRadius: '5px',
+    color: '#98acbd',
+    ':hover': { backgroundColor: '#F5F7F8' },
+}));
+
+const dropdownItemItextStyle: React.CSSProperties = {
+    color: '#4C6275',
+    fontFamily: 'Helvetica,Arial,"Microsoft Yahei",SimHei,sans-serif',
+};

--- a/libs/components/editor-plugins/src/menu/inline-menu/menu-item/IconItem.tsx
+++ b/libs/components/editor-plugins/src/menu/inline-menu/menu-item/IconItem.tsx
@@ -1,9 +1,8 @@
 import React, { useCallback } from 'react';
-import style9 from 'style9';
 
 import type { IconItemType, WithEditorSelectionType } from '../types';
 import { inlineMenuNamesKeys, inlineMenuShortcuts } from '../config';
-import { Tooltip } from '@toeverything/components/ui';
+import { styled, Tooltip } from '@toeverything/components/ui';
 type MenuIconItemProps = IconItemType & WithEditorSelectionType;
 
 export const MenuIconItem = ({
@@ -48,23 +47,17 @@ export const MenuIconItem = ({
             placement="top"
             trigger="hover"
         >
-            <button
-                onClick={handleToolbarItemClick}
-                className={styles('currentIcon')}
-                aria-label={name}
-            >
+            <CurrentIcon onClick={handleToolbarItemClick} aria-label={name}>
                 <MenuIcon sx={{ width: 20, height: 20 }} />
-            </button>
+            </CurrentIcon>
         </Tooltip>
     );
 };
 
-const styles = style9.create({
-    currentIcon: {
-        display: 'inline-flex',
-        padding: '0',
-        margin: '15px 6px',
-        color: '#98acbd',
-        ':hover': { backgroundColor: 'transparent' },
-    },
-});
+const CurrentIcon = styled('button')(() => ({
+    display: 'inline-flex',
+    padding: '0',
+    margin: '15px 6px',
+    color: '#98acbd',
+    ':hover': { backgroundColor: 'transparent' },
+}));

--- a/libs/components/editor-plugins/src/search/Search.tsx
+++ b/libs/components/editor-plugins/src/search/Search.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import style9 from 'style9';
 
 import { BlockPreview } from '@toeverything/components/common';
 import {
@@ -12,23 +11,23 @@ import {
 import { Virgo, BlockEditor } from '@toeverything/framework/virgo';
 import { throttle } from '@toeverything/utils';
 
-const styles = style9.create({
-    wrapper: {
-        position: 'absolute',
-        top: '20%',
-        left: '50%',
-        transform: 'translate(-50%, -50%)',
-        width: '50vw',
-        display: 'flex',
-        flexDirection: 'column',
-    },
-    resultItem: {
-        width: '100%',
-    },
-    resultHide: {
-        opacity: 0,
-    },
-});
+const wrapperStyle: React.CSSProperties = {
+    position: 'absolute',
+    top: '20%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: '50vw',
+    display: 'flex',
+    flexDirection: 'column',
+};
+
+const resultItemStyle: React.CSSProperties = {
+    width: '100%',
+};
+
+const resultHideStyle: React.CSSProperties = {
+    opacity: 0,
+};
 
 export type QueryResult = Awaited<ReturnType<BlockEditor['search']>>;
 
@@ -76,7 +75,7 @@ export const Search = (props: SearchProps) => {
                 props.onClose();
             }}
         >
-            <Box className={styles('wrapper')}>
+            <Box style={wrapperStyle}>
                 <SearchInput
                     autoFocus
                     value={search}
@@ -84,13 +83,11 @@ export const Search = (props: SearchProps) => {
                 />
                 <ResultContainer
                     sx={{ maxHeight: `${result.length * 28 + 32 + 20}px` }}
-                    className={styles({
-                        resultHide: !result.length,
-                    })}
+                    style={result.length === 0 ? resultHideStyle : {}}
                 >
                     {result.map(block => (
                         <BlockPreview
-                            className={styles('resultItem')}
+                            style={resultItemStyle}
                             key={block.id}
                             block={block}
                             onClick={() => {

--- a/libs/components/icons/package.json
+++ b/libs/components/icons/package.json
@@ -1,5 +1,6 @@
 {
     "name": "@toeverything/components/icons",
     "version": "0.0.1",
+    "main": "src/index.ts",
     "license": "MIT"
 }

--- a/libs/components/layout/package.json
+++ b/libs/components/layout/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/layout",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@date-io/date-fns": "^2.14.0",
         "@dnd-kit/core": "^6.0.5",

--- a/libs/components/layout/src/header/PageSharePortal.tsx
+++ b/libs/components/layout/src/header/PageSharePortal.tsx
@@ -1,4 +1,3 @@
-import style9 from 'style9';
 import LanguageIcon from '@mui/icons-material/Language';
 import { useState, MouseEvent } from 'react';
 import InsertLinkIcon from '@mui/icons-material/InsertLink';
@@ -14,48 +13,55 @@ import {
 } from '@toeverything/components/ui';
 import { copyToClipboard } from '@toeverything/utils';
 
-const styles = style9.create({
-    pageShareBox: {
-        width: '500px',
-        padding: '30px 20px 50px 20px',
-    },
-    btnPageShare: {
-        width: '24px',
-        height: '24px',
-    },
-    pageShareBoxIcon: {
-        position: 'absolute',
-        left: '5px',
-        top: '10px',
-        color: 'var(--color-gray-400)',
-    },
-    pageShareBoxForWeb: {
-        position: 'relative',
-        paddingLeft: '40px',
-        borderBottom: '1px solid var(--color-gray-400))',
-        marginBottom: '15px',
-    },
-    pageShareBoxSwitch: {
-        position: 'absolute',
-        right: '5px',
-        top: '10px',
-    },
-    pageShareBoxForWebP1: {
-        fontWeight: 'bold',
-        marginBottom: '5px',
-    },
-    pageShareBoxForWebP2: {
-        color: 'var(--color-gray-400)',
-    },
-    copyLinkBtn: {
-        marginTop: '15px',
-        float: 'right',
-        cursor: 'pointer',
-    },
-    copyLinkcon: {
-        verticalAlign: 'middle',
-    },
-});
+const pageShareBoxStyle: React.CSSProperties = {
+    width: '500px',
+    padding: '30px 20px 50px 20px',
+};
+
+const btnPageShareStyle: React.CSSProperties = {
+    width: '24px',
+    height: '24px',
+};
+
+const pageShareBoxIconStyle: React.CSSProperties = {
+    position: 'absolute',
+    left: '5px',
+    top: '10px',
+    color: 'var(--color-gray-400)',
+};
+
+const pageShareBoxForWebStyle: React.CSSProperties = {
+    position: 'relative',
+    paddingLeft: '40px',
+    borderBottom: '1px solid var(--color-gray-400))',
+    marginBottom: '15px',
+};
+
+const pageShareBoxSwitchStyle: React.CSSProperties = {
+    position: 'absolute',
+    right: '5px',
+    top: '10px',
+};
+
+const pageShareBoxForWebP1Style: React.CSSProperties = {
+    fontWeight: 'bold',
+    marginBottom: '5px',
+};
+
+const pageShareBoxForWebP2Style: React.CSSProperties = {
+    color: 'var(--color-gray-400)',
+};
+
+const copyLinkBtnStyle: React.CSSProperties = {
+    marginTop: '15px',
+    float: 'right',
+    cursor: 'pointer',
+};
+
+const copyLinkconStyle: React.CSSProperties = {
+    verticalAlign: 'middle',
+};
+
 const MESSAGES = {
     COPY_LINK: ' Copy Link',
     INVITE: 'Add people,emails, or groups',
@@ -79,18 +85,16 @@ function PageSharePortal() {
                 placement="bottom-start"
                 trigger="click"
                 content={
-                    <div className={styles('pageShareBox')}>
-                        <div className={styles('pageShareBoxForWeb')}>
-                            <LanguageIcon
-                                className={styles('pageShareBoxIcon')}
-                            />
-                            <p className={styles('pageShareBoxForWebP1')}>
+                    <div style={pageShareBoxStyle}>
+                        <div style={pageShareBoxForWebStyle}>
+                            <LanguageIcon style={pageShareBoxIconStyle} />
+                            <p style={pageShareBoxForWebP1Style}>
                                 {MESSAGES.SHARE_TO_WEB}
                             </p>
-                            <p className={styles('pageShareBoxForWebP2')}>
+                            <p style={pageShareBoxForWebP2Style}>
                                 {MESSAGES.SHARE_TO_ANYONE}
                             </p>
-                            <div className={styles('pageShareBoxSwitch')}>
+                            <div style={pageShareBoxSwitchStyle}>
                                 <Switch />
                             </div>
                         </div>
@@ -113,13 +117,8 @@ function PageSharePortal() {
                             </Paper>
                         </div>
                         <div>
-                            <a
-                                className={styles('copyLinkBtn')}
-                                onClick={handleCopy}
-                            >
-                                <InsertLinkIcon
-                                    className={styles('copyLinkcon')}
-                                />
+                            <a style={copyLinkBtnStyle} onClick={handleCopy}>
+                                <InsertLinkIcon style={copyLinkconStyle} />
                                 {MESSAGES.COPY_LINK}
                             </a>
                         </div>

--- a/libs/components/ui/package.json
+++ b/libs/components/ui/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/components/ui",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "@emotion/is-prop-valid": "^1.1.3",
         "@emotion/react": "^11.9.3",

--- a/libs/components/ui/src/button/ListButton.tsx
+++ b/libs/components/ui/src/button/ListButton.tsx
@@ -1,41 +1,38 @@
 import React from 'react';
-import clsx from 'clsx';
-import style9 from 'style9';
 
 import { BaseButton } from './base-button';
 import { SvgIconProps } from '../svg-icon';
 
-const styles = style9.create({
-    item: {
-        display: 'flex',
-        alignItems: 'center',
-        width: '220px',
-        paddingLeft: '22px',
-        paddingTop: '4px',
-        paddingBottom: '4px',
-        marginTop: '6px',
-        marginBottom: '6px',
-        borderRadius: '5px',
-        color: '#98ACBD',
-    },
-    item_hover: {
-        backgroundColor: 'rgba(152, 172, 189, 0.1)',
-    },
-    item_text: {
-        fontSize: '15px',
-        lineHeight: '17px',
-        textAlign: 'justify',
-        letterSpacing: '1.5px',
-        marginLeft: '8px',
-        color: '#4C6275',
-        textOverflow: 'ellipsis',
-        overflow: 'hidden',
-        whiteSpace: 'nowrap',
-    },
-});
+const itemStyle: React.CSSProperties = {
+    display: 'flex',
+    alignItems: 'center',
+    width: '220px',
+    paddingLeft: '22px',
+    paddingTop: '4px',
+    paddingBottom: '4px',
+    marginTop: '6px',
+    marginBottom: '6px',
+    borderRadius: '5px',
+    color: '#98ACBD',
+};
+const itemHoverStyle: React.CSSProperties = {
+    backgroundColor: 'rgba(152, 172, 189, 0.1)',
+};
+const itemTextStyle: React.CSSProperties = {
+    fontSize: '15px',
+    lineHeight: '17px',
+    textAlign: 'justify',
+    letterSpacing: '1.5px',
+    marginLeft: '8px',
+    color: '#4C6275',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+};
 
 type ListButtonProps = {
     className?: string;
+    style?: React.CSSProperties;
     onClick: () => void;
     onMouseOver?: () => void;
     content?: string;
@@ -50,13 +47,11 @@ export const ListButton = (props: ListButtonProps) => {
         <BaseButton
             onClick={props.onClick}
             onMouseOver={props.onMouseOver}
-            className={clsx(
-                styles('item', { item_hover: props.hover }),
-                props.className
-            )}
+            style={{ ...itemStyle, ...(props.hover ? itemHoverStyle : {}) }}
+            className={props.className}
         >
             {MenuIcon && <MenuIcon sx={{ width: 20, height: 20 }} />}
-            <span className={styles('item_text')}>{props.content}</span>
+            <span style={itemTextStyle}>{props.content}</span>
             {props.children}
         </BaseButton>
     );

--- a/libs/datasource/commands/package.json
+++ b/libs/datasource/commands/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/datasource/commands",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "type": "commonjs",
     "dependencies": {}
 }

--- a/libs/datasource/db-service/package.json
+++ b/libs/datasource/db-service/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/datasource/db-service",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "diff": "^5.1.0",
         "nanoid": "^4.0.0"

--- a/libs/datasource/feature-flags/package.json
+++ b/libs/datasource/feature-flags/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/datasource/feature-flags",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "ffc-js-client-side-sdk": "^1.1.4"
     }

--- a/libs/datasource/jwt-rpc/package.json
+++ b/libs/datasource/jwt-rpc/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "license": "MIT",
     "author": "DarkSky <darksky2048@gmail.com>",
+    "main": "src/index.ts",
     "dependencies": {
         "lib0": "^0.2.52",
         "sql.js": "^1.7.0",

--- a/libs/datasource/jwt/package.json
+++ b/libs/datasource/jwt/package.json
@@ -3,6 +3,7 @@
     "version": "0.0.1",
     "license": "MIT",
     "author": "DarkSky <darksky2048@gmail.com>",
+    "main": "src/index.ts",
     "devDependencies": {
         "@types/debug": "^4.1.7",
         "@types/file-saver": "^2.0.5",

--- a/libs/datasource/remote-kv/package.json
+++ b/libs/datasource/remote-kv/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/datasource/remote-kv",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "aws-sdk": "^2.1189.0",
         "file-saver": "^2.0.5",

--- a/libs/datasource/state/package.json
+++ b/libs/datasource/state/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/datasource/state",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "jotai": "^1.7.4"
     },

--- a/libs/framework/virgo/package.json
+++ b/libs/framework/virgo/package.json
@@ -2,5 +2,6 @@
     "name": "@toeverything/framework/virgo",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {}
 }

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -2,6 +2,7 @@
     "name": "@toeverything/utils",
     "version": "0.0.1",
     "license": "MIT",
+    "main": "src/index.ts",
     "dependencies": {
         "copy-to-clipboard": "^3.3.1",
         "ffc-js-client-side-sdk": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "start:affine": "nx serve ligo-virgo",
         "start:keck": "nx serve keck",
         "start:venus": "nx serve venus",
+        "vite-start:affine": "cd apps/ligo-virgo && npx vite",
         "build": "nx build ligo-virgo",
         "build:local": "env-cmd -f .github/env/.env.local-dev nx build ligo-virgo",
         "build:keck": "nx build keck",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,7 +194,7 @@ importers:
       yjs: ^13.5.41
     dependencies:
       authing-js-sdk: 4.23.35
-      firebase-admin: 11.0.1
+      firebase-admin: 11.0.1_@firebase+app-types@0.7.0
       lib0: 0.2.52
       lru-cache: 7.13.2
       nanoid: 4.0.0
@@ -209,14 +209,18 @@ importers:
   apps/ligo-virgo:
     specifiers:
       '@mui/icons-material': ^5.8.4
+      '@vitejs/plugin-react': ^2.0.1
       firebase: ^9.9.2
       mini-css-extract-plugin: ^2.6.1
+      vite: '3'
       webpack: ^5.74.0
     dependencies:
       '@mui/icons-material': 5.8.4
     devDependencies:
+      '@vitejs/plugin-react': 2.0.1_vite@3.0.6
       firebase: 9.9.2
       mini-css-extract-plugin: 2.6.1_webpack@5.74.0
+      vite: 3.0.6
       webpack: 5.74.0
 
   apps/venus:
@@ -571,9 +575,6 @@ importers:
     dependencies:
       ffc-js-client-side-sdk: 1.1.5
 
-  libs/datasource/jwst/pkg:
-    specifiers: {}
-
   libs/datasource/jwt:
     specifiers:
       '@types/debug': ^4.1.7
@@ -800,6 +801,34 @@ packages:
     resolution: {integrity: sha512-tzulrgDT0QD6U7BJ4TKVk2SDDg7wlP39P9yAx1RfLy7vP/7rsDRlWVfbWxElslu56+r7QOhB2NSDsabYYruoZQ==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/compat-data/7.18.8:
+    resolution: {integrity: sha512-HSmX4WZPPK3FUxYp7g2T6EyO8j96HlZJlxmKPSh6KAcqwyDrfx7hKjXpAW/0FhFfTJsR0Yt4lAjLI2coMptIHQ==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
+  /@babel/core/7.18.10:
+    resolution: {integrity: sha512-JQM6k6ENcBFKVtWvLavlvi/mPcpYZ3+R+2EySDEMSMbp7Mn4FexlbbJVrx2R7Ijhr01T8gyqrOaABWIOgxeUyw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.18.12
+      '@babel/helper-compilation-targets': 7.18.9_@babel+core@7.18.10
+      '@babel/helper-module-transforms': 7.18.9
+      '@babel/helpers': 7.18.9
+      '@babel/parser': 7.18.11
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.18.11
+      '@babel/types': 7.18.10
+      convert-source-map: 1.8.0
+      debug: 4.3.4
+      gensync: 1.0.0-beta.2
+      json5: 2.2.1
+      semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/core/7.18.6:
     resolution: {integrity: sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==}
     engines: {node: '>=6.9.0'}
@@ -822,6 +851,15 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/generator/7.18.12:
+    resolution: {integrity: sha512-dfQ8ebCN98SvyL7IxNMCUtZQSq5R7kxgN+r8qYTGDmmSion1hX2C0zq2yo1bsCDhXixokv1SAWTZUMYbO/V5zg==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/types': 7.18.10
+      '@jridgewell/gen-mapping': 0.3.2
+      jsesc: 2.5.2
+    dev: true
+
   /@babel/generator/7.18.7:
     resolution: {integrity: sha512-shck+7VLlY72a2w9c3zYWuE1pwOKEiQHV7GTUbSnhyl5eu3i04t30tBY82ZRWrDfo3gkakCFtevExnxbkf2a3A==}
     engines: {node: '>=6.9.0'}
@@ -834,7 +872,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.18.10
     dev: true
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.6:
@@ -859,6 +897,22 @@ packages:
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.1
       semver: 6.3.0
+
+  /@babel/helper-compilation-targets/7.18.9_@babel+core@7.18.10:
+    resolution: {integrity: sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/compat-data': 7.18.8
+      '@babel/core': 7.18.10
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.1
+      semver: 6.3.0
+    dev: true
 
   /@babel/helper-create-class-features-plugin/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-YfDzdnoxHGV8CzqHGyCbFvXg5QESPFkXlHtvdCkesLjjVMT2Adxe4FGUR5ChIb3DxSaXO12iIOCWoXdsUVwnqw==}
@@ -920,6 +974,11 @@ packages:
     resolution: {integrity: sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==}
     engines: {node: '>=6.9.0'}
 
+  /@babel/helper-environment-visitor/7.18.9:
+    resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
+    engines: {node: '>=6.9.0'}
+    dev: true
+
   /@babel/helper-explode-assignable-expression/7.18.6:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
@@ -934,11 +993,19 @@ packages:
       '@babel/template': 7.18.6
       '@babel/types': 7.18.7
 
+  /@babel/helper-function-name/7.18.9:
+    resolution: {integrity: sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/types': 7.18.10
+    dev: true
+
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.18.10
 
   /@babel/helper-member-expression-to-functions/7.18.6:
     resolution: {integrity: sha512-CeHxqwwipekotzPDUuJOfIMtcIHBuc7WAzLmTYWctVigqS5RktNMQ5bEwQSuGewzYnCtTWa3BARXeiLxDTv+Ng==}
@@ -951,7 +1018,7 @@ packages:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.18.10
 
   /@babel/helper-module-transforms/7.18.6:
     resolution: {integrity: sha512-L//phhB4al5uucwzlimruukHB3jRd5JGClwRMD/ROrVjXfLqovYnvQrK/JK36WYyVwGGO7OD3kMyVTjx+WVPhw==}
@@ -968,6 +1035,22 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helper-module-transforms/7.18.9:
+    resolution: {integrity: sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.18.6
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.18.11
+      '@babel/types': 7.18.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/helper-optimise-call-expression/7.18.6:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
@@ -978,6 +1061,11 @@ packages:
   /@babel/helper-plugin-utils/7.18.6:
     resolution: {integrity: sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==}
     engines: {node: '>=6.9.0'}
+
+  /@babel/helper-plugin-utils/7.18.9:
+    resolution: {integrity: sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==}
+    engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-remap-async-to-generator/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-z5wbmV55TveUPZlCLZvxWHtrjuJd+8inFhk7DG0WW87/oJuGDcjDiu7HIvGcpf5464L6xKCg3vNkmlVVz9hwyQ==}
@@ -1014,7 +1102,7 @@ packages:
     resolution: {integrity: sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.18.10
 
   /@babel/helper-skip-transparent-expression-wrappers/7.18.6:
     resolution: {integrity: sha512-4KoLhwGS9vGethZpAhYnMejWkX64wsnHPDwvOsKWU6Fg4+AlK2Jz3TyjQLMEPvz+1zemi/WBdkYxCD0bAfIkiw==}
@@ -1027,7 +1115,11 @@ packages:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.18.7
+      '@babel/types': 7.18.10
+
+  /@babel/helper-string-parser/7.18.10:
+    resolution: {integrity: sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==}
+    engines: {node: '>=6.9.0'}
 
   /@babel/helper-validator-identifier/7.18.6:
     resolution: {integrity: sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==}
@@ -1059,6 +1151,17 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
+  /@babel/helpers/7.18.9:
+    resolution: {integrity: sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.18.10
+      '@babel/traverse': 7.18.11
+      '@babel/types': 7.18.10
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@babel/highlight/7.18.6:
     resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
     engines: {node: '>=6.9.0'}
@@ -1066,6 +1169,14 @@ packages:
       '@babel/helper-validator-identifier': 7.18.6
       chalk: 2.4.2
       js-tokens: 4.0.0
+
+  /@babel/parser/7.18.11:
+    resolution: {integrity: sha512-9JKn5vN+hDt0Hdqn1PiJ2guflwP+B6Ga8qbDuoF0PzzVhrzsKIJo8yGqVk6CmMHiMei9w1C1Bp9IMJSIK+HPIQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.18.10
+    dev: true
 
   /@babel/parser/7.18.6:
     resolution: {integrity: sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==}
@@ -1484,6 +1595,19 @@ packages:
     dependencies:
       '@babel/helper-plugin-utils': 7.18.6
     dev: false
+
+  /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.10:
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/helper-plugin-utils': 7.18.9
+    dev: true
 
   /@babel/plugin-syntax-jsx/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -1972,6 +2096,19 @@ packages:
       '@babel/helper-plugin-utils': 7.18.6
     dev: true
 
+  /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.18.10:
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.10
+    dev: true
+
   /@babel/plugin-transform-react-jsx-development/7.18.6_@babel+core@7.18.6:
     resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
@@ -1983,6 +2120,49 @@ packages:
     dependencies:
       '@babel/core': 7.18.6
       '@babel/plugin-transform-react-jsx': 7.18.6_@babel+core@7.18.6
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-self/7.18.6_@babel+core@7.18.10:
+    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/helper-plugin-utils': 7.18.6
+    dev: true
+
+  /@babel/plugin-transform-react-jsx-source/7.18.6_@babel+core@7.18.10:
+    resolution: {integrity: sha512-utZmlASneDfdaMh0m/WausbjUjEdGrQJz0vFK93d7wD3xf5wBtX219+q6IlCNZeguIcxS2f/CvLZrlLSvSHQXw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/helper-plugin-utils': 7.18.6
+    dev: true
+
+  /@babel/plugin-transform-react-jsx/7.18.10_@babel+core@7.18.10:
+    resolution: {integrity: sha512-gCy7Iikrpu3IZjYZolFE4M1Sm+nrh1/6za2Ewj77Z+XirT4TsbJcvOFOyF+fRPwU6AKKK136CZxx6L8AbSFG6A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.18.9
+      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.18.10
+      '@babel/types': 7.18.10
     dev: true
 
   /@babel/plugin-transform-react-jsx/7.18.6_@babel+core@7.18.6:
@@ -2327,6 +2507,15 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.9
 
+  /@babel/template/7.18.10:
+    resolution: {integrity: sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.18.11
+      '@babel/types': 7.18.10
+    dev: true
+
   /@babel/template/7.18.6:
     resolution: {integrity: sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==}
     engines: {node: '>=6.9.0'}
@@ -2334,6 +2523,24 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.18.6
       '@babel/types': 7.18.7
+
+  /@babel/traverse/7.18.11:
+    resolution: {integrity: sha512-TG9PiM2R/cWCAy6BPJKeHzNbu4lPzOSZpeMfeNErskGpTJx6trEvFaVCbDvpcxwy49BKWmEPwiW8mrysNiDvIQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.18.12
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.18.9
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.18.11
+      '@babel/types': 7.18.10
+      debug: 4.3.4
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
 
   /@babel/traverse/7.18.6:
     resolution: {integrity: sha512-zS/OKyqmD7lslOtFqbscH6gMLFYOfG1YPqCKfAW5KrTeolKqvB8UelR49Fpr6y93kYkW2Ik00mT1LOGiAGvizw==}
@@ -2351,6 +2558,14 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  /@babel/types/7.18.10:
+    resolution: {integrity: sha512-MJvnbEiiNkpjo+LknnmRrqbY1GPUUggjv+wQVjetM/AONoupqRALB7I6jGqNUAZsKcRIEu2J6FRFvsczljjsaQ==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.18.10
+      '@babel/helper-validator-identifier': 7.18.6
+      to-fast-properties: 2.0.0
 
   /@babel/types/7.18.7:
     resolution: {integrity: sha512-QG3yxTcTIBoAcQmkCs+wAPYZhu7Dk9rXKacINfNbdJDNERTbLQbHGyVG8q/YGMPeCJRIhSY0+fTc5+xuh6WPSQ==}
@@ -3158,6 +3373,15 @@ packages:
     resolution: {integrity: sha512-AHPmaAx+RYfZz0eYu6Gviiagpmiyw98ySSlQvCUhVGDRtDFe4DBS0x1bSjdF3gqUDYOczB+yYvBTtEylYSdRhg==}
     dev: false
 
+  /@esbuild/linux-loong64/0.14.54:
+    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@eslint/eslintrc/1.3.0:
     resolution: {integrity: sha512-UWW0TMTmk2d7hLcWD1/e2g5HDM/HQ3csaLSqXCfqwh4uNDuNqlaKWXmEsL4Cs41Z0KnILNvwbHAah3C2yt06kw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -3294,15 +3518,6 @@ packages:
       - utf-8-validate
     dev: true
 
-  /@firebase/auth-interop-types/0.1.6_@firebase+util@1.6.3:
-    resolution: {integrity: sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==}
-    peerDependencies:
-      '@firebase/app-types': 0.x
-      '@firebase/util': 1.x
-    dependencies:
-      '@firebase/util': 1.6.3
-    dev: false
-
   /@firebase/auth-interop-types/0.1.6_pbfwexsq7uf6mrzcwnikj3g37m:
     resolution: {integrity: sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==}
     peerDependencies:
@@ -3311,7 +3526,6 @@ packages:
     dependencies:
       '@firebase/app-types': 0.7.0
       '@firebase/util': 1.6.3
-    dev: true
 
   /@firebase/auth-types/0.11.0_pbfwexsq7uf6mrzcwnikj3g37m:
     resolution: {integrity: sha512-q7Bt6cx+ySj9elQHTsKulwk3+qDezhzRBFC9zlQ1BjgMueUOnGMcvqmU0zuKlQ4RhLSH7MNAdBV2znVaoN3Vxw==}
@@ -3347,19 +3561,6 @@ packages:
       '@firebase/util': 1.6.3
       tslib: 2.4.0
 
-  /@firebase/database-compat/0.2.4:
-    resolution: {integrity: sha512-VtsGixO5mTjNMJn6PwxAJEAR70fj+3blCXIdQKel3q+eYGZAfdqxox1+tzZDnf9NWBJpaOgAHPk3JVDxEo9NFQ==}
-    dependencies:
-      '@firebase/component': 0.5.17
-      '@firebase/database': 0.13.4
-      '@firebase/database-types': 0.9.12
-      '@firebase/logger': 0.3.3
-      '@firebase/util': 1.6.3
-      tslib: 2.4.0
-    transitivePeerDependencies:
-      - '@firebase/app-types'
-    dev: false
-
   /@firebase/database-compat/0.2.4_@firebase+app-types@0.7.0:
     resolution: {integrity: sha512-VtsGixO5mTjNMJn6PwxAJEAR70fj+3blCXIdQKel3q+eYGZAfdqxox1+tzZDnf9NWBJpaOgAHPk3JVDxEo9NFQ==}
     dependencies:
@@ -3371,7 +3572,6 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@firebase/app-types'
-    dev: true
 
   /@firebase/database-types/0.9.10:
     resolution: {integrity: sha512-2ji6nXRRsY+7hgU6zRhUtK0RmSjVWM71taI7Flgaw+BnopCo/lDF5HSwxp8z7LtiHlvQqeRA3Ozqx5VhlAbiKg==}
@@ -3386,19 +3586,6 @@ packages:
       '@firebase/app-types': 0.7.0
       '@firebase/util': 1.6.3
 
-  /@firebase/database/0.13.4:
-    resolution: {integrity: sha512-NW7bOoiaC4sJCj6DY/m9xHoFNa0CK32YPMCh6FiMweLCDQbOZM8Ql/Kn6yyuxCb7K7ypz9eSbRlCWQJsJRQjhg==}
-    dependencies:
-      '@firebase/auth-interop-types': 0.1.6_@firebase+util@1.6.3
-      '@firebase/component': 0.5.17
-      '@firebase/logger': 0.3.3
-      '@firebase/util': 1.6.3
-      faye-websocket: 0.11.4
-      tslib: 2.4.0
-    transitivePeerDependencies:
-      - '@firebase/app-types'
-    dev: false
-
   /@firebase/database/0.13.4_@firebase+app-types@0.7.0:
     resolution: {integrity: sha512-NW7bOoiaC4sJCj6DY/m9xHoFNa0CK32YPMCh6FiMweLCDQbOZM8Ql/Kn6yyuxCb7K7ypz9eSbRlCWQJsJRQjhg==}
     dependencies:
@@ -3410,7 +3597,6 @@ packages:
       tslib: 2.4.0
     transitivePeerDependencies:
       - '@firebase/app-types'
-    dev: true
 
   /@firebase/firestore-compat/0.1.23_53yvy43rwpg2c45kgeszsxtrca:
     resolution: {integrity: sha512-QfcuyMAavp//fQnjSfCEpnbWi7spIdKaXys1kOLu7395fLr+U6ykmto1HUMCSz8Yus9cEr/03Ujdi2SUl2GUAA==}
@@ -7253,6 +7439,24 @@ packages:
       '@use-gesture/core': 10.2.16
     dev: false
 
+  /@vitejs/plugin-react/2.0.1_vite@3.0.6:
+    resolution: {integrity: sha512-uINzNHmjrbunlFtyVkST6lY1ewSfz/XwLufG0PIqvLGnpk2nOIOa/1CACTDNcKi1/RwaCzJLmsXwm1NsUVV/NA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^3.0.0
+    dependencies:
+      '@babel/core': 7.18.10
+      '@babel/plugin-transform-react-jsx': 7.18.10_@babel+core@7.18.10
+      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.18.10
+      '@babel/plugin-transform-react-jsx-source': 7.18.6_@babel+core@7.18.10
+      magic-string: 0.26.2
+      react-refresh: 0.14.0
+      vite: 3.0.6
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@webassemblyjs/ast/1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
     dependencies:
@@ -9956,6 +10160,215 @@ packages:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
     dev: false
 
+  /esbuild-android-64/0.14.54:
+    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-android-arm64/0.14.54:
+    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-64/0.14.54:
+    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-darwin-arm64/0.14.54:
+    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-64/0.14.54:
+    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-freebsd-arm64/0.14.54:
+    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-32/0.14.54:
+    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-64/0.14.54:
+    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm/0.14.54:
+    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-arm64/0.14.54:
+    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-mips64le/0.14.54:
+    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-ppc64le/0.14.54:
+    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-riscv64/0.14.54:
+    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-linux-s390x/0.14.54:
+    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-netbsd-64/0.14.54:
+    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-openbsd-64/0.14.54:
+    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-sunos-64/0.14.54:
+    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-32/0.14.54:
+    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-64/0.14.54:
+    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild-windows-arm64/0.14.54:
+    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /esbuild/0.14.54:
+    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/linux-loong64': 0.14.54
+      esbuild-android-64: 0.14.54
+      esbuild-android-arm64: 0.14.54
+      esbuild-darwin-64: 0.14.54
+      esbuild-darwin-arm64: 0.14.54
+      esbuild-freebsd-64: 0.14.54
+      esbuild-freebsd-arm64: 0.14.54
+      esbuild-linux-32: 0.14.54
+      esbuild-linux-64: 0.14.54
+      esbuild-linux-arm: 0.14.54
+      esbuild-linux-arm64: 0.14.54
+      esbuild-linux-mips64le: 0.14.54
+      esbuild-linux-ppc64le: 0.14.54
+      esbuild-linux-riscv64: 0.14.54
+      esbuild-linux-s390x: 0.14.54
+      esbuild-netbsd-64: 0.14.54
+      esbuild-openbsd-64: 0.14.54
+      esbuild-sunos-64: 0.14.54
+      esbuild-windows-32: 0.14.54
+      esbuild-windows-64: 0.14.54
+      esbuild-windows-arm64: 0.14.54
+    dev: true
+
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
     engines: {node: '>=6'}
@@ -10904,12 +11317,12 @@ packages:
       semver-regex: 2.0.0
     dev: true
 
-  /firebase-admin/11.0.1:
+  /firebase-admin/11.0.1_@firebase+app-types@0.7.0:
     resolution: {integrity: sha512-rL3wlZbi2Kb/KJgcmj1YHlD4ZhfmhfgRO2YJialxAllm0tj1IQea878hHuBLGmv4DpbW9t9nLvX9kddNR2Y65Q==}
     engines: {node: '>=14'}
     dependencies:
       '@fastify/busboy': 1.1.0
-      '@firebase/database-compat': 0.2.4
+      '@firebase/database-compat': 0.2.4_@firebase+app-types@0.7.0
       '@firebase/database-types': 0.9.10
       '@types/node': 18.0.1
       jsonwebtoken: 8.5.1
@@ -14196,6 +14609,13 @@ packages:
       sourcemap-codec: 1.4.8
     dev: true
 
+  /magic-string/0.26.2:
+    resolution: {integrity: sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==}
+    engines: {node: '>=12'}
+    dependencies:
+      sourcemap-codec: 1.4.8
+    dev: true
+
   /make-dir/1.3.0:
     resolution: {integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==}
     engines: {node: '>=4'}
@@ -15778,6 +16198,15 @@ packages:
       picocolors: 1.0.0
       source-map-js: 1.0.2
 
+  /postcss/8.4.16:
+    resolution: {integrity: sha512-ipHE1XBvKzm5xI7hiHCZJCSugxvsdq2mPnsq5+UF+VHCjiBvtDrlxJfMBToWaP9D5XlgNmcFGqoHmUn0EYEaRQ==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.4
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+    dev: true
+
   /postcss/8.4.5:
     resolution: {integrity: sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -16775,6 +17204,11 @@ packages:
 
   /react-refresh/0.10.0:
     resolution: {integrity: sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /react-refresh/0.14.0:
+    resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
     dev: true
 
@@ -19152,6 +19586,33 @@ packages:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
+    dev: true
+
+  /vite/3.0.6:
+    resolution: {integrity: sha512-pjfsWIzfUlQME/VAmU6SsjdHkTt6WAHysuqPkHDcjzNu6IGtxDSZ/VfRYOwHaCqX4M3Ivz0kxuSfAPM6gAIX+w==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    hasBin: true
+    peerDependencies:
+      less: '*'
+      sass: '*'
+      stylus: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      less:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      esbuild: 0.14.54
+      postcss: 8.4.16
+      resolve: 1.22.1
+      rollup: 2.75.7
+    optionalDependencies:
+      fsevents: 2.3.2
     dev: true
 
   /w3c-hr-time/1.0.2:


### PR DESCRIPTION
This PR tries to start the project using vite.

Faster development environment startup allows us to launch a large number of static pages concurrently without packaging, greatly increasing the speed of automated testing in parallel.

Style9 had to be removed here due to the need for an incompatible non-standardized build-time configuration. However, the equivalent standardized code does not actually incur extra maintenance costs. The page style of the Webpack environment on this branch appears to remain normal.

Except for style9, vite requires almost no additional configuration or modification to work ([config](https://github.com/toeverything/AFFiNE/blob/78fcee5da7e7fbfde36d1a1bd5862258dbc73dd7/apps/ligo-virgo/vite.config.ts)).

Currently the cold start speed using vite is about 6s.

Try it out locally:

``` sh
pnpm vite-start:affine
```

![AD900820-0395-45AF-98A4-6562EB7D2F01](https://user-images.githubusercontent.com/7312949/184467223-4bfcacb8-2d16-4c39-83f4-79719efdedc6.png)

Known issue: workspace seems to be staying blank due to routing issues, hopefully someone can try based on this branch if interested in further solutions.