### PR TITLE
fix(electron): add search to proxied url

### DIFF
--- a/packages/frontend/electron/src/main/protocol.ts
+++ b/packages/frontend/electron/src/main/protocol.ts
@@ -46,7 +46,10 @@ async function handleFileRequest(request: Request) {
   const urlObject = new URL(request.url);
   if (isNetworkResource(urlObject.pathname)) {
     // just pass through (proxy)
-    return net.fetch(CLOUD_BASE_URL + urlObject.pathname, clonedRequest);
+    return net.fetch(
+      CLOUD_BASE_URL + urlObject.pathname + urlObject.search,
+      clonedRequest
+    );
   } else {
     // this will be file types (in the web-static folder)
     let filepath = '';


### PR DESCRIPTION
It looks like the challenge was not being sent in the proxied request in electron, which is the cause of the below 
https://affine-pro.slack.com/archives/C05QRGNFWUW/p1698992455643899