### PR TITLE
fix: remove duplicated link css

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -155,13 +155,6 @@ body {
   background: #fff;
   overflow: hidden;
 }
-a,
-a:hover {
-  color: var(--affine-link-color);
-}
-a:visited {
-  color: var(--affine-link-visited-color);
-}
 
 input {
   border: none;


### PR DESCRIPTION
Link CSS has been declared in `affine-link` 

![Screenshot 2023-03-21 at 12 50 44 PM](https://user-images.githubusercontent.com/18554747/226521427-58c9ea66-b115-4c66-ad68-1012d197fb43.png)
