### PR TITLE
fix: init workspace before loaded

### DIFF
--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceAdapter } from '@affine/env/workspace';
 import { WorkspaceFlavour, WorkspaceVersion } from '@affine/env/workspace';
+import { createEmptyBlockSuiteWorkspace } from '@affine/workspace/utils';
 import type { BlockHub } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import { atom } from 'jotai';
@@ -171,6 +172,14 @@ const rootWorkspacesMetadataPromiseAtom = atom<
       }
     }
     const metadataMap = new Map(metadata.map(x => [x.id, x]));
+    // init workspace data
+    metadataMap.forEach((meta, id) => {
+      if (meta.flavour === WorkspaceFlavour.AFFINE_CLOUD) {
+        createEmptyBlockSuiteWorkspace(id, meta.flavour, {});
+      } else if (meta.flavour === WorkspaceFlavour.LOCAL) {
+        createEmptyBlockSuiteWorkspace(id, meta.flavour);
+      }
+    });
     return Array.from(metadataMap.values());
   }
 });


### PR DESCRIPTION
Workspace might not init because jotai-workspace is different from the CRUD data.

Example:

![img_v2_faafafa4-df48-4743-bf44-24076b9671eg](https://github.com/toeverything/AFFiNE/assets/14026360/272753ab-2e01-4633-9968-308fbc5b4721)

In this case, the local workspace might not init because the list API didn't create the workspace into the internal hashmap. We need to do this before the promise is resolved.

reported by @zqran 