### PR TITLE
style: import from './index' instead of '.'

### DIFF
--- a/packages/common/workspace/src/list/information.ts
+++ b/packages/common/workspace/src/list/information.ts
@@ -3,7 +3,7 @@ import { Slot } from '@blocksuite/global/utils';
 
 import type { WorkspaceMetadata } from '../metadata';
 import type { Workspace } from '../workspace';
-import type { WorkspaceListProvider } from '.';
+import type { WorkspaceListProvider } from './index';
 
 const logger = new DebugLogger('affine:workspace:list:information');
 

--- a/packages/common/workspace/src/manager.ts
+++ b/packages/common/workspace/src/manager.ts
@@ -5,8 +5,8 @@ import type { Workspace as BlockSuiteWorkspace } from '@blocksuite/store';
 import { fixWorkspaceVersion } from '@toeverything/infra/blocksuite';
 import { applyUpdate, encodeStateAsUpdate } from 'yjs';
 
-import type { BlobStorage } from '.';
 import type { WorkspaceFactory } from './factory';
+import type { BlobStorage } from './index';
 import type { WorkspaceList } from './list';
 import type { WorkspaceMetadata } from './metadata';
 import { WorkspacePool } from './pool';

--- a/packages/frontend/component/src/components/app-sidebar/add-page-button/index.stories.tsx
+++ b/packages/frontend/component/src/components/app-sidebar/add-page-button/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { AddPageButton } from '.';
+import { AddPageButton } from './index';
 
 export default {
   title: 'Components/AppSidebar/AddPageButton',

--- a/packages/frontend/component/src/components/app-sidebar/category-divider/index.stories.tsx
+++ b/packages/frontend/component/src/components/app-sidebar/category-divider/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { CategoryDivider } from '.';
+import { CategoryDivider } from './index';
 
 export default {
   title: 'Components/AppSidebar/CategoryDivider',

--- a/packages/frontend/component/src/components/app-sidebar/menu-item/index.stories.tsx
+++ b/packages/frontend/component/src/components/app-sidebar/menu-item/index.stories.tsx
@@ -2,7 +2,7 @@ import { SettingsIcon } from '@blocksuite/icons';
 import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 
-import { MenuItem, MenuLinkItem } from '.';
+import { MenuItem, MenuLinkItem } from './index';
 
 export default {
   title: 'Components/AppSidebar/MenuItem',

--- a/packages/frontend/component/src/components/app-sidebar/quick-search-input/index.stories.tsx
+++ b/packages/frontend/component/src/components/app-sidebar/quick-search-input/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { QuickSearchInput } from '.';
+import { QuickSearchInput } from './index';
 
 export default {
   title: 'Components/AppSidebar/QuickSearchInput',

--- a/packages/frontend/component/src/components/app-sidebar/spolight/index.stories.tsx
+++ b/packages/frontend/component/src/components/app-sidebar/spolight/index.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 import { type PropsWithChildren } from 'react';
 
-import { Spotlight } from '.';
+import { Spotlight } from './index';
 
 export default {
   title: 'Components/AppSidebar/Spotlight',

--- a/packages/frontend/component/src/ui/divider/divider.stories.tsx
+++ b/packages/frontend/component/src/ui/divider/divider.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Divider, type DividerProps } from '.';
+import { Divider, type DividerProps } from './index';
 
 export default {
   title: 'UI/Divider',

--- a/packages/frontend/component/src/ui/empty/empty.stories.tsx
+++ b/packages/frontend/component/src/ui/empty/empty.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Empty, type EmptyContentProps } from '.';
+import { Empty, type EmptyContentProps } from './index';
 
 export default {
   title: 'UI/Empty',

--- a/packages/frontend/component/src/ui/input/input.stories.tsx
+++ b/packages/frontend/component/src/ui/input/input.stories.tsx
@@ -1,7 +1,7 @@
 import { InformationIcon } from '@blocksuite/icons';
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Input, type InputProps } from '.';
+import { Input, type InputProps } from './index';
 
 export default {
   title: 'UI/Input',

--- a/packages/frontend/component/src/ui/menu/menu-trigger.stories.tsx
+++ b/packages/frontend/component/src/ui/menu/menu-trigger.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { MenuTrigger, type MenuTriggerProps } from '.';
+import { MenuTrigger, type MenuTriggerProps } from './index';
 
 export default {
   title: 'UI/MenuTrigger',

--- a/packages/frontend/component/src/ui/menu/menu.stories.tsx
+++ b/packages/frontend/component/src/ui/menu/menu.stories.tsx
@@ -13,7 +13,7 @@ import {
   MenuSeparator,
   MenuSub,
   MenuTrigger,
-} from '.';
+} from './index';
 
 export default {
   title: 'UI/Menu',

--- a/packages/frontend/component/src/ui/scrollbar/scrollbar.stories.tsx
+++ b/packages/frontend/component/src/ui/scrollbar/scrollbar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { ScrollableContainer, type ScrollableContainerProps } from '.';
+import { ScrollableContainer, type ScrollableContainerProps } from './index';
 
 export default {
   title: 'UI/Scrollbar',

--- a/packages/frontend/component/src/ui/skeleton/skeleton.stories.tsx
+++ b/packages/frontend/component/src/ui/skeleton/skeleton.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Skeleton, type SkeletonProps } from '.';
+import { Skeleton, type SkeletonProps } from './index';
 
 export default {
   title: 'UI/Skeleton',

--- a/packages/frontend/component/src/ui/switch/switch.stories.tsx
+++ b/packages/frontend/component/src/ui/switch/switch.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
-import { Switch, type SwitchProps } from '.';
+import { Switch, type SwitchProps } from './index';
 
 export default {
   title: 'UI/Switch',

--- a/packages/frontend/component/src/ui/table/table.stories.tsx
+++ b/packages/frontend/component/src/ui/table/table.stories.tsx
@@ -7,7 +7,7 @@ import {
   TableCell,
   TableHead,
   TableHeadRow,
-} from '.';
+} from './index';
 
 export default {
   title: 'UI/Table',

--- a/packages/frontend/component/src/ui/toast/toast.stories.tsx
+++ b/packages/frontend/component/src/ui/toast/toast.stories.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 
 import { Button } from '../button';
-import { toast } from '.';
+import { toast } from './index';
 
 export default {
   title: 'UI/Toast',

--- a/packages/frontend/component/src/ui/tooltip/tooltip.stories.tsx
+++ b/packages/frontend/component/src/ui/tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryFn } from '@storybook/react';
 
 import { Button } from '../button';
-import Tooltip, { type TooltipProps } from '.';
+import Tooltip, { type TooltipProps } from './index';
 
 export default {
   title: 'UI/Tooltip',

--- a/packages/frontend/core/src/components/cloud/share-header-right-item/authenticated-item.tsx
+++ b/packages/frontend/core/src/components/cloud/share-header-right-item/authenticated-item.tsx
@@ -4,7 +4,7 @@ import { useAFFiNEI18N } from '@affine/i18n/hooks';
 import { useCurrentUser } from '../../../hooks/affine/use-current-user';
 import { useMembers } from '../../../hooks/affine/use-members';
 import { useNavigateHelper } from '../../../hooks/use-navigate-helper';
-import type { ShareHeaderRightItemProps } from '.';
+import type { ShareHeaderRightItemProps } from './index';
 
 export const AuthenticatedItem = ({ ...props }: ShareHeaderRightItemProps) => {
   const { workspaceId, pageId } = props;

--- a/packages/frontend/core/src/components/page-list/view/collection-operations.tsx
+++ b/packages/frontend/core/src/components/page-list/view/collection-operations.tsx
@@ -15,8 +15,8 @@ import {
 } from 'react';
 
 import type { useCollectionManager } from '../use-collection-manager';
-import type { AllPageListConfig } from '.';
 import * as styles from './collection-operations.css';
+import type { AllPageListConfig } from './index';
 import {
   useEditCollection,
   useEditCollectionName,


### PR DESCRIPTION
This PR replaces all the `import x from '.'`s in the codebase with `import x from './index'`.

`import x from '.'` is a bit of a dead-end, since `'.'` is not a valid import specifier in browsers. As far as I'm aware, there's no way to even use import maps to map them into the right "index.js" files, so it will likely never become supported in browsers.

Reflame's React Fast Refresh implementation in development mode makes use of import maps to avoid having to invalidate more modules than necessary on updates, which is how I discovered these.