### PR TITLE
chore(server): remove bcrypt to avoid node-gyp usage

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -20,8 +20,8 @@
     "@nestjs/core": "^9.4.0",
     "@nestjs/graphql": "^11.0.5",
     "@nestjs/platform-express": "^9.4.0",
+    "@node-rs/bcrypt": "^1.7.1",
     "@prisma/client": "^4.14.0",
-    "bcrypt": "^5.1.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "graphql": "^16.6.0",
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@nestjs/testing": "^9.4.0",
-    "@types/bcrypt": "^5.0.0",
     "@types/express": "^4.17.17",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/lodash-es": "^4.17.7",

--- a/apps/server/scripts/gen-auth-key.ts
+++ b/apps/server/scripts/gen-auth-key.ts
@@ -1,6 +1,6 @@
 import crypto from 'node:crypto';
 
-import { genSalt } from 'bcrypt';
+import { genSalt } from '@node-rs/bcrypt';
 
 const { privateKey, publicKey } = crypto.generateKeyPairSync('ec', {
   namedCurve: 'prime256v1',

--- a/apps/server/src/config/def.ts
+++ b/apps/server/src/config/def.ts
@@ -170,10 +170,6 @@ export interface AFFiNEConfig {
    */
   auth: {
     /**
-     * Application sign key secret
-     */
-    readonly salt: string;
-    /**
      * Application access token expiration time
      */
     readonly accessTokenExpiresIn: string;

--- a/apps/server/src/config/default.ts
+++ b/apps/server/src/config/default.ts
@@ -56,7 +56,6 @@ export const getDefaultAFFiNEConfig: () => AFFiNEConfig = () => ({
     debug: true,
   },
   auth: {
-    salt: '$2b$10$x4VDo2nmlo74yB5jflNhlu',
     accessTokenExpiresIn: '1h',
     refreshTokenExpiresIn: '7d',
     publicKey: examplePublicKey,

--- a/apps/server/src/modules/auth/service.ts
+++ b/apps/server/src/modules/auth/service.ts
@@ -3,8 +3,8 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
+import { compare, hash } from '@node-rs/bcrypt';
 import { User } from '@prisma/client';
-import { compare, hash } from 'bcrypt';
 import jwt from 'jsonwebtoken';
 
 import { Config } from '../../config';
@@ -69,7 +69,7 @@ export class AuthService {
   }
 
   async register(name: string, email: string, password: string): Promise<User> {
-    const hashedPassword = await hash(password, this.config.auth.salt);
+    const hashedPassword = await hash(password);
 
     const user = await this.prisma.user.findFirst({
       where: {

--- a/apps/server/src/tests/app.e2e.ts
+++ b/apps/server/src/tests/app.e2e.ts
@@ -3,8 +3,8 @@ import { afterEach, beforeEach, describe, test } from 'node:test';
 
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { hash } from '@node-rs/bcrypt';
 import { PrismaClient } from '@prisma/client';
-import { hash } from 'bcrypt';
 import request from 'supertest';
 
 import { AppModule } from '../app';
@@ -27,7 +27,7 @@ describe('AppModule', () => {
         id: '1',
         name: 'Alex Yang',
         email: 'alex.yang@example.org',
-        password: await hash('123456', globalThis.AFFiNE.auth.salt),
+        password: await hash('123456'),
       },
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,14 +258,13 @@ __metadata:
     "@nestjs/graphql": ^11.0.5
     "@nestjs/platform-express": ^9.4.0
     "@nestjs/testing": ^9.4.0
+    "@node-rs/bcrypt": ^1.7.1
     "@prisma/client": ^4.14.0
-    "@types/bcrypt": ^5.0.0
     "@types/express": ^4.17.17
     "@types/jsonwebtoken": ^9.0.2
     "@types/lodash-es": ^4.17.7
     "@types/node": ^18.16.7
     "@types/supertest": ^2.0.12
-    bcrypt: ^5.1.0
     c8: ^7.13.0
     dotenv: ^16.0.3
     express: ^4.18.2
@@ -5189,25 +5188,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/node-pre-gyp@npm:^1.0.10":
-  version: 1.0.10
-  resolution: "@mapbox/node-pre-gyp@npm:1.0.10"
-  dependencies:
-    detect-libc: ^2.0.0
-    https-proxy-agent: ^5.0.0
-    make-dir: ^3.1.0
-    node-fetch: ^2.6.7
-    nopt: ^5.0.0
-    npmlog: ^5.0.1
-    rimraf: ^3.0.2
-    semver: ^7.3.5
-    tar: ^6.1.11
-  bin:
-    node-pre-gyp: bin/node-pre-gyp
-  checksum: 1a98db05d955b74dad3814679593df293b9194853698f3f5f1ed00ecd93128cdd4b14fb8767fe44ac6981ef05c23effcfdc88710e7c1de99ccb6f647890597c8
-  languageName: node
-  linkType: hard
-
 "@mdx-js/react@npm:^2.1.5":
   version: 2.3.0
   resolution: "@mdx-js/react@npm:2.3.0"
@@ -5736,6 +5716,145 @@ __metadata:
   version: 13.4.1
   resolution: "@next/swc-win32-x64-msvc@npm:13.4.1"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-android-arm-eabi@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-android-arm-eabi@npm:1.7.1"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-android-arm64@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-android-arm64@npm:1.7.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-darwin-arm64@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-darwin-arm64@npm:1.7.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-darwin-x64@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-darwin-x64@npm:1.7.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-freebsd-x64@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-freebsd-x64@npm:1.7.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-linux-arm-gnueabihf@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-linux-arm-gnueabihf@npm:1.7.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-linux-arm64-gnu@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-linux-arm64-gnu@npm:1.7.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-linux-arm64-musl@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-linux-arm64-musl@npm:1.7.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-linux-x64-gnu@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-linux-x64-gnu@npm:1.7.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-linux-x64-musl@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-linux-x64-musl@npm:1.7.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-win32-arm64-msvc@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-win32-arm64-msvc@npm:1.7.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-win32-ia32-msvc@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-win32-ia32-msvc@npm:1.7.1"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt-win32-x64-msvc@npm:1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt-win32-x64-msvc@npm:1.7.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@node-rs/bcrypt@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "@node-rs/bcrypt@npm:1.7.1"
+  dependencies:
+    "@node-rs/bcrypt-android-arm-eabi": 1.7.1
+    "@node-rs/bcrypt-android-arm64": 1.7.1
+    "@node-rs/bcrypt-darwin-arm64": 1.7.1
+    "@node-rs/bcrypt-darwin-x64": 1.7.1
+    "@node-rs/bcrypt-freebsd-x64": 1.7.1
+    "@node-rs/bcrypt-linux-arm-gnueabihf": 1.7.1
+    "@node-rs/bcrypt-linux-arm64-gnu": 1.7.1
+    "@node-rs/bcrypt-linux-arm64-musl": 1.7.1
+    "@node-rs/bcrypt-linux-x64-gnu": 1.7.1
+    "@node-rs/bcrypt-linux-x64-musl": 1.7.1
+    "@node-rs/bcrypt-win32-arm64-msvc": 1.7.1
+    "@node-rs/bcrypt-win32-ia32-msvc": 1.7.1
+    "@node-rs/bcrypt-win32-x64-msvc": 1.7.1
+  dependenciesMeta:
+    "@node-rs/bcrypt-android-arm-eabi":
+      optional: true
+    "@node-rs/bcrypt-android-arm64":
+      optional: true
+    "@node-rs/bcrypt-darwin-arm64":
+      optional: true
+    "@node-rs/bcrypt-darwin-x64":
+      optional: true
+    "@node-rs/bcrypt-freebsd-x64":
+      optional: true
+    "@node-rs/bcrypt-linux-arm-gnueabihf":
+      optional: true
+    "@node-rs/bcrypt-linux-arm64-gnu":
+      optional: true
+    "@node-rs/bcrypt-linux-arm64-musl":
+      optional: true
+    "@node-rs/bcrypt-linux-x64-gnu":
+      optional: true
+    "@node-rs/bcrypt-linux-x64-musl":
+      optional: true
+    "@node-rs/bcrypt-win32-arm64-msvc":
+      optional: true
+    "@node-rs/bcrypt-win32-ia32-msvc":
+      optional: true
+    "@node-rs/bcrypt-win32-x64-msvc":
+      optional: true
+  checksum: a31a4a9a4a49543eab0927704f2bb3ca4e0cb924392f205a01e5d1876ce31c2b0fc2764250b5a3af26c3644501ed98c6805631c14ca62cc1d1db3da69654b7a9
   languageName: node
   linkType: hard
 
@@ -8371,15 +8490,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/bcrypt@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "@types/bcrypt@npm:5.0.0"
-  dependencies:
-    "@types/node": "*"
-  checksum: 063c32c7a519d64768dfc0169a319b8244d6a6cb50a355c93992b3c5fee1dbc236526a1111f0e7bb25abc8b0473e5f40a5edfeb8b33cad2a6ea35aa2d7d7db14
-  languageName: node
-  linkType: hard
-
 "@types/better-sqlite3@npm:^7.6.4":
   version: 7.6.4
   resolution: "@types/better-sqlite3@npm:7.6.4"
@@ -10728,16 +10838,6 @@ __metadata:
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
-  languageName: node
-  linkType: hard
-
-"bcrypt@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "bcrypt@npm:5.1.0"
-  dependencies:
-    "@mapbox/node-pre-gyp": ^1.0.10
-    node-addon-api: ^5.0.0
-  checksum: a590b65d276d75d861dc85acc3128508b8f78c87431719658ea3be7996368b34b397b6efefe6bca0a3d555bf41a9267307fd4ce04e956598fca3ba81199c6706
   languageName: node
   linkType: hard
 
@@ -18895,7 +18995,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2, make-dir@npm:^3.1.0":
+"make-dir@npm:^3.0.0, make-dir@npm:^3.0.2":
   version: 3.1.0
   resolution: "make-dir@npm:3.1.0"
   dependencies:
@@ -19744,15 +19844,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-addon-api@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "node-addon-api@npm:5.1.0"
-  dependencies:
-    node-gyp: latest
-  checksum: 2508bd2d2981945406243a7bd31362fc7af8b70b8b4d65f869c61731800058fb818cc2fd36c8eac714ddd0e568cc85becf5e165cebbdf7b5024d5151bbc75ea1
-  languageName: node
-  linkType: hard
-
 "node-api-version@npm:^0.1.4":
   version: 0.1.4
   resolution: "node-api-version@npm:0.1.4"
@@ -19895,17 +19986,6 @@ __metadata:
   bin:
     nodemon: bin/nodemon.js
   checksum: 9c987e139748f5b5c480c6c9080bdc97304ee7d29172b7b3da1a7db590b1323ad57b96346304e9b522b0e445c336dc393ccd3f9f45c73b20d476d2347890dcd0
-  languageName: node
-  linkType: hard
-
-"nopt@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "nopt@npm:5.0.0"
-  dependencies:
-    abbrev: 1
-  bin:
-    nopt: bin/nopt.js
-  checksum: d35fdec187269503843924e0114c0c6533fb54bbf1620d0f28b4b60ba01712d6687f62565c55cc20a504eff0fbe5c63e22340c3fad549ad40469ffb611b04f2f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BTW, we don't need an application-level salt since `@node-rs/bcrypt` will generate a random salt by `OsRng` by default while hashing.