### PR TITLE
fix: typo in AFFiNE-Docs.md

### DIFF
--- a/packages/templates/src/AFFiNE-Docs.md
+++ b/packages/templates/src/AFFiNE-Docs.md
@@ -10,7 +10,7 @@ Please [file an issue](https://github.com/toeverything/AFFiNE-docs/issues) if yo
 
 ## Get Started
 
-This repo is split into folders - with each folder being a seperate category of documentation.
+This repo is split into folders - with each folder being a separate category of documentation.
 
 You can browse the folders to view the pages within each category.
 
@@ -22,4 +22,4 @@ All assets should be stored in `.gitbook/assets/`.
 
 The asset should be named according to where it will be used.
 
-If an image is needed for `/developer-docs/coding/setup.md` the expected filename would be `developer-docs_coding_setup` where `_` seperates each folder/file. And if multiple images are required a unique filename can be appeneded, such as `_01`.
+If an image is needed for `/developer-docs/coding/setup.md` the expected filename would be `developer-docs_coding_setup` where `_` separates each folder/file. And if multiple images are required a unique filename can be appeneded, such as `_01`.


### PR DESCRIPTION
seperate -> separate
seperates -> separates