### PR TITLE
Search hotkey prevent default

### DIFF
--- a/apps/web/src/components/quick-search/index.tsx
+++ b/apps/web/src/components/quick-search/index.tsx
@@ -49,6 +49,8 @@ export const QuickSearch = ({ open, onClose }: TransitionsModalProps) => {
     const down = (e: KeyboardEvent) => {
       if ((e.key === 'k' && e.metaKey) || (e.key === 'k' && e.ctrlKey)) {
         const selection = window.getSelection();
+        // prevent search bar focus in firefox
+        e.preventDefault();
         setQuery('');
         if (selection?.toString()) {
           triggerQuickSearchModal(false);


### PR DESCRIPTION
Ctrl + k is the default Firefox shortcut to focus the search bar. The default behavior should be prevented.