### PR TITLE
fix(core): reserve space for the editor scrollbar

### DIFF
--- a/packages/frontend/core/src/components/page-detail-editor.css.ts
+++ b/packages/frontend/core/src/components/page-detail-editor.css.ts
@@ -18,6 +18,8 @@ export const editor = style({
 
 globalStyle(`${editor} .affine-doc-viewport`, {
   paddingBottom: '150px',
+  paddingLeft: '20px',
+  scrollbarGutter: 'stable',
 });
 
 globalStyle('.is-public-page page-meta-tags', {


### PR DESCRIPTION
Because the space for the scroll bar on the right is reserved, in order to make the editor symmetrical, padding corresponding to the width of the scroll bar is added to the left.