### PR TITLE
fix: use cdn api when querying static CDN files

### DIFF
--- a/packages/workspace/src/blob/cloud-blob-storage.ts
+++ b/packages/workspace/src/blob/cloud-blob-storage.ts
@@ -8,13 +8,17 @@ import {
 import { fetcher } from '@affine/workspace/affine/gql';
 import type { BlobStorage } from '@blocksuite/store';
 
+import { predefinedStaticFiles } from './local-static-storage';
+
 export const createCloudBlobStorage = (workspaceId: string): BlobStorage => {
   return {
     crud: {
       get: async key => {
+        const suffix = predefinedStaticFiles.includes(key)
+          ? `/static/${key}`
+          : `/api/workspaces/${workspaceId}/blobs/${key}`;
         return fetchWithTraceReport(
-          runtimeConfig.serverUrlPrefix +
-            `/api/workspaces/${workspaceId}/blobs/${key}`
+          runtimeConfig.serverUrlPrefix + suffix
         ).then(res => res.blob());
       },
       set: async (key, value) => {

--- a/packages/workspace/src/blob/local-static-storage.ts
+++ b/packages/workspace/src/blob/local-static-storage.ts
@@ -1,6 +1,6 @@
 import type { BlobStorage } from '@blocksuite/store';
 
-const predefinedStaticFiles = [
+export const predefinedStaticFiles = [
   'v2yF7lY2L5rtorTtTmYFsoMb9dBPKs5M1y9cUKxcI1M=',
   'nSEEkYxrThpZfLoPNOzMp6HWekvutAIYmADElDe1J6I=',
   'CBWoKrhSDndjBJzscQKENRqiXOOZnzIA5qyiCoy4-A0=',
@@ -29,7 +29,7 @@ export const createStaticStorage = (): BlobStorage => {
             return response.blob();
           }
         } else if (predefinedStaticFiles.includes(key)) {
-          const response = await fetch(`/static/${key}.png`);
+          const response = await fetch(`/static/${key}`);
           if (response.ok) {
             return response.blob();
           }


### PR DESCRIPTION
after #4360, fix https://github.com/toeverything/AFFiNE/issues/4363

1. no need to add suffix for `/static/${key}`, reference:
![image](https://github.com/toeverything/AFFiNE/assets/20554850/d8d27a93-c669-481e-898f-84bb1aefe8bd)

2. use `/static` path when blob is stored in CDN