### PR TITLE
fix(core): retrieve missing search result titles

### DIFF
--- a/packages/frontend/core/src/components/pure/cmdk/data.tsx
+++ b/packages/frontend/core/src/components/pure/cmdk/data.tsx
@@ -157,6 +157,7 @@ export const pageToCommand = (
 ): CMDKCommand => {
   const pageMode = store.get(pageSettingsAtom)?.[page.id]?.mode;
   const currentWorkspaceId = store.get(currentWorkspaceIdAtom);
+
   const title = page.title || t['Untitled']();
   const commandLabel = label || {
     title: title,
@@ -222,7 +223,7 @@ export const usePageCommands = () => {
           pageMode === 'edgeless' ? 'affine:edgeless' : 'affine:pages';
 
         const label = {
-          title: page.title,
+          title: page.title || t['Untitled'](), // Used to ensure that a title exists
           subTitle:
             searchResults.find(result => result.space === page.id)?.content ||
             '',


### PR DESCRIPTION
fix #3294

The reason for the bug is that when the page itself has no title, the title cannot be displayed.

> 1. There will be no content in the search results(Please try to see if you can reproduce)
> 2. Search results document title disappears