### PR TITLE
fix(core): canvas font loading in desktop

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
           BUILD_TYPE: ${{ github.event.inputs.flavor }}
           SHOULD_REPORT_TRACE: false
           PUBLIC_PATH: '/'
+          SELF_HOSTED: true
       - name: Download selfhost fonts
         run: node ./scripts/download-blocksuite-fonts.mjs
       - name: Upload core artifact

--- a/packages/common/env/src/global.ts
+++ b/packages/common/env/src/global.ts
@@ -45,6 +45,7 @@ export const runtimeFlagsSchema = z.object({
     z.literal('internal'),
     z.literal('canary'),
   ]),
+  isSelfHosted: z.boolean().optional(),
 });
 
 export type BlockSuiteFeatureFlags = z.infer<typeof blockSuiteFeatureFlags>;

--- a/packages/frontend/core/.webpack/runtime-config.ts
+++ b/packages/frontend/core/.webpack/runtime-config.ts
@@ -145,6 +145,7 @@ export function getRuntimeConfig(buildFlags: BuildFlags): RuntimeConfig {
       : buildFlags.mode === 'development'
         ? true
         : currentBuildPreset.allowLocalWorkspace,
+    isSelfHosted: process.env.SELF_HOSTED === 'true',
   };
 
   const testEnvironmentPreset = {

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs.ts
@@ -21,8 +21,7 @@ class CustomAttachmentService extends AttachmentService {
 }
 
 function customLoadFonts(service: RootService): void {
-  const officialDomains = new Set(['app.affine.pro', 'affine.fail']);
-  if (!officialDomains.has(window.location.host)) {
+  if (runtimeConfig.isSelfHosted) {
     const fonts = CanvasTextFonts.map(font => ({
       ...font,
       // self-hosted fonts are served from /assets


### PR DESCRIPTION
https://github.com/toeverything/AFFiNE/blob/65b32156a86611fb9d5e4781d2d9864970362bef/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs.ts#L24-L25

`window.location.host` will be `'.'` in desktop (`Version 0.12.2 (0.12.2)`).

<img width="515" alt="Screenshot 2024-03-05 at 20 25 10" 
src="https://github.com/toeverything/AFFiNE/assets/27926/0674d377-d6ce-49ab-bee2-222bf5c83511">

