### PR TITLE
fix: share WorkspaceLayout for workspace routes

### DIFF
--- a/apps/core/src/app.tsx
+++ b/apps/core/src/app.tsx
@@ -12,9 +12,10 @@ import {
 } from '@toeverything/plugin-infra/manager';
 import type { PropsWithChildren, ReactElement } from 'react';
 import { lazy, memo, Suspense, useEffect } from 'react';
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, Outlet, RouterProvider } from 'react-router-dom';
 
 import { historyBaseAtom, MAX_HISTORY } from './atoms/history';
+import { WorkspaceLayout } from './layouts/workspace-layout';
 import createEmotionCache from './utils/create-emotion-cache';
 
 const router = createBrowserRouter([
@@ -27,16 +28,26 @@ const router = createBrowserRouter([
     lazy: () => import('./pages/404'),
   },
   {
-    path: '/workspace/:workspaceId/all',
-    lazy: () => import('./pages/workspace/all-page'),
-  },
-  {
-    path: '/workspace/:workspaceId/trash',
-    lazy: () => import('./pages/workspace/trash-page'),
-  },
-  {
-    path: '/workspace/:workspaceId/:pageId',
-    lazy: () => import('./pages/workspace/detail-page'),
+    path: '/workspace/:workspaceId',
+    Component: () => (
+      <WorkspaceLayout>
+        <Outlet />
+      </WorkspaceLayout>
+    ),
+    children: [
+      {
+        path: 'all',
+        lazy: () => import('./pages/workspace/all-page'),
+      },
+      {
+        path: 'trash',
+        lazy: () => import('./pages/workspace/trash-page'),
+      },
+      {
+        path: ':pageId',
+        lazy: () => import('./pages/workspace/detail-page'),
+      },
+    ],
   },
 ]);
 

--- a/apps/core/src/pages/workspace/all-page.tsx
+++ b/apps/core/src/pages/workspace/all-page.tsx
@@ -6,7 +6,6 @@ import { useCallback } from 'react';
 import { getUIAdapter } from '../../adapters/workspace';
 import { useCurrentWorkspace } from '../../hooks/current/use-current-workspace';
 import { useNavigateHelper } from '../../hooks/use-navigate-helper';
-import { WorkspaceLayout } from '../../layouts/workspace-layout';
 
 const AllPage = () => {
   const { jumpToPage } = useNavigateHelper();
@@ -42,9 +41,5 @@ const AllPage = () => {
 };
 
 export const Component = () => {
-  return (
-    <WorkspaceLayout>
-      <AllPage />
-    </WorkspaceLayout>
-  );
+  return <AllPage />;
 };

--- a/apps/core/src/pages/workspace/detail-page.tsx
+++ b/apps/core/src/pages/workspace/detail-page.tsx
@@ -16,7 +16,6 @@ import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import { getUIAdapter } from '../../adapters/workspace';
 import { useCurrentWorkspace } from '../../hooks/current/use-current-workspace';
 import { useNavigateHelper } from '../../hooks/use-navigate-helper';
-import { WorkspaceLayout } from '../../layouts/workspace-layout';
 
 const WorkspaceDetailPageImpl = (): ReactElement => {
   const { openPage, jumpToSubPath } = useNavigateHelper();
@@ -114,9 +113,5 @@ const WorkspaceDetailPage = (): ReactElement => {
 };
 
 export const Component = () => {
-  return (
-    <WorkspaceLayout>
-      <WorkspaceDetailPage />
-    </WorkspaceLayout>
-  );
+  return <WorkspaceDetailPage />;
 };

--- a/apps/core/src/pages/workspace/trash-page.tsx
+++ b/apps/core/src/pages/workspace/trash-page.tsx
@@ -6,7 +6,6 @@ import { getUIAdapter } from '../../adapters/workspace';
 import { BlockSuitePageList } from '../../components/blocksuite/block-suite-page-list';
 import { useCurrentWorkspace } from '../../hooks/current/use-current-workspace';
 import { useNavigateHelper } from '../../hooks/use-navigate-helper';
-import { WorkspaceLayout } from '../../layouts/workspace-layout';
 
 const TrashPage = () => {
   const { jumpToPage } = useNavigateHelper();
@@ -44,9 +43,5 @@ const TrashPage = () => {
 };
 
 export const Component = () => {
-  return (
-    <WorkspaceLayout>
-      <TrashPage />
-    </WorkspaceLayout>
-  );
+  return <TrashPage />;
 };


### PR DESCRIPTION
On route change under `/workspace`, every route content will restart the workspace disconnection/connection again and is a waste and may cause issues if provider is not well implemented.
This PR fix the issue by moving WorkspaceLayout to a common layer to /:pageId, /all and /trash