### PR TITLE
fix(electron): remove cors headers hack

### DIFF
--- a/packages/frontend/electron/src/main/protocol.ts
+++ b/packages/frontend/electron/src/main/protocol.ts
@@ -79,16 +79,6 @@ export function registerProtocol() {
     (responseDetails, callback) => {
       const { responseHeaders } = responseDetails;
       if (responseHeaders) {
-        delete responseHeaders['access-control-allow-origin'];
-        delete responseHeaders['access-control-allow-methods'];
-        responseHeaders['Access-Control-Allow-Origin'] = ['*'];
-        responseHeaders['Access-Control-Allow-Methods'] = [
-          'GET',
-          'POST',
-          'PUT',
-          'DELETE',
-          'OPTIONS',
-        ];
         // replace SameSite=Lax with SameSite=None
         const originalCookie =
           responseHeaders['set-cookie'] || responseHeaders['Set-Cookie'];


### PR DESCRIPTION
fix TOV-404

Looks like the cors headers will cause the youtube not loading in Electron