### PR TITLE
fix: css style should not apply on nested editor's viewport

### DIFF
--- a/packages/frontend/core/src/components/page-detail-editor.css.ts
+++ b/packages/frontend/core/src/components/page-detail-editor.css.ts
@@ -14,11 +14,14 @@ export const editor = style({
     },
   },
 });
-globalStyle(`${editor} .affine-doc-viewport`, {
-  paddingBottom: '150px',
-  paddingLeft: '20px',
-  scrollbarGutter: 'stable',
-});
+globalStyle(
+  `${editor} .affine-doc-viewport:not(.affine-embed-synced-doc-editor)`,
+  {
+    paddingBottom: '150px',
+    paddingLeft: '20px',
+    scrollbarGutter: 'stable',
+  }
+);
 globalStyle('.is-public-page page-meta-tags', {
   display: 'none',
 });


### PR DESCRIPTION
[AFF-610](https://linear.app/affine-design/issue/AFF-610/the-bottom-padding-of-the-embedded-page-needs-to-be-removed)