### PR TITLE
refactor(component): cmdk ordering

### DIFF
--- a/packages/common/infra/src/command/command.ts
+++ b/packages/common/infra/src/command/command.ts
@@ -25,7 +25,8 @@ export type CommandCategory =
   | 'affine:layout'
   | 'affine:updates'
   | 'affine:help'
-  | 'affine:general';
+  | 'affine:general'
+  | 'affine:results';
 
 export interface KeybindingOptions {
   binding: string;

--- a/packages/frontend/core/src/components/pure/cmdk/__tests__/filter-commands.spec.ts
+++ b/packages/frontend/core/src/components/pure/cmdk/__tests__/filter-commands.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, test } from 'vitest';
+
+import { filterSortAndGroupCommands } from '../filter-commands';
+import type { CMDKCommand } from '../types';
+
+const commands: CMDKCommand[] = (
+  [
+    {
+      id: 'affine:goto-all-pages',
+      category: 'affine:navigation',
+      label: { title: 'Go to All Pages' },
+    },
+    {
+      id: 'affine:goto-page-list',
+      category: 'affine:navigation',
+      label: { title: 'Go to Page List' },
+    },
+    {
+      id: 'affine:new-page',
+      category: 'affine:creation',
+      alwaysShow: true,
+      label: { title: 'New Page' },
+    },
+    {
+      id: 'affine:new-edgeless-page',
+      category: 'affine:creation',
+      alwaysShow: true,
+      label: { title: 'New Edgeless' },
+    },
+    {
+      id: 'affine:pages.foo',
+      category: 'affine:pages',
+      label: { title: 'New Page', subTitle: 'foo' },
+    },
+    {
+      id: 'affine:pages.bar',
+      category: 'affine:pages',
+      label: { title: 'New Page', subTitle: 'bar' },
+    },
+  ] as const
+).map(c => {
+  return {
+    ...c,
+    run: () => {},
+  };
+});
+
+describe('filterSortAndGroupCommands', () => {
+  function defineTest(
+    name: string,
+    query: string,
+    expected: [string, string[]][]
+  ) {
+    test(name, () => {
+      // Call the function
+      const result = filterSortAndGroupCommands(commands, query);
+      const sortedIds = result.map(([category, commands]) => {
+        return [category, commands.map(command => command.id)];
+      });
+
+      console.log(JSON.stringify(sortedIds));
+
+      // Assert the result
+      expect(sortedIds).toEqual(expected);
+    });
+  }
+
+  defineTest('without query', '', [
+    ['affine:navigation', ['affine:goto-all-pages', 'affine:goto-page-list']],
+    ['affine:creation', ['affine:new-page', 'affine:new-edgeless-page']],
+    ['affine:pages', ['affine:pages.foo', 'affine:pages.bar']],
+  ]);
+
+  defineTest('with query = a', 'a', [
+    [
+      'affine:results',
+      [
+        'affine:goto-all-pages',
+        'affine:pages.foo',
+        'affine:pages.bar',
+        'affine:new-page',
+        'affine:new-edgeless-page',
+        'affine:goto-page-list',
+      ],
+    ],
+  ]);
+
+  defineTest('with query = nepa', 'nepa', [
+    [
+      'affine:results',
+      [
+        'affine:pages.foo',
+        'affine:pages.bar',
+        'affine:new-page',
+        'affine:new-edgeless-page',
+      ],
+    ],
+  ]);
+
+  defineTest('with query = new', 'new', [
+    [
+      'affine:results',
+      [
+        'affine:pages.foo',
+        'affine:pages.bar',
+        'affine:new-page',
+        'affine:new-edgeless-page',
+      ],
+    ],
+  ]);
+
+  defineTest('with query = foo', 'foo', [
+    [
+      'affine:results',
+      ['affine:pages.foo', 'affine:new-page', 'affine:new-edgeless-page'],
+    ],
+  ]);
+});

--- a/packages/frontend/core/src/components/pure/cmdk/__tests__/use-highlight.spec.ts
+++ b/packages/frontend/core/src/components/pure/cmdk/__tests__/use-highlight.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { highlightTextFragments } from '../affine/use-highlight';
+import { highlightTextFragments } from '../use-highlight';
 
 describe('highlightTextFragments', () => {
   test('should correctly highlight full matches', () => {

--- a/packages/frontend/core/src/components/pure/cmdk/filter-commands.ts
+++ b/packages/frontend/core/src/components/pure/cmdk/filter-commands.ts
@@ -1,0 +1,102 @@
+import type { CommandCategory } from '@toeverything/infra/command';
+import { commandScore } from 'cmdk';
+import { groupBy } from 'lodash-es';
+
+import type { CMDKCommand } from './types';
+import { highlightTextFragments } from './use-highlight';
+
+export function filterSortAndGroupCommands(
+  commands: CMDKCommand[],
+  query: string
+): [CommandCategory, CMDKCommand[]][] {
+  const scoredCommands = commands
+    .map(command => {
+      // attach value = id to each command
+      return {
+        ...command,
+        value: command.id.toLowerCase(), // required by cmdk library
+        score: getCommandScore(command, query),
+      };
+    })
+    .filter(c => c.score > 0);
+
+  const sorted = scoredCommands.sort((a, b) => {
+    return b.score - a.score;
+  });
+
+  if (query) {
+    const onlyCreation = sorted.every(
+      command => command.category === 'affine:creation'
+    );
+    if (onlyCreation) {
+      return [['affine:creation', sorted]];
+    } else {
+      return [['affine:results', sorted]];
+    }
+  } else {
+    const groups = groupBy(sorted, command => command.category);
+    return Object.entries(groups) as [CommandCategory, CMDKCommand[]][];
+  }
+}
+
+const highlightScore = (text: string, search: string) => {
+  if (text.trim().length === 0) {
+    return 0;
+  }
+  const fragments = highlightTextFragments(text, search);
+  const highlightedFragment = fragments.filter(fragment => fragment.highlight);
+  // check the longest highlighted fragment
+  const longestFragment = Math.max(
+    0,
+    ...highlightedFragment.map(fragment => fragment.text.length)
+  );
+  return longestFragment / search.length;
+};
+
+const getCategoryWeight = (command: CommandCategory) => {
+  switch (command) {
+    case 'affine:recent':
+      return 1;
+    case 'affine:pages':
+    case 'affine:edgeless':
+    case 'affine:collections':
+      return 0.8;
+    case 'affine:creation':
+      return 0.2;
+    default:
+      return 0.5;
+  }
+};
+
+const subTitleWeight = 0.8;
+
+export const getCommandScore = (command: CMDKCommand, search: string) => {
+  if (search.trim() === '') {
+    return 1;
+  }
+  const title =
+    (typeof command?.label === 'string'
+      ? command.label
+      : command?.label.title) || '';
+  const subTitle =
+    (typeof command?.label === 'string' ? '' : command?.label.subTitle) || '';
+
+  const catWeight = getCategoryWeight(command.category);
+
+  const zeroComScore = Math.max(
+    commandScore(title, search),
+    commandScore(subTitle, search) * subTitleWeight
+  );
+
+  // if both title and subtitle has matched, we will use the higher score
+  const hlScore = Math.max(
+    highlightScore(title, search),
+    highlightScore(subTitle, search) * subTitleWeight
+  );
+
+  const score = Math.max(
+    zeroComScore * hlScore * catWeight,
+    command.alwaysShow ? 0.1 : 0
+  );
+  return score;
+};

--- a/packages/frontend/core/src/components/pure/cmdk/highlight.tsx
+++ b/packages/frontend/core/src/components/pure/cmdk/highlight.tsx
@@ -1,7 +1,7 @@
 import { memo } from 'react';
 
-import { useHighlight } from '../../../hooks/affine/use-highlight';
 import * as styles from './highlight.css';
+import { useHighlight } from './use-highlight';
 
 type SearchResultLabel = {
   title: string;
@@ -22,10 +22,7 @@ export const Highlight = memo(function Highlight({
   text = '',
   highlight = '',
 }: HighlightProps) {
-  // Use regular expression to replace all line breaks and carriage returns in the text
-  const cleanedText = text.replace(/\r?\n|\r/g, '');
-
-  const highlights = useHighlight(cleanedText, highlight.toLowerCase());
+  const highlights = useHighlight(text, highlight);
 
   return (
     <div className={styles.highlightContainer}>

--- a/packages/frontend/core/src/components/pure/cmdk/not-found.tsx
+++ b/packages/frontend/core/src/components/pure/cmdk/not-found.tsx
@@ -2,7 +2,7 @@ import { SearchIcon } from '@blocksuite/icons';
 import { useCommandState } from 'cmdk';
 import { useAtomValue } from 'jotai';
 
-import { cmdkQueryAtom } from './data';
+import { cmdkQueryAtom } from './data-hooks';
 import * as styles from './not-found.css';
 
 export const NotFoundGroup = () => {

--- a/packages/frontend/core/src/components/pure/cmdk/types.ts
+++ b/packages/frontend/core/src/components/pure/cmdk/types.ts
@@ -19,6 +19,7 @@ export interface CMDKCommand {
   category: CommandCategory;
   keyBinding?: string | { binding: string };
   timestamp?: number;
+  alwaysShow?: boolean;
   value?: string; // this is used for item filtering
   originalValue?: string; // some values may be transformed, this is the original value
   run: (e?: Event) => void | Promise<void>;

--- a/packages/frontend/core/src/components/pure/cmdk/use-highlight.ts
+++ b/packages/frontend/core/src/components/pure/cmdk/use-highlight.ts
@@ -1,7 +1,8 @@
 import { useMemo } from 'react';
 
 function* highlightTextFragmentsGenerator(text: string, query: string) {
-  const lowerCaseText = text.toLowerCase();
+  const lowerCaseText = text.replace(/\r?\n|\r/g, '').toLowerCase();
+  query = query.toLowerCase();
   let startIndex = lowerCaseText.indexOf(query);
 
   if (startIndex !== -1) {

--- a/packages/frontend/core/src/hooks/affine/use-register-blocksuite-editor-commands.tsx
+++ b/packages/frontend/core/src/hooks/affine/use-register-blocksuite-editor-commands.tsx
@@ -126,6 +126,7 @@ export function useRegisterBlocksuiteEditorCommands(
       })
     );
 
+    // todo: should not show duplicate for journal
     unsubs.push(
       registerAffineCommand({
         id: `editor:${mode}-duplicate`,

--- a/tests/affine-local/e2e/quick-search.spec.ts
+++ b/tests/affine-local/e2e/quick-search.spec.ts
@@ -24,10 +24,12 @@ const insertInputText = async (page: Page, text: string) => {
 
 const keyboardDownAndSelect = async (page: Page, label: string) => {
   await page.keyboard.press('ArrowDown');
+  const selectedEl = page.locator(
+    '[cmdk-item][data-selected] [data-testid="cmdk-label"]'
+  );
   if (
-    (await page
-      .locator('[cmdk-item][data-selected] [data-testid="cmdk-label"]')
-      .innerText()) !== label
+    !(await selectedEl.isVisible()) ||
+    (await selectedEl.innerText()) !== label
   ) {
     await keyboardDownAndSelect(page, label);
   } else {

--- a/tests/storybook/src/stories/quick-search/quick-search-modal.stories.tsx
+++ b/tests/storybook/src/stories/quick-search/quick-search-modal.stories.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@affine/component/ui/button';
 import { CMDKContainer, CMDKModal } from '@affine/core/components/pure/cmdk';
+import { useCMDKCommandGroups } from '@affine/core/components/pure/cmdk/data-hooks';
 import type { Meta, StoryFn } from '@storybook/react';
 import { useState } from 'react';
 
@@ -27,9 +28,15 @@ export const CMDKModalStory: StoryFn = () => {
 
 export const CMDKPanelStory: StoryFn = () => {
   const [query, setQuery] = useState('');
+  const groups = useCMDKCommandGroups();
   return (
     <CMDKModal open>
-      <CMDKContainer open query={query} onQueryChange={setQuery} />
+      <CMDKContainer
+        open
+        query={query}
+        onQueryChange={setQuery}
+        groups={groups}
+      />
     </CMDKModal>
   );
 };


### PR DESCRIPTION
Replace internal CMDK command filtering/sorting logic.
The new implementation includes the following for command scoring:
- categories weights
- highlighted fragments
- original command score value

The new logic should be much cleaner and remove some hacks in the original implementation.

Not sure if this is optimal yet. Could be changed later.

fix https://github.com/toeverything/AFFiNE/issues/5699