### PR TITLE
fix(electron): disable auto updater on linux by default

### DIFF
--- a/packages/frontend/electron/src/main/updater/electron-updater.ts
+++ b/packages/frontend/electron/src/main/updater/electron-updater.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import { autoUpdater } from 'electron-updater';
 
+import { isMacOS, isWindows } from '../../shared/utils';
 import { buildType } from '../config';
 import { logger } from '../logger';
 import { CustomGitHubProvider } from './custom-github-provider';
@@ -81,7 +82,8 @@ export const registerUpdater = async () => {
     return;
   }
 
-  const allowAutoUpdate = true;
+  // TODO: support auto update on linux
+  const allowAutoUpdate = isMacOS() || isWindows();
 
   autoUpdater.logger = logger;
   autoUpdater.autoDownload = false;


### PR DESCRIPTION
```
[2024-03-05 19:14:07.570] [info]  (main) [ipc-event] updater:onUpdateReady []
[2024-03-05 19:14:07.571] [info]  (main) Update downloaded, ready to install
[2024-03-05 19:14:10.551] [info]  (main) Install on explicit quitAndInstall
[2024-03-05 19:14:10.553] [info]  (main) Install: isSilent: false, isForceRunAfter: true
[2024-03-05 19:14:10.554] [error] (main) Error: Error: ENOENT: no such file or directory, unlink '1'
    at Object.unlink (node:internal/fs/sync:93:18)
    at unlinkSync (node:fs:1853:17)
    at AppImageUpdater.doInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/node_modules/electron-updater/out/AppImageUpdater.js:76:29)
    at AppImageUpdater.install (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/node_modules/electron-updater/out/BaseUpdater.js:54:25)
    at AppImageUpdater.quitAndInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/node_modules/electron-updater/out/BaseUpdater.js:15:34)
    at quitAndInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/dist/main.js:19366:44)
    at quitAndInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/dist/main.js:19497:16)
    at /tmp/.mount_AFFiNECsNxfI/resources/app.asar/dist/main.js:51524:36
    at WebContents.<anonymous> (node:electron/js2c/browser_init:2:78180)
    at WebContents.emit (node:events:514:28)
[2024-03-05 19:14:10.555] [error] (main) Error while updating client Error: ENOENT: no such file or directory, unlink '1'
    at Object.unlink (node:internal/fs/sync:93:18)
    at unlinkSync (node:fs:1853:17)
    at AppImageUpdater.doInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/node_modules/electron-updater/out/AppImageUpdater.js:76:29)
    at AppImageUpdater.install (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/node_modules/electron-updater/out/BaseUpdater.js:54:25)
    at AppImageUpdater.quitAndInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/node_modules/electron-updater/out/BaseUpdater.js:15:34)
    at quitAndInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/dist/main.js:19366:44)
    at quitAndInstall (/tmp/.mount_AFFiNECsNxfI/resources/app.asar/dist/main.js:19497:16)
    at /tmp/.mount_AFFiNECsNxfI/resources/app.asar/dist/main.js:51524:36
    at WebContents.<anonymous> (node:electron/js2c/browser_init:2:78180)
    at WebContents.emit (node:events:514:28)
```

looks like there is still issue on auto updating for appimage