### PR TITLE
chore: replace cross-env with shell-emulator & misc

### DIFF
--- a/.github/workflows/client-app.yml
+++ b/.github/workflows/client-app.yml
@@ -86,10 +86,8 @@ jobs:
             apps/desktop/src-tauri
 
       - name: Make App Binary
-        run: pnpm build:app
-        working-directory: apps/desktop
+        run: pnpm build:client
         env:
-          CI: true
           CI_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ yarn-error.log
 testem.log
 .pnpm-debug.log
 /typings
+tsconfig.tsbuildinfo
 
 # System Files
 .DS_Store

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shell-emulator=true

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -6,7 +6,7 @@
   "license": "MPL-2.0",
   "module": "true",
   "scripts": {
-    "dev:app": "cross-env NODE_ENV=development tauri dev",
+    "dev:app": "NODE_ENV=development tauri dev",
     "dev:web": "pnpm --filter @affine/app dev",
     "build:rs-types": "zx scripts/generateTsTypingsFromJsonSchema.mjs",
     "build:affine": "zx scripts/buildAffine.mjs",
@@ -34,8 +34,6 @@
     "@types/node": "^18.14.4",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
-    "concurrently": "^7.6.0",
-    "cross-env": "^7.0.3",
     "esbuild": "^0.17.8",
     "lit": "^2.6.1",
     "prettier": "2.8.4",

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -93,8 +93,8 @@ pub async fn create_workspace<'s>(
 
 #[tauri::command]
 pub async fn update_workspace<'s>(
-  state: tauri::State<'s, AppState>,
-  parameters: UpdateWorkspace,
+  _state: tauri::State<'s, AppState>,
+  _parameters: UpdateWorkspace,
 ) -> Result<bool, String> {
   // TODO: check user permission
   // No thing to update now. The avatar is update in YDoc using websocket or yrs.update

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -1,5 +1,4 @@
 use cloud_database::SqliteDBContext;
-use jwst::Workspace;
 use jwst_storage::{BlobAutoStorage, DocAutoStorage};
 use std::{fs, path::Path};
 use tauri::api::path::document_dir;

--- a/apps/web/src/hooks/__tests__/use-blocksuite-workspace-helper.spec.ts
+++ b/apps/web/src/hooks/__tests__/use-blocksuite-workspace-helper.spec.ts
@@ -16,7 +16,7 @@ let blockSuiteWorkspace: BlockSuiteWorkspace;
 
 beforeEach(() => {
   blockSuiteWorkspace = new BlockSuiteWorkspace({
-    room: 'test',
+    id: 'test',
   })
     .register(builtInSchemas)
     .register(__unstableSchemas);

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "license": "MPL-2.0",
   "scripts": {
     "dev": "pnpm --filter @affine/app dev",
-    "dev:ac": "cross-env NODE_API_SERVER=ac pnpm --filter @affine/app dev",
-    "dev:local": "cross-env NODE_API_SERVER=local pnpm --filter @affine/app dev",
+    "dev:ac": "NODE_API_SERVER=ac pnpm --filter @affine/app dev",
+    "dev:local": "NODE_API_SERVER=local pnpm --filter @affine/app dev",
     "build": "pnpm --filter @affine/app build",
     "build:client": "pnpm --filter @affine/client-app build:app",
     "build:storybook": "pnpm -r build-storybook",
@@ -16,17 +16,17 @@
     "lint": "eslint . --ext .js,mjs,.ts,.tsx",
     "lint:fix": "pnpm lint --fix",
     "test": "playwright test",
-    "test:coverage": "cross-env COVERAGE=true pnpm test -- --forbid-only",
+    "test:coverage": "COVERAGE=true pnpm test -- --forbid-only",
     "test:unit": "vitest --run",
     "test:unit:ui": "vitest --ui",
     "test:unit:coverage": "vitest run --coverage",
     "postinstall": "husky install",
     "notify": "node scripts/notify.mjs",
-    "update:core": "pnpm up @blocksuite/*@nightly !@blocksuite/icons -r"
+    "update:core": "pnpm up '@blocksuite/*@nightly' !@blocksuite/icons -r"
   },
   "lint-staged": {
     "*": "prettier --write --ignore-unknown",
-    "*.{ts,tsx,js,jsx}": "npx eslint --cache --fix"
+    "*.{ts,tsx,js,jsx}": "eslint --cache --fix"
   },
   "devDependencies": {
     "@perfsee/sdk": "^1.3.0",
@@ -39,8 +39,6 @@
     "@vitejs/plugin-react": "^3.1.0",
     "@vitest/coverage-istanbul": "^0.28.5",
     "@vitest/ui": "^0.29.2",
-    "concurrently": "^7.6.0",
-    "cross-env": "^7.0.3",
     "eslint": "^8.35.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-import": "^2.27.5",

--- a/packages/component/src/stories/BlockSuiteEditor.stories.tsx
+++ b/packages/component/src/stories/BlockSuiteEditor.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from '../components/BlockSuiteEditor';
 
 const workspace = new Workspace({
-  room: 'test',
+  id: 'test',
   providers: [],
   isSSR: typeof window === 'undefined',
 }).register(builtInSchemas);

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -51,6 +51,12 @@ export type Environment = Browser | Server | Desktop;
 
 let environment: Environment | null = null;
 
+declare global {
+  interface Window {
+    CLIENT_APP?: boolean;
+  }
+}
+
 export function getEnvironment() {
   if (environment) {
     return environment;

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,6 @@ importers:
       '@vitejs/plugin-react': ^3.1.0
       '@vitest/coverage-istanbul': ^0.28.5
       '@vitest/ui': ^0.29.2
-      concurrently: ^7.6.0
-      cross-env: ^7.0.3
       eslint: ^8.35.0
       eslint-config-prettier: ^8.6.0
       eslint-plugin-import: ^2.27.5
@@ -55,8 +53,6 @@ importers:
       '@vitejs/plugin-react': 3.1.0_vite@4.1.4
       '@vitest/coverage-istanbul': 0.28.5_oscpa7jhv6f2pwrg7t4qxe6ngi
       '@vitest/ui': 0.29.2
-      concurrently: 7.6.0
-      cross-env: 7.0.3
       eslint: 8.35.0
       eslint-config-prettier: 8.6.0_eslint@8.35.0
       eslint-plugin-import: 2.27.5_ajyizmi44oc3hrc35l6ndh7p4e
@@ -91,8 +87,6 @@ importers:
       '@types/node': ^18.14.4
       '@types/react': ^18.0.28
       '@types/react-dom': ^18.0.11
-      concurrently: ^7.6.0
-      cross-env: ^7.0.3
       esbuild: ^0.17.8
       json-schema-to-typescript: ^11.0.5
       lib0: ^0.2.63
@@ -128,8 +122,6 @@ importers:
       '@types/node': 18.14.4
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
-      concurrently: 7.6.0
-      cross-env: 7.0.3
       esbuild: 0.17.10
       lit: 2.6.1
       prettier: 2.8.4
@@ -5372,7 +5364,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.21.0
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.4_@types+node@18.14.4
+      vite: 4.1.4
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6416,15 +6408,6 @@ packages:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  /cliui/8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: true
-
   /clone-deep/4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
@@ -6548,22 +6531,6 @@ packages:
       typedarray: 0.0.6
     dev: true
 
-  /concurrently/7.6.0:
-    resolution: {integrity: sha512-BKtRgvcJGeZ4XttiDiNcFiRlxoAeZOseqUvyYRUp/Vtd+9p1ULmeoSqGsDA+2ivdeDFpqrJvGvmI+StKfKl5hw==}
-    engines: {node: ^12.20.0 || ^14.13.0 || >=16.0.0}
-    hasBin: true
-    dependencies:
-      chalk: 4.1.2
-      date-fns: 2.29.3
-      lodash: 4.17.21
-      rxjs: 7.8.0
-      shell-quote: 1.8.0
-      spawn-command: 0.0.2-1
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.6.2
-    dev: true
-
   /console-control-strings/1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
@@ -6630,14 +6597,6 @@ packages:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
     dev: true
 
-  /cross-env/7.0.3:
-    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
-    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
-    hasBin: true
-    dependencies:
-      cross-spawn: 7.0.3
-    dev: true
-
   /cross-fetch/3.1.5:
     resolution: {integrity: sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==}
     dependencies:
@@ -6687,11 +6646,6 @@ packages:
   /data-uri-to-buffer/4.0.0:
     resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
     engines: {node: '>= 12'}
-
-  /date-fns/2.29.3:
-    resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
-    engines: {node: '>=0.11'}
-    dev: true
 
   /dayjs/1.11.7:
     resolution: {integrity: sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==}
@@ -11517,10 +11471,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shell-quote/1.8.0:
-    resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
-    dev: true
-
   /shelljs/0.8.5:
     resolution: {integrity: sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==}
     engines: {node: '>=4'}
@@ -11659,10 +11609,6 @@ packages:
 
   /space-separated-tokens/1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
-    dev: true
-
-  /spawn-command/0.0.2-1:
-    resolution: {integrity: sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==}
     dev: true
 
   /spawn-wrap/2.0.0:
@@ -12206,11 +12152,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       punycode: 2.1.1
-    dev: true
-
-  /tree-kill/1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
     dev: true
 
   /ts-dedent/2.2.0:
@@ -13185,11 +13126,6 @@ packages:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
 
-  /yargs-parser/21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-    dev: true
-
   /yargs/15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
@@ -13218,19 +13154,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-
-  /yargs/17.6.2:
-    resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-    dev: true
 
   /yauzl/2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -44,9 +44,6 @@
       "path": "./packages/i18n"
     },
     {
-      "path": "./packages/logger"
-    },
-    {
       "path": "./packages/env"
     }
   ],


### PR DESCRIPTION
This PR removes the usage of cross-env in favor of the pnpm shell-emulator.

refs: vitejs/vite#10023

