### PR TITLE
BlobStorage should provide consistent behaviour

### DIFF
--- a/packages/frontend/workspace/src/blob/sqlite-blob-storage.ts
+++ b/packages/frontend/workspace/src/blob/sqlite-blob-storage.ts
@@ -4,13 +4,15 @@ import type { BlobStorage } from '@blocksuite/store';
 export const createSQLiteStorage = (workspaceId: string): BlobStorage => {
   const apis = window.apis;
   assertExists(apis);
+  const typeMap = new Map();
   return {
     crud: {
       get: async (key: string) => {
         const buffer = await apis.db.getBlob(workspaceId, key);
-        return buffer ? new Blob([buffer]) : null;
+        return buffer ? new Blob([buffer], { type: typeMap.get(key) ?? buffer.type }) : null;
       },
       set: async (key: string, value: Blob) => {
+        typeMap.set(key, value.type);
         await apis.db.addBlob(
           workspaceId,
           key,
@@ -19,6 +21,7 @@ export const createSQLiteStorage = (workspaceId: string): BlobStorage => {
         return key;
       },
       delete: async (key: string) => {
+        typeMap.delete(key);
         return apis.db.deleteBlob(workspaceId, key);
       },
       list: async () => {


### PR DESCRIPTION
https://github.com/toeverything/AFFiNE/issues/3245

In order to avoid major changes, I defined a variable in `createSQLiteStorage` to store the type.

The default type of the blob returned in the `createStaticStorage` method is response.headers["content-type"], and I believe it does not need to be changed. If it is necessary to make changes, I list the following for reference.
```
get: async (key: string) => {
    let blob: Blob | null = null;
    if (key.startsWith('/static/')) {
        const response = await fetch(key);
        if (response.ok) blob = response.blob();
    } else if (predefinedStaticFiles.includes(key)) {
        const response = await fetch(`static/${key}`);
        if (response.ok) blob = response.blob();
    }
    if (blob && !blob.type) {
        // Determine the type based on the blob's headers.
        const type = ...;
        blob = new Blob([blob], { type });
    }
    return blob;
},
```
