### PR TITLE
Add ENV for nodemailer, rejectUnauthorized

### DIFF
--- a/packages/backend/server/src/config/affine.env.ts
+++ b/packages/backend/server/src/config/affine.env.ts
@@ -17,6 +17,7 @@ AFFiNE.ENV_MAP = {
   MAILER_PASSWORD: 'mailer.auth.pass',
   MAILER_SENDER: 'mailer.from.address',
   MAILER_SECURE: ['mailer.secure', 'boolean'],
+  MAILER_TLS_VERIFICATION: ['mailer.tls.rejectUnauthorized', 'boolean']
   THROTTLE_TTL: ['rateLimiter.ttl', 'int'],
   THROTTLE_LIMIT: ['rateLimiter.limit', 'int'],
   REDIS_SERVER_HOST: 'plugins.redis.host',


### PR DESCRIPTION
Hi!😘
I deploy the AFFiNE on my own server and use my own mail server.
So it requires the nodemailer to allow invalid TLS certificate.

Based on https://nodemailer.com/smtp/#3-allow-self-signed-certificates, I made this change.

It really simple! What a great design ---- the ENV mapping!