### PR TITLE
fix: vertical alignment of item on share menu

### DIFF
--- a/packages/component/src/ui/menu/styles.ts
+++ b/packages/component/src/ui/menu/styles.ts
@@ -21,6 +21,7 @@ export const StyledMenuWrapper = styled(StyledPopperContainer)<{
 
 export const StyledStartIconWrapper = styled('div')(() => {
   return {
+    display: 'flex',
     marginRight: '12px',
     fontSize: '20px',
     color: 'var(--affine-icon-color)',
@@ -28,6 +29,7 @@ export const StyledStartIconWrapper = styled('div')(() => {
 });
 export const StyledEndIconWrapper = styled('div')(() => {
   return {
+    display: 'flex',
     marginLeft: '12px',
     fontSize: '20px',
     color: 'var(--affine-icon-color)',


### PR DESCRIPTION
### before
<img width="290" alt="Screenshot 2023-05-09 at 9 08 40 AM" src="https://user-images.githubusercontent.com/27926/236968680-828dfe93-6293-4a5d-8485-efb7517c8d50.png">

### after
<img width="551" alt="Screenshot 2023-05-09 at 9 09 26 AM" src="https://user-images.githubusercontent.com/27926/236968773-a9e25fd7-6102-4947-8d85-9eaaedd47c42.png">
