### PR TITLE
fix(core): update src in video tag to correct URL

### DIFF
--- a/packages/frontend/core/src/components/affine/star-affine-modal/index.tsx
+++ b/packages/frontend/core/src/components/affine/star-affine-modal/index.tsx
@@ -15,7 +15,7 @@ export const StarAFFiNEModal = () => {
           width={400}
           height={300}
           style={{ objectFit: 'cover' }}
-          src={'/static/gitHubStar.mp4'}
+          src={'/static/githubStar.mp4'}
           autoPlay
           loop
         />


### PR DESCRIPTION
In app.affine.pro the video is not displayed correctly.

<img width="1026" alt="image" src="https://github.com/toeverything/AFFiNE/assets/102217452/8e9d9bb2-f973-433e-88c9-bedfe0f55935">
