### PR TITLE
fix(electron): add back bundle test for appimage

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -541,12 +541,20 @@ jobs:
         run: yarn workspace @affine-test/affine-desktop e2e
 
       - name: Make bundle
-        if: ${{ matrix.spec.os == 'macos-14' && matrix.spec.arch == 'arm64' }}
+        if: ${{ matrix.spec.target == 'aarch64-apple-darwin' }}
         env:
           SKIP_BUNDLE: true
           SKIP_WEB_BUILD: true
           HOIST_NODE_MODULES: 1
         run: yarn workspace @affine/electron package --platform=darwin --arch=arm64
+
+      - name: Make AppImage
+        run: yarn workspace @affine/electron make --platform=linux --arch=x64
+        if: ${{ matrix.spec.target == 'x86_64-unknown-linux-gnu' }}
+        env:
+          SKIP_PLUGIN_BUILD: 1
+          SKIP_WEB_BUILD: 1
+          HOIST_NODE_MODULES: 1
 
       - name: Output check
         if: ${{ matrix.spec.os == 'macos-14' && matrix.spec.arch == 'arm64' }}


### PR DESCRIPTION
In an attempt to fix AppImage build test, I incorrectly removed the script.
This PR add it back.