### PR TITLE
fix(hooks): missing page preview and references

### DIFF
--- a/packages/frontend/hooks/src/use-block-suite-page-preview.ts
+++ b/packages/frontend/hooks/src/use-block-suite-page-preview.ts
@@ -25,14 +25,19 @@ export function useBlockSuitePagePreview(page: Page | null): Atom<string> {
   } else if (weakMap.has(page)) {
     return weakMap.get(page) as Atom<string>;
   } else {
-    const baseAtom = atom<string>(getPagePreviewText(page));
+    const baseAtom = atom<string>('');
     baseAtom.onMount = set => {
-      const disposable = page.slots.yUpdated.on(() => {
-        set(getPagePreviewText(page));
-      });
+      const disposables = [
+        page.slots.ready.on(() => {
+          set(getPagePreviewText(page));
+        }),
+        page.slots.yUpdated.on(() => {
+          set(getPagePreviewText(page));
+        }),
+      ];
       set(getPagePreviewText(page));
       return () => {
-        disposable.dispose();
+        disposables.forEach(disposable => disposable.dispose());
       };
     };
     weakMap.set(page, baseAtom);

--- a/packages/frontend/hooks/src/use-block-suite-page-references.ts
+++ b/packages/frontend/hooks/src/use-block-suite-page-references.ts
@@ -19,13 +19,19 @@ const getPageReferencesAtom = (page: Page | null) => {
   }
 
   if (!weakMap.has(page)) {
-    const baseAtom = atom<string[]>(getPageReferences(page));
+    const baseAtom = atom<string[]>([]);
     baseAtom.onMount = set => {
-      const dispose = page.slots.yUpdated.on(() => {
-        set(getPageReferences(page));
-      });
+      const disposables = [
+        page.slots.ready.on(() => {
+          set(getPageReferences(page));
+        }),
+        page.slots.yUpdated.on(() => {
+          set(getPageReferences(page));
+        }),
+      ];
+      set(getPageReferences(page));
       return () => {
-        dispose.dispose();
+        disposables.forEach(disposable => disposable.dispose());
       };
     };
     weakMap.set(page, baseAtom);


### PR DESCRIPTION
status: This pr fix [#11](https://github.com/toeverything/AFFiNE/issues/4865) , would be able to improve if blocksuite was able to provide page.onSync slat https://github.com/toeverything/blocksuite/issues/5249.


![image](https://github.com/toeverything/AFFiNE/assets/13579374/38021885-2b49-4ce5-931c-f154dadb65fd)
