### PR TITLE
fix: circular dependencies

### DIFF
--- a/apps/core/src/components/affine/new-workspace-setting-detail/delete-leave-workspace/index.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/delete-leave-workspace/index.tsx
@@ -6,7 +6,7 @@ import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { ArrowRightSmallIcon } from '@blocksuite/icons';
 import { useCallback, useState } from 'react';
 
-import type { WorkspaceSettingDetailProps } from '../index';
+import type { WorkspaceSettingDetailProps } from '../types';
 import { WorkspaceDeleteModal } from './delete';
 
 export interface DeleteLeaveWorkspaceProps extends WorkspaceSettingDetailProps {

--- a/apps/core/src/components/affine/new-workspace-setting-detail/index.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/index.tsx
@@ -3,10 +3,6 @@ import {
   SettingRow,
   SettingWrapper,
 } from '@affine/component/setting-components';
-import type {
-  WorkspaceFlavour,
-  WorkspaceRegistry,
-} from '@affine/env/workspace';
 import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { useBlockSuiteWorkspaceName } from '@toeverything/hooks/use-block-suite-workspace-name';
 import { useMemo } from 'react';
@@ -19,22 +15,7 @@ import { MembersPanel } from './members';
 import { ProfilePanel } from './profile';
 import { PublishPanel } from './publish';
 import { StoragePanel } from './storage';
-
-export interface WorkspaceSettingDetailProps {
-  workspaceId: string;
-  isOwner: boolean;
-  onDeleteLocalWorkspace: () => void;
-  onDeleteCloudWorkspace: () => void;
-  onLeaveWorkspace: () => void;
-  onTransferWorkspace: <
-    From extends WorkspaceFlavour,
-    To extends WorkspaceFlavour,
-  >(
-    from: From,
-    to: To,
-    workspace: WorkspaceRegistry[From]
-  ) => void;
-}
+import type { WorkspaceSettingDetailProps } from './types';
 
 export const WorkspaceSettingDetail = (props: WorkspaceSettingDetailProps) => {
   const { workspaceId } = props;

--- a/apps/core/src/components/affine/new-workspace-setting-detail/labels.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/labels.tsx
@@ -1,8 +1,8 @@
 import type { AffineOfficialWorkspace } from '@affine/env/workspace';
 import { useMemo } from 'react';
 
-import { type WorkspaceSettingDetailProps } from './index';
 import * as style from './style.css';
+import type { WorkspaceSettingDetailProps } from './types';
 
 export interface LabelsPanelProps extends WorkspaceSettingDetailProps {
   workspace: AffineOfficialWorkspace;

--- a/apps/core/src/components/affine/new-workspace-setting-detail/members.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/members.tsx
@@ -25,8 +25,8 @@ import { useInviteMember } from '../../../hooks/affine/use-invite-member';
 import { type Member, useMembers } from '../../../hooks/affine/use-members';
 import { useRevokeMemberPermission } from '../../../hooks/affine/use-revoke-member-permission';
 import { AnyErrorBoundary } from '../any-error-boundary';
-import { type WorkspaceSettingDetailProps } from './index';
 import * as style from './style.css';
+import type { WorkspaceSettingDetailProps } from './types';
 
 export interface MembersPanelProps extends WorkspaceSettingDetailProps {
   workspace: AffineOfficialWorkspace;

--- a/apps/core/src/components/affine/new-workspace-setting-detail/profile.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/profile.tsx
@@ -15,8 +15,8 @@ import {
 } from 'react';
 
 import { Upload } from '../../pure/file-upload';
-import { type WorkspaceSettingDetailProps } from './index';
 import * as style from './style.css';
+import type { WorkspaceSettingDetailProps } from './types';
 
 export interface ProfilePanelProps extends WorkspaceSettingDetailProps {
   workspace: AffineOfficialWorkspace;

--- a/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx
@@ -17,8 +17,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from '../../../utils';
 import { EnableAffineCloudModal } from '../enable-affine-cloud-modal';
 import { TmpDisableAffineCloudModal } from '../tmp-disable-affine-cloud-modal';
-import type { WorkspaceSettingDetailProps } from './index';
 import * as style from './style.css';
+import type { WorkspaceSettingDetailProps } from './types';
 
 export interface PublishPanelProps
   extends Omit<WorkspaceSettingDetailProps, 'workspaceId'> {

--- a/apps/core/src/components/affine/new-workspace-setting-detail/types.ts
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/types.ts
@@ -1,0 +1,20 @@
+import type {
+  WorkspaceFlavour,
+  WorkspaceRegistry,
+} from '@affine/env/workspace';
+
+export interface WorkspaceSettingDetailProps {
+  workspaceId: string;
+  isOwner: boolean;
+  onDeleteLocalWorkspace: () => void;
+  onDeleteCloudWorkspace: () => void;
+  onLeaveWorkspace: () => void;
+  onTransferWorkspace: <
+    From extends WorkspaceFlavour,
+    To extends WorkspaceFlavour,
+  >(
+    from: From,
+    to: To,
+    workspace: WorkspaceRegistry[From]
+  ) => void;
+}

--- a/apps/electron/src/helper/db/ensure-db.ts
+++ b/apps/electron/src/helper/db/ensure-db.ts
@@ -25,7 +25,8 @@ import {
 } from 'rxjs/operators';
 
 import { logger } from '../logger';
-import { getWorkspaceMeta, workspaceSubjects } from '../workspace';
+import { getWorkspaceMeta } from '../workspace/meta';
+import { workspaceSubjects } from '../workspace/subjects';
 import { SecondaryWorkspaceSQLiteDB } from './secondary-db';
 import type { WorkspaceSQLiteDB } from './workspace-db-adapter';
 import { openWorkspaceDatabase } from './workspace-db-adapter';

--- a/apps/electron/src/helper/db/secondary-db.ts
+++ b/apps/electron/src/helper/db/secondary-db.ts
@@ -6,7 +6,7 @@ import { applyUpdate, Doc as YDoc } from 'yjs';
 
 import { logger } from '../logger';
 import type { YOrigin } from '../type';
-import { getWorkspaceMeta } from '../workspace';
+import { getWorkspaceMeta } from '../workspace/meta';
 import { BaseSQLiteAdapter } from './base-db-adapter';
 import type { WorkspaceSQLiteDB } from './workspace-db-adapter';
 

--- a/apps/electron/src/helper/db/workspace-db-adapter.ts
+++ b/apps/electron/src/helper/db/workspace-db-adapter.ts
@@ -5,7 +5,7 @@ import { applyUpdate, Doc as YDoc, encodeStateAsUpdate } from 'yjs';
 
 import { logger } from '../logger';
 import type { YOrigin } from '../type';
-import { getWorkspaceMeta } from '../workspace';
+import { getWorkspaceMeta } from '../workspace/meta';
 import { BaseSQLiteAdapter } from './base-db-adapter';
 import { dbSubjects } from './subjects';
 

--- a/apps/electron/src/helper/dialog/dialog.ts
+++ b/apps/electron/src/helper/dialog/dialog.ts
@@ -21,13 +21,12 @@ import {
 import type { WorkspaceSQLiteDB } from '../db/workspace-db-adapter';
 import { logger } from '../logger';
 import { mainRPC } from '../main-rpc';
+import { listWorkspaces, storeWorkspaceMeta } from '../workspace';
 import {
   getWorkspaceDBPath,
   getWorkspaceMeta,
   getWorkspacesBasePath,
-  listWorkspaces,
-  storeWorkspaceMeta,
-} from '../workspace';
+} from '../workspace/meta';
 
 // NOTE:
 // we are using native dialogs because HTML dialogs do not give full file paths

--- a/apps/electron/src/helper/exposed.ts
+++ b/apps/electron/src/helper/exposed.ts
@@ -6,6 +6,7 @@ import type {
 
 import { dbEvents, dbHandlers } from './db';
 import { dialogHandlers } from './dialog';
+import { provideExposed } from './provide';
 import { workspaceEvents, workspaceHandlers } from './workspace';
 
 type AllHandlers = {
@@ -25,7 +26,7 @@ export const events = {
   workspace: workspaceEvents,
 };
 
-export const getExposedMeta = () => {
+const getExposedMeta = () => {
   const handlersMeta = Object.entries(handlers).map(
     ([namespace, namespaceHandlers]) => {
       return [namespace, Object.keys(namespaceHandlers)] as [string, string[]];
@@ -43,3 +44,5 @@ export const getExposedMeta = () => {
     events: eventsMeta,
   };
 };
+
+provideExposed(getExposedMeta());

--- a/apps/electron/src/helper/main-rpc.ts
+++ b/apps/electron/src/helper/main-rpc.ts
@@ -1,13 +1,17 @@
+import { assertExists } from '@blocksuite/global/utils';
 import type {
   HelperToMain,
   MainToHelper,
 } from '@toeverything/infra/preload/electron';
 import { AsyncCall } from 'async-call-rpc';
 
-import { getExposedMeta } from './exposed';
+import { exposed } from './provide';
 
 const helperToMainServer: HelperToMain = {
-  getMeta: () => getExposedMeta(),
+  getMeta: () => {
+    assertExists(exposed);
+    return exposed;
+  },
 };
 
 export const mainRPC = AsyncCall<MainToHelper>(helperToMainServer, {

--- a/apps/electron/src/helper/provide.ts
+++ b/apps/electron/src/helper/provide.ts
@@ -1,0 +1,11 @@
+import type { ExposedMeta } from '@toeverything/infra/preload/electron';
+
+/**
+ * A naive DI implementation to get rid of circular dependency.
+ */
+
+export let exposed: ExposedMeta | undefined;
+
+export const provideExposed = (exposedMeta: ExposedMeta) => {
+  exposed = exposedMeta;
+};

--- a/apps/electron/src/helper/workspace/__tests__/handlers.spec.ts
+++ b/apps/electron/src/helper/workspace/__tests__/handlers.spec.ts
@@ -74,7 +74,7 @@ describe('delete workspace', () => {
 
 describe('getWorkspaceMeta', () => {
   test('can get meta', async () => {
-    const { getWorkspaceMeta } = await import('../handlers');
+    const { getWorkspaceMeta } = await import('../meta');
     const workspaceId = v4();
     const workspacePath = path.join(appDataPath, 'workspaces', workspaceId);
     const meta = {
@@ -86,7 +86,7 @@ describe('getWorkspaceMeta', () => {
   });
 
   test('can create meta if not exists', async () => {
-    const { getWorkspaceMeta } = await import('../handlers');
+    const { getWorkspaceMeta } = await import('../meta');
     const workspaceId = v4();
     const workspacePath = path.join(appDataPath, 'workspaces', workspaceId);
     await fs.ensureDir(workspacePath);
@@ -100,7 +100,7 @@ describe('getWorkspaceMeta', () => {
   });
 
   test('can migrate meta if db file is a link', async () => {
-    const { getWorkspaceMeta } = await import('../handlers');
+    const { getWorkspaceMeta } = await import('../meta');
     const workspaceId = v4();
     const workspacePath = path.join(appDataPath, 'workspaces', workspaceId);
     await fs.ensureDir(workspacePath);

--- a/apps/electron/src/helper/workspace/handlers.ts
+++ b/apps/electron/src/helper/workspace/handlers.ts
@@ -4,19 +4,14 @@ import fs from 'fs-extra';
 
 import { ensureSQLiteDB } from '../db/ensure-db';
 import { logger } from '../logger';
-import { mainRPC } from '../main-rpc';
 import type { WorkspaceMeta } from '../type';
+import {
+  getDeletedWorkspacesBasePath,
+  getWorkspaceBasePath,
+  getWorkspaceMeta,
+  getWorkspacesBasePath,
+} from './meta';
 import { workspaceSubjects } from './subjects';
-
-let _appDataPath = '';
-
-async function getAppDataPath() {
-  if (_appDataPath) {
-    return _appDataPath;
-  }
-  _appDataPath = await mainRPC.getPath('sessionData');
-  return _appDataPath;
-}
 
 export async function listWorkspaces(): Promise<
   [workspaceId: string, meta: WorkspaceMeta][]
@@ -55,67 +50,6 @@ export async function deleteWorkspace(id: string) {
     });
   } catch (error) {
     logger.error('deleteWorkspace', error);
-  }
-}
-
-export async function getWorkspacesBasePath() {
-  return path.join(await getAppDataPath(), 'workspaces');
-}
-
-export async function getWorkspaceBasePath(workspaceId: string) {
-  return path.join(await getAppDataPath(), 'workspaces', workspaceId);
-}
-
-async function getDeletedWorkspacesBasePath() {
-  return path.join(await getAppDataPath(), 'deleted-workspaces');
-}
-
-export async function getWorkspaceDBPath(workspaceId: string) {
-  return path.join(await getWorkspaceBasePath(workspaceId), 'storage.db');
-}
-
-export async function getWorkspaceMetaPath(workspaceId: string) {
-  return path.join(await getWorkspaceBasePath(workspaceId), 'meta.json');
-}
-
-/**
- * Get workspace meta, create one if not exists
- * This function will also migrate the workspace if needed
- */
-export async function getWorkspaceMeta(
-  workspaceId: string
-): Promise<WorkspaceMeta> {
-  try {
-    const basePath = await getWorkspaceBasePath(workspaceId);
-    const metaPath = await getWorkspaceMetaPath(workspaceId);
-    if (!(await fs.exists(metaPath))) {
-      // since not meta is found, we will migrate symlinked db file if needed
-      await fs.ensureDir(basePath);
-      const dbPath = await getWorkspaceDBPath(workspaceId);
-
-      // todo: remove this after migration (in stable version)
-      const realDBPath = (await fs.exists(dbPath))
-        ? await fs.realpath(dbPath)
-        : dbPath;
-      const isLink = realDBPath !== dbPath;
-      if (isLink) {
-        await fs.copy(realDBPath, dbPath);
-      }
-      // create one if not exists
-      const meta = {
-        id: workspaceId,
-        mainDBPath: dbPath,
-        secondaryDBPath: isLink ? realDBPath : undefined,
-      };
-      await fs.writeJSON(metaPath, meta);
-      return meta;
-    } else {
-      const meta = await fs.readJSON(metaPath);
-      return meta;
-    }
-  } catch (err) {
-    logger.error('getWorkspaceMeta failed', err);
-    throw err;
   }
 }
 

--- a/apps/electron/src/helper/workspace/index.ts
+++ b/apps/electron/src/helper/workspace/index.ts
@@ -1,5 +1,6 @@
 import type { MainEventRegister, WorkspaceMeta } from '../type';
-import { deleteWorkspace, getWorkspaceMeta, listWorkspaces } from './handlers';
+import { deleteWorkspace, listWorkspaces } from './handlers';
+import { getWorkspaceMeta } from './meta';
 import { workspaceSubjects } from './subjects';
 
 export * from './handlers';

--- a/apps/electron/src/helper/workspace/meta.ts
+++ b/apps/electron/src/helper/workspace/meta.ts
@@ -1,0 +1,78 @@
+import path from 'node:path';
+
+import fs from 'fs-extra';
+
+import { logger } from '../logger';
+import { mainRPC } from '../main-rpc';
+import type { WorkspaceMeta } from '../type';
+
+let _appDataPath = '';
+
+export async function getAppDataPath() {
+  if (_appDataPath) {
+    return _appDataPath;
+  }
+  _appDataPath = await mainRPC.getPath('sessionData');
+  return _appDataPath;
+}
+
+export async function getWorkspacesBasePath() {
+  return path.join(await getAppDataPath(), 'workspaces');
+}
+
+export async function getWorkspaceBasePath(workspaceId: string) {
+  return path.join(await getAppDataPath(), 'workspaces', workspaceId);
+}
+
+export async function getDeletedWorkspacesBasePath() {
+  return path.join(await getAppDataPath(), 'deleted-workspaces');
+}
+
+export async function getWorkspaceDBPath(workspaceId: string) {
+  return path.join(await getWorkspaceBasePath(workspaceId), 'storage.db');
+}
+
+export async function getWorkspaceMetaPath(workspaceId: string) {
+  return path.join(await getWorkspaceBasePath(workspaceId), 'meta.json');
+}
+
+/**
+ * Get workspace meta, create one if not exists
+ * This function will also migrate the workspace if needed
+ */
+export async function getWorkspaceMeta(
+  workspaceId: string
+): Promise<WorkspaceMeta> {
+  try {
+    const basePath = await getWorkspaceBasePath(workspaceId);
+    const metaPath = await getWorkspaceMetaPath(workspaceId);
+    if (!(await fs.exists(metaPath))) {
+      // since not meta is found, we will migrate symlinked db file if needed
+      await fs.ensureDir(basePath);
+      const dbPath = await getWorkspaceDBPath(workspaceId);
+
+      // todo: remove this after migration (in stable version)
+      const realDBPath = (await fs.exists(dbPath))
+        ? await fs.realpath(dbPath)
+        : dbPath;
+      const isLink = realDBPath !== dbPath;
+      if (isLink) {
+        await fs.copy(realDBPath, dbPath);
+      }
+      // create one if not exists
+      const meta = {
+        id: workspaceId,
+        mainDBPath: dbPath,
+        secondaryDBPath: isLink ? realDBPath : undefined,
+      };
+      await fs.writeJSON(metaPath, meta);
+      return meta;
+    } else {
+      const meta = await fs.readJSON(metaPath);
+      return meta;
+    }
+  } catch (err) {
+    logger.error('getWorkspaceMeta failed', err);
+    throw err;
+  }
+}

--- a/packages/component/src/components/page-list/all-page.tsx
+++ b/packages/component/src/components/page-list/all-page.tsx
@@ -1,7 +1,3 @@
-import {
-  CollectionBar,
-  type CollectionsAtom,
-} from '@affine/component/page-list';
 import { DEFAULT_SORT_KEY } from '@affine/env/constant';
 import type { PropertiesMeta } from '@affine/env/filter';
 import type { GetPageInfoById } from '@affine/env/page-info';
@@ -28,8 +24,10 @@ import { AllPageListMobileView, TrashListMobileView } from './mobile';
 import { TrashOperationCell } from './operation-cell';
 import { StyledTableContainer } from './styles';
 import type { ListData, PageListProps, TrashListData } from './type';
+import type { CollectionsAtom } from './use-collection-manager';
 import { useSorter } from './use-sorter';
 import { formatDate, useIsSmallDevices } from './utils';
+import { CollectionBar } from './view/collection-bar';
 
 interface AllPagesHeadProps {
   isPublicWorkspace: boolean;

--- a/packages/component/src/components/page-list/view/collection-bar.tsx
+++ b/packages/component/src/components/page-list/view/collection-bar.tsx
@@ -1,7 +1,3 @@
-import {
-  type CollectionsAtom,
-  EditCollectionModel,
-} from '@affine/component/page-list';
 import type { PropertiesMeta } from '@affine/env/filter';
 import type { GetPageInfoById } from '@affine/env/page-info';
 import { useAFFiNEI18N } from '@affine/i18n/hooks';
@@ -11,8 +7,12 @@ import { Tooltip } from '@toeverything/components/tooltip';
 import clsx from 'clsx';
 import { useCallback, useState } from 'react';
 
-import { useCollectionManager } from '../use-collection-manager';
+import {
+  type CollectionsAtom,
+  useCollectionManager,
+} from '../use-collection-manager';
 import * as styles from './collection-bar.css';
+import { EditCollectionModel } from './create-collection';
 import { useActions } from './use-action';
 
 interface CollectionBarProps {

--- a/packages/component/src/components/page-list/view/collection-list.tsx
+++ b/packages/component/src/components/page-list/view/collection-list.tsx
@@ -1,5 +1,4 @@
 import { FlexWrapper } from '@affine/component';
-import { EditCollectionModel } from '@affine/component/page-list';
 import type { Collection, Filter } from '@affine/env/filter';
 import type { PropertiesMeta } from '@affine/env/filter';
 import type { GetPageInfoById } from '@affine/env/page-info';
@@ -15,6 +14,7 @@ import { useCallback, useRef, useState } from 'react';
 import { CreateFilterMenu } from '../filter/vars';
 import type { useCollectionManager } from '../use-collection-manager';
 import * as styles from './collection-list.css';
+import { EditCollectionModel } from './create-collection';
 import { useActions } from './use-action';
 
 const CollectionOption = ({


### PR DESCRIPTION
thanks to https://github.com/web-infra-dev/oxc and https://github.com/antoine-coulon/skott.

This is a one time fix for the current master branch. Later we could replace parts of import plugin with oxclint for identifying circular issues in CI.

Before:

```shell

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
   ╭─[apps/electron/src/helper/main-rpc.ts:6:1]
 6 │
 7 │ import { getExposedMeta } from './exposed';
   ·                                ───────────
 8 │
   ╰────
  help: These paths form a cycle:
        -> ./exposed - apps/electron/src/helper/exposed.ts
        -> ./db - apps/electron/src/helper/db/index.ts
        -> ../main-rpc - apps/electron/src/helper/main-rpc.ts

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
   ╭─[apps/electron/src/helper/workspace/handlers.ts:6:1]
 6 │ import { logger } from '../logger';
 7 │ import { mainRPC } from '../main-rpc';
   ·                         ─────────────
 8 │ import type { WorkspaceMeta } from '../type';
   ╰────
  help: These paths form a cycle:
        -> ../main-rpc - apps/electron/src/helper/main-rpc.ts
        -> ./exposed - apps/electron/src/helper/exposed.ts
        -> ./workspace - apps/electron/src/helper/workspace/index.ts
        -> ./handlers - apps/electron/src/helper/workspace/handlers.ts

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[apps/core/src/components/affine/new-workspace-setting-detail/index.tsx:16:1]
 16 │ import { ExportPanel } from './export';
 17 │ import { LabelsPanel } from './labels';
    ·                             ──────────
 18 │ import { MembersPanel } from './members';
    ╰────
  help: These paths form a cycle:
        -> ./labels - apps/core/src/components/affine/new-workspace-setting-detail/labels.tsx
        -> ./index - apps/core/src/components/affine/new-workspace-setting-detail/index.tsx

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[apps/core/src/components/affine/new-workspace-setting-detail/profile.tsx:17:1]
 17 │ import { Upload } from '../../pure/file-upload';
 18 │ import { type WorkspaceSettingDetailProps } from './index';
    ·                                                  ─────────
 19 │ import * as style from './style.css';
    ╰────
  help: These paths form a cycle:
        -> ./index - apps/core/src/components/affine/new-workspace-setting-detail/index.tsx
        -> ./profile - apps/core/src/components/affine/new-workspace-setting-detail/profile.tsx

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
   ╭─[packages/component/src/components/page-list/index.tsx:1:1]
 1 │ export * from './all-page';
   ·               ────────────
 2 │ export * from './components/favorite-tag';
   ╰────
  help: These paths form a cycle:
        -> ./all-page - packages/component/src/components/page-list/all-page.tsx
        -> @affine/component/page-list - packages/component/src/components/page-list/index.tsx

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
    ╭─[apps/electron/src/helper/db/ensure-db.ts:28:1]
 28 │ import { getWorkspaceMeta, workspaceSubjects } from '../workspace';
 29 │ import { SecondaryWorkspaceSQLiteDB } from './secondary-db';
    ·                                            ────────────────
 30 │ import type { WorkspaceSQLiteDB } from './workspace-db-adapter';
    ╰────
  help: These paths form a cycle:
        -> ./secondary-db - apps/electron/src/helper/db/secondary-db.ts
        -> ./base-db-adapter - apps/electron/src/helper/db/base-db-adapter.ts
        -> ../db/migration - apps/electron/src/helper/db/migration.ts
        -> ../main-rpc - apps/electron/src/helper/main-rpc.ts
        -> ./exposed - apps/electron/src/helper/exposed.ts
        -> ./workspace - apps/electron/src/helper/workspace/index.ts
        -> ./handlers - apps/electron/src/helper/workspace/handlers.ts
        -> ../db/ensure-db - apps/electron/src/helper/db/ensure-db.ts

  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
   ╭─[apps/electron/src/helper/dialog/index.ts:7:1]
 7 │   setFakeDialogResult,
 8 │ } from './dialog';
   ·        ──────────
 9 │
   ╰────
  help: These paths form a cycle:
        -> ./dialog - apps/electron/src/helper/dialog/dialog.ts
        -> ../db/migration - apps/electron/src/helper/db/migration.ts
        -> ../main-rpc - apps/electron/src/helper/main-rpc.ts
        -> ./exposed - apps/electron/src/helper/exposed.ts
        -> ./dialog - apps/electron/src/helper/dialog/index.ts

Finished in 183ms on 843 files with 1 rules using 10 threads.
Found 7 warnings and 0 errors.
```

After
```shell
Finished in 172ms on 846 files with 1 rules using 10 threads.
Found 0 warnings and 0 errors.
```