### PR TITLE
fix(core): remove duplicate windows controls when right sidebar is expanded

### DIFF
--- a/packages/frontend/core/src/modules/workbench/view/route-container.tsx
+++ b/packages/frontend/core/src/modules/workbench/view/route-container.tsx
@@ -72,7 +72,7 @@ export const RouteContainer = ({ route }: Props) => {
                 onToggle={handleToggleRightSidebar}
               />
             )}
-            {isWindowsDesktop && (
+            {isWindowsDesktop && !rightSidebarOpen && (
               <div className={styles.windowsAppControlsContainer}>
                 <WindowsAppControls />
               </div>


### PR DESCRIPTION
close TOV-786