### PR TITLE
fix(core): viewport element not found in share page

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -118,7 +118,7 @@ export const BlocksuiteDocEditor = forwardRef<
           specs={specs}
           hasViewport={false}
         />
-        {docPage ? (
+        {docPage && !page.readonly ? (
           <div
             className={styles.docEditorGap}
             onClick={() => {

--- a/packages/frontend/core/src/pages/share/share-detail-page.tsx
+++ b/packages/frontend/core/src/pages/share/share-detail-page.tsx
@@ -28,6 +28,7 @@ import {
   WorkspaceManager,
   WorkspaceScope,
 } from '@toeverything/infra';
+import clsx from 'clsx';
 import { useCallback, useEffect, useState } from 'react';
 import type { LoaderFunction } from 'react-router-dom';
 import {
@@ -214,7 +215,12 @@ export const Component = () => {
                 docCollection={page.blockSuiteDoc.collection}
               />
               <Scrollable.Root>
-                <Scrollable.Viewport className={styles.editorContainer}>
+                <Scrollable.Viewport
+                  className={clsx(
+                    'affine-page-viewport',
+                    styles.editorContainer
+                  )}
+                >
                   <PageDetailEditor
                     isPublic
                     publishMode={publishMode}


### PR DESCRIPTION
- Disable append paragraph in readonly mode https://github.com/toeverything/blocksuite/pull/6686
- BlockSuiteError

![image](https://github.com/toeverything/AFFiNE/assets/20479050/65c6498d-f7f1-4517-ad7c-79a99caf0618)

It seems that the className in these two pieces of code needs to be consistent because BlockSuite requires `'.affine-page-viewport'` to locate the viewport. But I cannot confirm wheter `styles.affineDocViewport` to be added to `share-detail-page`

https://github.com/toeverything/AFFiNE/blob/edef9b27353dbc3c5b429c62919fa74dc074dc90/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx#L220-L227

https://github.com/toeverything/AFFiNE/blob/edef9b27353dbc3c5b429c62919fa74dc074dc90/packages/frontend/core/src/pages/share/share-detail-page.tsx#L217-L224
