### PR TITLE
Edgeless mode > Edit text mode on dblclick

### DIFF
--- a/libs/components/board-shapes/src/editor-util/EditorUtil.tsx
+++ b/libs/components/board-shapes/src/editor-util/EditorUtil.tsx
@@ -114,10 +114,28 @@ export class EditorUtil extends TDShapeUtil<T, E> {
                 }
             }, [onShapeChange]);
 
-            const stopPropagation = useCallback(
+            let numClicks = 0;
+            const handlePointerDown = useCallback(
                 (e: SyntheticEvent) => {
-                    if (isEditing) {
+                    numClicks++;
+                    let isDblClick = false;
+                    let singleClickTimer;
+                    if (numClicks === 1) {
+                        singleClickTimer = setTimeout(() => {
+                            numClicks = 0;
+                            isDblClick = false;
+                        }, 400);
+                    } else if (numClicks === 2) {
+                        clearTimeout(singleClickTimer);
+                        numClicks = 0;
+                        isDblClick = true;
+                    }
+
+                    if (isEditing || isDblClick) {
                         e.stopPropagation();
+                    }
+                    if (isDblClick) {
+                        app.setEditingText(shape.id);
                     }
                 },
                 [isEditing]
@@ -140,7 +158,7 @@ export class EditorUtil extends TDShapeUtil<T, E> {
                     <Container
                         ref={containerRef}
                         editing={isEditing}
-                        onPointerDown={stopPropagation}
+                        onPointerDown={handlePointerDown}
                         onMouseEnter={activateIfEditing}
                         onDragEnter={activateIfEditing}
                     >


### PR DESCRIPTION
Now in edgeless mode it is very difficult to edit text.

This PR helps below:-
- Single Click allow to select text shape & ability to drag
- On double click enter the edit text mode. Now much better experience.

Default ondblclick event is not triggering due to TLDraw hijacking the pointer events. That's why used a dbl click detection logic.