### PR TITLE
style: fix popover z-index

### DIFF
--- a/packages/theme/src/index.ts
+++ b/packages/theme/src/index.ts
@@ -45,7 +45,7 @@ export const baseTheme = {
   lineHeight: 'calc(1em + 8px)',
 
   zIndexModal: '1000',
-  zIndexPopover: '100',
+  zIndexPopover: '1000',
 
   paragraphSpace: '8px',
   popoverRadius: '12px',


### PR DESCRIPTION
Fixes: https://github.com/toeverything/AFFiNE/issues/2234

<img width="884" alt="image" src="https://user-images.githubusercontent.com/63531512/235870494-1e609cd4-4f5c-4aa1-9424-6d648dc078c4.png">
Fix issue #2205 
z-index of the pop-over comoponent should not be smaller than the side bar component.