### PR TITLE
fix: potential race condition on app load when migration

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -88,7 +88,7 @@ const nextConfig = {
       // ['@swc-jotai/react-refresh', {}],
     ].filter(Boolean),
   },
-  reactStrictMode: false,
+  reactStrictMode: true,
   transpilePackages: [
     'jotai-devtools',
     '@affine/component',

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -88,7 +88,7 @@ const nextConfig = {
       // ['@swc-jotai/react-refresh', {}],
     ].filter(Boolean),
   },
-  reactStrictMode: true,
+  reactStrictMode: false,
   transpilePackages: [
     'jotai-devtools',
     '@affine/component',

--- a/apps/web/src/bootstrap/index.ts
+++ b/apps/web/src/bootstrap/index.ts
@@ -129,7 +129,7 @@ if (environment.isBrowser) {
         })
         .finally(() => {
           window.dispatchEvent(new CustomEvent('migration-done'));
-          window.__migration_done__ = true;
+          window.$migrationDone = true;
         });
     } catch (e) {
       console.error('error when migrating data', e);

--- a/apps/web/src/bootstrap/index.ts
+++ b/apps/web/src/bootstrap/index.ts
@@ -129,16 +129,10 @@ if (environment.isBrowser) {
         })
         .finally(() => {
           window.dispatchEvent(new CustomEvent('migration-done'));
+          window.__migration_done__ = true;
         });
     } catch (e) {
       console.error('error when migrating data', e);
     }
-  }
-}
-
-declare global {
-  // global Events
-  interface WindowEventMap {
-    'migration-done': CustomEvent;
   }
 }

--- a/packages/env/src/global.ts
+++ b/packages/env/src/global.ts
@@ -33,6 +33,11 @@ declare global {
       workspace: UnwrapManagerHandlerToClientSide<WorkspaceHandlerManager>;
     };
     events: any;
+    __migration_done__: boolean;
+  }
+
+  interface WindowEventMap {
+    'migration-done': CustomEvent;
   }
 
   // eslint-disable-next-line no-var

--- a/packages/env/src/global.ts
+++ b/packages/env/src/global.ts
@@ -33,13 +33,14 @@ declare global {
       workspace: UnwrapManagerHandlerToClientSide<WorkspaceHandlerManager>;
     };
     events: any;
-    __migration_done__: boolean;
   }
 
   interface WindowEventMap {
     'migration-done': CustomEvent;
   }
 
+  // eslint-disable-next-line no-var
+  var $migrationDone: boolean;
   // eslint-disable-next-line no-var
   var platform: Platform | undefined;
   // eslint-disable-next-line no-var

--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -118,7 +118,10 @@ const rootWorkspacesMetadataPromiseAtom = atom<
       }
 
       // migration step, only data in `METADATA_STORAGE_KEY` will be migrated
-      if (metadata.some(meta => !('version' in meta))) {
+      if (
+        metadata.some(meta => !('version' in meta)) &&
+        !window.__migration_done__
+      ) {
         await new Promise<void>((resolve, reject) => {
           signal.addEventListener('abort', () => reject(), { once: true });
           window.addEventListener('migration-done', () => resolve(), {

--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -120,7 +120,7 @@ const rootWorkspacesMetadataPromiseAtom = atom<
       // migration step, only data in `METADATA_STORAGE_KEY` will be migrated
       if (
         metadata.some(meta => !('version' in meta)) &&
-        !window.__migration_done__
+        !globalThis.$migrationDone
       ) {
         await new Promise<void>((resolve, reject) => {
           signal.addEventListener('abort', () => reject(), { once: true });


### PR DESCRIPTION
When `rootWorkspacesMetadataPromiseAtom` waits for `migration-done` event, it may be already loaded.
Added another hidden flag `__migration_done__: boolean;` to global to mitigate this issue.