### PR TITLE
fix: dnd workspace list will cause page to reload

### DIFF
--- a/apps/web/src/components/pure/workspace-list-modal/index.tsx
+++ b/apps/web/src/components/pure/workspace-list-modal/index.tsx
@@ -29,6 +29,7 @@ import {
 } from './styles';
 
 interface WorkspaceModalProps {
+  disabled?: boolean;
   user: AccessTokenMessage | null;
   workspaces: AllWorkspace[];
   currentWorkspaceId: AllWorkspace['id'] | null;
@@ -43,6 +44,7 @@ interface WorkspaceModalProps {
 }
 
 export const WorkspaceListModal = ({
+  disabled,
   open,
   onClose,
   workspaces,
@@ -96,6 +98,7 @@ export const WorkspaceListModal = ({
 
         <StyledModalContent>
           <WorkspaceList
+            disabled={disabled}
             items={workspaces}
             currentWorkspaceId={currentWorkspaceId}
             onClick={onClickWorkspace}

--- a/apps/web/src/layouts/index.tsx
+++ b/apps/web/src/layouts/index.tsx
@@ -2,11 +2,11 @@ import { DebugLogger } from '@affine/debug';
 import { config } from '@affine/env';
 import { setUpLanguage, useTranslation } from '@affine/i18n';
 import { createAffineGlobalChannel } from '@affine/workspace/affine/sync';
-import { jotaiWorkspacesAtom } from '@affine/workspace/atom';
+import { jotaiStore, jotaiWorkspacesAtom } from '@affine/workspace/atom';
 import { WorkspaceFlavour } from '@affine/workspace/type';
 import { assertExists, nanoid } from '@blocksuite/store';
 import { NoSsr } from '@mui/material';
-import { useAtom, useAtomValue } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import dynamic from 'next/dynamic';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
@@ -123,6 +123,46 @@ export const WorkspaceLayout: FC<PropsWithChildren> =
     useCreateFirstWorkspace();
     const currentWorkspaceId = useAtomValue(currentWorkspaceIdAtom);
     const jotaiWorkspaces = useAtomValue(jotaiWorkspacesAtom);
+    const set = useSetAtom(jotaiWorkspacesAtom);
+    useEffect(() => {
+      logger.info('mount');
+      const controller = new AbortController();
+      const lists = Object.values(WorkspacePlugins)
+        .sort((a, b) => a.loadPriority - b.loadPriority)
+        .map(({ CRUD }) => CRUD.list);
+
+      async function fetch() {
+        const jotaiWorkspaces = jotaiStore.get(jotaiWorkspacesAtom);
+        const items = [];
+        for (const list of lists) {
+          try {
+            const item = await list();
+            if (jotaiWorkspaces.length) {
+              item.sort((a, b) => {
+                return (
+                  jotaiWorkspaces.findIndex(x => x.id === a.id) -
+                  jotaiWorkspaces.findIndex(x => x.id === b.id)
+                );
+              });
+            }
+            items.push(...item.map(x => ({ id: x.id, flavour: x.flavour })));
+          } catch (e) {
+            logger.error('list data error:', e);
+          }
+        }
+        if (controller.signal.aborted) {
+          return;
+        }
+        set([...items]);
+        logger.info('mount first data:', items);
+      }
+
+      fetch();
+      return () => {
+        controller.abort();
+        logger.info('unmount');
+      };
+    }, [set]);
 
     useEffect(() => {
       const flavour = jotaiWorkspaces.find(

--- a/apps/web/src/providers/ModalProvider.tsx
+++ b/apps/web/src/providers/ModalProvider.tsx
@@ -4,7 +4,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import type React from 'react';
-import { useCallback } from 'react';
+import { useCallback, useTransition } from 'react';
 
 import {
   currentWorkspaceIdAtom,
@@ -45,10 +45,12 @@ export function Modals() {
   const currentWorkspaceId = useAtomValue(currentWorkspaceIdAtom);
   const [, setCurrentWorkspace] = useCurrentWorkspace();
   const { createLocalWorkspace } = useWorkspacesHelper();
+  const [transitioning, transition] = useTransition();
 
   return (
     <>
       <WorkspaceListModal
+        disabled={transitioning}
         user={user}
         workspaces={workspaces}
         currentWorkspaceId={currentWorkspaceId}
@@ -60,8 +62,10 @@ export function Modals() {
           (activeId, overId) => {
             const oldIndex = workspaces.findIndex(w => w.id === activeId);
             const newIndex = workspaces.findIndex(w => w.id === overId);
-            setWorkspaces(workspaces =>
-              arrayMove(workspaces, oldIndex, newIndex)
+            transition(() =>
+              setWorkspaces(workspaces =>
+                arrayMove(workspaces, oldIndex, newIndex)
+              )
             );
           },
           [setWorkspaces, workspaces]

--- a/packages/component/src/components/workspace-list/index.tsx
+++ b/packages/component/src/components/workspace-list/index.tsx
@@ -12,6 +12,7 @@ import type { FC } from 'react';
 import { WorkspaceCard } from '../workspace-card';
 
 export type WorkspaceListProps = {
+  disabled?: boolean;
   currentWorkspaceId: string | null;
   items: (AffineWorkspace | LocalWorkspace)[];
   onClick: (workspace: AffineWorkspace | LocalWorkspace) => void;
@@ -27,11 +28,13 @@ const SortableWorkspaceItem: FC<
   const { setNodeRef, attributes, listeners, transform } = useSortable({
     id: props.item.id,
   });
-  const style = transform
-    ? {
-        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
-      }
-    : undefined;
+  const style: React.CSSProperties = {
+    transform: transform
+      ? `translate3d(${transform.x}px, ${transform.y}px, 0)`
+      : undefined,
+    pointerEvents: props.disabled ? 'none' : undefined,
+    opacity: props.disabled ? 0.6 : undefined,
+  };
   return (
     <div
       data-testid="draggable-item"


### PR DESCRIPTION
Use `useTransition` to get rid of reloading issue when rearranging workspaces


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e07770a</samp>

### Summary
🚫🔧🔄

<!--
1.  🚫 - This emoji represents the `disabled` prop and the improved user experience when the modal is transitioning. It conveys the idea of blocking or preventing something from happening.
2.  🔧 - This emoji represents the refactoring of the logic for fetching and setting the workspaces data. It conveys the idea of fixing or improving something.
3.  🔄 - This emoji represents the transition effect for the workspace list modal. It conveys the idea of changing or updating something.
-->
This pull request improves the user interface and performance of the workspace list modal component. It adds a `disabled` prop and a transition effect to the modal, and refactors the workspaces data fetching logic to a separate component. It also updates the `WorkspaceList` component to accept a `disabled` prop.

> _We are the masters of the modal_
> _We control the transition and the flow_
> _We disable the list when we need to_
> _We refactor the atom with our code_

### Walkthrough
*  Add `disabled` prop to `WorkspaceList` and `WorkspaceListItem` components to disable drag and drop and opacity when transitioning ([link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-f000449c2c7baaa608e6b74f948d89470f0b0decfaeb02e932e736d935970edbR32), [link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-f000449c2c7baaa608e6b74f948d89470f0b0decfaeb02e932e736d935970edbR47), [link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-f000449c2c7baaa608e6b74f948d89470f0b0decfaeb02e932e736d935970edbR101), [link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-a6156ee3bbe215da9a8ef758d1514a4dcaf7b0f82bcb6a36b098124290a4f0bdR15), [link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-a6156ee3bbe215da9a8ef758d1514a4dcaf7b0f82bcb6a36b098124290a4f0bdL30-R37))
*  Use `useTransition` hook to create a transition state and function for the `WorkspaceListModal` component and pass it to the `WorkspaceList` component as the `disabled` prop ([link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-d4b6f5432724b623be0ce5a944dfc66c22e85ede3c43983e6c810a18d308340cL7-R7), [link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-d4b6f5432724b623be0ce5a944dfc66c22e85ede3c43983e6c810a18d308340cL48-R53))
*  Wrap the `setWorkspaces` function with the `transition` function to update the workspaces order after a drag and drop action without unmounting or remounting the modal component ([link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-d4b6f5432724b623be0ce5a944dfc66c22e85ede3c43983e6c810a18d308340cL63-R68))
*  Move the workspaces data fetching and setting logic from `WorkspaceListModal` to a separate component `WorkspacesSuspense` in `./apps/web/src/layouts/index.tsx` ([link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-9ee125086a7f445c18b4a28e6d9cfccfaf490986a35a6fc090fc0f42ef1f9bfbL5-R9), [link](https://github.com/toeverything/AFFiNE/pull/1848/files?diff=unified&w=0#diff-9ee125086a7f445c18b4a28e6d9cfccfaf490986a35a6fc090fc0f42ef1f9bfbL126-R126))

