### PR TITLE
feat: add paragraph when clicking end area

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -1,5 +1,6 @@
 import { createReactComponentFromLit } from '@affine/component';
 import { useJournalInfoHelper } from '@affine/core/hooks/use-journal';
+import type { DocPageService } from '@blocksuite/blocks';
 import {
   BiDirectionalLinkPanel,
   DocEditor,
@@ -117,6 +118,16 @@ export const BlocksuiteDocEditor = forwardRef<
           specs={specs}
           hasViewport={false}
         />
+        {docPage ? (
+          <div
+            className={styles.docEditorGap}
+            onClick={() => {
+              (
+                docPage.std.spec.getService('affine:page') as DocPageService
+              ).appendParagraph();
+            }}
+          ></div>
+        ) : null}
         {docPage ? (
           <adapted.BiDirectionalLinkPanel page={page} docPageBlock={docPage} />
         ) : null}

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/styles.css.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/styles.css.ts
@@ -26,11 +26,20 @@ export const affineDocViewport = style({
     },
   },
 });
+
 export const docContainer = style({
   display: 'block',
-  paddingBottom: 64,
   flexGrow: 1,
 });
+
+export const docEditorGap = style({
+  display: 'block',
+  width: '100%',
+  margin: '0 auto',
+  paddingTop: 50,
+  paddingBottom: 50,
+});
+
 const titleTagBasic = style({
   fontSize: cssVar('fontH4'),
   fontWeight: 600,


### PR DESCRIPTION
Close [TOV-442](https://linear.app/affine-design/issue/TOV-442/结尾是非编辑yuan素时，无法在最底部添加block)