### PR TITLE
fix(core): currentUser undefined when all workspaces deleted

### DIFF
--- a/packages/frontend/workspace/src/affine/gql.ts
+++ b/packages/frontend/workspace/src/affine/gql.ts
@@ -8,6 +8,7 @@ import type {
 } from '@affine/graphql';
 import { gqlFetcherFactory } from '@affine/graphql';
 import type { GraphQLError } from 'graphql';
+import { useMemo } from 'react';
 import type { Key, SWRConfiguration, SWRResponse } from 'swr';
 import useSWR from 'swr';
 import type {
@@ -70,10 +71,18 @@ export function useQuery<Query extends GraphQLQuery>(
   options: QueryOptions<Query>,
   config?: any
 ) {
+  const configWithSuspense: SWRConfiguration = useMemo(
+    () => ({
+      suspense: true,
+      ...config,
+    }),
+    [config]
+  );
+
   return useSWR(
     () => ['cloud', options.query.id, options.variables],
     () => fetcher(options),
-    config
+    configWithSuspense
   );
 }
 


### PR DESCRIPTION
# Issue Fixed #4809 

error log:

```
react-dom.production.min.js:189 TypeError: Cannot read properties of undefined (reading 'currentUser')
  at l (use-subscription.ts:12:8)
  at o (use-subscription.ts:39:11)
  at x (user-plan-button.tsx:12:26)
  at ay (react-dom.production.min.js:167:137)
  at s (react-dom.production.min.js:290:337)
  at i_ (react-dom.production.min.js:280:389)
  at react-dom.production.min.js:280:320
  at iT (react-dom.production.min.js:280:325)
  at iC (react-dom.production.min.js:271:88)
  at iZ (react-dom.production.min.js:268:429)
a6 @ react-dom.production.min.js:189
index.js:481 React Router caught the following error during render TypeError: Cannot read properties of undefined (reading 'currentUser')
  at l (use-subscription.ts:12:8)
  at o (use-subscription.ts:39:11)
  at x (user-plan-button.tsx:12:26)
  at ay (react-dom.production.min.js:167:137)
  at s (react-dom.production.min.js:290:337)
  at i_ (react-dom.production.min.js:280:389)
  at react-dom.production.min.js:280:320
  at iT (react-dom.production.min.js:280:325)
  at iC (react-dom.production.min.js:271:88)
  at iZ (react-dom.production.min.js:268:429) Object
```

# Cause

Because we used `UserAccountItem` within `pages/index`, and made a GraphQL query using `useQuery`, but there is no `SWRConfig` in this route (actually only the workspace route has `SWRConfig`), the call returned `undefined` incorrectly.

# Solution

It seems reasonable to integrate SWRConfig at a global level.

After all, this is a global level change. 
If this is inappropriate, please tell me.
