### PR TITLE
fix(core): fix page priority load

### DIFF
--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
@@ -255,6 +255,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
 });
 
 export const DetailPage = ({ pageId }: { pageId: string }): ReactElement => {
+  const currentWorkspace = useService(Workspace);
   const pageRecordList = useService(PageRecordList);
 
   const pageListReady = useLiveData(pageRecordList.isReady);
@@ -280,6 +281,11 @@ export const DetailPage = ({ pageId }: { pageId: string }): ReactElement => {
       release();
     };
   }, [pageManager, pageRecord]);
+
+  // set sync engine priority target
+  useEffect(() => {
+    currentWorkspace.setPriorityRule(id => id.endsWith(pageId));
+  }, [currentWorkspace, pageId]);
 
   const jumpOnce = useLiveData(pageRecord?.meta.map(meta => meta.jumpOnce));
 


### PR DESCRIPTION
When refactoring, I planned to put the logic of loading current pages priority in `PageManager.open`, but I forgot, so the current page will not be loaded priority.

But currently `PageManager.open` has been used in many places, but only one priority page can be set, so the logic of setting the priority page is still placed in the detail page.