### PR TITLE
chore: remove dependency of blocksuite/blocks/std

### DIFF
--- a/apps/core/src/bootstrap/plugins/setup.ts
+++ b/apps/core/src/bootstrap/plugins/setup.ts
@@ -130,7 +130,6 @@ const rootImportsMapSetupPromise = setupImportsMap(_rootImportsMap, {
     pushLayoutAtom: pushLayoutAtom,
     deleteLayoutAtom: deleteLayoutAtom,
   },
-  '@blocksuite/blocks/std': import('@blocksuite/blocks/std'),
   '@blocksuite/global/utils': import('@blocksuite/global/utils'),
   '@toeverything/infra/atom': import('@toeverything/infra/atom'),
   '@toeverything/components/button': import('@toeverything/components/button'),


### PR DESCRIPTION
This should be removed since nowhere using it. And I'll remove this export in blocksuite soon.