### PR TITLE
fix: disconnect awareness properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 node_modules
 
 # IDEs and editors
-/.idea
+**/.idea
 .project
 .classpath
 .c9/

--- a/apps/server/src/modules/sync/events/events.gateway.ts
+++ b/apps/server/src/modules/sync/events/events.gateway.ts
@@ -75,5 +75,7 @@ export class EventsGateway {
       .emit('server-awareness-broadcast', {
         ...message,
       });
+
+    return 'ack';
   }
 }

--- a/apps/server/src/modules/sync/events/workspace.ts
+++ b/apps/server/src/modules/sync/events/workspace.ts
@@ -53,6 +53,7 @@ export class WorkspaceService {
         Y.applyUpdate(doc, update);
       } catch (e) {
         console.error(e);
+        return null;
       }
     }
 


### PR DESCRIPTION
There are two ways to remove an awareness client's state:

1. provider should set local awareness state to null and inform other clients in awareness update callback
2. Local awareness will periodically check, each client's states have 30 seconds' timeout time  https://github.com/yjs/y-protocols/blob/ba21a9c92990743554e47223c49513630b7eadda/awareness.js#L69C8-L69C8

This PR ensures the first method work normally