### PR TITLE
fix: keyboard shortcut style in cmdk

### DIFF
--- a/packages/frontend/core/src/components/pure/cmdk/main.css.ts
+++ b/packages/frontend/core/src/components/pure/cmdk/main.css.ts
@@ -90,8 +90,9 @@ export const keybindingFragment = style({
   borderRadius: 4,
   color: cssVar('textSecondaryColor'),
   backgroundColor: cssVar('backgroundTertiaryColor'),
-  width: 24,
+  minWidth: 24,
   height: 20,
+  textTransform: 'uppercase',
 });
 globalStyle(`${root} [cmdk-root]`, {
   height: '100%',


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/7eb2fa93-675a-43a6-8db4-9681fbbd1406.png)

