### PR TITLE
fix: edgeless font loading

### DIFF
--- a/apps/core/src/app.tsx
+++ b/apps/core/src/app.tsx
@@ -46,8 +46,11 @@ const languageLoadingPromise = new Promise<void>(resolve => {
   }
 });
 
+const loadFontPromise = document.fonts.load('16px Kalam');
+
 export const App = memo(function App() {
   use(languageLoadingPromise);
+  use(loadFontPromise);
   return (
     <CacheProvider value={cache}>
       <AffineContext>

--- a/packages/component/src/theme/fonts.css
+++ b/packages/component/src/theme/fonts.css
@@ -43,14 +43,6 @@
   src: url(/fonts/kalam/Kalam-Light.ttf);
 }
 
-@font-face {
-  font-family: 'Kalam';
-  font-style: normal;
-  font-weight: 700;
-  font-display: swap;
-  src: url(/fonts/kalam/Kalam-Bold.ttf);
-}
-
 /*
  * Source Serif 4
  */


### PR DESCRIPTION
Fixes : toeverything/blocksuite#3777 

I dont know why but after removing font-face Kalam-Bold.ttf from .css file it works correctly otherwise atleast in first render the font is different.
Is this the correct solution?

https://github.com/toeverything/AFFiNE/assets/30045569/86a999e8-4c47-4002-9b90-42de4df0d2a5

