### PR TITLE
fix: add feature flag token to env

### DIFF
--- a/apps/ligo-virgo/webpack.config.js
+++ b/apps/ligo-virgo/webpack.config.js
@@ -170,6 +170,9 @@ module.exports = function (webpackConfig) {
         ),
         new webpack.DefinePlugin({
             JWT_DEV: !isProd,
+            'process.env.AFFINE_FEATURE_FLAG_TOKEN': JSON.stringify(
+                process.env['AFFINE_FEATURE_FLAG_TOKEN']
+            ),
             global: {},
         }),
         isProd &&


### PR DESCRIPTION
Please ensure the environment variable exists `AFFINE_FEATURE_FLAG_TOKEN` before merging.