### PR TITLE
fix: show border around pagetitle when renaming

### DIFF
--- a/apps/core/src/components/blocksuite/block-suite-header-title/styles.css.ts
+++ b/apps/core/src/components/blocksuite/block-suite-header-title/styles.css.ts
@@ -25,6 +25,15 @@ export const titleInput = style({
   margin: 'auto',
   width: '100%',
   height: '100%',
+
+  selectors: {
+    '&:focus': {
+      border: '1px solid var(--affine-black-10)',
+      borderRadius: '8px',
+      height: '32px',
+      padding: '6px 8px',
+    },
+  },
 });
 export const shadowTitle = style({
   visibility: 'hidden',


### PR DESCRIPTION
fix: #4056 

Showed a border around the page title only when title input is on focus.