### PR TITLE
chore: track doc create action in bs editor

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs.ts
@@ -1,12 +1,16 @@
 import type { ElementOrFactory } from '@affine/component';
+import { mixpanel } from '@affine/core/utils';
 import type { BlockSpec } from '@blocksuite/block-std';
 import type { ParagraphService, RootService } from '@blocksuite/blocks';
 import {
+  AffineLinkedDocWidget,
+  AffineSlashMenuWidget,
   AttachmentService,
   CanvasTextFonts,
   EdgelessRootService,
   PageRootService,
 } from '@blocksuite/blocks';
+import type { BlockModel } from '@blocksuite/store';
 import bytes from 'bytes';
 import type { TemplateResult } from 'lit';
 
@@ -48,6 +52,37 @@ class CustomEdgelessPageService extends EdgelessRootService {
   override loadFonts(): void {
     customLoadFonts(this);
   }
+
+  override addElement<T = Record<string, unknown>>(type: string, props: T) {
+    const res = super.addElement(type, props);
+    mixpanel.track('WhiteboardObjectCreated', {
+      page: 'whiteboard editor',
+      module: 'whiteboard',
+      segment: 'canvas',
+      // control:
+      type: 'whiteboard object',
+      category: type,
+    });
+    return res;
+  }
+
+  override addBlock(
+    flavour: string,
+    props: Record<string, unknown>,
+    parent?: string | BlockModel,
+    parentIndex?: number
+  ) {
+    const res = super.addBlock(flavour, props, parent, parentIndex);
+    mixpanel.track('WhiteboardObjectCreated', {
+      page: 'whiteboard editor',
+      module: 'whiteboard',
+      segment: 'canvas',
+      // control:
+      type: 'whiteboard object',
+      category: flavour.split(':')[1], // affine:paragraph -> paragraph
+    });
+    return res;
+  }
 }
 
 type AffineReference = HTMLElementTagNameMap['affine-reference'];
@@ -84,6 +119,63 @@ function patchSpecsWithReferenceRenderer(
     return spec;
   });
 }
+
+function patchSlashMenuWidget() {
+  const menuGroup = AffineSlashMenuWidget.DEFAULT_OPTIONS.menus.find(group => {
+    return group.name === 'Docs';
+  });
+
+  if (Array.isArray(menuGroup?.items)) {
+    const newDocItem = menuGroup.items.find(item => {
+      return item.name === 'New Doc';
+    });
+
+    if (newDocItem) {
+      const oldAction = newDocItem.action;
+      newDocItem.action = async (...props) => {
+        await oldAction(...props);
+        mixpanel.track('DocCreated', {
+          segment: 'doc',
+          module: 'command menu',
+          control: 'new doc command',
+          type: 'doc',
+          category: 'doc',
+        });
+      };
+    }
+  }
+}
+
+function patchLinkedDocPopover() {
+  const oldGetMenus = AffineLinkedDocWidget.DEFAULT_OPTIONS.getMenus;
+
+  AffineLinkedDocWidget.DEFAULT_OPTIONS.getMenus = ctx => {
+    const menus = oldGetMenus(ctx);
+    const newDocGroup = menus.find(group => group.name === 'New Doc');
+    const newDocItem = newDocGroup?.items.find(item => item.key === 'create');
+    // todo: patch import doc/workspace action
+    // const importItem = newDocGroup?.items.find(item => item.key === 'import');
+
+    if (newDocItem) {
+      const oldAction = newDocItem.action;
+      newDocItem.action = async () => {
+        await oldAction();
+        mixpanel.track('DocCreated', {
+          segment: 'doc',
+          module: 'linked doc popover',
+          control: 'new doc command',
+          type: 'doc',
+          category: 'doc',
+        });
+      };
+    }
+
+    return menus;
+  };
+}
+
+patchSlashMenuWidget();
+patchLinkedDocPopover();
 
 /**
  * Patch the block specs with custom renderers.


### PR DESCRIPTION
fix TOV-855

added shape element create & doc create event tracking in blocksuite editor.
What's still missing: 
the control (source) that triggered whiteboard element creation, i.e., from canvas dbclick, dnd or pasting.