### PR TITLE
fix: try redirecting api requests in electron

### DIFF
--- a/apps/electron/scripts/common.mjs
+++ b/apps/electron/scripts/common.mjs
@@ -12,6 +12,9 @@ export const NODE_MAJOR_VERSION = 18;
 // fixme(xp): report error if app is not running on DEV_SERVER_URL
 const DEV_SERVER_URL = process.env.DEV_SERVER_URL;
 
+// Cloud url for APIs
+const CLOUD_URL = process.env.CLOUD_URL || 'http://localhost:3000';
+
 /** @type 'production' | 'development'' */
 const mode = (process.env.NODE_ENV = process.env.NODE_ENV || 'development');
 
@@ -24,6 +27,10 @@ export const config = () => {
 
   if (DEV_SERVER_URL) {
     define['process.env.DEV_SERVER_URL'] = `"${DEV_SERVER_URL}"`;
+  }
+
+  if (CLOUD_URL) {
+    define['process.env.CLOUD_URL'] = `"${CLOUD_URL}"`;
   }
 
   return {

--- a/apps/electron/src/helper/workspace/index.ts
+++ b/apps/electron/src/helper/workspace/index.ts
@@ -19,7 +19,5 @@ export const workspaceEvents = {
 export const workspaceHandlers = {
   list: async () => listWorkspaces(),
   delete: async (id: string) => deleteWorkspace(id),
-  getMeta: async (id: string) => {
-    return getWorkspaceMeta(id);
-  },
+  getMeta: async (id: string) => getWorkspaceMeta(id),
 };

--- a/apps/electron/src/main/main-window.ts
+++ b/apps/electron/src/main/main-window.ts
@@ -101,7 +101,7 @@ async function createWindow() {
   /**
    * URL for main window.
    */
-  const pageUrl = process.env.DEV_SERVER_URL || 'file://./index.html'; // see protocol.ts
+  const pageUrl = process.env.DEV_SERVER_URL || 'assets://./index.html'; // see protocol.ts
 
   logger.info('loading page at', pageUrl);
 

--- a/apps/electron/src/main/protocol.ts
+++ b/apps/electron/src/main/protocol.ts
@@ -1,4 +1,4 @@
-import { protocol, session } from 'electron';
+import { net, protocol, session } from 'electron';
 import { join } from 'path';
 
 protocol.registerSchemesAsPrivileged([
@@ -10,38 +10,63 @@ protocol.registerSchemesAsPrivileged([
       supportFetchAPI: true,
       standard: true,
       bypassCSP: true,
+      stream: true,
     },
   },
 ]);
 
-function toAbsolutePath(url: string) {
-  let realpath = decodeURIComponent(url);
-  const webStaticDir = join(__dirname, '../resources/web-static');
-  if (url.startsWith('./')) {
-    // if is a file type, load the file in resources
-    if (url.split('/').at(-1)?.includes('.')) {
-      realpath = join(webStaticDir, decodeURIComponent(url));
-    } else {
-      // else, fallback to load the index.html instead
-      realpath = join(webStaticDir, 'index.html');
-    }
-  }
-  return realpath;
-}
+const NETWORK_REQUESTS = ['/api', '/socket.io', '/graphql'];
+
+// function toAbsolutePath(url: string): Electron.ProtocolResponse | string {
+//   let realpath = decodeURIComponent(url);
+//   const webStaticDir = join(__dirname, '../resources/web-static');
+//   // ALL URLs should start with ./
+//   if (url.startsWith('./')) {
+//     if (url.split('/').at(-1)?.includes('.')) {
+//       realpath = join(webStaticDir, decodeURIComponent(url));
+//     } else {
+//       // else, fallback to load the index.html instead
+//       realpath = join(webStaticDir, 'index.html');
+//     }
+//     return {
+//       path: realpath,
+//     };
+//   }
+//   return realpath;
+// }
 
 export function registerProtocol() {
-  protocol.interceptFileProtocol('file', (request, callback) => {
-    const url = request.url.replace(/^file:\/\//, '');
-    const realpath = toAbsolutePath(url);
-    callback(realpath);
-    return true;
-  });
+  // protocol.interceptFileProtocol('file', (request, callback) => {
+  //   const url = request.url.replace(/^file:\/\//, '');
+  //   const realpath = toAbsolutePath(url);
+  //   callback(realpath);
+  //   return true;
+  // });
 
-  protocol.registerFileProtocol('assets', (request, callback) => {
+  protocol.handle('assets', request => {
     const url = request.url.replace(/^assets:\/\//, '');
-    const realpath = toAbsolutePath(url);
-    callback(realpath);
-    return true;
+    let realpath = decodeURIComponent(url);
+
+    const webStaticDir = join(__dirname, '../resources/web-static');
+    // ALL URLs should start with ./
+    if (url.startsWith('./')) {
+      if (NETWORK_REQUESTS.some(path => url.startsWith('.' + path))) {
+        const realUrl = process.env.CLOUD_URL + url.substring(1);
+        return net.fetch(realUrl, {
+          body: request.body,
+          method: request.method,
+          headers: request.headers,
+        });
+      }
+      // if is a file type, load the file in resources
+      else if (url.split('/').at(-1)?.includes('.')) {
+        realpath = join(webStaticDir, decodeURIComponent(url));
+      } else {
+        // else, fallback to load the index.html instead
+        realpath = join(webStaticDir, 'index.html');
+      }
+    }
+    return net.fetch('file://' + realpath);
   });
 
   session.defaultSession.webRequest.onHeadersReceived(

--- a/apps/electron/src/main/security-restrictions.ts
+++ b/apps/electron/src/main/security-restrictions.ts
@@ -14,7 +14,7 @@ app.on('web-contents-created', (_, contents) => {
       (process.env.DEV_SERVER_URL &&
         url.startsWith(process.env.DEV_SERVER_URL)) ||
       url.startsWith('affine://') ||
-      url.startsWith('file://.')
+      url.startsWith('assets://.')
     ) {
       return;
     }

--- a/apps/electron/src/main/updater/electron-updater.ts
+++ b/apps/electron/src/main/updater/electron-updater.ts
@@ -26,10 +26,13 @@ export const quitAndInstall = async () => {
 
 let lastCheckTime = 0;
 export const checkForUpdatesAndNotify = async (force = true) => {
+  logger.info('checkForUpdatesAndNotify', autoUpdater);
   // check every 30 minutes (1800 seconds) at most
   if (force || lastCheckTime + 1000 * 1800 < Date.now()) {
     lastCheckTime = Date.now();
-    return await autoUpdater.checkForUpdatesAndNotify();
+    const info = await autoUpdater.checkForUpdates();
+    logger.info('checkForUpdatesAndNotify', info);
+    return info;
   }
   return void 0;
 };
@@ -98,6 +101,8 @@ export const registerUpdater = async () => {
     logger.error('Error while updating client', e);
   });
   autoUpdater.forceDevUpdateConfig = isDev;
+
+  await checkForUpdatesAndNotify();
 
   app.on('activate', async () => {
     await checkForUpdatesAndNotify(false);


### PR DESCRIPTION
This PR tries to use `protocol.handle` to redirect `/api` and `/graphql` requests to `CLOUD_URL`.
However the attempt was blocked:
- when using `file://` scheme, it seems we cannot overwrite it with `protocol.handle`. see https://github.com/electron/electron/issues/39031
- when using `assets://` scheme, the message from render to helper cannot be intercepted.

In either way, the proposal seems to be stuck at the moment. Alternatively and maybe more reasonably, we shall add prefix urls to `fetch` usage in the renderer, instead of calling `/api/xxx` instead.