### PR TITLE
fix: spacing issue in getting-started template

### DIFF
--- a/packages/templates/v1/getting-started.json
+++ b/packages/templates/v1/getting-started.json
@@ -65,7 +65,7 @@
           }
         },
         {
-          "insert": "(put a symbol) at the bottom right of the page to insert a new block, list,database, etc."
+          "insert": "(put a symbol) at the bottom right of the page to insert a new block, list, database, etc."
         }
       ],
       "prop:checked": false


### PR DESCRIPTION
There seems to be a missing space in getting-started template. 
BTW, it's a cool project. Thank you for maintaining this incredible project, and please keep up the great work!