### PR TITLE
refactor(plugin-cli): use separate output

### DIFF
--- a/apps/core/.webpack/config.ts
+++ b/apps/core/.webpack/config.ts
@@ -90,7 +90,6 @@ export const createConfiguration: (
   runtimeConfig: RuntimeConfig
 ) => Promise<webpack.Configuration> = async (buildFlags, runtimeConfig) => {
   const plugins = await readdir(resolve(projectRoot, 'plugins'));
-  console.log('plugins', plugins);
   const copyPatterns = plugins.map(plugin => {
     return {
       from: resolve(projectRoot, 'plugins', plugin, 'dist', 'core'),

--- a/apps/core/.webpack/webpack.config.ts
+++ b/apps/core/.webpack/webpack.config.ts
@@ -14,7 +14,7 @@ export default async function (cli_env: any, _: any) {
   console.log('build flags', flags);
   const runtimeConfig = getRuntimeConfig(flags);
   console.log('runtime config', runtimeConfig);
-  const config = createConfiguration(flags, runtimeConfig);
+  const config = await createConfiguration(flags, runtimeConfig);
   return merge(config, {
     entry: {
       'polyfill/intl-segmenter': {

--- a/apps/electron/forge.config.js
+++ b/apps/electron/forge.config.js
@@ -87,7 +87,7 @@ const makers = [
 ].filter(Boolean);
 
 /**
- * @type {import('@electron-forge/shared-types').ForgeConfig}
+ * @type {import("@electron-forge/shared-types").ForgeConfig}
  */
 module.exports = {
   buildIdentifier: buildType,

--- a/apps/electron/scripts/build-layers.mjs
+++ b/apps/electron/scripts/build-layers.mjs
@@ -1,9 +1,12 @@
 #!/usr/bin/env zx
 import 'zx/globals';
 
+import { cp } from 'node:fs/promises';
+import path from 'node:path';
+
 import * as esbuild from 'esbuild';
 
-import { config } from './common.mjs';
+import { config, electronDir, projectRoot } from './common.mjs';
 
 const NODE_ENV =
   process.env.NODE_ENV === 'development' ? 'development' : 'production';
@@ -15,6 +18,14 @@ if (process.platform === 'win32') {
 
 async function buildLayers() {
   const common = config();
+  await cp(
+    path.resolve(projectRoot, './plugins/bookmark/dist/desktop'),
+    path.resolve(electronDir, './dist/plugins/bookmark'),
+    {
+      recursive: true,
+      force: true,
+    }
+  );
   await esbuild.build({
     ...common.layers,
     define: {

--- a/apps/electron/scripts/common.mjs
+++ b/apps/electron/scripts/common.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 
 export const electronDir = fileURLToPath(new URL('..', import.meta.url));
 
-export const rootDir = resolve(electronDir, '..', '..');
+export const projectRoot = resolve(electronDir, '..', '..', '..');
 
 export const NODE_MAJOR_VERSION = 18;
 

--- a/apps/electron/scripts/dev.mjs
+++ b/apps/electron/scripts/dev.mjs
@@ -1,10 +1,15 @@
 /* eslint-disable no-async-promise-executor */
 import { spawn } from 'node:child_process';
+import { cp } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import electronPath from 'electron';
 import * as esbuild from 'esbuild';
 
 import { config } from './common.mjs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 // this means we don't spawn electron windows, mainly for testing
 const watchMode = process.argv.includes('--watch');
@@ -63,6 +68,20 @@ async function watchLayers() {
         {
           name: 'electron-dev:reload-app-on-layers-change',
           setup(build) {
+            build.onStart(async () => {
+              console.log(`[layers] has changed, copy bookmark plugin`);
+              await cp(
+                path.resolve(
+                  __dirname,
+                  '../../../plugins/bookmark/dist/desktop'
+                ),
+                path.resolve(__dirname, '../dist/plugins/bookmark'),
+                {
+                  recursive: true,
+                  force: true,
+                }
+              );
+            });
             build.onEnd(() => {
               if (initialBuild) {
                 console.log(`[layers] has changed, [re]launching electron...`);

--- a/apps/electron/scripts/dev.mjs
+++ b/apps/electron/scripts/dev.mjs
@@ -2,14 +2,11 @@
 import { spawn } from 'node:child_process';
 import { cp } from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
 import electronPath from 'electron';
 import * as esbuild from 'esbuild';
 
-import { config } from './common.mjs';
-
-const __dirname = fileURLToPath(new URL('.', import.meta.url));
+import { config, electronDir, projectRoot } from './common.mjs';
 
 // this means we don't spawn electron windows, mainly for testing
 const watchMode = process.argv.includes('--watch');
@@ -71,11 +68,8 @@ async function watchLayers() {
             build.onStart(async () => {
               console.log(`[layers] has changed, copy bookmark plugin`);
               await cp(
-                path.resolve(
-                  __dirname,
-                  '../../../plugins/bookmark/dist/desktop'
-                ),
-                path.resolve(__dirname, '../dist/plugins/bookmark'),
+                path.resolve(projectRoot, './plugins/bookmark/dist/desktop'),
+                path.resolve(electronDir, './dist/plugins/bookmark'),
                 {
                   recursive: true,
                   force: true,

--- a/plugins/bookmark/project.json
+++ b/plugins/bookmark/project.json
@@ -17,7 +17,7 @@
       "dependsOn": ["^build"],
       "inputs": ["default"],
       "outputs": [
-        "{workspaceRoot}/apps/core/public/plugins/bookmark",
+        "{projectRoot}/dist",
         "{workspaceRoot}/apps/electron/dist/plugins/bookmark"
       ]
     }

--- a/plugins/bookmark/project.json
+++ b/plugins/bookmark/project.json
@@ -16,10 +16,7 @@
       },
       "dependsOn": ["^build"],
       "inputs": ["default"],
-      "outputs": [
-        "{projectRoot}/dist",
-        "{workspaceRoot}/apps/electron/dist/plugins/bookmark"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     }
   },
   "tags": ["plugin"]

--- a/plugins/copilot/project.json
+++ b/plugins/copilot/project.json
@@ -17,7 +17,7 @@
       "dependsOn": ["^build"],
       "inputs": ["default"],
       "outputs": [
-        "{workspaceRoot}/apps/core/public/plugins/copilot",
+        "{projectRoot}/dist",
         "{workspaceRoot}/apps/electron/dist/plugins/copilot"
       ]
     }

--- a/plugins/copilot/project.json
+++ b/plugins/copilot/project.json
@@ -16,10 +16,7 @@
       },
       "dependsOn": ["^build"],
       "inputs": ["default"],
-      "outputs": [
-        "{projectRoot}/dist",
-        "{workspaceRoot}/apps/electron/dist/plugins/copilot"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     }
   },
   "tags": ["plugin"]

--- a/plugins/hello-world/project.json
+++ b/plugins/hello-world/project.json
@@ -17,7 +17,7 @@
       "dependsOn": ["^build"],
       "inputs": ["default"],
       "outputs": [
-        "{workspaceRoot}/apps/core/public/plugins/hello-world",
+        "{projectRoot}/dist",
         "{workspaceRoot}/apps/electron/dist/plugins/hello-world"
       ]
     }

--- a/plugins/hello-world/project.json
+++ b/plugins/hello-world/project.json
@@ -16,10 +16,7 @@
       },
       "dependsOn": ["^build"],
       "inputs": ["default"],
-      "outputs": [
-        "{projectRoot}/dist",
-        "{workspaceRoot}/apps/electron/dist/plugins/hello-world"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     }
   },
   "tags": ["plugin"]

--- a/plugins/image-preview/project.json
+++ b/plugins/image-preview/project.json
@@ -17,7 +17,7 @@
       "dependsOn": ["^build"],
       "inputs": ["default"],
       "outputs": [
-        "{workspaceRoot}/apps/core/public/plugins/image-preview",
+        "{projectRoot}/dist",
         "{workspaceRoot}/apps/electron/dist/plugins/image-preview"
       ]
     }

--- a/plugins/image-preview/project.json
+++ b/plugins/image-preview/project.json
@@ -16,10 +16,7 @@
       },
       "dependsOn": ["^build"],
       "inputs": ["default"],
-      "outputs": [
-        "{projectRoot}/dist",
-        "{workspaceRoot}/apps/electron/dist/plugins/image-preview"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     }
   },
   "tags": ["plugin"]

--- a/plugins/outline/project.json
+++ b/plugins/outline/project.json
@@ -16,10 +16,7 @@
       },
       "dependsOn": ["^build"],
       "inputs": ["default"],
-      "outputs": [
-        "{workspaceRoot}/apps/core/public/plugins/outline",
-        "{workspaceRoot}/apps/electron/dist/plugins/outline"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     }
   },
   "tags": ["plugin"]

--- a/plugins/vue-hello-world/project.json
+++ b/plugins/vue-hello-world/project.json
@@ -16,10 +16,7 @@
       },
       "dependsOn": ["^build"],
       "inputs": ["default"],
-      "outputs": [
-        "{workspaceRoot}/apps/core/public/plugins/vue-hello-world",
-        "{workspaceRoot}/apps/electron/dist/plugins/vue-hello-world"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     }
   },
   "tags": ["plugin"]


### PR DESCRIPTION
We will publish the `plugin-cli` to make sure third-party repo can generate the code

I think `bookmark` shouldn't be a plugin as it too hacky