### PR TITLE
fix(core): fix block suite edit mode switch shortcut

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-mode-switch/index.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-mode-switch/index.tsx
@@ -51,11 +51,7 @@ export const EditorModeSwitch = ({
       return;
     }
     const keydown = (e: KeyboardEvent) => {
-      if (
-        !environment.isServer && environment.isMacOs
-          ? e.key === 'ß'
-          : e.key === 's' && e.altKey
-      ) {
+      if (e.code === 'KeyS' && e.altKey) {
         e.preventDefault();
         togglePageMode(pageId);
         toast(


### PR DESCRIPTION
# fixed issue https://github.com/toeverything/AFFiNE/issues/4793

After my test, using `⌥ + S` in macos, event.key is `ß`, event.code is `KeyS`

Using KeyboardEvent.code seems to be a better solution.

The relevant code was last changed here:

https://github.com/toeverything/AFFiNE/pull/3097/files#diff-7d9ad95b8b3e47ad3d6edd26562e2553cc03171c58ed65c4c14a38b9c41effa7R48

