### PR TITLE
fix(core): flaky local avartar test

### DIFF
--- a/tests/affine-local/e2e/local-first-avatar.spec.ts
+++ b/tests/affine-local/e2e/local-first-avatar.spec.ts
@@ -16,14 +16,11 @@ test('should create a page with a local first avatar and remove it', async ({
   await waitForEditorLoad(page);
   await clickNewPageButton(page);
   await page.getByTestId('workspace-name').click();
-  await page.getByTestId('new-workspace').click({ delay: 50 });
-  await page
-    .getByTestId('create-workspace-input')
-    .pressSequentially('Test Workspace 1', { delay: 50 });
+  await page.getByTestId('new-workspace').click();
+  await page.getByTestId('create-workspace-input').fill('Test Workspace 1');
   await page.getByTestId('create-workspace-create-button').click();
-  await page.getByTestId('workspace-name').click({
-    delay: 50,
-  });
+  await page.waitForTimeout(1000);
+  await page.getByTestId('workspace-name').click();
   await page.getByTestId('workspace-card').nth(1).click();
   await page.getByTestId('settings-modal-trigger').click();
   await page.getByTestId('current-workspace-label').click();
@@ -31,14 +28,10 @@ test('should create a page with a local first avatar and remove it', async ({
     .getByTestId('upload-avatar')
     .setInputFiles(resolve(rootDir, 'tests', 'fixtures', 'smile.png'));
   await page.mouse.click(0, 0);
-  await page.getByTestId('workspace-name').click({
-    delay: 50,
-  });
+  await page.getByTestId('workspace-name').click();
   await page.getByTestId('workspace-card').nth(0).click();
   await page.waitForTimeout(1000);
-  await page.getByTestId('workspace-name').click({
-    delay: 50,
-  });
+  await page.getByTestId('workspace-name').click();
   await page.getByTestId('workspace-card').nth(1).click();
   const blobUrl = await page
     .getByTestId('workspace-avatar')


### PR DESCRIPTION
it seems we should not reopen workspace card list just after created a new workspace