### PR TITLE
feat: support google login on desktop

### DIFF
--- a/apps/core/src/components/affine/auth/after-sign-in-send-email.tsx
+++ b/apps/core/src/components/affine/auth/after-sign-in-send-email.tsx
@@ -35,7 +35,7 @@ export const AfterSignInSendEmail: FC<AuthPanelProps> = ({
         onClick={useCallback(() => {
           signIn('email', {
             email,
-            callbackUrl: buildCallbackUrl('signIn'),
+            callbackUrl: buildCallbackUrl('/auth/signIn'),
             redirect: true,
           }).catch(console.error);
         }, [email])}

--- a/apps/core/src/components/affine/auth/after-sign-up-send-email.tsx
+++ b/apps/core/src/components/affine/auth/after-sign-up-send-email.tsx
@@ -34,7 +34,7 @@ export const AfterSignUpSendEmail: FC<AuthPanelProps> = ({
         onClick={useCallback(() => {
           signIn('email', {
             email: email,
-            callbackUrl: buildCallbackUrl('signUp'),
+            callbackUrl: buildCallbackUrl('/auth/signUp'),
             redirect: true,
           }).catch(console.error);
         }, [email])}

--- a/apps/core/src/components/affine/auth/callback-url.ts
+++ b/apps/core/src/components/affine/auth/callback-url.ts
@@ -1,9 +1,6 @@
 import { isDesktop } from '@affine/env/constant';
 
-type Action = 'signUp' | 'changePassword' | 'signIn' | 'signUp';
-
-export function buildCallbackUrl(action: Action) {
-  const callbackUrl = `/auth/${action}`;
+export function buildCallbackUrl(callbackUrl: string) {
   const params: string[][] = [];
   if (isDesktop && window.appInfo.schema) {
     params.push(['schema', window.appInfo.schema]);

--- a/apps/core/src/components/affine/auth/sign-in.tsx
+++ b/apps/core/src/components/affine/auth/sign-in.tsx
@@ -1,6 +1,7 @@
 import { AuthInput, ModalHeader } from '@affine/component/auth-components';
 import { pushNotificationAtom } from '@affine/component/notification-center';
 import type { Notification } from '@affine/component/notification-center/index.jotai';
+import { isDesktop } from '@affine/env/constant';
 import { getUserQuery } from '@affine/graphql';
 import { Trans } from '@affine/i18n';
 import { useAFFiNEI18N } from '@affine/i18n/hooks';
@@ -68,7 +69,7 @@ export const SignIn: FC<AuthPanelProps> = ({
     if (user) {
       signIn('email', {
         email: email,
-        callbackUrl: buildCallbackUrl('signIn'),
+        callbackUrl: buildCallbackUrl('/auth/signIn'),
         redirect: false,
       })
         .then(res => handleSendEmailError(res, pushNotification))
@@ -77,7 +78,7 @@ export const SignIn: FC<AuthPanelProps> = ({
     } else {
       signIn('email', {
         email: email,
-        callbackUrl: buildCallbackUrl('signUp'),
+        callbackUrl: buildCallbackUrl('/auth/signUp'),
         redirect: false,
       })
         .then(res => handleSendEmailError(res, pushNotification))
@@ -102,7 +103,16 @@ export const SignIn: FC<AuthPanelProps> = ({
         }}
         icon={<GoogleDuotoneIcon />}
         onClick={useCallback(() => {
-          signIn('google').catch(console.error);
+          if (isDesktop) {
+            open(
+              `/desktop-signin?provider=google&callback_url=${buildCallbackUrl(
+                '/open-app/oauth-jwt'
+              )}`,
+              '_target'
+            );
+          } else {
+            signIn('google').catch(console.error);
+          }
         }, [])}
       >
         {t['Continue with Google']()}

--- a/apps/core/src/pages/desktop-signin.tsx
+++ b/apps/core/src/pages/desktop-signin.tsx
@@ -1,0 +1,35 @@
+import { signIn, type SignInResponse } from 'next-auth/react';
+import { useEffect, useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { z } from 'zod';
+
+const supportedProvider = z.enum(['google']);
+
+let wip = false;
+
+export const Component = () => {
+  const [params] = useSearchParams();
+  const provider = useMemo(() => {
+    const maybeProvider = supportedProvider.safeParse(params.get('provider'));
+    return maybeProvider.success ? maybeProvider.data : null;
+  }, [params]);
+
+  const callback_url = params.get('callback_url');
+
+  useEffect(() => {
+    if (wip) {
+      return;
+    }
+    if (provider && callback_url) {
+      wip = true;
+      signIn(provider, {
+        callbackUrl: callback_url,
+      }).catch((res: SignInResponse | undefined) => {
+        if (res?.error) {
+          console.error(res.error);
+        }
+      });
+    }
+  }, [provider, callback_url]);
+  return null;
+};

--- a/apps/core/src/pages/desktop-signin.tsx
+++ b/apps/core/src/pages/desktop-signin.tsx
@@ -1,35 +1,31 @@
 import { signIn, type SignInResponse } from 'next-auth/react';
-import { useEffect, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import type { LoaderFunction } from 'react-router-dom';
 import { z } from 'zod';
 
 const supportedProvider = z.enum(['google']);
 
-let wip = false;
+export const loader: LoaderFunction = async ({ request }) => {
+  const url = new URL(request.url);
+  const searchParams = url.searchParams;
+  const provider = searchParams.get('provider');
+  const callback_url = searchParams.get('callback_url');
+  if (!callback_url) {
+    return null;
+  }
+  const maybeProvider = supportedProvider.safeParse(provider);
+  if (maybeProvider.success) {
+    const provider = maybeProvider.data;
+    await signIn(provider, {
+      callbackUrl: callback_url,
+    }).catch((res: SignInResponse | undefined) => {
+      if (res?.error) {
+        console.error(res.error);
+      }
+    });
+  }
+  return null;
+};
 
 export const Component = () => {
-  const [params] = useSearchParams();
-  const provider = useMemo(() => {
-    const maybeProvider = supportedProvider.safeParse(params.get('provider'));
-    return maybeProvider.success ? maybeProvider.data : null;
-  }, [params]);
-
-  const callback_url = params.get('callback_url');
-
-  useEffect(() => {
-    if (wip) {
-      return;
-    }
-    if (provider && callback_url) {
-      wip = true;
-      signIn(provider, {
-        callbackUrl: callback_url,
-      }).catch((res: SignInResponse | undefined) => {
-        if (res?.error) {
-          console.error(res.error);
-        }
-      });
-    }
-  }, [provider, callback_url]);
   return null;
 };

--- a/apps/core/src/router.ts
+++ b/apps/core/src/router.ts
@@ -49,8 +49,12 @@ export const routes = [
     lazy: () => import('./pages/sign-in'),
   },
   {
-    path: '/open-app',
+    path: '/open-app/:action',
     lazy: () => import('./pages/open-app'),
+  },
+  {
+    path: '/desktop-signin',
+    lazy: () => import('./pages/desktop-signin'),
   },
   {
     path: '*',

--- a/apps/electron/src/main/main-window.ts
+++ b/apps/electron/src/main/main-window.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 
-import { BrowserWindow, nativeTheme } from 'electron';
+import { BrowserWindow, type CookiesSetDetails, nativeTheme } from 'electron';
 import electronWindowState from 'electron-window-state';
 import { join } from 'path';
 
@@ -174,7 +174,22 @@ export function reloadApp() {
   browserWindow?.reload();
 }
 
-export async function setCookie(origin: string, cookie: string) {
+export async function setCookie(cookie: CookiesSetDetails): Promise<void>;
+export async function setCookie(origin: string, cookie: string): Promise<void>;
+
+export async function setCookie(
+  arg0: CookiesSetDetails | string,
+  arg1?: string
+) {
   const window = await restoreOrCreateWindow();
-  await window.webContents.session.cookies.set(parseCookie(cookie, origin));
+  const details =
+    typeof arg1 === 'string' && typeof arg0 === 'string'
+      ? parseCookie(arg0, arg1)
+      : arg0;
+
+  if (typeof details !== 'object') {
+    throw new Error('invalid cookie details');
+  }
+
+  await window.webContents.session.cookies.set(details);
 }

--- a/apps/server/src/modules/auth/resolver.ts
+++ b/apps/server/src/modules/auth/resolver.ts
@@ -34,7 +34,7 @@ export class AuthResolver {
 
   @ResolveField(() => TokenType)
   token(@CurrentUser() currentUser: UserType, @Parent() user: UserType) {
-    if (user !== currentUser) {
+    if (user.id !== currentUser.id) {
       throw new ForbiddenException();
     }
 

--- a/apps/server/src/modules/users/resolver.ts
+++ b/apps/server/src/modules/users/resolver.ts
@@ -83,14 +83,20 @@ export class UserResolver {
     description: 'Get current user',
   })
   async currentUser(@CurrentUser() user: User) {
+    const storedUser = await this.prisma.user.findUnique({
+      where: { id: user.id },
+    });
+    if (!storedUser) {
+      throw new BadRequestException(`User ${user.id} not found in db`);
+    }
     return {
-      id: user.id,
-      name: user.name,
-      email: user.email,
-      emailVerified: user.emailVerified,
-      avatarUrl: user.avatarUrl,
-      createdAt: user.createdAt,
-      hasPassword: !!user.password,
+      id: storedUser.id,
+      name: storedUser.name,
+      email: storedUser.email,
+      emailVerified: storedUser.emailVerified,
+      avatarUrl: storedUser.avatarUrl,
+      createdAt: storedUser.createdAt,
+      hasPassword: !!storedUser.password,
     };
   }
 

--- a/packages/graphql/src/graphql/get-current-user.gql
+++ b/packages/graphql/src/graphql/get-current-user.gql
@@ -6,5 +6,8 @@ query getCurrentUser {
     emailVerified
     avatarUrl
     createdAt
+    token {
+      token
+    }
   }
 }

--- a/packages/graphql/src/graphql/index.ts
+++ b/packages/graphql/src/graphql/index.ts
@@ -125,6 +125,9 @@ query getCurrentUser {
     emailVerified
     avatarUrl
     createdAt
+    token {
+      token
+    }
   }
 }`,
 };

--- a/packages/graphql/src/schema.ts
+++ b/packages/graphql/src/schema.ts
@@ -147,6 +147,7 @@ export type GetCurrentUserQuery = {
     emailVerified: string | null;
     avatarUrl: string | null;
     createdAt: string | null;
+    token: { __typename?: 'TokenType'; token: string };
   };
 };
 


### PR DESCRIPTION
Thanks to the help of @darkskygit, it turns out that we don't need any hacks within Electron by creating a hidden window and handling login inside it. Now, we have a much easier solution:

- Instead of directly calling the signin function when signing in is initiated via Electron, we can pop up the login window in the browser and initiate signIn there.
- Once Google signin is finished, it can redirect to the open-app route, fetch the JWT token, and send it to the desktop app.
- The desktop app can then accept the token and set it to the browser window using cookie.

It seems like we don't need to change the electron origin after all. I will go back and fix email login as well later on.