### PR TITLE
fix: internal build updater

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     outputs:
-      version: 0.0.0-${{ steps.version.outputs.version }}
+      version: 0.0.0-internal.${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v3
       - uses: toeverything/set-build-version@latest


### PR DESCRIPTION
Looks like `0.0.0-20230714031808-0ca9f2c` is not a valid semversion for electron-updater.
It requires it to be something like `0.0.0-channel.build-number`. The channel in the name is crucial here. 

https://github.com/electron-userland/electron-builder/blob/84ed3ff123b5ae92cd3350d64677434f9b397b76/packages/electron-updater/src/providers/GitHubProvider.ts#L59-L94