### PR TITLE
fix: `zh-Hans` i18n fails on page reload

### DIFF
--- a/.github/workflows/languages-sync.yml
+++ b/.github/workflows/languages-sync.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'packages/i18n/**'
       - '.github/workflows/languages-sync.yml'
-  pull_request:
+  pull_request_target:
     branches: ['master']
     paths:
       - 'packages/i18n/**'

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -33,7 +33,7 @@ const resources = LOCALES.reduce<Resource>(
 
 const fallbackLng = 'en';
 const standardizeLocale = (language: string) => {
-  if (language === 'zh-CN' || language === 'zh') {
+  if (language === 'zh-CN' || language === 'zh' || language === 'zh-Hans') {
     language = 'zh-Hans';
   } else if (language.slice(0, 2).toLowerCase() === 'zh') {
     language = 'zh-Hant';


### PR DESCRIPTION
Steps to reproduce:

1. switch to "简体中文"
2. fefresh page

expect: "简体中文"
received: 'en'