### PR TITLE
ci: setup pnpm from corepack config to avoid flaky lockfile

### DIFF
--- a/.github/workflows/build-test-version.yml
+++ b/.github/workflows/build-test-version.yml
@@ -23,13 +23,11 @@ jobs:
     environment: development
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 'latest'
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           registry-url: https://npm.pkg.github.com
@@ -98,7 +96,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,14 @@ jobs:
     environment: development
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 'latest'
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'pnpm'
 
       - name: Restore cache
         uses: actions/cache@v3
@@ -73,8 +72,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 'latest'
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18.x
@@ -131,13 +129,11 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 'latest'
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           registry-url: https://npm.pkg.github.com
@@ -199,7 +195,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/changlog.yml
+++ b/.github/workflows/changlog.yml
@@ -20,13 +20,11 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 'latest'
 
       - name: Use Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 18.x
           registry-url: https://npm.pkg.github.com

--- a/.github/workflows/client-app.yml
+++ b/.github/workflows/client-app.yml
@@ -34,7 +34,7 @@ jobs:
       RELEASE_UPLOAD_ID: ${{ steps.create_release.outputs.id }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Query version number
         id: get_version
         shell: bash
@@ -72,29 +72,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev libappindicator3-dev librsvg2-dev patchelf
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
+          cache: 'pnpm'
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
-      - name: Install pnpm
-        uses: pnpm/action-setup@v2
-        with:
-          version: latest
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - name: Get npm cache directory
-        uses: actions/cache@v3
-        id: cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+
       - name: Get rust cache
         uses: Swatinem/rust-cache@v2
         id: rust-cache

--- a/.github/workflows/languages-sync.yml
+++ b/.github/workflows/languages-sync.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Use pnpm
         uses: pnpm/action-setup@v2
-        with:
-          version: 7
 
       - name: Use Node.js ${{ matrix.node-version }}
         # https://github.com/actions/setup-node

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,10 +19,8 @@ jobs:
     environment: development
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
-        with:
-          version: 'latest'
 
       - name: Use Node.js
         uses: actions/setup-node@v2
@@ -82,7 +80,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download artifact
         uses: actions/download-artifact@v3

--- a/.github/workflows/update-block-suite.yml
+++ b/.github/workflows/update-block-suite.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Use pnpm
         uses: pnpm/action-setup@v2
-        with:
-          version: 7
 
       - name: Use Node.js 18
         # https://github.com/actions/setup-node

--- a/package.json
+++ b/package.json
@@ -65,5 +65,6 @@
     "patchedDependencies": {
       "@tauri-apps/api@1.2.0": "patches/@tauri-apps__api@1.2.0.patch"
     }
-  }
+  },
+  "packageManager": "pnpm@7.28.0"
 }


### PR DESCRIPTION
Ref: https://github.com/pnpm/action-setup#version

Everyone should run `corepack prepare` && `corepack enable` locally before modifying `pnpm-lock.yaml`