### PR TITLE
fix: reference page crash for deleted items

### DIFF
--- a/apps/core/src/components/pure/workspace-slider-bar/components/reference-page.tsx
+++ b/apps/core/src/components/pure/workspace-slider-bar/components/reference-page.tsx
@@ -29,7 +29,11 @@ export const ReferencePage = ({
   const icon = setting?.mode === 'edgeless' ? <EdgelessIcon /> : <PageIcon />;
   const references = useBlockSuitePageReferences(workspace, pageId);
   const referencesToShow = useMemo(() => {
-    return [...new Set(references.filter(ref => !metaMapping[ref]?.trash))];
+    return [
+      ...new Set(
+        references.filter(ref => metaMapping[ref] && !metaMapping[ref]?.trash)
+      ),
+    ];
   }, [references, metaMapping]);
   const [collapsed, setCollapsed] = useState(true);
   const collapsible = referencesToShow.length > 0;

--- a/packages/hooks/src/use-block-suite-page-references.ts
+++ b/packages/hooks/src/use-block-suite-page-references.ts
@@ -1,4 +1,3 @@
-import { assertExists } from '@blocksuite/global/utils';
 import type { Page, Workspace } from '@blocksuite/store';
 import { type Atom, atom, useAtomValue } from 'jotai';
 
@@ -14,7 +13,11 @@ function getPageReferences(page: Page): string[] {
     .filter(Boolean);
 }
 
-const getPageReferencesAtom = (page: Page) => {
+const getPageReferencesAtom = (page: Page | null) => {
+  if (!page) {
+    return atom([]);
+  }
+
   if (!weakMap.has(page)) {
     const baseAtom = atom<string[]>(getPageReferences(page));
     baseAtom.onMount = set => {
@@ -35,6 +38,5 @@ export function useBlockSuitePageReferences(
   pageId: string
 ): string[] {
   const page = useBlockSuiteWorkspacePage(blockSuiteWorkspace, pageId);
-  assertExists(page);
   return useAtomValue(getPageReferencesAtom(page));
 }


### PR DESCRIPTION
`useBlockSuitePageReferences` should not crash if the page is being deleted.