### PR TITLE
refactor(workspace): simplify provider

### DIFF
--- a/packages/common/env/src/workspace.ts
+++ b/packages/common/env/src/workspace.ts
@@ -32,24 +32,21 @@ export interface BroadCastChannelProvider extends PassiveDocProvider {
  */
 export interface LocalIndexedDBBackgroundProvider
   extends DataSourceAdapter,
-    PassiveDocProvider {
+    PassiveDocProvider,
+    ActiveDocProvider {
   flavour: 'local-indexeddb-background';
 }
 
-export interface LocalIndexedDBDownloadProvider extends ActiveDocProvider {
-  flavour: 'local-indexeddb';
-}
-
-export interface SQLiteProvider extends PassiveDocProvider, DataSourceAdapter {
+export interface SQLiteProvider
+  extends PassiveDocProvider,
+    ActiveDocProvider,
+    DataSourceAdapter {
   flavour: 'sqlite';
-}
-
-export interface SQLiteDBDownloadProvider extends ActiveDocProvider {
-  flavour: 'sqlite-download';
 }
 
 export interface AffineSocketIOProvider
   extends PassiveDocProvider,
+    ActiveDocProvider,
     DataSourceAdapter {
   flavour: 'affine-socket-io';
 }

--- a/packages/common/y-indexeddb/src/provider.ts
+++ b/packages/common/y-indexeddb/src/provider.ts
@@ -152,6 +152,17 @@ export const createIndexedDBProvider = (
     cleanup: async () => {
       await datasource?.cleanup();
     },
+    sync: () => {
+      if (!provider) {
+        apis.connect();
+      }
+      provider?.sync(true).catch(() => {
+        /* noop */
+      });
+    },
+    get whenReady() {
+      return Promise.resolve(provider?.whenReady);
+    },
     get connected() {
       return provider?.connected || false;
     },

--- a/packages/common/y-indexeddb/src/shared.ts
+++ b/packages/common/y-indexeddb/src/shared.ts
@@ -12,6 +12,8 @@ export function upgradeDB(db: IDBPDatabase<BlockSuiteBinaryDB>) {
 export interface IndexedDBProvider extends DataSourceAdapter {
   connect: () => void;
   disconnect: () => void;
+  sync: () => void;
+  readonly whenReady: Promise<void>;
   cleanup: () => Promise<void>;
   readonly connected: boolean;
 }

--- a/packages/common/y-provider/src/__tests__/index.spec.ts
+++ b/packages/common/y-provider/src/__tests__/index.spec.ts
@@ -216,6 +216,7 @@ describe('y-provider', () => {
     const provider = createLazyProvider(rootDoc, datasource);
 
     await provider.sync(true);
+    provider.disconnect();
     expect(rootDoc.getText().toJSON()).toBe('hello, world!');
 
     const remotesubdoc = new Doc();
@@ -224,12 +225,15 @@ describe('y-provider', () => {
     expect(rootDoc.subdocs.size).toBe(0);
 
     await provider.sync(true);
+    provider.disconnect();
     expect(rootDoc.subdocs.size).toBe(1);
     const subdoc = rootDoc.getMap('map').get('subdoc') as Doc;
     expect(subdoc.getText('text').toJSON()).toBe('');
     await provider.sync(true);
+    provider.disconnect();
     expect(subdoc.getText('text').toJSON()).toBe('');
     await provider.sync(false);
+    provider.disconnect();
     expect(subdoc.getText('text').toJSON()).toBe('test-subdoc-value');
   });
 });

--- a/packages/frontend/core/src/adapters/local/index.tsx
+++ b/packages/frontend/core/src/adapters/local/index.tsx
@@ -3,7 +3,7 @@ import {
   DEFAULT_WORKSPACE_NAME,
   PageNotFoundError,
 } from '@affine/env/constant';
-import type { LocalIndexedDBDownloadProvider } from '@affine/env/workspace';
+import type { LocalIndexedDBBackgroundProvider } from '@affine/env/workspace';
 import type { WorkspaceAdapter } from '@affine/env/workspace';
 import {
   LoadPriority,
@@ -18,7 +18,7 @@ import {
   getOrCreateWorkspace,
   globalBlockSuiteSchema,
 } from '@affine/workspace/manager';
-import { createIndexedDBDownloadProvider } from '@affine/workspace/providers';
+import { createIndexedDBBackgroundProvider } from '@affine/workspace/providers';
 import { getBlockSuiteWorkspaceAtom } from '@toeverything/infra/__internal__/workspace';
 import { getCurrentStore } from '@toeverything/infra/atom';
 import { initEmptyPage } from '@toeverything/infra/blocksuite';
@@ -67,13 +67,13 @@ export const LocalAdapter: WorkspaceAdapter<WorkspaceFlavour.LOCAL> = {
           logger.error('init page with empty failed', error);
         });
       }
-      const provider = createIndexedDBDownloadProvider(
+      const provider = createIndexedDBBackgroundProvider(
         blockSuiteWorkspace.id,
         blockSuiteWorkspace.doc,
         {
           awareness: blockSuiteWorkspace.awarenessStore.awareness,
         }
-      ) as LocalIndexedDBDownloadProvider;
+      ) as LocalIndexedDBBackgroundProvider;
       provider.sync();
       provider.whenReady.catch(console.error);
       saveWorkspaceToLocalStorage(blockSuiteWorkspace.id);

--- a/packages/frontend/workspace/src/providers/__tests__/indexeddb-provider.spec.ts
+++ b/packages/frontend/workspace/src/providers/__tests__/indexeddb-provider.spec.ts
@@ -3,18 +3,12 @@
  */
 import 'fake-indexeddb/auto';
 
-import type {
-  LocalIndexedDBBackgroundProvider,
-  LocalIndexedDBDownloadProvider,
-} from '@affine/env/workspace';
+import type { LocalIndexedDBBackgroundProvider } from '@affine/env/workspace';
 import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
 import { Schema, Workspace } from '@blocksuite/store';
 import { afterEach, describe, expect, test } from 'vitest';
 
-import {
-  createIndexedDBBackgroundProvider,
-  createIndexedDBDownloadProvider,
-} from '..';
+import { createIndexedDBBackgroundProvider } from '..';
 
 const schema = new Schema();
 
@@ -63,13 +57,13 @@ describe('download provider', () => {
         isSSR: true,
         schema,
       });
-      const provider = createIndexedDBDownloadProvider(
+      const provider = createIndexedDBBackgroundProvider(
         workspace.id,
         workspace.doc,
         {
           awareness: workspace.awarenessStore.awareness,
         }
-      ) as LocalIndexedDBDownloadProvider;
+      ) as LocalIndexedDBBackgroundProvider;
       provider.sync();
       await provider.whenReady;
       expect(workspace.doc.toJSON()).toEqual({

--- a/packages/frontend/workspace/src/providers/__tests__/sqlite-provider.spec.ts
+++ b/packages/frontend/workspace/src/providers/__tests__/sqlite-provider.spec.ts
@@ -1,7 +1,4 @@
-import type {
-  SQLiteDBDownloadProvider,
-  SQLiteProvider,
-} from '@affine/env/workspace';
+import type { SQLiteProvider } from '@affine/env/workspace';
 import { __unstableSchemas, AffineSchemas } from '@blocksuite/blocks/models';
 import type { Y as YType } from '@blocksuite/store';
 import { Schema, Workspace } from '@blocksuite/store';
@@ -15,17 +12,14 @@ import { setTimeout } from 'timers/promises';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { getDoc } from 'y-provider';
 
-import {
-  createSQLiteDBDownloadProvider,
-  createSQLiteProvider,
-} from '../sqlite-providers';
+import { createSQLiteProvider } from '../sqlite-providers';
 
 const Y = Workspace.Y;
 
 let id: string;
 let workspace: Workspace;
 let provider: SQLiteProvider;
-let downloadProvider: SQLiteDBDownloadProvider;
+let downloadProvider: SQLiteProvider;
 
 let offlineYdoc: YType.Doc;
 
@@ -89,13 +83,9 @@ beforeEach(() => {
   provider = createSQLiteProvider(workspace.id, workspace.doc, {
     awareness: workspace.awarenessStore.awareness,
   }) as SQLiteProvider;
-  downloadProvider = createSQLiteDBDownloadProvider(
-    workspace.id,
-    workspace.doc,
-    {
-      awareness: workspace.awarenessStore.awareness,
-    }
-  ) as SQLiteDBDownloadProvider;
+  downloadProvider = createSQLiteProvider(workspace.id, workspace.doc, {
+    awareness: workspace.awarenessStore.awareness,
+  }) as SQLiteProvider;
   offlineYdoc = new Y.Doc();
   offlineYdoc.getText('text').insert(0, 'sqlite-hello');
 });

--- a/packages/frontend/workspace/src/providers/cloud/index.ts
+++ b/packages/frontend/workspace/src/providers/cloud/index.ts
@@ -66,33 +66,3 @@ export const createCloudDownloadProvider: DocProviderCreator = (
     },
   };
 };
-
-export const createMergeCloudSnapshotProvider: DocProviderCreator = (
-  id,
-  doc
-): ActiveDocProvider => {
-  let _resolve: () => void;
-  const promise = new Promise<void>(resolve => {
-    _resolve = resolve;
-  });
-
-  return {
-    flavour: 'affine-cloud-merge-snapshot',
-    active: true,
-    sync() {
-      downloadBinary(id, doc)
-        .then(() => {
-          logger.info(`Downloaded ${id}`);
-          _resolve();
-        })
-        // ignore error
-        .catch(e => {
-          console.error(e);
-          _resolve();
-        });
-    },
-    get whenReady() {
-      return promise;
-    },
-  };
-};

--- a/packages/frontend/workspace/src/providers/sqlite-providers.ts
+++ b/packages/frontend/workspace/src/providers/sqlite-providers.ts
@@ -1,18 +1,7 @@
-import type {
-  SQLiteDBDownloadProvider,
-  SQLiteProvider,
-} from '@affine/env/workspace';
+import type { SQLiteProvider } from '@affine/env/workspace';
 import { assertExists } from '@blocksuite/global/utils';
 import type { DocProviderCreator } from '@blocksuite/store';
-import { Workspace as BlockSuiteWorkspace } from '@blocksuite/store';
 import { createLazyProvider, type DocDataSource } from 'y-provider';
-import type { Doc } from 'yjs';
-
-import { localProviderLogger as logger } from './logger';
-
-const Y = BlockSuiteWorkspace.Y;
-
-const sqliteOrigin = 'sqlite-provider-origin';
 
 const createDatasource = (workspaceId: string): DocDataSource => {
   if (!window.apis?.db) {
@@ -53,11 +42,13 @@ export const createSQLiteProvider: DocProviderCreator = (
 ): SQLiteProvider => {
   const datasource = createDatasource(id);
   let provider: ReturnType<typeof createLazyProvider> | null = null;
+
   let connected = false;
-  return {
+  const apis = {
     flavour: 'sqlite',
     datasource,
     passive: true,
+    active: true,
     get status() {
       assertExists(provider);
       return provider.status;
@@ -71,6 +62,17 @@ export const createSQLiteProvider: DocProviderCreator = (
       provider.connect();
       connected = true;
     },
+    sync: () => {
+      if (!provider) {
+        apis.connect();
+      }
+      provider?.sync(true).catch(() => {
+        /* noop */
+      });
+    },
+    get whenReady() {
+      return Promise.resolve(provider?.whenReady);
+    },
     disconnect: () => {
       provider?.disconnect();
       provider = null;
@@ -79,55 +81,7 @@ export const createSQLiteProvider: DocProviderCreator = (
     get connected() {
       return connected;
     },
-  };
-};
+  } satisfies SQLiteProvider;
 
-/**
- * A provider that is responsible for DOWNLOADING updates from the local SQLite database.
- */
-export const createSQLiteDBDownloadProvider: DocProviderCreator = (
-  id,
-  rootDoc
-): SQLiteDBDownloadProvider => {
-  const { apis } = window;
-
-  let _resolve: () => void;
-  let _reject: (error: unknown) => void;
-  const promise = new Promise<void>((resolve, reject) => {
-    _resolve = resolve;
-    _reject = reject;
-  });
-
-  async function syncUpdates(doc: Doc) {
-    logger.info('syncing updates from sqlite', doc.guid);
-    const subdocId = doc.guid === id ? undefined : doc.guid;
-    const updates = await apis.db.getDocAsUpdates(id, subdocId);
-
-    if (updates) {
-      Y.applyUpdate(doc, updates, sqliteOrigin);
-    }
-
-    return true;
-  }
-
-  return {
-    flavour: 'sqlite-download',
-    active: true,
-    get whenReady() {
-      return promise;
-    },
-    cleanup: () => {
-      // todo
-    },
-    sync: () => {
-      logger.info('connect sqlite download provider', id);
-      syncUpdates(rootDoc)
-        .then(() => {
-          _resolve();
-        })
-        .catch(error => {
-          _reject(error);
-        });
-    },
-  };
+  return apis;
 };


### PR DESCRIPTION
# Summary

This PR simplifies the workspace provider by consolidating its functionality. Previously, the provider was divided into two versions: background and download. This PR eliminates the download version and enhances the background provider to support the `sync` method previously support by download.