### PR TITLE
fix: divider styles issue

### DIFF
--- a/packages/frontend/core/src/components/affine/page-properties/styles.css.ts
+++ b/packages/frontend/core/src/components/affine/page-properties/styles.css.ts
@@ -97,10 +97,10 @@ export const tableHeaderTimestamp = style({
 });
 
 export const tableHeaderDivider = style({
-  height: '0.5px',
+  height: 0,
+  borderTop: `1px solid ${cssVar('borderColor')}`,
   width: '100%',
   margin: '8px 0',
-  backgroundColor: cssVar('borderColor'),
 });
 
 export const tableBodyRoot = style({

--- a/packages/frontend/core/src/components/affine/setting-modal/workspace-setting/properties/styles.css.ts
+++ b/packages/frontend/core/src/components/affine/setting-modal/workspace-setting/properties/styles.css.ts
@@ -65,8 +65,8 @@ export const propertyDocCount = style({
 
 export const divider = style({
   width: '100%',
-  height: 1,
-  backgroundColor: cssVar('dividerColor'),
+  height: 0,
+  borderTop: `1px solid ${cssVar('borderColor')}`,
 });
 
 export const spacer = style({


### PR DESCRIPTION
Using height: 1 as divider may have some display issues on Chrome. No idea why yet.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/42b342fb-d109-4bf7-b458-e870099710bc.png)

