### PR TITLE
fix: globalThis.editor undefined

### DIFF
--- a/apps/web/src/components/blocksuite/header/header-right-items/EditorOptionMenu.tsx
+++ b/apps/web/src/components/blocksuite/header/header-right-items/EditorOptionMenu.tsx
@@ -84,7 +84,7 @@ export const EditorOptionMenu = () => {
             <MenuItem
               onClick={() => {
                 // @ts-expect-error
-                globalThis.editor.contentParser.onExportHtml();
+                globalThis.currentEditor.contentParser.onExportHtml();
               }}
               icon={<ExportToHtmlIcon />}
               iconSize={[20, 20]}
@@ -94,7 +94,7 @@ export const EditorOptionMenu = () => {
             <MenuItem
               onClick={() => {
                 // @ts-expect-error
-                globalThis.editor.contentParser.onExportMarkdown();
+                globalThis.currentEditor.contentParser.onExportMarkdown();
               }}
               icon={<ExportToMarkdownIcon />}
               iconSize={[20, 20]}


### PR DESCRIPTION
To fix this [Could not export as markdown](https://github.com/toeverything/AFFiNE/issues/1588).