### PR TITLE
refactor: optimize the use of notification center

### DIFF
--- a/apps/storybook/src/stories/notification-center.stories.tsx
+++ b/apps/storybook/src/stories/notification-center.stories.tsx
@@ -223,6 +223,21 @@ export const Basic = () => {
           gif
         </button>
       </div>
+      <div>
+        <button
+          onClick={() => {
+            const key = id++;
+            push({
+              title: `${key} title`,
+              type: 'info',
+              theme: 'default',
+              timeout: 3000,
+            });
+          }}
+        >
+          default message
+        </button>
+      </div>
       <NotificationCenter />
     </>
   );

--- a/packages/component/src/components/notification-center/index.css.ts
+++ b/packages/component/src/components/notification-center/index.css.ts
@@ -177,7 +177,7 @@ export const notificationContentStyle = style({
   width: '380px',
   borderRadius: '8px',
   boxShadow: 'var(--affine-shadow-1)',
-  border: '1px solid var(--affine-border-color)',
+  border: '1px solid var(--affine-black-10)',
   background: 'var(--affine-white)',
   transition: 'all 0.3s',
 });
@@ -234,7 +234,7 @@ export const closeButtonWithMediaStyle = style({
   },
 });
 export const closeButtonColorStyle = style({
-  color: 'var(--affine-white)',
+  color: 'var(--affine-text-primary-color)',
 });
 export const undoButtonStyle = style({
   fontSize: 'var(--affine-font-sm)',
@@ -296,10 +296,10 @@ export const lightWarningStyle = style({
   borderRadius: '8px',
 });
 export const darkColorStyle = style({
-  color: 'var(--affine-white)',
+  color: 'var(--affine-pure-white)',
 });
 export const lightInfoIconStyle = style({
-  color: 'var(--affine-processing-color)',
+  color: 'var(--affine-icon-color)',
 });
 export const defaultCollapseStyle = styleVariants({
   secondary: {

--- a/packages/component/src/components/notification-center/index.jotai.ts
+++ b/packages/component/src/components/notification-center/index.jotai.ts
@@ -1,11 +1,12 @@
+import { uuidv4 } from '@blocksuite/store';
 import { atom } from 'jotai';
 
 export type Notification = {
-  key: string;
+  key?: string;
   title: string;
-  message: string;
+  message?: string;
   type: 'success' | 'error' | 'warning' | 'info';
-  theme?: 'light' | 'dark';
+  theme?: 'light' | 'dark' | 'default';
   timeout?: number;
   progressingBar?: boolean;
   multimedia?: React.ReactNode | JSX.Element | HTMLElement;
@@ -41,6 +42,7 @@ export const removeNotificationAtom = atom(null, (_, set, key: string) => {
 export const pushNotificationAtom = atom<null, [Notification], void>(
   null,
   (_, set, newNotification) => {
+    newNotification.key = newNotification.key || uuidv4();
     const key = newNotification.key;
     const removeNotification = () =>
       set(notificationsBaseAtom, notifications =>

--- a/packages/component/src/components/page-list/operation-menu-items/export.tsx
+++ b/packages/component/src/components/page-list/operation-menu-items/export.tsx
@@ -9,7 +9,6 @@ import {
   ExportToPdfIcon,
   ExportToPngIcon,
 } from '@blocksuite/icons';
-import { uuidv4 } from '@blocksuite/store';
 import { useSetAtom } from 'jotai';
 import { useCallback } from 'react';
 
@@ -37,7 +36,6 @@ export const ExportToPdfMenuItem = ({
         .then(() => {
           onSelect?.({ type: 'pdf' });
           setPushNotification({
-            key: uuidv4(),
             title: t['com.affine.export.success.title'](),
             message: t['com.affine.export.success.message'](),
             type: 'success',
@@ -46,7 +44,6 @@ export const ExportToPdfMenuItem = ({
         .catch(err => {
           console.error(err);
           setPushNotification({
-            key: uuidv4(),
             title: t['com.affine.export.error.title'](),
             message: t['com.affine.export.error.message'](),
             type: 'error',
@@ -60,7 +57,6 @@ export const ExportToPdfMenuItem = ({
         .then(() => {
           onSelect?.({ type: 'pdf' });
           setPushNotification({
-            key: uuidv4(),
             title: t['com.affine.export.success.title'](),
             message: t['com.affine.export.success.message'](),
             type: 'success',
@@ -69,7 +65,6 @@ export const ExportToPdfMenuItem = ({
         .catch(err => {
           console.error(err);
           setPushNotification({
-            key: uuidv4(),
             title: t['com.affine.export.error.title'](),
             message: t['com.affine.export.error.message'](),
             type: 'error',
@@ -105,7 +100,6 @@ export const ExportToHtmlMenuItem = ({
       .then(() => {
         onSelect?.({ type: 'html' });
         setPushNotification({
-          key: uuidv4(),
           title: t['com.affine.export.success.title'](),
           message: t['com.affine.export.success.message'](),
           type: 'success',
@@ -114,7 +108,6 @@ export const ExportToHtmlMenuItem = ({
       .catch(err => {
         console.error(err);
         setPushNotification({
-          key: uuidv4(),
           title: t['com.affine.export.error.title'](),
           message: t['com.affine.export.error.message'](),
           type: 'error',
@@ -153,7 +146,6 @@ export const ExportToPngMenuItem = ({
       .then(() => {
         onSelect?.({ type: 'png' });
         setPushNotification({
-          key: uuidv4(),
           title: t['com.affine.export.success.title'](),
           message: t['com.affine.export.success.message'](),
           type: 'success',
@@ -162,7 +154,6 @@ export const ExportToPngMenuItem = ({
       .catch(err => {
         console.error(err);
         setPushNotification({
-          key: uuidv4(),
           title: t['com.affine.export.error.title'](),
           message: t['com.affine.export.error.message'](),
           type: 'error',
@@ -199,7 +190,6 @@ export const ExportToMarkdownMenuItem = ({
       .then(() => {
         onSelect?.({ type: 'markdown' });
         setPushNotification({
-          key: uuidv4(),
           title: t['com.affine.export.success.title'](),
           message: t['com.affine.export.success.message'](),
           type: 'success',
@@ -208,7 +198,6 @@ export const ExportToMarkdownMenuItem = ({
       .catch(err => {
         console.error(err);
         setPushNotification({
-          key: uuidv4(),
           title: t['com.affine.export.error.title'](),
           message: t['com.affine.export.error.message'](),
           type: 'error',


### PR DESCRIPTION
Notification Center now allows only title and type to be passed in as parameters. The default is ` theme: 'dark' `, you can pass ` theme: 'default' ` to switch to plain style.
```
  setPushNotification({
            title: t['com.affine.export.success.title'](),
            type: 'success',
          });
```
or:
```
  setPushNotification({
            title: t['com.affine.export.success.title'](),
            type: 'info',
            theme: 'default'
          });
``` 