### PR TITLE
fix: api url for electron

### DIFF
--- a/apps/electron/src/main/config.ts
+++ b/apps/electron/src/main/config.ts
@@ -17,7 +17,7 @@ export const isDev = mode === 'development';
 
 const API_URL_MAPPING = {
   stable: `https://app.affine.pro`,
-  beta: `https://ambassador.affine.pro`,
+  beta: `https://insider.affine.pro`,
   canary: `https://affine.fail`,
   internal: `https://affine.fail`,
 };

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,7 +1,7 @@
 const ALLOW_ORIGIN = [
   'https://affine.pro',
   'https://app.affine.pro',
-  'https://ambassador.affine.pro',
+  'https://insider.affine.pro',
   'https://affine.fail',
 ];
 


### PR DESCRIPTION
maybe we need a single-source-of-truth config for these urls