### PR TITLE
fix(core): storybook build issue

### DIFF
--- a/packages/frontend/component/.storybook/main.ts
+++ b/packages/frontend/component/.storybook/main.ts
@@ -25,6 +25,9 @@ export default {
   async viteFinal(config, _options) {
     return mergeConfig(config, {
       plugins: [vanillaExtractPlugin()],
+      esbuild: {
+        target: 'ES2022',
+      },
       define: {
         'process.env': {},
         'process.env.COVERAGE': JSON.stringify(!!process.env.COVERAGE),

--- a/packages/frontend/component/.storybook/polyfill.ts
+++ b/packages/frontend/component/.storybook/polyfill.ts
@@ -1,0 +1,2 @@
+import 'core-js/modules/esnext.symbol.async-dispose';
+import 'core-js/modules/esnext.symbol.dispose';

--- a/packages/frontend/component/.storybook/preview.tsx
+++ b/packages/frontend/component/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import './polyfill';
 import '../src/theme/global.css';
 import './preview.css';
 import { ThemeProvider, useTheme } from 'next-themes';

--- a/packages/frontend/component/package.json
+++ b/packages/frontend/component/package.json
@@ -75,7 +75,7 @@
   "devDependencies": {
     "@blocksuite/blocks": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/global": "0.13.0-canary-202403140735-2367cd5",
-    "@blocksuite/icons": "2.1.45",
+    "@blocksuite/icons": "2.1.46",
     "@blocksuite/lit": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/presets": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/store": "0.13.0-canary-202403140735-2367cd5",

--- a/tests/storybook/.storybook/main.ts
+++ b/tests/storybook/.storybook/main.ts
@@ -1,7 +1,7 @@
 import { runCli } from '@magic-works/i18n-codegen';
 import type { StorybookConfig } from '@storybook/react-vite';
 import { fileURLToPath } from 'node:url';
-import { mergeConfig } from 'vite';
+import { mergeConfig, type InlineConfig } from 'vite';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { getRuntimeConfig } from '@affine/cli/src/webpack/runtime-config';
 
@@ -40,7 +40,7 @@ export default {
     });
     // disable for storybook build
     runtimeConfig.enableCloud = false;
-    return mergeConfig(config, {
+    return mergeConfig<InlineConfig, InlineConfig>(config, {
       assetsInclude: ['**/*.md'],
       resolve: {
         alias: {
@@ -50,6 +50,9 @@ export default {
             new URL('../../../packages/frontend/core/src', import.meta.url)
           ),
         },
+      },
+      esbuild: {
+        target: 'ES2022',
       },
       plugins: [vanillaExtractPlugin()],
       define: {

--- a/tests/storybook/.storybook/polyfill.ts
+++ b/tests/storybook/.storybook/polyfill.ts
@@ -1,0 +1,2 @@
+import 'core-js/modules/esnext.symbol.async-dispose';
+import 'core-js/modules/esnext.symbol.dispose';

--- a/tests/storybook/.storybook/preview.tsx
+++ b/tests/storybook/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import './polyfill';
 import '@affine/component/theme/global.css';
 import '@affine/component/theme/theme.css';
 import { createI18n } from '@affine/i18n';

--- a/tests/storybook/package.json
+++ b/tests/storybook/package.json
@@ -26,7 +26,7 @@
     "@blocksuite/block-std": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/blocks": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/global": "0.13.0-canary-202403140735-2367cd5",
-    "@blocksuite/icons": "2.1.45",
+    "@blocksuite/icons": "2.1.46",
     "@blocksuite/inline": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/lit": "0.13.0-canary-202403140735-2367cd5",
     "@blocksuite/presets": "0.13.0-canary-202403140735-2367cd5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -228,7 +228,7 @@ __metadata:
     "@affine/i18n": "workspace:*"
     "@blocksuite/blocks": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/global": "npm:0.13.0-canary-202403140735-2367cd5"
-    "@blocksuite/icons": "npm:2.1.45"
+    "@blocksuite/icons": "npm:2.1.46"
     "@blocksuite/lit": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/presets": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/store": "npm:0.13.0-canary-202403140735-2367cd5"
@@ -762,7 +762,7 @@ __metadata:
     "@blocksuite/block-std": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/blocks": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/global": "npm:0.13.0-canary-202403140735-2367cd5"
-    "@blocksuite/icons": "npm:2.1.45"
+    "@blocksuite/icons": "npm:2.1.46"
     "@blocksuite/inline": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/lit": "npm:0.13.0-canary-202403140735-2367cd5"
     "@blocksuite/presets": "npm:0.13.0-canary-202403140735-2367cd5"
@@ -3527,16 +3527,6 @@ __metadata:
   dependencies:
     zod: "npm:^3.22.4"
   checksum: 10/e3f8cba5dff63c53082398085b09eee4688e7d1fc246247310898d18329b2d2df62be7cce5c2b09a049deb475c1d6d53fb932523c697de72c2abdcf0a4fc09a9
-  languageName: node
-  linkType: hard
-
-"@blocksuite/icons@npm:2.1.45":
-  version: 2.1.45
-  resolution: "@blocksuite/icons@npm:2.1.45"
-  peerDependencies:
-    "@types/react": ^18.0.25
-    react: ^18.2.0
-  checksum: 10/a77b46ab6f2325005fb873f5d1e5982bcf01588fa1c03cebaf6f4c4a1cb380dfc39c60334ceb4a7fca9486cb9e4911c15f79e54da45ed87bcea6425b00cb20e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
1. es2022 is required and should be set separately in storybook.
2. @blocksuite/icons versions are not consistent across packages. 
