### PR TITLE
feat(core): separate runtimeConfig for e2e tests and deployment

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -118,6 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DISTRIBUTION: browser
+      IN_CI_TEST: true
     strategy:
       fail-fast: false
       matrix:
@@ -370,6 +371,7 @@ jobs:
     env:
       DISTRIBUTION: browser
       DATABASE_URL: postgresql://affine:affine@localhost:5432/affine
+      IN_CI_TEST: true
     strategy:
       fail-fast: false
       matrix:

--- a/packages/frontend/core/.webpack/runtime-config.ts
+++ b/packages/frontend/core/.webpack/runtime-config.ts
@@ -147,6 +147,10 @@ export function getRuntimeConfig(buildFlags: BuildFlags): RuntimeConfig {
         : currentBuildPreset.allowLocalWorkspace,
   };
 
+  const testEnvironmentPreset = {
+    allowLocalWorkspace: true,
+  };
+
   if (buildFlags.mode === 'development') {
     currentBuildPreset.serverUrlPrefix = 'http://localhost:8080';
   }
@@ -156,6 +160,10 @@ export function getRuntimeConfig(buildFlags: BuildFlags): RuntimeConfig {
     // environment preset will overwrite current build preset
     // this environment variable is for debug proposes only
     // do not put them into CI
-    ...(process.env.CI ? { allowLocalWorkspace: true } : environmentPreset),
+    ...(process.env.CI ? {} : environmentPreset),
+
+    // test environment preset will overwrite current build preset
+    // this environment variable is for github workflow e2e-test only
+    ...(process.env.IN_CI_TEST ? testEnvironmentPreset : {}),
   };
 }


### PR DESCRIPTION
Prior to modification, it will function for both `deploy` and `e2e-test`. Consequently, `allowLocalWorkspace` is also set to `true` in the production environment.
https://github.com/toeverything/AFFiNE/actions/runs/8093473180/job/22116199541#step:5:120