### PR TITLE
fix: add padding between editor and link panel

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/styles.css.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/styles.css.ts
@@ -29,7 +29,7 @@ export const affineDocViewport = style({
 
 export const docContainer = style({
   display: 'block',
-  flexGrow: 1,
+  paddingBottom: 64,
 });
 
 const titleTagBasic = style({


### PR DESCRIPTION
Fix [AFF-561](https://linear.app/affine-design/issue/AFF-561/bi-directional-link-与文本编辑区域的-top-padding)