### PR TITLE
fix(core): possible crash issues

### DIFF
--- a/packages/frontend/component/src/components/page-list/page-content-preview.tsx
+++ b/packages/frontend/component/src/components/page-list/page-content-preview.tsx
@@ -1,4 +1,3 @@
-import { assertExists } from '@blocksuite/global/utils';
 import type { Workspace } from '@blocksuite/store';
 import { useBlockSuitePagePreview } from '@toeverything/hooks/use-block-suite-page-preview';
 import { useBlockSuiteWorkspacePage } from '@toeverything/hooks/use-block-suite-workspace-page';
@@ -12,7 +11,6 @@ interface PagePreviewInnerProps {
 
 const PagePreviewInner = ({ workspace, pageId }: PagePreviewInnerProps) => {
   const page = useBlockSuiteWorkspacePage(workspace, pageId);
-  assertExists(page);
   const previewAtom = useBlockSuitePagePreview(page);
   const preview = useAtomValue(previewAtom);
   return preview ? preview : null;

--- a/packages/frontend/hooks/src/use-block-suite-page-preview.ts
+++ b/packages/frontend/hooks/src/use-block-suite-page-preview.ts
@@ -17,8 +17,12 @@ export const getPagePreviewText = (page: Page) => {
   return text.slice(0, 300);
 };
 
-export function useBlockSuitePagePreview(page: Page): Atom<string> {
-  if (weakMap.has(page)) {
+const emptyAtom = atom<string>('');
+
+export function useBlockSuitePagePreview(page: Page | null): Atom<string> {
+  if (page === null) {
+    return emptyAtom;
+  } else if (weakMap.has(page)) {
     return weakMap.get(page) as Atom<string>;
   } else {
     const baseAtom = atom<string>(getPagePreviewText(page));


### PR DESCRIPTION
1. Sometimes `useBlockSuiteWorkspacePage(workspace, pageId)` may return `null` when switching workspace. 
2. When deleting the last workspace, based on how jotai works the atom get dep in `useWorkspace` could rerun and throw flavour not found issue.