### PR TITLE
fix(component): make Select close when option chosen with Enter key

### DIFF
--- a/libs/components/ui/src/select/Select.tsx
+++ b/libs/components/ui/src/select/Select.tsx
@@ -1,5 +1,6 @@
 import {
     forwardRef,
+    useState,
     type CSSProperties,
     type ForwardedRef,
     type ReactNode,
@@ -39,6 +40,7 @@ export const Select = forwardRef(function CustomSelect<TValue>(
     props: ExtendSelectProps & SelectUnstyledProps<TValue>,
     ref: ForwardedRef<HTMLUListElement>
 ) {
+    const [isOpen, setIsOpen] = useState(false);
     const { width = '100%', style, listboxStyle, placeholder } = props;
     const components: SelectUnstyledProps<TValue>['components'] = {
         // Root: generateStyledRoot({ width, ...style }),
@@ -76,7 +78,21 @@ export const Select = forwardRef(function CustomSelect<TValue>(
         ...props.components,
     };
 
-    return <SelectUnstyled {...props} ref={ref} components={components} />;
+    return (
+        <SelectUnstyled
+            listboxOpen={isOpen}
+            onListboxOpenChange={() => {
+                setIsOpen(true);
+            }}
+            {...props}
+            onChange={v => {
+                setIsOpen(false);
+                props.onChange && props.onChange(v);
+            }}
+            ref={ref}
+            components={components}
+        />
+    );
 }) as <TValue>(
     props: ExtendSelectProps &
         SelectUnstyledProps<TValue> &


### PR DESCRIPTION
When selecting a language in the code block, using arrow keys, enter selects the language but gets the drop down stuck in an open state, no clicking elsewhere can close it, you must pick another (or the same) option

Fixed by explicitly controlling the open state, though left it open for override if need be by putting it before the spread props.

BEFORE:
https://www.loom.com/share/8d1e360e18034468817be165bdb698e2

AFTER:
https://www.loom.com/share/34dd8bb52e7146d780e02a383da5919f