### PR TITLE
fix(core): should not reset page preset on rerender

### DIFF
--- a/packages/frontend/component/src/components/block-suite-editor/index.tsx
+++ b/packages/frontend/component/src/components/block-suite-editor/index.tsx
@@ -21,7 +21,7 @@ import {
   blockSuiteEditorHeaderStyle,
   blockSuiteEditorStyle,
 } from './index.css';
-import { getPresets } from './preset';
+import { editorPresets } from './preset';
 
 interface BlockElement extends Element {
   path: string[];
@@ -104,11 +104,9 @@ const BlockSuiteEditorImpl = ({
 
   if (editor.page !== page) {
     editor.page = page;
+    editor.pagePreset = editorPresets.pageModePreset;
+    editor.edgelessPreset = editorPresets.edgelessModePreset;
   }
-
-  const presets = getPresets();
-  editor.pagePreset = presets.pageModePreset;
-  editor.edgelessPreset = presets.edgelessModePreset;
 
   useLayoutEffect(() => {
     if (editor) {

--- a/packages/frontend/component/src/components/block-suite-editor/preset.ts
+++ b/packages/frontend/component/src/components/block-suite-editor/preset.ts
@@ -17,7 +17,7 @@ class CustomAttachmentService extends AttachmentService {
   }
 }
 
-export function getPresets() {
+function getPresets() {
   const pageModePreset = PagePreset.map(preset => {
     if (preset.schema.model.flavour === 'affine:attachment') {
       return {
@@ -42,3 +42,5 @@ export function getPresets() {
     edgelessModePreset,
   };
 }
+
+export const editorPresets = getPresets();


### PR DESCRIPTION
Should not reset editor preset when re-render.

See https://github.com/toeverything/blocksuite/blob/ce7ac88fc750fb465a6b4227b8f93eafe8e894fc/packages/editor/src/components/editor-container.ts#L197. If these props changes, it will trigger some unexpected side effects.