### PR TITLE
add codespace configs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/debian
+{
+    "name": "Debian",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+        "version": "18",
+        "nvmVersion": "0.39"
+    },
+    "ghcr.io/devcontainers/features/rust:1": {
+        "version": "1.70",
+        "profile": "default"
+    }
+    },
+    "customizations": {
+    "vscode": {
+        "extensions": ["ms-playwright.playwright", "esbenp.prettier-vscode"]
+    }
+    },
+    // Command to run once the repo contents are available
+    "updateContentCommand": "sh build.sh",
+
+    // Command to run once container has started
+    "postStartCommand": "./node_modules/.bin/nx reset"
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+}

--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ For feature request, please see [community.affine.pro](https://community.affine.
 
 ## Building
 
+### Codespaces
+
+From the GitHub repo main page, click the green "Code" button and select "Create codespace on master". This will open a new Codespace with the (supposedly auto-forked
+ AFFiNE repo cloned, built, and ready to go.
+
+### Local
+
 See [BUILDING.md] for instructions on how to build AFFiNE from source code.
 
 ## Contributing

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# This is a script used by the devcontainer to build the project
+
+#Enable yarn
+corepack enable
+corepack prepare yarn@stable --activate
+
+# install dependencies
+yarn install
+
+### Build Native Dependencies
+yarn workspace @affine/native build
+
+### Build Infra
+yarn run build:infra
+
+### Build Plugins
+yarn run build:plugins
+
+### Build Server Dependencies
+yarn workspace @affine/storage build


### PR DESCRIPTION
If you merge this and set up Codespace prebuilds, this would allow any contributor to have a fully working development environment within a minute. GitHub provides 120 "core minutes" of free codespace time per month (60 hours on a 2-core machine) per user

Developer experience:

- Click "Code" and select "Create codespace on master"
- Wait ~1 minute for codespace to start
- run `yarn test`