### PR TITLE
fix: move traffic lights based on zoom level

### DIFF
--- a/packages/frontend/core/src/bootstrap/setup.ts
+++ b/packages/frontend/core/src/bootstrap/setup.ts
@@ -4,6 +4,7 @@ import './edgeless-template';
 import { apis, events } from '@affine/electron-api';
 import { setupGlobal } from '@affine/env/global';
 import * as Sentry from '@sentry/react';
+import { debounce } from 'lodash-es';
 import { useEffect } from 'react';
 import {
   createRoutesFromChildren,
@@ -61,6 +62,11 @@ export function setup() {
     };
     apis?.ui.isMaximized().then(handleMaximized).catch(console.error);
     events?.ui.onMaximized(handleMaximized);
+
+    const handleResize = debounce(() => {
+      apis?.ui.handleWindowResize().catch(console.error);
+    }, 50);
+    window.addEventListener('resize', handleResize);
   }
 
   performanceSetupLogger.info('done');

--- a/packages/frontend/electron/src/main/ui/handlers.ts
+++ b/packages/frontend/electron/src/main/ui/handlers.ts
@@ -4,7 +4,11 @@ import { getLinkPreview } from 'link-preview-js';
 import { isMacOS } from '../../shared/utils';
 import { persistentConfig } from '../config-storage/persist';
 import { logger } from '../logger';
-import { getMainWindow, initAndShowMainWindow } from '../main-window';
+import {
+  getMainWindow,
+  handleWebContentsResize,
+  initAndShowMainWindow,
+} from '../main-window';
 import { getOnboardingWindow } from '../onboarding';
 import type { NamespaceHandlers } from '../type';
 import { launchStage } from '../windows-manager/stage';
@@ -43,6 +47,9 @@ export const uiHandlers = {
     } else {
       window.maximize();
     }
+  },
+  handleWindowResize: async () => {
+    await handleWebContentsResize();
   },
   handleCloseApp: async () => {
     app.quit();


### PR DESCRIPTION
<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/T2klNLEk0wxLh4NRDzhk/f75d1f6f-18f4-4dff-8174-67223f5f9807.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/T2klNLEk0wxLh4NRDzhk/f75d1f6f-18f4-4dff-8174-67223f5f9807.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/f75d1f6f-18f4-4dff-8174-67223f5f9807.mp4">Kapture 2024-03-19 at 18.05.20.mp4</video>

