### PR TITLE
fix(electron): should not continue pull when db closed

### DIFF
--- a/apps/electron/layers/main/src/db/__tests__/ensure-db.spec.ts
+++ b/apps/electron/layers/main/src/db/__tests__/ensure-db.spec.ts
@@ -78,6 +78,10 @@ beforeEach(() => {
 
 afterEach(async () => {
   await runHandler('before-quit');
+  // wait for the db to be closed on Windows
+  if (process.platform === 'win32') {
+    await setTimeout(200);
+  }
   await fs.remove(tmpDir);
   vi.useRealTimers();
 });

--- a/apps/electron/layers/main/src/db/base-db-adapter.ts
+++ b/apps/electron/layers/main/src/db/base-db-adapter.ts
@@ -18,6 +18,7 @@ export abstract class BaseSQLiteAdapter {
     if (!this.db) {
       this.db = new SqliteConnection(this.path);
       await this.db.connect();
+      logger.info(`[SQLiteAdapter:${this.role}]`, 'connected:', this.path);
     }
     return this.db;
   }


### PR DESCRIPTION
After moving the database, a meta change was triggered. At this time, the main database was destroyed, but the sync process of the external database was still ongoing.