### PR TITLE
fix(workspace): remove item not in the adapter

### DIFF
--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -127,6 +127,19 @@ const rootWorkspacesMetadataPromiseAtom = atom<
       for (const list of lists) {
         try {
           const item = await list();
+          // remove the metadata that is not in the list
+          {
+            const removed = metadata.filter(
+              meta =>
+                !item.some(x => x.id === meta.id && x.flavour === meta.flavour)
+            );
+            // remove the metadata that is not in the list
+            //  because we treat the workspace adapter as the source of truth
+            removed.forEach(meta => {
+              metadata.splice(metadata.indexOf(meta), 1);
+            });
+          }
+          // sort the metadata by the order of the list
           if (metadata.length) {
             item.sort((a, b) => {
               return (

--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -132,7 +132,7 @@ const rootWorkspacesMetadataPromiseAtom = atom<
           {
             const removed = metadata.filter(
               meta =>
-                !item.some(x => x.id === meta.id && x.flavour === meta.flavour)
+                !item.some(x => x.id !== meta.id && x.flavour === meta.flavour)
             );
             removed.forEach(meta => {
               metadata.splice(metadata.indexOf(meta), 1);

--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -120,19 +120,21 @@ const rootWorkspacesMetadataPromiseAtom = atom<
     }
     // step 2: fetch from adapters
     {
-      const lists = Object.values(WorkspaceAdapters)
-        .sort((a, b) => a.loadPriority - b.loadPriority)
-        .map(({ CRUD }) => CRUD.list);
+      const Adapters = Object.values(WorkspaceAdapters).sort(
+        (a, b) => a.loadPriority - b.loadPriority
+      );
 
-      for (const list of lists) {
+      for (const Adapter of Adapters) {
+        const { CRUD, flavour: currentFlavour } = Adapter;
         try {
-          const item = await list();
+          const item = await CRUD.list();
           // remove the metadata that is not in the list
           //  because we treat the workspace adapter as the source of truth
           {
             const removed = metadata.filter(
               meta =>
-                !item.some(x => x.id !== meta.id && x.flavour === meta.flavour)
+                meta.flavour === currentFlavour &&
+                !item.some(x => x.id === meta.id)
             );
             removed.forEach(meta => {
               metadata.splice(metadata.indexOf(meta), 1);

--- a/packages/workspace/src/atom.ts
+++ b/packages/workspace/src/atom.ts
@@ -128,13 +128,12 @@ const rootWorkspacesMetadataPromiseAtom = atom<
         try {
           const item = await list();
           // remove the metadata that is not in the list
+          //  because we treat the workspace adapter as the source of truth
           {
             const removed = metadata.filter(
               meta =>
                 !item.some(x => x.id === meta.id && x.flavour === meta.flavour)
             );
-            // remove the metadata that is not in the list
-            //  because we treat the workspace adapter as the source of truth
             removed.forEach(meta => {
               metadata.splice(metadata.indexOf(meta), 1);
             });


### PR DESCRIPTION
This will guarantee that if AFFiNE cloud server remove some workspace, we will also not display such workspace 