### PR TITLE
fix: eslint stack overflow issue

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,3 +12,5 @@ e2e-dist-*
 static
 web-static
 public
+packages/sdk/src/*.d.ts
+packages/sdk/src/*.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ const createPattern = packageName => [
     allowTypeImports: false,
   },
   {
-    group: ['@blocksuite  /store'],
+    group: ['@blocksuite/store'],
     message: "Import from '@blocksuite/global/utils'",
     importNames: ['assertExists', 'assertEquals'],
   },

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -5,12 +5,13 @@
   },
   "include": ["."],
   "exclude": [
-    "target",
-    "node_modules",
-    "dist",
-    "lib",
+    "**/target",
+    "**/node_modules",
+    "**/dist",
+    "**/lib",
     ".coverage",
     ".yarn",
-    "test-results"
+    "**/test-results",
+    "**/web-static"
   ]
 }


### PR DESCRIPTION
seems like eslint gets stuck in parsing ts files within `apps/electron/resources/web-static` in the following line

```ts
function getSourceFileVersionAsHashFromText(host, text) {
    if (text.match(sourceMapCommentRegExpDontCareLineStart)) {
```