### PR TITLE
fix(core): navigation shortcut keys can't be used when the sidebar is collapsed

### DIFF
--- a/packages/frontend/core/src/layouts/workspace-layout.tsx
+++ b/packages/frontend/core/src/layouts/workspace-layout.tsx
@@ -40,6 +40,7 @@ import {
 } from '../hooks/affine/use-global-dnd-helper';
 import { useNavigateHelper } from '../hooks/use-navigate-helper';
 import { useRegisterWorkspaceCommands } from '../hooks/use-register-workspace-commands';
+import { useRegisterNavigationCommands } from '../modules/navigation/view/use-register-navigation-commands';
 import { WorkbenchService } from '../modules/workbench';
 import {
   AllWorkspaceModals,
@@ -122,6 +123,7 @@ export const WorkspaceLayoutInner = ({ children }: PropsWithChildren) => {
   );
 
   useRegisterWorkspaceCommands();
+  useRegisterNavigationCommands();
 
   useEffect(() => {
     // hotfix for blockVersions

--- a/packages/frontend/core/src/modules/navigation/view/navigation-buttons.tsx
+++ b/packages/frontend/core/src/modules/navigation/view/navigation-buttons.tsx
@@ -7,14 +7,11 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { useGeneralShortcuts } from '../../../hooks/affine/use-shortcuts';
 import { NavigatorService } from '../services/navigator';
 import * as styles from './navigation-buttons.css';
-import { useRegisterNavigationCommands } from './use-register-navigation-commands';
 
 export const NavigationButtons = () => {
   const t = useAFFiNEI18N();
 
   const shortcuts = useGeneralShortcuts().shortcuts;
-
-  useRegisterNavigationCommands();
 
   const shortcutsObject = useMemo(() => {
     const goBack = t['com.affine.keyboardShortcuts.goBack']();


### PR DESCRIPTION
close #6877 