### PR TITLE
fix: remove redundant package in data-center

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postinstall": "husky install",
     "notify": "node --experimental-modules scripts/notify.mjs",
     "check:ci": "pnpm lint & pnpm test",
-    "update:blocksuite": "pnpm i --filter @affine/app --filter @affine/datacenter @blocksuite/blocks@nightly @blocksuite/store@nightly @blocksuite/editor@nightly"
+    "update:blocksuite": "pnpm i --filter @affine/app --filter @affine/datacenter @blocksuite/blocks@nightly @blocksuite/store@nightly && pnpm i --filter @affine/app @blocksuite/editor@nightly"
   },
   "lint-staged": {
     "*": "prettier --write --ignore-unknown",

--- a/packages/data-center/package.json
+++ b/packages/data-center/package.json
@@ -27,7 +27,6 @@
   },
   "dependencies": {
     "@blocksuite/blocks": "0.4.0-20230111171650-bc63456",
-    "@blocksuite/editor": "0.4.0-20230111171650-bc63456",
     "@blocksuite/store": "0.4.0-20230111171650-bc63456",
     "debug": "^4.3.4",
     "encoding": "^0.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,7 +124,6 @@ importers:
   packages/data-center:
     specifiers:
       '@blocksuite/blocks': 0.4.0-20230111171650-bc63456
-      '@blocksuite/editor': 0.4.0-20230111171650-bc63456
       '@blocksuite/store': 0.4.0-20230111171650-bc63456
       '@playwright/test': ^1.29.1
       '@types/debug': ^4.1.7
@@ -142,7 +141,6 @@ importers:
       yjs: ^13.5.44
     dependencies:
       '@blocksuite/blocks': 0.4.0-20230111171650-bc63456_yjs@13.5.44
-      '@blocksuite/editor': 0.4.0-20230111171650-bc63456_yjs@13.5.44
       '@blocksuite/store': 0.4.0-20230111171650-bc63456_yjs@13.5.44
       debug: 4.3.4
       encoding: 0.1.13


### PR DESCRIPTION
@blocksuite/editor is not needed in data-center, I removed the dependency and changed update BlockSuite script accordingly