### PR TITLE
fix(core): adjust error boundary level

### DIFF
--- a/packages/frontend/core/src/components/affine/page-history-modal/history-modal.tsx
+++ b/packages/frontend/core/src/components/affine/page-history-modal/history-modal.tsx
@@ -79,7 +79,7 @@ const ModalContainer = ({
       withoutCloseButton
       contentOptions={contentOptions}
     >
-      <AffineErrorBoundary>{children}</AffineErrorBoundary>
+      {children}
     </Modal>
   );
 };
@@ -138,12 +138,14 @@ const HistoryEditorPreview = ({
       </div>
 
       {snapshotPage ? (
-        <BlockSuiteEditor
-          className={styles.editor}
-          mode={mode}
-          page={snapshotPage}
-          onModeChange={onModeChange}
-        />
+        <AffineErrorBoundary>
+          <BlockSuiteEditor
+            className={styles.editor}
+            mode={mode}
+            page={snapshotPage}
+            onModeChange={onModeChange}
+          />
+        </AffineErrorBoundary>
       ) : (
         <div className={styles.loadingContainer}>
           <Loading size={24} />

--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
@@ -177,14 +177,17 @@ const DetailPageImpl = memo(function DetailPageImpl({ page }: { page: Page }) {
           </>
         }
         main={
-          <div className={styles.editorContainer}>
-            <PageDetailEditor
-              pageId={currentPageId}
-              onLoad={onLoad}
-              workspace={blockSuiteWorkspace}
-            />
-            <HubIsland />
-          </div>
+          // Add a key to force rerender when page changed, to avoid error boundary persisting.
+          <AffineErrorBoundary key={currentPageId}>
+            <div className={styles.editorContainer}>
+              <PageDetailEditor
+                pageId={currentPageId}
+                onLoad={onLoad}
+                workspace={blockSuiteWorkspace}
+              />
+              <HubIsland />
+            </div>
+          </AffineErrorBoundary>
         }
         footer={isInTrash ? <TrashPageFooter pageId={page.id} /> : null}
         sidebar={
@@ -268,10 +271,5 @@ export const Component = () => {
 
   const pageId = params.pageId;
 
-  // Add a key to force rerender when page changed, to avoid error boundary persisting.
-  return (
-    <AffineErrorBoundary key={params.pageId}>
-      {pageId ? <DetailPage pageId={pageId} /> : null}
-    </AffineErrorBoundary>
-  );
+  return pageId ? <DetailPage pageId={pageId} /> : null;
 };


### PR DESCRIPTION
Allowing showing page title for page detail when page throws error.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/398bef13-c52d-40b4-bf53-5157582d030a.png)