### PR TITLE
chore(core): update react-resizable-panels

### DIFF
--- a/packages/frontend/core/package.json
+++ b/packages/frontend/core/package.json
@@ -71,7 +71,7 @@
     "react-dom": "18.2.0",
     "react-error-boundary": "^4.0.11",
     "react-is": "18.2.0",
-    "react-resizable-panels": "^0.0.55",
+    "react-resizable-panels": "^0.0.61",
     "react-router-dom": "^6.16.0",
     "rxjs": "^7.8.1",
     "ses": "^0.18.8",

--- a/packages/frontend/core/src/components/page-detail-editor.tsx
+++ b/packages/frontend/core/src/components/page-detail-editor.tsx
@@ -289,7 +289,7 @@ const LayoutPanel = memo(function LayoutPanel(
         className={depth === 0 ? editorContainer : undefined}
       >
         <Panel
-          defaultSize={node.splitPercentage}
+          defaultSizePercentage={node.splitPercentage}
           style={{
             maxWidth: node.maxWidth?.[0],
           }}
@@ -304,7 +304,7 @@ const LayoutPanel = memo(function LayoutPanel(
         </Panel>
         <PanelResizeHandle />
         <Panel
-          defaultSize={100 - node.splitPercentage}
+          defaultSizePercentage={100 - node.splitPercentage}
           style={{
             overflow: 'scroll',
             maxWidth: node.maxWidth?.[1],

--- a/yarn.lock
+++ b/yarn.lock
@@ -388,7 +388,7 @@ __metadata:
     react-dom: "npm:18.2.0"
     react-error-boundary: "npm:^4.0.11"
     react-is: "npm:18.2.0"
-    react-resizable-panels: "npm:^0.0.55"
+    react-resizable-panels: "npm:^0.0.61"
     react-router-dom: "npm:^6.16.0"
     rxjs: "npm:^7.8.1"
     ses: "npm:^0.18.8"
@@ -30991,13 +30991,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-resizable-panels@npm:^0.0.55":
-  version: 0.0.55
-  resolution: "react-resizable-panels@npm:0.0.55"
+"react-resizable-panels@npm:^0.0.61":
+  version: 0.0.61
+  resolution: "react-resizable-panels@npm:0.0.61"
   peerDependencies:
     react: ^16.14.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
-  checksum: 9b83287d2c962ff87cddae85b5233aaf61c0ff3ac30e29fcc51ac1a0ae5ea45fe78092ecf79b2e4a9dd898ca95c43dd698295b72e737d9275daac85c1ae59339
+  checksum: 6a2eca04892f24f3b270c782a03e8302799391b1436f73ff7fb6ff5cb0eabd8695772b809f34a2ead34f3d1361fe6cfcdf5229856acc6a268448e15413c09a5d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`react-resizable-panels` will throw some errors sometime when showing history modal dialog.
I haven't checked the root cause, but upgrade it to the latest will get rid of the error. 