### PR TITLE
fix: allow empty mailer password

### DIFF
--- a/packages/backend/server/src/fundamentals/mailer/index.ts
+++ b/packages/backend/server/src/fundamentals/mailer/index.ts
@@ -8,7 +8,7 @@ import { MAILER } from './mailer';
 @OptionalModule({
   providers: [MAILER],
   exports: [MAILER],
-  requires: ['mailer.auth.user', 'mailer.auth.pass'],
+  requires: ['mailer.auth.user'],
 })
 class MailerModule {}
 

--- a/packages/backend/server/src/fundamentals/mailer/mailer.ts
+++ b/packages/backend/server/src/fundamentals/mailer/mailer.ts
@@ -1,4 +1,4 @@
-import { FactoryProvider } from '@nestjs/common';
+import { FactoryProvider, Logger } from '@nestjs/common';
 import { createTransport, Transporter } from 'nodemailer';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
@@ -15,7 +15,19 @@ export const MAILER: FactoryProvider<
 > = {
   provide: MAILER_SERVICE,
   useFactory: (config: Config) => {
-    return config.mailer ? createTransport(config.mailer) : undefined;
+    if (config.mailer) {
+      const logger = new Logger('Mailer');
+      const auth = config.mailer.auth;
+      if (auth && auth.user && !('pass' in auth)) {
+        logger.warn(
+          'Mailer service has not configured password, please make sure your mailer service allow empty password.'
+        );
+      }
+
+      return createTransport(config.mailer);
+    } else {
+      return undefined;
+    }
   },
   inject: [Config],
 };


### PR DESCRIPTION
fix #6046 
smtp relay may allow empty password, although this is usually not safe