### PR TITLE
fix: disabled form item in the settings can still be operated via keyboard

### DIFF
--- a/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx
@@ -100,7 +100,7 @@ const FakePublishPanelAffine = (_props: FakePublishPanelAffineProps) => {
     <Tooltip content={t['com.affine.settings.workspace.publish-tooltip']()}>
       <div className={style.fakeWrapper}>
         <SettingRow name={t['Publish']()} desc={t['Unpublished hint']()}>
-          <Switch checked={false} />
+          <Switch checked={false} onChange={() => {}} />
         </SettingRow>
       </div>
     </Tooltip>

--- a/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx
+++ b/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx
@@ -12,6 +12,7 @@ import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { Button } from '@toeverything/components/button';
 import { Tooltip } from '@toeverything/components/tooltip';
 import { useBlockSuiteWorkspaceName } from '@toeverything/hooks/use-block-suite-workspace-name';
+import { noop } from 'foxact/noop';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { toast } from '../../../utils';
@@ -100,7 +101,7 @@ const FakePublishPanelAffine = (_props: FakePublishPanelAffineProps) => {
     <Tooltip content={t['com.affine.settings.workspace.publish-tooltip']()}>
       <div className={style.fakeWrapper}>
         <SettingRow name={t['Publish']()} desc={t['Unpublished hint']()}>
-          <Switch checked={false} onChange={() => {}} />
+          <Switch checked={false} onChange={noop} />
         </SettingRow>
       </div>
     </Tooltip>


### PR DESCRIPTION
## Summary
- Currently, while pressing the tab key the [Tooltip](https://github.com/toeverything/AFFiNE/blob/master/apps/core/src/components/affine/new-workspace-setting-detail/publish.tsx#L100) component gets triggered which puts the focus on it, and after pressing the space key it goes to its child node Switch which activates its event and still gets trigger in disable mode.
- To fix the issue we need to pass a prop onChange which on getting a trigger will not enable the switch.

Fixes: https://github.com/toeverything/AFFiNE/issues/4570

## Videos

**Before**

https://github.com/toeverything/AFFiNE/assets/132813311/b7a79f96-283c-4be0-92a8-4e47baf1d2f4

**After**

https://github.com/toeverything/AFFiNE/assets/132813311/4e3365c3-a966-4fe7-9ca4-0b96e5a08523