### PR TITLE
fix: flaky tests

### DIFF
--- a/apps/core/src/providers/modal-provider.tsx
+++ b/apps/core/src/providers/modal-provider.tsx
@@ -8,7 +8,13 @@ import {
 } from '@toeverything/plugin-infra/atom';
 import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import type { FC, ReactElement } from 'react';
-import { lazy, Suspense, useCallback, useTransition } from 'react';
+import {
+  lazy,
+  startTransition,
+  Suspense,
+  useCallback,
+  useTransition,
+} from 'react';
 
 import type { SettingAtom } from '../atoms';
 import {
@@ -195,11 +201,13 @@ export const AllWorkspaceModals = (): ReactElement => {
             setOpenCreateWorkspaceModal(false);
           }, [setOpenCreateWorkspaceModal])}
           onCreate={useCallback(
-            async id => {
-              setOpenCreateWorkspaceModal(false);
-              setOpenWorkspacesModal(false);
-              setCurrentWorkspaceId(id);
-              return jumpToSubPath(id, WorkspaceSubPath.ALL);
+            id => {
+              startTransition(() => {
+                setOpenCreateWorkspaceModal(false);
+                setOpenWorkspacesModal(false);
+                setCurrentWorkspaceId(id);
+                jumpToSubPath(id, WorkspaceSubPath.ALL);
+              });
             },
             [
               jumpToSubPath,

--- a/packages/workspace/src/providers/sqlite-providers.ts
+++ b/packages/workspace/src/providers/sqlite-providers.ts
@@ -14,7 +14,7 @@ import { localProviderLogger as logger } from './logger';
 
 const Y = BlockSuiteWorkspace.Y;
 
-const sqliteOrigin = Symbol('sqlite-provider-origin');
+const sqliteOrigin = 'sqlite-provider-origin';
 
 const createDatasource = (workspaceId: string): DatasourceDocAdapter => {
   if (!window.apis?.db) {


### PR DESCRIPTION
The issue is: 
- if importing workspace at the `page detail` route, when importing the page goes in skeleton
- even if we have route as `workspace/NEW_WORKSPACE_ID/all`, it still stays at the DetailPage route

Not sure why but it seems the navigation was blocked by suspense