### PR TITLE
fix(core): the pitch zooming function incorrectly zooms the toolbar

### DIFF
--- a/packages/frontend/core/src/components/image-preview/hooks/use-zoom.tsx
+++ b/packages/frontend/core/src/components/image-preview/hooks/use-zoom.tsx
@@ -1,5 +1,6 @@
 import type { MouseEvent as ReactMouseEvent, RefObject } from 'react';
 import { useCallback, useEffect, useState } from 'react';
+import { useRef } from 'react';
 
 interface UseZoomControlsProps {
   zoomRef: RefObject<HTMLDivElement>;
@@ -21,6 +22,7 @@ export const useZoomControls = ({
     x: 0,
     y: 0,
   });
+  const zoomInScaleRef = useRef<number>(1);
 
   const handleDragStart = useCallback(
     (event: ReactMouseEvent) => {
@@ -124,6 +126,7 @@ export const useZoomControls = ({
     if (image && currentScale < 2) {
       const newScale = currentScale + 0.1;
       setCurrentScale(newScale);
+      zoomInScaleRef.current = newScale; // Update the ref
       image.style.width = `${image.naturalWidth * newScale}px`;
       image.style.height = `${image.naturalHeight * newScale}px`;
     }
@@ -134,6 +137,7 @@ export const useZoomControls = ({
     if (image && currentScale > 0.2) {
       const newScale = currentScale - 0.1;
       setCurrentScale(newScale);
+      zoomInScaleRef.current = newScale; // Update the ref
       image.style.width = `${image.naturalWidth * newScale}px`;
       image.style.height = `${image.naturalHeight * newScale}px`;
       const zoomedWidth = image.naturalWidth * newScale;
@@ -186,7 +190,7 @@ export const useZoomControls = ({
       const { deltaY } = event;
       if (deltaY > 0) {
         zoomOut();
-      } else if (deltaY < 0) {
+      } else if (deltaY < 0 && currentScale < 2 && zoomInScaleRef.current < 2) {
         zoomIn();
       }
     };


### PR DESCRIPTION
The issue was having when the image is filling up the entire screen after zoomIn , so it was zooming in the background container as well . So , I have created a reference to check the zoomIn and zoomOut scale . And Checking that on handleScroll function.

https://github.com/toeverything/AFFiNE/assets/83939820/47b52692-527f-4ec6-b42f-9c72d4d48ac4

- Close #5293
- Close #5294

