### PR TITLE
build: MacOS code signing

### DIFF
--- a/.github/workflows/release-desktop-app.yml
+++ b/.github/workflows/release-desktop-app.yml
@@ -168,16 +168,12 @@ jobs:
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
 
       - name: make build
-        run: yarn make-macos-x64
+        run: yarn make-macos-arm64
         working-directory: apps/electron
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-
-      - name: make build
-        run: yarn make-macos-arm64
-        working-directory: apps/electron
 
       - name: Save arm64 artifacts
         run: |

--- a/.github/workflows/release-desktop-app.yml
+++ b/.github/workflows/release-desktop-app.yml
@@ -99,7 +99,7 @@ jobs:
         run: cp ./packages/octobase-node/octobase.*.node ./apps/electron/dist/layers/main/
 
       - name: Signing By Apple Developer ID
-        uses: apple-actions/import-codesign-certs@v1
+        uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
@@ -162,7 +162,7 @@ jobs:
         run: cp ./packages/octobase-node/octobase.*.node ./apps/electron/dist/layers/main/
 
       - name: Signing By Apple Developer ID
-        uses: apple-actions/import-codesign-certs@v1
+        uses: apple-actions/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
           p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}

--- a/.github/workflows/release-desktop-app.yml
+++ b/.github/workflows/release-desktop-app.yml
@@ -98,9 +98,19 @@ jobs:
       - name: move octobase Binary
         run: cp ./packages/octobase-node/octobase.*.node ./apps/electron/dist/layers/main/
 
+      - name: Signing By Apple Developer ID
+        uses: apple-actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
+
       - name: make build
         run: yarn make-macos-x64
         working-directory: apps/electron
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Save x64 artifacts
         run: |
@@ -150,6 +160,20 @@ jobs:
 
       - name: move octobase Binary
         run: cp ./packages/octobase-node/octobase.*.node ./apps/electron/dist/layers/main/
+
+      - name: Signing By Apple Developer ID
+        uses: apple-actions/import-codesign-certs@v1
+        with:
+          p12-file-base64: ${{ secrets.CERTIFICATES_P12 }}
+          p12-password: ${{ secrets.CERTIFICATES_P12_PASSWORD }}
+
+      - name: make build
+        run: yarn make-macos-x64
+        working-directory: apps/electron
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: make build
         run: yarn make-macos-arm64

--- a/apps/electron/forge.config.js
+++ b/apps/electron/forge.config.js
@@ -2,6 +2,16 @@ module.exports = {
   packagerConfig: {
     name: 'AFFiNE',
     icon: './resources/icons/icon.icns',
+    osxSign: {
+      identity: 'Developer ID Application: TOEVERYTHING PTE. LTD.',
+      'hardened-runtime': true,
+    }, // object must exist even if empty
+    osxNotarize: {
+      tool: 'notarytool',
+      appleId: process.env.APPLE_ID,
+      appleIdPassword: process.env.APPLE_PASSWORD,
+      teamId: process.env.APPLE_TEAM_ID,
+    },
   },
   makers: [
     {

--- a/apps/electron/yarn.lock
+++ b/apps/electron/yarn.lock
@@ -5552,6 +5552,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@toeverything/hooks@workspace:../../packages/hooks":
+  version: 0.0.0-use.local
+  resolution: "@toeverything/hooks@workspace:../../packages/hooks"
+  languageName: unknown
+  linkType: soft
+
 "@toeverything/y-indexeddb@workspace:*, @toeverything/y-indexeddb@workspace:../../packages/y-indexeddb":
   version: 0.0.0-use.local
   resolution: "@toeverything/y-indexeddb@workspace:../../packages/y-indexeddb"


### PR DESCRIPTION
fix https://github.com/toeverything/AFFiNE/issues/1509

Successful build at https://github.com/pengx17/AFFiNE/actions/runs/4598337291

References:
- [Logseq's code signing workflow](https://github.com/logseq/logseq/actions/runs/4575859183/jobs/8079439397)
- https://www.codiga.io/blog/notarize-sign-electron-app/
- https://www.electronforge.io/guides/code-signing/code-signing-macos
 

Requires to set the following new secrets:
![image](https://user-images.githubusercontent.com/584378/229562677-e43e8c5e-6fae-43f9-90b9-4ba5466b2af2.png)

