### PR TITLE
fix(playground): storybook story load issue

### DIFF
--- a/tests/storybook/src/stories/blocksuite-editor.stories.tsx
+++ b/tests/storybook/src/stories/blocksuite-editor.stories.tsx
@@ -37,7 +37,7 @@ DocEditor.loaders = [
       id: 'test-workspace-id',
       schema,
     });
-
+    workspace.doc.emit('sync', []);
     workspace.meta.setProperties({
       tags: {
         options: [],


### PR DESCRIPTION
Since the properties adapter now depends on whenLoaded status of the ydoc, we may need to explicitly mark doc as emit if the workspace is created without using a provider.