### PR TITLE
fix: adjust email template font-family

### DIFF
--- a/apps/server/src/modules/auth/mailer/template.ts
+++ b/apps/server/src/modules/auth/mailer/template.ts
@@ -39,7 +39,7 @@ export const emailTemplate = ({
               font-size: 20px;
               font-weight: 600;
               line-height: 28px;
-              font-family: Inter;
+              font-family: inter, Arial, Helvetica, sans-serif;
               color: #444;
               padding-top: 0;
             "
@@ -51,7 +51,7 @@ export const emailTemplate = ({
               font-size: 15px;
               font-weight: 400;
               line-height: 24px;
-              font-family: Inter;
+              font-family: inter, Arial, Helvetica, sans-serif;
               color: #444;
               padding-top: 0;
             "
@@ -67,7 +67,7 @@ export const emailTemplate = ({
                     target="_blank"
                     style="
                       font-size: 15px;
-                      font-family: Inter;
+                      font-family: inter, Arial, Helvetica, sans-serif;
                       font-weight: 600;
                       line-height: 24px;
                       color: #fff;
@@ -163,7 +163,7 @@ export const emailTemplate = ({
               font-size: 12px;
               font-weight: 400;
               line-height: 20px;
-              font-family: Inter;
+              font-family: inter, Arial, Helvetica, sans-serif;
               color: #8e8d91;
               padding-top: 8px;
             "
@@ -177,7 +177,7 @@ export const emailTemplate = ({
               font-size: 12px;
               font-weight: 400;
               line-height: 20px;
-              font-family: Inter;
+              font-family: inter, Arial, Helvetica, sans-serif;
               color: #8e8d91;
               padding-top: 8px;
             "

--- a/apps/server/src/modules/auth/next-auth-options.ts
+++ b/apps/server/src/modules/auth/next-auth-options.ts
@@ -335,7 +335,7 @@ function html(params: { url: string; host: string }) {
             font-size: 20px;
             font-weight: 600;
             line-height: 28px;
-            font-family: Inter;
+            font-family: inter, Arial, Helvetica, sans-serif;
             color: #444;
             padding-top: 0;
           "
@@ -349,7 +349,7 @@ function html(params: { url: string; host: string }) {
             font-size: 15px;
             font-weight: 400;
             line-height: 24px;
-            font-family: Inter;
+            font-family: inter, Arial, Helvetica, sans-serif;
             color: #444;
             padding-top: 0;
           "
@@ -369,7 +369,7 @@ function html(params: { url: string; host: string }) {
                   target="_blank"
                   style="
                     font-size: 15px;
-                    font-family: Inter;
+                    font-family: inter, Arial, Helvetica, sans-serif;
                     font-weight: 600;
                     line-height: 24px;
                     color: #fff;
@@ -463,7 +463,7 @@ function html(params: { url: string; host: string }) {
             font-size: 12px;
             font-weight: 400;
             line-height: 20px;
-            font-family: Inter;
+            font-family: inter, Arial, Helvetica, sans-serif;
             color: #8e8d91;
             padding-top: 8px;
           "
@@ -477,7 +477,7 @@ function html(params: { url: string; host: string }) {
             font-size: 12px;
             font-weight: 400;
             line-height: 20px;
-            font-family: Inter;
+            font-family: inter, Arial, Helvetica, sans-serif;
             color: #8e8d91;
             padding-top: 8px;
           "


### PR DESCRIPTION
The inline font-family "Inter" is not pre-installed on any mainstream OS. We give it "Inter,Arial,Helvetica,sans-serif" instead.

Before
![image](https://github.com/toeverything/AFFiNE/assets/584378/b73ba26d-76a8-4818-8bb1-87d87b100895)

After
![image](https://github.com/toeverything/AFFiNE/assets/584378/cf30d0f8-389f-4dd4-aa8a-b077199f18ae)
