### PR TITLE
fix: filter empty string when getContentBetween

### DIFF
--- a/libs/components/common/src/lib/text/slate-utils.ts
+++ b/libs/components/common/src/lib/text/slate-utils.ts
@@ -605,6 +605,11 @@ class SlateUtils {
             }
             textChildren.push(child);
         }
+        // If nothing, should preserve empty string
+        // Fix Slate Cannot get the start point in the node at path [0] because it has no start text node.
+        if (!textChildren.length) {
+            textChildren.push({ text: '' });
+        }
 
         return textChildren;
     }


### PR DESCRIPTION
# Reason

Due to https://github.com/toeverything/AFFiNE/pull/198

```ts
// start
{
    "text": {
      "value": [
        {
          "text": "1111222"
        }
      ]
    }
}

// after enter
{
    "text": {
      "value": [
        {
          "text": "1111"
        }
      ]
    }
},
{
    "text": {
      "value": [
        {
          "text": "222"
        }
      ]
    }
}

// after backspace
{
    "text": {
      "value": [
        {
          "text": "1111"
        },
        {
          "text": "222"
        },
      ]
    }
}

// after enter again
{
    "text": {
      "value": [
        {
          "text": "1111"
        }
      ]
    }
},
{
    "text": {
      "value": [
        {
          "text": ""  // <-- a empty text
        },
        {
          "text": "222"
        },
      ]
    }
}
```

https://user-images.githubusercontent.com/18554747/184800616-4fab1ab7-1065-40ab-bf5f-bb10605d0379.mov


