### PR TITLE
fix: submenu dark theme hover background theming

### DIFF
--- a/packages/component/src/styles/theme.ts
+++ b/packages/component/src/styles/theme.ts
@@ -95,7 +95,7 @@ export const getDarkTheme = (
       primaryColor: '#6880FF',
       pageBackground: '#2c2c2c',
       hoverBackground: '#3C3C42',
-      innerHoverBackground: '#E0E6FF',
+      innerHoverBackground: '#5A5A5A',
       popoverBackground: '#1F2021',
       tooltipBackground: '#1F2021',
       codeBackground:


### PR DESCRIPTION
Preview:
<img width="304" alt="螢幕截圖 2023-01-23 上午1 15 07" src="https://user-images.githubusercontent.com/12156547/213929875-2083f6d4-66bb-4692-a076-d6aecacaf866.png">
When there is a submenu, the old hovering color was considered too bright in dark theme. This PR can mitigate this issue by changing to a color with less brightness.