### PR TITLE
Fixes the button alignment for page and endless.

### DIFF
--- a/apps/core/src/components/pure/trash-button-group/styles.css.ts
+++ b/apps/core/src/components/pure/trash-button-group/styles.css.ts
@@ -3,11 +3,11 @@ import { style } from '@vanilla-extract/css';
 export const group = style({
   width: '100%',
   position: 'absolute',
-  bottom: '100px',
-  left: '0',
+  top: '1.2%',
   display: 'flex',
   gap: '24px',
-  justifyContent: 'center',
+  justifyContent: 'right',
+  paddingRight: '6%',
   zIndex: 2,
 });
 export const buttonContainer = style({


### PR DESCRIPTION
fixes toeverything/blocksuite#4390

I placed the restore and delete permanently button on the page head which is more user friendly and also does not create problem to both endless and page format.

<img width="1440" alt="Screenshot 2023-08-27 at 4 57 49 PM" src="https://github.com/toeverything/AFFiNE/assets/108489118/0810d559-5e34-4317-9c83-cbde09ad5ea3">
<img width="1440" alt="Screenshot 2023-08-27 at 4 57 35 PM" src="https://github.com/toeverything/AFFiNE/assets/108489118/c55e0e85-c2cd-49bd-8729-a091779fd974">
