### PR TITLE
test(server): incorrect prisma overriding

### DIFF
--- a/packages/backend/server/tests/app.e2e.ts
+++ b/packages/backend/server/tests/app.e2e.ts
@@ -4,13 +4,14 @@ import { randomUUID } from 'node:crypto';
 import { Transformer } from '@napi-rs/image';
 import type { INestApplication } from '@nestjs/common';
 import { hashSync } from '@node-rs/argon2';
-import { PrismaClient, type User } from '@prisma/client';
+import { type User } from '@prisma/client';
 import ava, { type TestFn } from 'ava';
 import type { Express } from 'express';
 import request from 'supertest';
 
 import { AppModule } from '../src/app.module';
 import { FeatureManagementService } from '../src/core/features';
+import { PrismaService } from '../src/fundamentals/prisma';
 import { createTestingApp } from './utils';
 
 const gql = '/graphql';
@@ -51,7 +52,7 @@ test.beforeEach(async t => {
     imports: [AppModule],
     tapModule(builder) {
       builder
-        .overrideProvider(PrismaClient)
+        .overrideProvider(PrismaService)
         .useClass(FakePrisma)
         .overrideProvider(FeatureManagementService)
         .useValue({ canEarlyAccess: () => true });


### PR DESCRIPTION
In some backend server tests, `overrideProvider(PrismaClient).useClass(FakePrisma)` dose not have effect.

https://github.com/toeverything/AFFiNE/blob/67dffc2a5a95527c86c587bb6a14b1342d1667be/packages/backend/server/tests/app.e2e.ts#L49-L59

https://github.com/toeverything/AFFiNE/blob/67dffc2a5a95527c86c587bb6a14b1342d1667be/packages/backend/server/tests/mailer.spec.ts#L129-L143

the Injectable may only effect the `PrismaService` not `PrismaClient`

https://github.com/toeverything/AFFiNE/blob/67dffc2a5a95527c86c587bb6a14b1342d1667be/packages/backend/server/src/fundamentals/prisma/service.ts#L5-L10

In `mailer.spec.ts`, however, it seem some methods are missing in `FakePrisma`, which led to the test failing after fixing the override problem. So I keep this code unchanged. 

The test of mailer.spec.ts seems to only test the success of sending emails. I think there is no need to mock Prisma behavior. Just providing some fake data to the send function is good.

https://github.com/toeverything/AFFiNE/blob/67dffc2a5a95527c86c587bb6a14b1342d1667be/packages/backend/server/tests/mailer.spec.ts#L171-L189