### PR TITLE
Fix: Added seperate shortcut keys for Windows and Mac.

### DIFF
--- a/libs/components/editor-plugins/src/menu/inline-menu/config.ts
+++ b/libs/components/editor-plugins/src/menu/inline-menu/config.ts
@@ -12,12 +12,19 @@ export const INLINE_MENU_UI_TYPES = {
 } as const;
 
 /** inline menu item { key : display-name } */
-export const inlineMenuShortcuts = {
+export const MacInlineMenuShortcuts = {
     textBold: '⌘+B',
     textItalic: '⌘+I',
     textStrikethrough: '⌘+S',
     link: '⌘+K',
     [Protocol.Block.Type.code]: '⌘+E',
+};
+export const WinInlineMenuShortcuts = {
+    textBold: 'Ctrl+B',
+    textItalic: 'Ctrl+I',
+    textStrikethrough: 'Ctrl+S',
+    link: 'Ctrl+K',
+    [Protocol.Block.Type.code]: 'Ctrl+E',
 };
 export const inlineMenuNames = {
     currentText: 'TEXT SIZE',

--- a/libs/components/editor-plugins/src/menu/inline-menu/menu-item/DropdownItem.tsx
+++ b/libs/components/editor-plugins/src/menu/inline-menu/menu-item/DropdownItem.tsx
@@ -12,10 +12,12 @@ import {
 } from '@toeverything/components/common';
 import { ArrowDropDownIcon } from '@toeverything/components/icons';
 import type { DropdownItemType, WithEditorSelectionType } from '../types';
+import { uaHelper } from '@toeverything/utils';
 import {
     inlineMenuNamesKeys,
     inlineMenuNamesForFontColor,
-    inlineMenuShortcuts,
+    MacInlineMenuShortcuts,
+    WinInlineMenuShortcuts
 } from '../config';
 
 type MenuDropdownItemProps = DropdownItemType & WithEditorSelectionType;
@@ -37,7 +39,7 @@ export const MenuDropdownItem = ({
     }, []);
 
     //@ts-ignore
-    const shortcut = inlineMenuShortcuts[nameKey];
+    const shortcut = uaHelper.isMacOs ? MacInlineMenuShortcuts[nameKey] : WinInlineMenuShortcuts[nameKey];
 
     return (
         <>

--- a/libs/components/editor-plugins/src/menu/inline-menu/menu-item/IconItem.tsx
+++ b/libs/components/editor-plugins/src/menu/inline-menu/menu-item/IconItem.tsx
@@ -2,8 +2,9 @@ import React, { useCallback } from 'react';
 import style9 from 'style9';
 
 import type { IconItemType, WithEditorSelectionType } from '../types';
-import { inlineMenuNamesKeys, inlineMenuShortcuts } from '../config';
+import { inlineMenuNamesKeys, MacInlineMenuShortcuts, WinInlineMenuShortcuts } from '../config';
 import { Tooltip } from '@toeverything/components/ui';
+import { uaHelper } from '@toeverything/utils';
 type MenuIconItemProps = IconItemType & WithEditorSelectionType;
 
 export const MenuIconItem = ({
@@ -35,7 +36,7 @@ export const MenuIconItem = ({
     );
 
     //@ts-ignore
-    const shortcut = inlineMenuShortcuts[nameKey];
+    const shortcut = uaHelper.isMacOs ? MacInlineMenuShortcuts[nameKey] : WinInlineMenuShortcuts[nameKey];
 
     return (
         <Tooltip


### PR DESCRIPTION
Modified the code used for assigning shortcuts based on the OS.

Feat : Split 'inlineMenuShortcuts' to 'WinInlineMenuShortcuts' and 'MacInlineMenuShortcuts' functions

**_Fix #346_**