### PR TITLE
ci(storybook): fix import page failed problem

### DIFF
--- a/apps/storybook/src/stories/core.stories.tsx
+++ b/apps/storybook/src/stories/core.stories.tsx
@@ -1,7 +1,7 @@
 import { routes } from '@affine/core/router';
 import { assertExists } from '@blocksuite/global/utils';
 import type { StoryFn } from '@storybook/react';
-import { userEvent, waitFor, within } from '@storybook/testing-library';
+import { screen, userEvent, waitFor, within } from '@storybook/testing-library';
 import { Outlet, useLocation } from 'react-router-dom';
 import {
   reactRouterOutlets,
@@ -157,10 +157,10 @@ ImportPage.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getByTestId('header-dropDownButton'));
   await waitFor(() => {
     assertExists(
-      canvasElement.querySelector('[data-testid="editor-option-menu-import"]')
+      document.body.querySelector('[data-testid="editor-option-menu-import"]')
     );
   });
-  await userEvent.click(canvas.getByTestId('editor-option-menu-import'));
+  await userEvent.click(screen.getByTestId('editor-option-menu-import'));
 };
 ImportPage.decorators = [withRouter];
 ImportPage.parameters = {


### PR DESCRIPTION
Because of dropdown menu is shown in body element not in storybook root, so the assertion should use global api.