### PR TITLE
fix: electron white screen

### DIFF
--- a/apps/electron/forge.config.js
+++ b/apps/electron/forge.config.js
@@ -114,7 +114,6 @@ module.exports = {
       : undefined,
     // We need the following line for updater
     extraResource: ['./resources/app-update.yml'],
-    ignore: ['e2e', 'tests'],
     protocols: [
       {
         name: productName,


### PR DESCRIPTION
It turns out the auto-generated hash in file names may cause them to be excluded in the final bundle.

E.g., see the following
![img_v2_a3af313d-e206-4df1-9e8b-d04abff92bbg](https://github.com/toeverything/AFFiNE/assets/584378/690fa600-bd6c-4273-bd95-d8a808663192)

The e2e part in ses-**e2e**4fb59.js causes it to be excluded in the final bundle.