### PR TITLE
fix: position is set to relative is needed in wrapper of editor-container

### DIFF
--- a/apps/web/src/components/editor/index.tsx
+++ b/apps/web/src/components/editor/index.tsx
@@ -6,6 +6,7 @@ import { styled } from '@affine/component';
 
 const StyledEditorContainer = styled('div')(() => {
   return {
+    position: 'relative',
     height: 'calc(100vh - 60px)',
     padding: '0 32px',
   };


### PR DESCRIPTION
Related to https://github.com/toeverything/blocksuite/commit/2776d93b2322162ed401a6e0db4b0c2aecddd152.

drag handle is be the same level with editor-container.