### PR TITLE
fix(server): doc guid may contains colon mark

### DIFF
--- a/apps/server/src/modules/doc/redis-manager.ts
+++ b/apps/server/src/modules/doc/redis-manager.ts
@@ -85,7 +85,9 @@ export class RedisDocManager extends DocManager {
 
     const updateKey = updates`${pendingDoc}`;
     const lockKey = lock`${pendingDoc}`;
-    const [workspaceId, id] = pendingDoc.split(':');
+    const splitAt = pendingDoc.indexOf(':');
+    const workspaceId = pendingDoc.substring(0, splitAt);
+    const id = pendingDoc.substring(splitAt + 1);
 
     // acquire the lock
     const lockResult = await this.redis


### PR DESCRIPTION
doc guid could be like `spafe:xxxxx`, the redis key should not be destructed directly by `str.split`