### PR TITLE
refactor(core): remove jump once

### DIFF
--- a/packages/frontend/core/src/components/affine/create-workspace-modal/index.tsx
+++ b/packages/frontend/core/src/components/affine/create-workspace-modal/index.tsx
@@ -36,7 +36,7 @@ const logger = new DebugLogger('CreateWorkspaceModal');
 interface ModalProps {
   mode: CreateWorkspaceMode; // false means not open
   onClose: () => void;
-  onCreate: (id: string) => void;
+  onCreate: (id: string, defaultDocId?: string) => void;
 }
 
 interface NameWorkspaceContentProps extends ConfirmModalProps {
@@ -236,25 +236,24 @@ export const CreateWorkspaceModal = ({
       // this will be the last step for web for now
       // fix me later
       if (runtimeConfig.enablePreloading) {
-        const { id } = await buildShowcaseWorkspace(
+        const { meta, defaultDocId } = await buildShowcaseWorkspace(
           workspacesService,
           workspaceFlavour,
           name
         );
-        onCreate(id);
+        onCreate(meta.id, defaultDocId);
       } else {
+        let defaultDocId: string | undefined = undefined;
         const { id } = await workspacesService.create(
           workspaceFlavour,
           async workspace => {
             workspace.meta.setName(name);
             const page = workspace.createDoc();
-            workspace.setDocMeta(page.id, {
-              jumpOnce: true,
-            });
+            defaultDocId = page.id;
             initEmptyPage(page);
           }
         );
-        onCreate(id);
+        onCreate(id, defaultDocId);
       }
 
       setLoading(false);

--- a/packages/frontend/core/src/pages/workspace/all-page/all-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/all-page/all-page.tsx
@@ -4,11 +4,10 @@ import {
   VirtualizedPageList,
 } from '@affine/core/components/page-list';
 import { useBlockSuiteDocMeta } from '@affine/core/hooks/use-block-suite-page-meta';
-import { useNavigateHelper } from '@affine/core/hooks/use-navigate-helper';
 import { performanceRenderLogger } from '@affine/core/shared';
 import type { Filter } from '@affine/env/filter';
 import { useService, WorkspaceService } from '@toeverything/infra';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import { ViewBodyIsland, ViewHeaderIsland } from '../../../modules/workbench';
 import { EmptyPageList } from '../page-list-empty';
@@ -58,26 +57,6 @@ export const AllPage = () => {
 
 export const Component = () => {
   performanceRenderLogger.info('AllPage');
-
-  const currentWorkspace = useService(WorkspaceService).workspace;
-  const navigateHelper = useNavigateHelper();
-
-  useEffect(() => {
-    function checkJumpOnce() {
-      for (const [pageId] of currentWorkspace.docCollection.docs) {
-        const page = currentWorkspace.docCollection.getDoc(pageId);
-        if (page && page.meta?.jumpOnce) {
-          currentWorkspace.docCollection.meta.setDocMeta(page.id, {
-            jumpOnce: false,
-          });
-          navigateHelper.jumpToPage(currentWorkspace.id, pageId);
-        }
-      }
-    }
-    checkJumpOnce();
-    return currentWorkspace.docCollection.slots.docUpdated.on(checkJumpOnce)
-      .dispose;
-  }, [currentWorkspace.docCollection, currentWorkspace.id, navigateHelper]);
 
   return <AllPage />;
 };

--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
@@ -325,14 +325,6 @@ export const DetailPage = ({ pageId }: { pageId: string }): ReactElement => {
     };
   }, [currentWorkspace, pageId]);
 
-  const jumpOnce = useLiveData(doc?.meta$.map(meta => meta.jumpOnce));
-
-  useEffect(() => {
-    if (jumpOnce) {
-      doc?.record.setMeta({ jumpOnce: false });
-    }
-  }, [doc?.record, jumpOnce]);
-
   const isInTrash = useLiveData(doc?.meta$.map(meta => meta.trash));
 
   useEffect(() => {

--- a/packages/frontend/core/src/providers/modal-provider.tsx
+++ b/packages/frontend/core/src/providers/modal-provider.tsx
@@ -259,7 +259,7 @@ export const AllWorkspaceModals = (): ReactElement => {
     openCreateWorkspaceModalAtom
   );
 
-  const { jumpToSubPath } = useNavigateHelper();
+  const { jumpToSubPath, jumpToPage } = useNavigateHelper();
 
   return (
     <>
@@ -270,15 +270,19 @@ export const AllWorkspaceModals = (): ReactElement => {
             setOpenCreateWorkspaceModal(false);
           }, [setOpenCreateWorkspaceModal])}
           onCreate={useCallback(
-            id => {
+            (id, defaultDocId) => {
               setOpenCreateWorkspaceModal(false);
               // if jumping immediately, the page may stuck in loading state
               // not sure why yet .. here is a workaround
               setTimeout(() => {
-                jumpToSubPath(id, WorkspaceSubPath.ALL);
+                if (!defaultDocId) {
+                  jumpToSubPath(id, WorkspaceSubPath.ALL);
+                } else {
+                  jumpToPage(id, defaultDocId);
+                }
               });
             },
-            [jumpToSubPath, setOpenCreateWorkspaceModal]
+            [jumpToPage, jumpToSubPath, setOpenCreateWorkspaceModal]
           )}
         />
       </Suspense>

--- a/tools/@types/env/__all.d.ts
+++ b/tools/@types/env/__all.d.ts
@@ -30,7 +30,6 @@ declare module '@blocksuite/store' {
     trashDate?: number;
     updatedDate?: number;
     mode?: 'page' | 'edgeless';
-    jumpOnce?: boolean;
     // todo: support `number` in the future
     isPublic?: boolean;
   }


### PR DESCRIPTION
Previously, we marked `jumpOnce: true` on `doc.meta` to open a specific doc after creating a new workspace. This pr removes `jumpOnce` and directly jumps to the specific doc URL.

This PR also fixes an error when opening the all-page page, because the all-page page scans the jumpOnce attribute of all docs, and the code in it will fail on damaged data.
