### PR TITLE
fix: unable to add a second collection

### DIFF
--- a/apps/core/src/components/pure/workspace-slider-bar/collections/add-collection-button.tsx
+++ b/apps/core/src/components/pure/workspace-slider-bar/collections/add-collection-button.tsx
@@ -7,7 +7,7 @@ import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { PlusIcon } from '@blocksuite/icons';
 import type { Workspace } from '@blocksuite/store';
 import { uuidv4 } from '@blocksuite/store';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useGetPageInfoById } from '../../../../hooks/use-get-page-info';
 
@@ -22,16 +22,13 @@ export const AddCollectionButton = ({
   const setting = useCollectionManager(workspace.id);
   const t = useAFFiNEI18N();
   const [show, showUpdateCollection] = useState(false);
-  const defaultCollection = useMemo(
-    () => ({
-      id: uuidv4(),
-      name: '',
-      pinned: true,
-      filterList: [],
-      workspaceId: workspace.id,
-    }),
-    [workspace.id]
-  );
+  const defaultCollection = {
+    id: uuidv4(),
+    name: '',
+    pinned: true,
+    filterList: [],
+    workspaceId: workspace.id,
+  };
   return (
     <>
       <IconButton


### PR DESCRIPTION
After creating a collection, it cannot be created again, and the click will change to modify the collection. This is not expected behavior.