### PR TITLE
fix(electron): dev reload

### DIFF
--- a/packages/frontend/electron/package.json
+++ b/packages/frontend/electron/package.json
@@ -51,7 +51,7 @@
     "builder-util-runtime": "^9.2.1",
     "cross-env": "^7.0.3",
     "electron": "^27.0.0",
-    "electron-log": "^5.0.0-rc.1",
+    "electron-log": "^5.0.0",
     "electron-squirrel-startup": "1.0.0",
     "electron-window-state": "^5.0.3",
     "esbuild": "^0.19.4",

--- a/packages/frontend/electron/scripts/dev.ts
+++ b/packages/frontend/electron/scripts/dev.ts
@@ -54,7 +54,6 @@ function spawnOrReloadElectron() {
     if (code && code !== 0) {
       console.log(`Electron exited with code ${code}`);
     }
-    process.exit(code ?? 0);
   });
 }
 

--- a/packages/frontend/electron/src/main/logger.ts
+++ b/packages/frontend/electron/src/main/logger.ts
@@ -1,4 +1,5 @@
 import { shell } from 'electron';
+import { app } from 'electron';
 import log from 'electron-log';
 
 export const logger = log.scope('main');
@@ -12,3 +13,7 @@ export async function revealLogFile() {
   const filePath = getLogFilePath();
   return await shell.openPath(filePath);
 }
+
+app.on('before-quit', () => {
+  log.transports.console.level = false;
+});

--- a/packages/frontend/electron/src/main/updater/electron-updater.ts
+++ b/packages/frontend/electron/src/main/updater/electron-updater.ts
@@ -10,6 +10,9 @@ import { updaterSubjects } from './event';
 const mode = process.env.NODE_ENV;
 const isDev = mode === 'development';
 
+// skip auto update in dev mode & internal
+const disabled = buildType === 'internal' || isDev;
+
 export const quitAndInstall = async () => {
   autoUpdater.quitAndInstall();
 };
@@ -17,7 +20,7 @@ export const quitAndInstall = async () => {
 let lastCheckTime = 0;
 export const checkForUpdates = async (force = true) => {
   // check every 30 minutes (1800 seconds) at most
-  if (force || lastCheckTime + 1000 * 1800 < Date.now()) {
+  if (!disabled && (force || lastCheckTime + 1000 * 1800 < Date.now())) {
     lastCheckTime = Date.now();
     return await autoUpdater.checkForUpdates();
   }
@@ -25,8 +28,7 @@ export const checkForUpdates = async (force = true) => {
 };
 
 export const registerUpdater = async () => {
-  // skip auto update in dev mode & internal
-  if (buildType === 'internal' || isDev) {
+  if (disabled) {
     return;
   }
 
@@ -43,7 +45,6 @@ export const registerUpdater = async () => {
     channel: buildType,
     // hack for custom provider
     provider: 'custom' as 'github',
-    // @ts-expect-error - just ignore for now
     repo: buildType !== 'internal' ? 'AFFiNE' : 'AFFiNE-Releases',
     owner: 'toeverything',
     releaseType: buildType === 'stable' ? 'release' : 'prerelease',

--- a/yarn.lock
+++ b/yarn.lock
@@ -445,7 +445,7 @@ __metadata:
     builder-util-runtime: "npm:^9.2.1"
     cross-env: "npm:^7.0.3"
     electron: "npm:^27.0.0"
-    electron-log: "npm:^5.0.0-rc.1"
+    electron-log: "npm:^5.0.0"
     electron-squirrel-startup: "npm:1.0.0"
     electron-updater: "npm:^6.1.5"
     electron-window-state: "npm:^5.0.3"
@@ -19164,10 +19164,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-log@npm:^5.0.0-rc.1":
-  version: 5.0.0-rc.1
-  resolution: "electron-log@npm:5.0.0-rc.1"
-  checksum: f4ec437197ec5801a325e062c19f182a14eba960ee683034bfea5854efe452cfa91985b7f7ab159599c8264fde869f7101d4e82303231865a6b7c8e621815f87
+"electron-log@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "electron-log@npm:5.0.0"
+  checksum: 23b14119a5753be24880e7466ee80ae1386f9df4123ed59bc8f4426a814c728875b07de13bf0729cba7202888fcd6230375e2b5302cee0d0c5f25584d9db3334
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
root cause:
- should not exit the current process when reload
- electron log should not continue logging when process is quitting (which will crash if doing so