### PR TITLE
fix(core): escape special characters for cmdk item values

### DIFF
--- a/packages/frontend/core/src/components/pure/cmdk/data.tsx
+++ b/packages/frontend/core/src/components/pure/cmdk/data.tsx
@@ -168,14 +168,15 @@ export const pageToCommand = (
 
   // hack: when comparing, the part between >>> and <<< will be ignored
   // adding this patch so that CMDK will not complain about duplicated commands
-  const id =
+  const id = CSS.escape(
     title +
-    (label?.subTitle || '') +
-    valueWrapperStart +
-    page.id +
-    '.' +
-    category +
-    valueWrapperEnd;
+      (label?.subTitle || '') +
+      valueWrapperStart +
+      page.id +
+      '.' +
+      category +
+      valueWrapperEnd
+  );
 
   return {
     id,


### PR DESCRIPTION
![image](https://github.com/toeverything/AFFiNE/assets/102217452/301ef02e-f0df-4a1b-843f-240cad44af0f)
