### PR TITLE
fix: notification text cannot be selected when there is a modal

### DIFF
--- a/packages/component/src/ui/modal/modal.tsx
+++ b/packages/component/src/ui/modal/modal.tsx
@@ -49,6 +49,7 @@ export const Modal = (props: ModalProps) => {
       slots={{ backdrop: Backdrop }}
       alignItems={transformConfig[vertical]}
       justifyContent={transformConfig[horizontal]}
+      disableEnforceFocus
     >
       <Fade in={open}>{children}</Fade>
     </StyledModal>


### PR DESCRIPTION
This fixes issue #4100 where the notification text was not able to be selected when modal was open. 
@JimmFly can you review?