### PR TITLE
build(electron): add nsis build to release-desktop workflow

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -260,6 +260,10 @@ jobs:
       - name: Setup Node.js
         timeout-minutes: 10
         uses: ./.github/actions/setup-node
+        with:
+          extra-flags: workspaces focus @affine/electron @affine/monorepo
+          hard-link-nm: false
+          nmHoistingLimits: workspaces
       - name: Download and overwrite packaged artifacts
         uses: actions/download-artifact@v4
         with:
@@ -270,6 +274,9 @@ jobs:
 
       - name: Make squirrel.windows installer
         run: yarn workspace @affine/electron make-squirrel --platform=${{ matrix.spec.platform }} --arch=${{ matrix.spec.arch }}
+
+      - name: Make nsis.windows installer
+        run: yarn workspace @affine/electron make-nsis --platform=${{ matrix.spec.platform }} --arch=${{ matrix.spec.arch }}
 
       - name: Zip artifacts for faster upload
         run: Compress-Archive -CompressionLevel Fastest -Path packages/frontend/electron/out/${{ env.BUILD_TYPE }}/make/* -DestinationPath archive.zip
@@ -318,7 +325,7 @@ jobs:
           mkdir -p builds
           mv packages/frontend/electron/out/*/make/zip/win32/x64/AFFiNE*-win32-x64-*.zip ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-windows-x64.zip
           mv packages/frontend/electron/out/*/make/squirrel.windows/x64/*.exe ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-windows-x64.exe
-          mv packages/frontend/electron/out/*/make/squirrel.windows/x64/*.msi ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-windows-x64.msi
+          mv packages/frontend/electron/out/*/make/nsis.windows/x64/*.exe ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-windows-x64.snis.exe
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/packages/frontend/electron/scripts/make-nsis.ts
+++ b/packages/frontend/electron/scripts/make-nsis.ts
@@ -16,7 +16,7 @@ import {
   ROOT,
 } from './make-env.js';
 
-const log = debug('electron-forge:make-nsis');
+const log = debug('make-nsis');
 
 async function make() {
   const appName = productName;
@@ -44,6 +44,8 @@ async function make() {
     { dir: tmpPath },
     {
       win: [`nsis:${arch}`],
+      // @ts-expect-error - upstream type is wrong
+      publish: null, // buildForge will incorrectly publish the build
       config: {
         appId: appIdMap[buildType],
         productName,
@@ -73,7 +75,7 @@ async function make() {
   );
 
   // Move the output to the actual output folder, app-builder-lib might get it wrong
-  log('Received output files', output);
+  log('making nsis.windows done:', output);
 
   const result: Array<string> = [];
   for (const file of output) {

--- a/packages/frontend/electron/scripts/make-squirrel.ts
+++ b/packages/frontend/electron/scripts/make-squirrel.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 
+import debug from 'debug';
 import type { Options as ElectronWinstallerOptions } from 'electron-winstaller';
 import { convertVersion, createWindowsInstaller } from 'electron-winstaller';
 import fs from 'fs-extra';
@@ -14,12 +15,7 @@ import {
   ROOT,
 } from './make-env.js';
 
-async function ensureDirectory(dir: string) {
-  if (await fs.pathExists(dir)) {
-    await fs.remove(dir);
-  }
-  return fs.mkdirs(dir);
-}
+const log = debug('make-squirrel');
 
 // taking from https://github.com/electron/forge/blob/main/packages/maker/squirrel/src/MakerSquirrel.ts
 // it was for forge's maker, but can be used standalone as well
@@ -33,7 +29,7 @@ async function make() {
     buildType,
     `${appName}-${platform}-${arch}`
   );
-  await ensureDirectory(outPath);
+  await fs.ensureDir(outPath);
 
   const packageJSON = await fs.readJson(path.resolve(ROOT, 'package.json'));
 
@@ -78,7 +74,7 @@ async function make() {
   if (!winstallerConfig.noMsi && (await fs.pathExists(msiPath))) {
     artifacts.push(msiPath);
   }
-  console.log('making squirrel.windows done:', artifacts);
+  log('making squirrel.windows done:', artifacts);
   return artifacts;
 }
 


### PR DESCRIPTION
Updater may break after this PR and will be fixed in the next one

After this PR, we will have two windows installer options
- affine-0.14.0-canary.9-canary-windows-x64.exe
- affine-0.14.0-canary.9-canary-windows-x64.nsis.exe (added)
