### PR TITLE
fix: on token invalidation it shall be redirected to home page

### DIFF
--- a/apps/web/src/components/message-center-handler/index.tsx
+++ b/apps/web/src/components/message-center-handler/index.tsx
@@ -25,6 +25,7 @@ export function MessageCenterHandler({
           //
           // fix: a better option is to keep loading the app, and prompt the user to login
           // or perhaps displaying page 401?
+          await router.push('/');
           router.reload();
         }
       });


### PR DESCRIPTION
tested locally by following steps:
- login app
- change `affine:token` in localstorage to an invalid one
- refresh page
- `/api/user/token` reports 400 and following load workspace calls will fail with 401
- on 401 error, the page will be redirected to the home page ('/')

this and https://github.com/toeverything/AFFiNE/pull/770 should fix https://github.com/toeverything/AFFiNE/issues/932
