### PR TITLE
fix(electron): clone db file when enable cloud for desktop

### DIFF
--- a/packages/common/infra/src/type.ts
+++ b/packages/common/infra/src/type.ts
@@ -200,6 +200,7 @@ export type WorkspaceHandlers = {
   list: () => Promise<[workspaceId: string, meta: WorkspaceMeta][]>;
   delete: (id: string) => Promise<void>;
   getMeta: (id: string) => Promise<WorkspaceMeta>;
+  clone: (id: string, newId: string) => Promise<void>;
 };
 
 export type UnwrapManagerHandlerToServerSide<

--- a/packages/frontend/electron/src/helper/workspace/index.ts
+++ b/packages/frontend/electron/src/helper/workspace/index.ts
@@ -1,5 +1,5 @@
 import type { MainEventRegister, WorkspaceMeta } from '../type';
-import { deleteWorkspace, listWorkspaces } from './handlers';
+import { cloneWorkspace, deleteWorkspace, listWorkspaces } from './handlers';
 import { getWorkspaceMeta } from './meta';
 import { workspaceSubjects } from './subjects';
 
@@ -23,4 +23,5 @@ export const workspaceHandlers = {
   getMeta: async (id: string) => {
     return getWorkspaceMeta(id);
   },
+  clone: async (id: string, newId: string) => cloneWorkspace(id, newId),
 };


### PR DESCRIPTION
At the moment on desktop the user's local blob data will be lost after enable cloud.
This is because blob data is only synced from old idb to new idb, but not sync into sqlitedb.

This pr will simply clone the db file for desktop app. It should also speed up the time when enabling cloud for a large local workspace.