### PR TITLE
fix(core): date formatter timezone issue

### DIFF
--- a/packages/frontend/core/src/utils/intl-formatter.ts
+++ b/packages/frontend/core/src/utils/intl-formatter.ts
@@ -1,3 +1,5 @@
+import dayjs from 'dayjs';
+
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
   timeStyle: 'short',
 });
@@ -9,9 +11,9 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
 });
 
 export const timestampToLocalTime = (ts: string | number) => {
-  return timeFormatter.format(new Date(ts));
+  return timeFormatter.format(dayjs(ts).toDate());
 };
 
 export const timestampToLocalDate = (ts: string | number) => {
-  return dateFormatter.format(new Date(ts));
+  return dateFormatter.format(dayjs(ts).toDate());
 };


### PR DESCRIPTION
date seems not hornoring the locale browser's locale when parsing date string like "2024-02-28".
fixed by using dayjs instead.

Fix incorrect journal title issue 