### PR TITLE
fix: reduce the number of files being packed

### DIFF
--- a/apps/electron/package.json
+++ b/apps/electron/package.json
@@ -42,6 +42,7 @@
     "@electron-forge/shared-types": "^6.4.1",
     "@electron/remote": "2.0.10",
     "@reforged/maker-appimage": "^3.3.1",
+    "@toeverything/infra": "workspace:*",
     "@types/fs-extra": "^11.0.1",
     "@types/uuid": "^9.0.2",
     "cross-env": "7.0.3",
@@ -53,6 +54,8 @@
     "fs-extra": "^11.1.1",
     "glob": "^10.3.3",
     "jotai": "^2.4.0",
+    "lodash-es": "^4.17.21",
+    "rxjs": "^7.8.1",
     "ts-node": "^10.9.1",
     "undici": "^5.23.0",
     "uuid": "^9.0.0",
@@ -61,13 +64,10 @@
     "zx": "^7.2.3"
   },
   "dependencies": {
-    "@toeverything/infra": "workspace:*",
     "async-call-rpc": "^6.3.1",
     "electron-updater": "^6.1.4",
     "link-preview-js": "^3.0.5",
-    "lodash-es": "^4.17.21",
     "nanoid": "^4.0.2",
-    "rxjs": "^7.8.1",
     "yjs": "^13.6.7"
   },
   "build": {


### PR DESCRIPTION
Because the way how [Electron packager](https://github.com/electron/electron-packager) works, only the dependencies defined in `dependencies` in `package.json` will be copied into the final package.

Removing some of the blackholes greatly reduces the number of packaged files. See the result below.
This could speed up some tasks like code signing on Windows and [the lag of updater on Mac](https://github.com/toeverything/AFFiNE/issues/3834).



Before
![image](https://github.com/toeverything/AFFiNE/assets/584378/8344787c-e11f-4894-98df-5c7d1d7449ca)

After
![image](https://github.com/toeverything/AFFiNE/assets/584378/fd4853da-40e6-4460-8f08-41b5fa2743c3)

