### PR TITLE
fix: cookie issues in Electron

### DIFF
--- a/apps/core/src/components/affine/auth/sign-in-with-password.tsx
+++ b/apps/core/src/components/affine/auth/sign-in-with-password.tsx
@@ -9,10 +9,11 @@ import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { Button } from '@toeverything/components/button';
 import { useSetAtom } from 'jotai';
 // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { signIn, useSession } from 'next-auth/react';
+import { useSession } from 'next-auth/react';
 import type { FC } from 'react';
 import { useCallback, useState } from 'react';
 
+import { signInCloud } from '../../../utils/cloud-utils';
 import type { AuthPanelProps } from './index';
 import { forgetPasswordButton } from './style.css';
 
@@ -30,7 +31,7 @@ export const SignInWithPassword: FC<AuthPanelProps> = ({
   const [passwordError, setPasswordError] = useState(false);
 
   const onSignIn = useCallback(async () => {
-    const res = await signIn('credentials', {
+    const res = await signInCloud('credentials', {
       redirect: false,
       email,
       password,

--- a/apps/core/src/utils/cloud-utils.tsx
+++ b/apps/core/src/utils/cloud-utils.tsx
@@ -17,26 +17,30 @@ export const signInCloud: typeof signIn = async (provider, ...rest) => {
         '_target'
       );
       return;
-    } else if (provider === 'email') {
+    } else {
       const [options, ...tail] = rest;
+      const callbackUrl =
+        runtimeConfig.serverUrlPrefix +
+        (provider === 'email' ? '/open-app/oauth-jwt' : location.pathname);
       return signIn(
         provider,
         {
           ...options,
-          callbackUrl: buildCallbackUrl('/open-app/oauth-jwt'),
+          callbackUrl: buildCallbackUrl(callbackUrl),
         },
         ...tail
       );
-    } else {
-      throw new Error('Unsupported provider');
     }
   } else {
     return signIn(provider, ...rest);
   }
 };
 
-export const signOutCloud: typeof signOut = async (...args) => {
-  return signOut(...args).then(result => {
+export const signOutCloud: typeof signOut = async options => {
+  return signOut({
+    ...options,
+    callbackUrl: '/',
+  }).then(result => {
     if (result) {
       startTransition(() => {
         getCurrentStore().set(refreshRootMetadataAtom);

--- a/apps/electron/src/main/deep-link.ts
+++ b/apps/electron/src/main/deep-link.ts
@@ -77,12 +77,17 @@ async function handleOauthJwt(url: string) {
         return;
       }
 
+      const isSecure = CLOUD_BASE_URL.startsWith('https://');
+
       // set token to cookie
       await setCookie({
         url: CLOUD_BASE_URL,
         httpOnly: true,
         value: token,
-        name: 'next-auth.session-token',
+        secure: true,
+        name: isSecure
+          ? '__Secure-next-auth.session-token'
+          : 'next-auth.session-token',
         expirationDate: Math.floor(Date.now() / 1000 + 3600 * 24 * 7),
       });
 

--- a/apps/electron/src/main/deep-link.ts
+++ b/apps/electron/src/main/deep-link.ts
@@ -2,10 +2,11 @@ import path from 'node:path';
 
 import type { App } from 'electron';
 
-import { buildType, isDev } from './config';
+import { buildType, CLOUD_BASE_URL, isDev } from './config';
 import { logger } from './logger';
 import {
   handleOpenUrlInHiddenWindow,
+  mainWindowOrigin,
   restoreOrCreateWindow,
   setCookie,
 } from './main-window';
@@ -70,7 +71,6 @@ async function handleOauthJwt(url: string) {
       mainWindow.show();
       const urlObj = new URL(url);
       const token = urlObj.searchParams.get('token');
-      const mainOrigin = new URL(mainWindow.webContents.getURL()).origin;
 
       if (!token) {
         logger.error('no token in url', url);
@@ -79,15 +79,23 @@ async function handleOauthJwt(url: string) {
 
       // set token to cookie
       await setCookie({
-        url: mainOrigin,
+        url: CLOUD_BASE_URL,
         httpOnly: true,
         value: token,
         name: 'next-auth.session-token',
+        expirationDate: Math.floor(Date.now() / 1000 + 3600 * 24 * 7),
+      });
+
+      // force reset next-auth.callback-url
+      await setCookie({
+        url: CLOUD_BASE_URL,
+        httpOnly: true,
+        name: 'next-auth.callback-url',
       });
 
       // hacks to refresh auth state in the main window
       const window = await handleOpenUrlInHiddenWindow(
-        mainOrigin + '/auth/signIn'
+        mainWindowOrigin + '/auth/signIn'
       );
       uiSubjects.onFinishLogin.next({
         success: true,

--- a/apps/electron/src/main/main-window.ts
+++ b/apps/electron/src/main/main-window.ts
@@ -147,16 +147,11 @@ export async function restoreOrCreateWindow() {
 }
 
 export async function handleOpenUrlInHiddenWindow(url: string) {
-  const mainExposedMeta = getExposedMeta();
   const win = new BrowserWindow({
     width: 1200,
     height: 600,
     webPreferences: {
       preload: join(__dirname, './preload.js'),
-      additionalArguments: [
-        `--main-exposed-meta=` + JSON.stringify(mainExposedMeta),
-        // popup window does not need helper process, right?
-      ],
     },
     show: false,
   });

--- a/apps/server/src/modules/auth/next-auth-options.ts
+++ b/apps/server/src/modules/auth/next-auth-options.ts
@@ -98,7 +98,7 @@ export const NextAuthOptionsProvider: FactoryProvider<NextAuthOptions> = {
       adapter: prismaAdapter,
       debug: !config.node.prod,
       session: {
-        strategy: config.node.prod ? 'database' : 'jwt',
+        strategy: 'jwt',
       },
       // @ts-expect-error Third part library type mismatch
       logger: console,


### PR DESCRIPTION
need to handling cookies more gracefully
- if getting back cookies from api, we will mark it cross-domain available
- if sending request, add the cookies to headers

also fix some issues related to callbackUrl. If not being explicitly set in electron, it will be something like `file://./xxxx` and the api server does not like it and throw.