### PR TITLE
fix: client not saving avatar blob on first creating workspace

### DIFF
--- a/packages/data-center/src/provider/tauri-ipc/index.ts
+++ b/packages/data-center/src/provider/tauri-ipc/index.ts
@@ -10,10 +10,11 @@ import {
 import { Workspace as BlocksuiteWorkspace } from '@blocksuite/store';
 import { IPCBlobProvider } from './blocksuite-provider/blob.js';
 import type { WorkspaceUnit } from 'src/workspace-unit.js';
-import { createWorkspaceUnit, loadWorkspaceUnit } from '../local/utils.js';
+import { loadWorkspaceUnit } from '../local/utils.js';
 import { WorkspaceWithPermission } from './ipc/types/workspace.js';
 import { applyUpdate } from '../../utils/index.js';
 import { User } from 'src/types/index.js';
+import { createWorkspaceUnit } from './utils.js';
 
 /**
  * init - createUser - create first workspace and ydoc - loadWorkspace - return the first workspace - wrapWorkspace - #initDocFromIPC - applyUpdate - on('update') - updateYDocument

--- a/packages/data-center/src/provider/tauri-ipc/utils.ts
+++ b/packages/data-center/src/provider/tauri-ipc/utils.ts
@@ -1,0 +1,25 @@
+import { WorkspaceUnit } from '../../workspace-unit.js';
+import type { WorkspaceUnitCtorParams } from '../../workspace-unit';
+import { createBlocksuiteWorkspace } from '../../utils/index.js';
+import { setDefaultAvatar } from '../utils.js';
+import { IPCBlobProvider } from './blocksuite-provider/blob.js';
+
+export const createWorkspaceUnit = async (params: WorkspaceUnitCtorParams) => {
+  const workspaceUnit = new WorkspaceUnit(params);
+
+  const blocksuiteWorkspace = createBlocksuiteWorkspace(workspaceUnit.id, {
+    blobOptionsGetter: (k: string) => undefined,
+  });
+  blocksuiteWorkspace.meta.setName(workspaceUnit.name);
+  (await blocksuiteWorkspace.blobs)?.setProvider(
+    await IPCBlobProvider.init(workspaceUnit.id)
+  );
+  if (!workspaceUnit.avatar) {
+    await setDefaultAvatar(blocksuiteWorkspace);
+    workspaceUnit.update({ avatar: blocksuiteWorkspace.meta.avatar });
+  }
+
+  workspaceUnit.setBlocksuiteWorkspace(blocksuiteWorkspace);
+
+  return workspaceUnit;
+};


### PR DESCRIPTION
This will cause "Failed to read blob file /t5GGutpCXHqh53U8jt1ozHAKhcf2DaQZGSGLzwp6mUU=" on the console.