### PR TITLE
fix(core): avoid shaking when renaming doc in title bar

### DIFF
--- a/packages/frontend/component/src/ui/editable/inline-edit.tsx
+++ b/packages/frontend/component/src/ui/editable/inline-edit.tsx
@@ -179,8 +179,8 @@ export const InlineEdit = ({
   } as CSSProperties;
   const inputInheritsStyles = {
     ...inputWrapperInheritsStyles,
-    padding: undefined,
-    margin: undefined,
+    padding: 0,
+    margin: 0,
   };
 
   return (

--- a/packages/frontend/core/src/components/blocksuite/block-suite-header/title/style.css.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-header/title/style.css.ts
@@ -6,7 +6,6 @@ export const title = style({
   selectors: {
     '&[data-editing="true"]': {
       ['WebkitAppRegion' as string]: 'no-drag',
-      flexGrow: 1,
     },
   },
 });


### PR DESCRIPTION
- before
    ![CleanShot 2024-05-09 at 14.42.45.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/5c7b6beb-d24f-49b8-a2c2-f3ab07f4972a.gif)

- after
    ![CleanShot 2024-05-09 at 14.43.57.gif](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/325b68b5-a904-425a-b2c4-5f914237b497.gif)

