### PR TITLE
fix: recent pages list doesn't update

### DIFF
--- a/apps/core/src/components/blocksuite/block-suite-page-list/utils.tsx
+++ b/apps/core/src/components/blocksuite/block-suite-page-list/utils.tsx
@@ -20,9 +20,7 @@ export const usePageHelper = (blockSuiteWorkspace: BlockSuiteWorkspace) => {
     (id?: string, mode?: 'page' | 'edgeless') => {
       const page = createPage(id);
       initEmptyPage(page); // we don't need to wait it to be loaded right?
-      if (mode) {
-        setPageMode(page.id, mode);
-      }
+      setPageMode(page.id, mode || 'page');
       openPage(blockSuiteWorkspace.id, page.id);
     },
     [blockSuiteWorkspace.id, createPage, openPage, setPageMode]

--- a/apps/core/src/pages/workspace/detail-page.tsx
+++ b/apps/core/src/pages/workspace/detail-page.tsx
@@ -14,12 +14,14 @@ import {
   currentWorkspaceIdAtom,
   getCurrentStore,
 } from '@toeverything/infra/atom';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { type ReactElement, useCallback } from 'react';
 import type { LoaderFunction } from 'react-router-dom';
 import { redirect } from 'react-router-dom';
 
 import { getUIAdapter } from '../../adapters/workspace';
+import { setPageModeAtom } from '../../atoms';
+import { currentModeAtom } from '../../atoms/mode';
 import { useCurrentWorkspace } from '../../hooks/current/use-current-workspace';
 import { useNavigateHelper } from '../../hooks/use-navigate-helper';
 
@@ -31,8 +33,12 @@ const DetailPageImpl = (): ReactElement => {
   assertExists(currentPageId);
   const blockSuiteWorkspace = currentWorkspace.blockSuiteWorkspace;
   const collectionManager = useCollectionManager(currentWorkspace.id);
+  const mode = useAtomValue(currentModeAtom);
+  const setPageMode = useSetAtom(setPageModeAtom);
+
   const onLoad = useCallback(
     (_: Page, editor: EditorContainer) => {
+      setPageMode(currentPageId, mode);
       const dispose = editor.slots.pageLinkClicked.on(({ pageId }) => {
         return openPage(blockSuiteWorkspace.id, pageId);
       });

--- a/apps/core/src/pages/workspace/detail-page.tsx
+++ b/apps/core/src/pages/workspace/detail-page.tsx
@@ -55,9 +55,12 @@ const DetailPageImpl = (): ReactElement => {
     [
       blockSuiteWorkspace.id,
       collectionManager,
+      currentPageId,
       currentWorkspace.id,
       jumpToSubPath,
+      mode,
       openPage,
+      setPageMode,
     ]
   );
 


### PR DESCRIPTION
I think the issue appeared because "mode" was coming as undefined in utils.tsx file. 
So, set a default value of 'page' if mode is undefined.  With that change I was able to see the newly created page in recent list.

The other case is, When we click on existing page, it did not appear in the recent list. So, I performed setPageMode in detail-page.tsx.