### PR TITLE
fix(infra): fix sqlite not save data

### DIFF
--- a/packages/common/infra/src/workspace/engine/index.ts
+++ b/packages/common/infra/src/workspace/engine/index.ts
@@ -42,6 +42,7 @@ export class WorkspaceEngine {
         blob: status,
       };
     });
+    this.doc.setPriority(yDoc.guid, 100);
     this.doc.addDoc(yDoc);
   }
 


### PR DESCRIPTION
SQLiteDB will not save subdoc data that does not exist on rootdoc, so we must save rootdoc first, and then save subdoc