### PR TITLE
fix: remove vite-tsconfig-paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
     "vite": "^5.1.4",
     "vite-plugin-istanbul": "^5.0.0",
     "vite-plugin-static-copy": "^1.0.1",
-    "vite-tsconfig-paths": "^4.3.1",
     "vitest": "1.3.1",
     "vitest-fetch-mock": "^0.2.2",
     "vitest-mock-extended": "^1.3.1"

--- a/packages/frontend/component/.storybook/main.ts
+++ b/packages/frontend/component/.storybook/main.ts
@@ -2,7 +2,6 @@ import { StorybookConfig } from '@storybook/react-vite';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { fileURLToPath } from 'url';
 import { mergeConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { getRuntimeConfig } from '../../core/.webpack/runtime-config';
 
 export default {
@@ -26,13 +25,7 @@ export default {
   },
   async viteFinal(config, _options) {
     return mergeConfig(config, {
-      plugins: [
-        vanillaExtractPlugin(),
-        tsconfigPaths({
-          root: fileURLToPath(new URL('../../../../', import.meta.url)),
-          ignoreConfigErrors: true,
-        }),
-      ],
+      plugins: [vanillaExtractPlugin()],
       define: {
         'process.env': {},
         'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),

--- a/packages/frontend/templates/templates.gen.ts
+++ b/packages/frontend/templates/templates.gen.ts
@@ -1,11 +1,11 @@
 /* eslint-disable simple-import-sort/imports */
 // Auto generated, do not edit manually
-import json_0 from './onboarding/info.json';
-import json_1 from './onboarding/blob.json';
-import json_2 from './onboarding/W-d9_llZ6rE-qoTiHKTk4.snapshot.json';
+import json_0 from './onboarding/W-d9_llZ6rE-qoTiHKTk4.snapshot.json';
+import json_1 from './onboarding/info.json';
+import json_2 from './onboarding/blob.json';
 
 export const onboarding = {
-  'info.json': json_0,
-  'blob.json': json_1,
-  'W-d9_llZ6rE-qoTiHKTk4.snapshot.json': json_2
+  'W-d9_llZ6rE-qoTiHKTk4.snapshot.json': json_0,
+  'info.json': json_1,
+  'blob.json': json_2
 }

--- a/tests/storybook/.storybook/main.ts
+++ b/tests/storybook/.storybook/main.ts
@@ -2,7 +2,6 @@ import { runCli } from '@magic-works/i18n-codegen';
 import type { StorybookConfig } from '@storybook/react-vite';
 import { fileURLToPath } from 'node:url';
 import { mergeConfig } from 'vite';
-import tsconfigPaths from 'vite-tsconfig-paths';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { getRuntimeConfig } from '../../../packages/frontend/core/.webpack/runtime-config';
 
@@ -26,7 +25,6 @@ export default {
     '@storybook/addon-links',
     '@storybook/addon-essentials',
     '@storybook/addon-interactions',
-    '@storybook/addon-storysource',
     'storybook-dark-mode',
     'storybook-addon-react-router-v6',
   ],
@@ -53,13 +51,7 @@ export default {
           ),
         },
       },
-      plugins: [
-        vanillaExtractPlugin(),
-        tsconfigPaths({
-          root: fileURLToPath(new URL('../../../', import.meta.url)),
-          ignoreConfigErrors: true,
-        }),
-      ],
+      plugins: [vanillaExtractPlugin()],
       define: {
         'process.on': 'undefined',
         'process.env': {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -593,7 +593,6 @@ __metadata:
     vite: "npm:^5.1.4"
     vite-plugin-istanbul: "npm:^5.0.0"
     vite-plugin-static-copy: "npm:^1.0.1"
-    vite-tsconfig-paths: "npm:^4.3.1"
     vitest: "npm:1.3.1"
     vitest-fetch-mock: "npm:^0.2.2"
     vitest-mock-extended: "npm:^1.3.1"
@@ -22089,13 +22088,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globrex@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "globrex@npm:0.1.2"
-  checksum: 10/81ce62ee6f800d823d6b7da7687f841676d60ee8f51f934ddd862e4057316d26665c4edc0358d4340a923ac00a514f8b67c787e28fe693aae16350f4e60d55e9
-  languageName: node
-  linkType: hard
-
 "glur@npm:^1.1.2":
   version: 1.1.2
   resolution: "glur@npm:1.1.2"
@@ -33574,20 +33566,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tsconfck@npm:^3.0.1":
-  version: 3.0.2
-  resolution: "tsconfck@npm:3.0.2"
-  peerDependencies:
-    typescript: ^5.0.0
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  bin:
-    tsconfck: bin/tsconfck.js
-  checksum: 10/bd0666cde64d576701b6b74b45795b76f002ea3c44279ce373426b075f56b47b4a34ee51083a4df7844b0077e2af4cb752a6c6ef246a80339a44351d6367c98c
-  languageName: node
-  linkType: hard
-
 "tsconfig-paths@npm:^4.1.2":
   version: 4.2.0
   resolution: "tsconfig-paths@npm:4.2.0"
@@ -34601,22 +34579,6 @@ __metadata:
   peerDependencies:
     vite: ^5.0.0
   checksum: 10/c0ca7f3695e293d3a4efc5f0900d0da7a5a2ee73821a52ff515aaf71d88551b0e4571faa7ad7d22a6d1c067ed5d5cb704b5652a45e7bb68d9734ec4fa3062d4d
-  languageName: node
-  linkType: hard
-
-"vite-tsconfig-paths@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "vite-tsconfig-paths@npm:4.3.1"
-  dependencies:
-    debug: "npm:^4.1.1"
-    globrex: "npm:^0.1.2"
-    tsconfck: "npm:^3.0.1"
-  peerDependencies:
-    vite: "*"
-  peerDependenciesMeta:
-    vite:
-      optional: true
-  checksum: 10/1432f80750f5cbe181c265eb9fc2e9fff8b25a2858f176dc0a02311e3e826333526ee9c16bb0aaaa8555a417ea944d68a2e8225181215cd9502370f913eb3f79
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
It will block storybook from running.
related to https://github.com/aleclarson/vite-tsconfig-paths/issues/132

We are not actually using `vite-tsconfig-paths` now because we rely on package.json's export field to do path mapping.