### PR TITLE
fix: fix windows release not found

### DIFF
--- a/.github/workflows/client-app.yml
+++ b/.github/workflows/client-app.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Save windows artifacts
         run: |
           mkdir -p builds
-          mv apps/electron/out/make/zip/win32/x64/AFFiNE-win32-x64-0.0.0.zip ./builds/affine-windows-x64-${{ github.event.inputs.version }}.zip
+          mv apps/electron/out/make/zip/win32/x64/AFFiNE-win32-x64-${{ github.event.inputs.version }}.zip ./builds/affine-windows-x64-${{ github.event.inputs.version }}.zip
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
@@ -220,4 +220,3 @@ jobs:
             ./RELEASES
             ./*.AppImage
             ./*.apk
-            ./*.zip


### PR DESCRIPTION
before: duplicate rules will trigger upload twice but will delete after uploaded the first time

![image](https://user-images.githubusercontent.com/4948120/226160773-1a9c64cc-6ad4-43de-a93a-d5644c55c771.png)

after:

https://github.com/toeverything/AFFiNE/actions/runs/4459528720
https://github.com/toeverything/AFFiNE/releases/tag/untagged-ae7937bcf4e84127959d
