### PR TITLE
Fix: Move cursor to end of markdown

### DIFF
--- a/libs/components/common/src/lib/text/EditableText.tsx
+++ b/libs/components/common/src/lib/text/EditableText.tsx
@@ -551,7 +551,7 @@ export const Text = forwardRef<ExtendedTextUtils, TextProps>((props, ref) => {
             }
         }
         // markdown interception
-        if (supportMarkdown && !!handleMarkdown(e)) {
+        if (supportMarkdown && handleMarkdown(e)) {
             const start_selection = utils.current.getStartSelection();
             utils.current.setSelection(start_selection);
             e.preventDefault();

--- a/libs/components/common/src/lib/text/EditableText.tsx
+++ b/libs/components/common/src/lib/text/EditableText.tsx
@@ -552,8 +552,8 @@ export const Text = forwardRef<ExtendedTextUtils, TextProps>((props, ref) => {
         }
         // markdown interception
         if (supportMarkdown && handleMarkdown(e)) {
-            const start_selection = utils.current.getStartSelection();
-            utils.current.setSelection(start_selection);
+            const endOfMarkdown = utils.current.getEndSelection();
+            utils.current.setSelection(endOfMarkdown);
             e.preventDefault();
             return true;
         }


### PR DESCRIPTION
## Description

Fixes issue #336.

TL;DR: Previously when using markdown, after hitting space and having your markdown processed, the text editor would move the cursor all the way to start. This PR keeps it at the end of the last thing processed.

## Before

https://user-images.githubusercontent.com/32908859/192921998-a549a1e8-cb39-4a07-814d-5e66c1600aa0.mov

## After

https://user-images.githubusercontent.com/32908859/192921636-c3d12b80-6a48-4f8d-8d0b-60aeaee8d67f.mov
