### PR TITLE
fix: add prompt select_account for google login

### DIFF
--- a/apps/server/src/modules/auth/next-auth-options.ts
+++ b/apps/server/src/modules/auth/next-auth-options.ts
@@ -158,6 +158,9 @@ export const NextAuthOptionsProvider: FactoryProvider<NextAuthOptions> = {
           clientSecret: config.auth.oauthProviders.google.clientSecret,
           checks: 'nonce',
           allowDangerousEmailAccountLinking: true,
+          authorization: {
+            params: { scope: 'openid email profile', prompt: 'select_account' },
+          },
         })
       );
     }


### PR DESCRIPTION
https://developers.google.com/identity/openid-connect/openid-connect#authenticationuriparameters:~:text=to%20the%20client.-,select_account,-The%20authorization%20server

I am not sure but it looks like I always got the account selection prompted every time I signin with google oauth. It may help to explicitly show account selection for some users.