### PR TITLE
fix: list page storybook not rendering issue

### DIFF
--- a/apps/storybook/src/stories/page-list.stories.tsx
+++ b/apps/storybook/src/stories/page-list.stories.tsx
@@ -6,10 +6,12 @@ import {
   PageList,
   PageListTrashView,
 } from '@affine/component/page-list';
+import type { Collection } from '@affine/env/filter';
 import { PageIcon } from '@blocksuite/icons';
 import { expect } from '@storybook/jest';
 import type { Meta, StoryFn } from '@storybook/react';
 import { userEvent } from '@storybook/testing-library';
+import { atom } from 'jotai';
 
 export default {
   title: 'AFFiNE/PageList',
@@ -61,11 +63,18 @@ export const AffineAllPageList: StoryFn<typeof PageList> = ({ ...props }) => (
   <PageList {...props} />
 );
 
+const baseAtom = atom<Collection[]>([]);
 AffineAllPageList.args = {
   isPublicWorkspace: false,
   onCreateNewPage: () => toast('Create new page'),
   onCreateNewEdgeless: () => toast('Create new edgeless'),
   onImportFile: () => toast('Import file'),
+  collectionsAtom: atom(
+    get => get(baseAtom),
+    async (_, set, update) => {
+      set(baseAtom, update);
+    }
+  ),
   list: [
     {
       pageId: '1',


### PR DESCRIPTION
fix `Invalid value used as weak map key` issue.
