### PR TITLE
feat: add padding for editor

### DIFF
--- a/packages/app/src/pages/workspace/[workspaceId]/[pageId].tsx
+++ b/packages/app/src/pages/workspace/[workspaceId]/[pageId].tsx
@@ -19,6 +19,7 @@ import { usePageHelper } from '@/hooks/use-page-helper';
 const StyledEditorContainer = styled('div')(() => {
   return {
     height: 'calc(100vh - 60px)',
+    padding: '0 32px',
   };
 });
 


### PR DESCRIPTION
When the screen width is 1050px, there is no spacing between the editor and the sidebar and it looks a bit awkward.

<img width="781" alt="image" src="https://user-images.githubusercontent.com/85140972/210934276-163e11f3-c41a-4dde-a34f-d82dfa810cff.png">

This pr add padding.