### PR TITLE
build: fix electron build gain focus on reloading in dev

### DIFF
--- a/apps/electron/layers/main/src/main-window.ts
+++ b/apps/electron/layers/main/src/main-window.ts
@@ -8,6 +8,7 @@ import { isMacOS } from '../../utils';
 const IS_DEV = process.env.NODE_ENV === 'development';
 
 async function createWindow() {
+  logger.info('create window');
   const mainWindowState = electronWindowState({
     defaultWidth: 1000,
     defaultHeight: 800,
@@ -46,7 +47,14 @@ async function createWindow() {
    * @see https://github.com/electron/electron/issues/25012
    */
   browserWindow.on('ready-to-show', () => {
-    browserWindow.show();
+    if (IS_DEV) {
+      // do not gain focus in dev mode
+      browserWindow.showInactive();
+    } else {
+      browserWindow.show();
+    }
+
+    logger.info('main window is ready to show');
 
     if (IS_DEV) {
       browserWindow.webContents.openDevTools();
@@ -62,12 +70,11 @@ async function createWindow() {
   /**
    * URL for main window.
    */
-  const pageUrl =
-    IS_DEV && process.env.DEV_SERVER_URL !== undefined
-      ? process.env.DEV_SERVER_URL
-      : 'file://./index.html'; // see protocol.ts
+  const pageUrl = process.env.DEV_SERVER_URL || 'file://./index.html'; // see protocol.ts
 
   await browserWindow.loadURL(pageUrl);
+
+  logger.info('main window is loaded at' + pageUrl);
 
   return browserWindow;
 }
@@ -86,9 +93,8 @@ export async function restoreOrCreateWindow() {
 
   if (browserWindow.isMinimized()) {
     browserWindow.restore();
+    logger.info('restore main window');
   }
-
-  logger.info('Create main window');
 
   return browserWindow;
 }

--- a/apps/electron/layers/main/src/protocol.ts
+++ b/apps/electron/layers/main/src/protocol.ts
@@ -30,23 +30,21 @@ function toAbsolutePath(url: string) {
 }
 
 export function registerProtocol() {
-  if (process.env.NODE_ENV === 'production') {
-    protocol.interceptFileProtocol('file', (request, callback) => {
-      const url = request.url.replace(/^file:\/\//, '');
-      const realpath = toAbsolutePath(url);
-      // console.log('realpath', realpath, 'for', url);
-      callback(realpath);
-      return true;
-    });
+  protocol.interceptFileProtocol('file', (request, callback) => {
+    const url = request.url.replace(/^file:\/\//, '');
+    const realpath = toAbsolutePath(url);
+    // console.log('realpath', realpath, 'for', url);
+    callback(realpath);
+    return true;
+  });
 
-    protocol.registerFileProtocol('assets', (request, callback) => {
-      const url = request.url.replace(/^assets:\/\//, '');
-      const realpath = toAbsolutePath(url);
-      // console.log('realpath', realpath, 'for', url);
-      callback(realpath);
-      return true;
-    });
-  }
+  protocol.registerFileProtocol('assets', (request, callback) => {
+    const url = request.url.replace(/^assets:\/\//, '');
+    const realpath = toAbsolutePath(url);
+    // console.log('realpath', realpath, 'for', url);
+    callback(realpath);
+    return true;
+  });
 
   session.defaultSession.webRequest.onHeadersReceived(
     (responseDetails, callback) => {

--- a/apps/electron/layers/preload/src/index.ts
+++ b/apps/electron/layers/preload/src/index.ts
@@ -23,7 +23,6 @@ import { isMacOS } from '../../utils';
  */
 contextBridge.exposeInMainWorld('apis', {
   db: {
-    // TODO: do we need to store the workspace list locally?
     // workspace providers
     getDoc: (id: string): Promise<Uint8Array | null> =>
       ipcRenderer.invoke('db:get-doc', id),

--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -6,8 +6,8 @@
   "description": "AFFiNE App",
   "homepage": "https://github.com/toeverything/AFFiNE",
   "scripts": {
-    "dev": "cross-env NODE_ENV=development node scripts/dev.mjs",
-    "prod": "cross-env NODE_ENV=production node scripts/dev.mjs",
+    "dev": "cross-env DEV_SERVER_URL=http://localhost:8080 node scripts/dev.mjs",
+    "prod": "node scripts/dev.mjs",
     "generate-assets": "zx scripts/generate-assets.mjs",
     "package": "electron-forge package",
     "make": "electron-forge make",


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad9e520</samp>

This pull request enhances the electron app's logging, window showing, and protocol handling. It adds more log messages to `main-window.ts` and `dev.mjs`, and adjusts the window showing logic based on the `development` mode. It also removes the node environment check for the file and assets protocols in `protocol.ts`, and deletes an obsolete TODO comment in `preload.ts`.

- clean up some development script
- use `showInactive` instead of `show` when creating new window in development