### PR TITLE
feat: only follow `serverUrlPrefix` at redirect to client (#5295)

### DIFF
--- a/packages/frontend/core/src/components/affine/page-history-modal/data.ts
+++ b/packages/frontend/core/src/components/affine/page-history-modal/data.ts
@@ -81,8 +81,7 @@ const snapshotFetcher = async (
     return null;
   }
   const res = await fetchWithTraceReport(
-    runtimeConfig.serverUrlPrefix +
-      `/api/workspaces/${workspaceId}/docs/${pageDocId}/histories/${ts}`,
+    `/api/workspaces/${workspaceId}/docs/${pageDocId}/histories/${ts}`,
     {
       priority: 'high',
     }

--- a/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-page.tsx
+++ b/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-page.tsx
@@ -140,7 +140,9 @@ export const AffineSharePage = (props: ShareMenuProps) => {
             lineHeight: '20px',
           }}
           value={
-            isSharedPage ? sharingUrl : `${runtimeConfig.serverUrlPrefix}/...`
+            isSharedPage
+              ? sharingUrl
+              : `${location.protocol}//${location.hostname}/...`
           }
           readOnly
         />

--- a/packages/frontend/core/src/components/affine/share-page-modal/share-menu/use-share-url.ts
+++ b/packages/frontend/core/src/components/affine/share-page-modal/share-menu/use-share-url.ts
@@ -19,8 +19,11 @@ export const generateUrl = ({
   // to generate a public url like https://affine.app/share/123/456
   // or https://affine.app/share/123/456?mode=edgeless
 
+  const { protocol, hostname, port } = window.location;
   const url = new URL(
-    `${runtimeConfig.serverUrlPrefix}/${urlType}/${workspaceId}/${pageId}`
+    `${protocol}//${hostname}${
+      port ? `:${port}` : ''
+    }/${urlType}/${workspaceId}/${pageId}`
   );
   return url.toString();
 };

--- a/packages/frontend/core/src/pages/share/share-detail-page.tsx
+++ b/packages/frontend/core/src/pages/share/share-detail-page.tsx
@@ -38,8 +38,7 @@ export async function downloadBinaryFromCloud(
   pageGuid: string
 ): Promise<CloudDoc | null> {
   const response = await fetchWithTraceReport(
-    runtimeConfig.serverUrlPrefix +
-      `/api/workspaces/${rootGuid}/docs/${pageGuid}`,
+    `/api/workspaces/${rootGuid}/docs/${pageGuid}`,
     {
       priority: 'high',
     }

--- a/packages/frontend/workspace/src/affine/gql.ts
+++ b/packages/frontend/workspace/src/affine/gql.ts
@@ -22,9 +22,7 @@ import useSWRMutation from 'swr/mutation';
 
 setupGlobal();
 
-export const fetcher = gqlFetcherFactory(
-  runtimeConfig.serverUrlPrefix + '/graphql'
-);
+export const fetcher = gqlFetcherFactory('/graphql');
 
 /**
  * A `useSWR` wrapper for sending graphql queries

--- a/packages/frontend/workspace/src/impl/cloud/blob.ts
+++ b/packages/frontend/workspace/src/impl/cloud/blob.ts
@@ -21,15 +21,13 @@ export const createAffineCloudBlobStorage = (
         ? key
         : `/api/workspaces/${workspaceId}/blobs/${key}`;
 
-      return fetchWithTraceReport(runtimeConfig.serverUrlPrefix + suffix).then(
-        async res => {
-          if (!res.ok) {
-            // status not in the range 200-299
-            return null;
-          }
-          return bufferToBlob(await res.arrayBuffer());
+      return fetchWithTraceReport(suffix).then(async res => {
+        if (!res.ok) {
+          // status not in the range 200-299
+          return null;
         }
-      );
+        return bufferToBlob(await res.arrayBuffer());
+      });
     },
     set: async (key, value) => {
       const {

--- a/packages/frontend/workspace/src/utils/affine-io.ts
+++ b/packages/frontend/workspace/src/utils/affine-io.ts
@@ -7,9 +7,16 @@ export function getIoManager(): Manager {
   if (ioManager) {
     return ioManager;
   }
-  ioManager = new Manager(runtimeConfig.serverUrlPrefix + '/', {
-    autoConnect: false,
-    transports: ['websocket'],
-  });
+  const { protocol, hostname, port } = window.location;
+  ioManager = new Manager(
+    `${protocol === 'https:' ? 'wss' : 'ws'}://${hostname}${
+      port ? `:${port}` : ''
+    }/`,
+    {
+      autoConnect: false,
+      transports: ['websocket'],
+      secure: location.protocol === 'https:',
+    }
+  );
   return ioManager;
 }


### PR DESCRIPTION
feat: only follow `serverUrlPrefix` at redirect to client (#5295)

fix: use secure websocket (#5297)