### PR TITLE
fix(core): back home botton has no reaction 

### DIFF
--- a/apps/core/src/pages/404.tsx
+++ b/apps/core/src/pages/404.tsx
@@ -1,5 +1,4 @@
 import { displayFlex, styled } from '@affine/component';
-import { WorkspaceSubPath } from '@affine/env/workspace';
 import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { Button } from '@toeverything/components/button';
 import type { ReactElement } from 'react';
@@ -26,22 +25,14 @@ export const StyledContainer = styled('div')(() => {
 
 export const NotFoundPage = () => {
   const t = useAFFiNEI18N();
-  const { jumpToSubPath, jumpToIndex } = useNavigateHelper();
+  const { jumpToIndex } = useNavigateHelper();
+
   return (
     <StyledContainer data-testid="notFound">
       <img alt="404" src="/imgs/invite-error.svg" width={360} height={270} />
 
       <p>{t['com.affine.notFoundPage.title']()}</p>
-      <Button
-        onClick={() => {
-          const id = localStorage.getItem('last_workspace_id');
-          if (id) {
-            jumpToSubPath(id, WorkspaceSubPath.ALL);
-          } else {
-            jumpToIndex();
-          }
-        }}
-      >
+      <Button onClick={() => jumpToIndex()}>
         {t['com.affine.notFoundPage.backButton']()}
       </Button>
     </StyledContainer>

--- a/apps/core/src/pages/404.tsx
+++ b/apps/core/src/pages/404.tsx
@@ -27,13 +27,14 @@ export const StyledContainer = styled('div')(() => {
 export const NotFoundPage = () => {
   const t = useAFFiNEI18N();
   const { jumpToIndex } = useNavigateHelper();
+  const handleBackButtonClick = useCallback(() => jumpToIndex(), [jumpToIndex]);
 
   return (
     <StyledContainer data-testid="notFound">
       <img alt="404" src="/imgs/invite-error.svg" width={360} height={270} />
 
       <p>{t['com.affine.notFoundPage.title']()}</p>
-      <Button onClick={useCallback(() => jumpToIndex(), [])}>
+      <Button onClick={handleBackButtonClick}>
         {t['com.affine.notFoundPage.backButton']()}
       </Button>
     </StyledContainer>

--- a/apps/core/src/pages/404.tsx
+++ b/apps/core/src/pages/404.tsx
@@ -2,6 +2,7 @@ import { displayFlex, styled } from '@affine/component';
 import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { Button } from '@toeverything/components/button';
 import type { ReactElement } from 'react';
+import { useCallback } from 'react';
 
 import { useNavigateHelper } from '../hooks/use-navigate-helper';
 
@@ -32,7 +33,7 @@ export const NotFoundPage = () => {
       <img alt="404" src="/imgs/invite-error.svg" width={360} height={270} />
 
       <p>{t['com.affine.notFoundPage.title']()}</p>
-      <Button onClick={() => jumpToIndex()}>
+      <Button onClick={useCallback(() => jumpToIndex(), [])}>
         {t['com.affine.notFoundPage.backButton']()}
       </Button>
     </StyledContainer>


### PR DESCRIPTION
close #4201 

The back to last workspace logic in 404 page just been removed, because index page will do this more safely.

There have some others logic should be improved but not this commit:
1. no 400 exception page, all in 404
2. 404 should have search params to know what resource not found and what page from