### PR TITLE
fix(electron): optimize bundle size by removing unused dependencies

### DIFF
--- a/packages/frontend/electron/scripts/build-layers.ts
+++ b/packages/frontend/electron/scripts/build-layers.ts
@@ -1,6 +1,9 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import * as esbuild from 'esbuild';
 
-import { config, mode } from './common';
+import { config, mode, rootDir } from './common';
 
 async function buildLayers() {
   const common = config();
@@ -16,10 +19,20 @@ async function buildLayers() {
       `"${process.env.BUILD_TYPE_OVERRIDE}"`;
   }
 
-  await esbuild.build({
+  const metafile = process.env.METAFILE;
+
+  const result = await esbuild.build({
     ...common,
     define: define,
+    metafile: !!metafile,
   });
+
+  if (metafile) {
+    await fs.writeFile(
+      path.resolve(rootDir, `metafile-${Date.now()}.json`),
+      JSON.stringify(result.metafile, null, 2)
+    );
+  }
 }
 
 await buildLayers();


### PR DESCRIPTION
Should greatly reduce the size of helper.js and could speed up the time on starting the client app.

fix https://github.com/toeverything/AFFiNE/issues/6312

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/681d6766-7d48-4574-b791-49e2c0ae6e1b.png)



After:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/ab13e624-7e03-407d-9538-3b9452694402.png)