### PR TITLE
fix(server): earlyAccessPreview env override

### DIFF
--- a/packages/backend/server/src/config/default.ts
+++ b/packages/backend/server/src/config/default.ts
@@ -117,11 +117,8 @@ export const getDefaultAFFiNEConfig: () => AFFiNEConfig = () => {
     get deploy() {
       return !this.node.dev && !this.node.test;
     },
-    get featureFlags() {
-      return {
-        earlyAccessPreview:
-          this.node.prod && (this.affine.beta || this.affine.canary),
-      };
+    featureFlags: {
+      earlyAccessPreview: false,
     },
     get https() {
       return !this.node.dev;


### PR DESCRIPTION
`TypeError: Cannot set property featureFlags of #<Object> which has only a getter`