### PR TITLE
fix: default language

### DIFF
--- a/apps/venus/src/app/common/Header.tsx
+++ b/apps/venus/src/app/common/Header.tsx
@@ -140,7 +140,7 @@ export const AFFiNEHeader = () => {
                     }}
                 />
                 <Select
-                    defaultValue={i18n.language}
+                    defaultValue={i18n.resolvedLanguage}
                     sx={{ display: matchesIPAD ? 'none' : 'intial' }}
                     onChange={changeLanguage}
                     size="md"

--- a/apps/venus/src/app/common/MobileHeader.tsx
+++ b/apps/venus/src/app/common/MobileHeader.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { LOCALES } from '../i18n';
 import AFFiNETextLogo from './affine-text-logo.png';
 
 export const MobileHeader = () => {
@@ -163,18 +164,21 @@ export const MobileHeader = () => {
                             timeout="auto"
                             unmountOnExit
                         >
-                            <ListItemButton
-                                onClick={() => i18n.changeLanguage('en')}
-                            >
-                                <ListItemText primary="English" />
-                                <Checkbox checked={i18n.language === 'en'} />
-                            </ListItemButton>
-                            <ListItemButton
-                                onClick={() => i18n.changeLanguage('zh')}
-                            >
-                                <ListItemText primary="简体中文" />
-                                <Checkbox checked={i18n.language === 'zh'} />
-                            </ListItemButton>
+                            {LOCALES.map(lang => (
+                                <ListItemButton
+                                    key={lang.tag}
+                                    onClick={() =>
+                                        i18n.changeLanguage(lang.tag)
+                                    }
+                                >
+                                    <ListItemText primary={lang.originalName} />
+                                    <Checkbox
+                                        checked={
+                                            i18n.resolvedLanguage === lang.tag
+                                        }
+                                    />
+                                </ListItemButton>
+                            ))}
                         </Collapse>
                     </List>
                 </StyledDrawerContainer>

--- a/libs/components/layout/src/settings-sidebar/Settings/SettingsList.tsx
+++ b/libs/components/layout/src/settings-sidebar/Settings/SettingsList.tsx
@@ -48,7 +48,7 @@ export const SettingsList = () => {
                         {item.key === 'Language' ? (
                             <div style={{ marginLeft: '12em' }}>
                                 <Select
-                                    defaultValue={i18n.language}
+                                    defaultValue={i18n.resolvedLanguage}
                                     onChange={changeLanguage}
                                 >
                                     {LOCALES.map(option => (


### PR DESCRIPTION
- Fix empty language select at first time
  - the `i18n.language` return `"en-US"`, but we only have `"en"` option
- Add mobile multiple languages support

<img width="428" alt="Screen Shot 2022-09-21 at 8 48 25 PM" src="https://user-images.githubusercontent.com/18554747/191507828-162424b0-1dbd-4985-8457-2441afdc684b.png">

<img width="767" alt="Screen Shot 2022-09-21 at 9 05 58 PM" src="https://user-images.githubusercontent.com/18554747/191511704-99b7aa1c-d0bf-4569-ac4b-493a4fca4be6.png">


`i18n.language` is set to the current detected or set language.

> ## resolvedLanguage
> i18next.resolvedLanguage
> Is set to the current resolved language.
> It can be used as primary used language, for example in a language switcher.

see https://www.i18next.com/overview/api#resolvedlanguage