### PR TITLE
fix(core): unable to create share page link

### DIFF
--- a/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-menu.tsx
+++ b/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-menu.tsx
@@ -73,10 +73,7 @@ const CloudShareMenu = (props: ShareMenuProps) => {
     workspace: { id: workspaceId },
     currentPage,
   } = props;
-  const { isSharedPage } = useIsSharedPage(
-    workspaceId,
-    currentPage.spaceDoc.guid
-  );
+  const { isSharedPage } = useIsSharedPage(workspaceId, currentPage.id);
 
   return (
     <Menu

--- a/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-page.tsx
+++ b/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-page.tsx
@@ -80,7 +80,7 @@ export const AffineSharePage = (props: ShareMenuProps) => {
     changeShare,
     currentShareMode,
     disableShare,
-  } = useIsSharedPage(workspaceId, currentPage.spaceDoc.guid);
+  } = useIsSharedPage(workspaceId, currentPage.id);
   const currentPageMode = useAtomValue(currentModeAtom);
 
   const defaultMode = useMemo(() => {


### PR DESCRIPTION
For some reasons, our `spaceDoc.guid` and `page.id` may not necessarily be the same, so we switched to using the more accurate `page.id`.