### PR TITLE
fix: force to use powershell on windows to fix zx script crash

### DIFF
--- a/apps/electron/scripts/generate-assets.mjs
+++ b/apps/electron/scripts/generate-assets.mjs
@@ -29,6 +29,10 @@ console.log('build with following dir', {
 await cleanup();
 echo('Clean up done');
 
+if (process.platform === 'win32') {
+  $.shell = 'powershell.exe';
+  $.prefix = '';
+}
 // step 1: build web (nextjs) dist
 cd(repoRootDir);
 await $`yarn add`;


### PR DESCRIPTION
fix https://github.com/toeverything/AFFiNE/issues/1960

There are two options to fix this issue:

1. just use git bash on windows https://gitforwindows.org/
2. force zx to read powershell as execute shell env