### PR TITLE
chore: disable slider bar link item drag

### DIFF
--- a/apps/web/src/components/pure/workspace-slider-bar/style.ts
+++ b/apps/web/src/components/pure/workspace-slider-bar/style.ts
@@ -69,6 +69,12 @@ export const StyledLink = styled(Link)(() => {
     ':visited': {
       color: 'inherit',
     },
+    userDrag: 'none',
+    userSelect: 'none',
+    appRegion: 'no-drag',
+    '-webkit-user-select': 'none',
+    '-webkit-user-drag': 'none',
+    '-webkit-app-region': 'no-drag',
   };
 });
 export const StyledNewPageButton = styled('button')(({ theme }) => {


### PR DESCRIPTION
Using some css properties that are not very compatible may be risky.