### PR TITLE
chore: ignore output files

### DIFF
--- a/packages/sdk/.gitignore
+++ b/packages/sdk/.gitignore
@@ -1,0 +1,4 @@
+src/entry.d.ts
+src/entry.d.ts.map
+src/entry.js
+src/entry.js.map


### PR DESCRIPTION
I don't know why these files are emitted in `src` instead of `dist`

Guessing because I use `export declare const` grammar