### PR TITLE
fix(core): right sidebar's content is not centered when clientBorder enabled

### DIFF
--- a/packages/frontend/core/src/modules/multi-tab-sidebar/view/body.css.ts
+++ b/packages/frontend/core/src/modules/multi-tab-sidebar/view/body.css.ts
@@ -6,7 +6,6 @@ export const root = style({
   flex: 1,
   width: '100%',
   height: '100%',
-  minWidth: '320px',
   overflow: 'hidden',
   alignItems: 'center',
   borderTop: `1px solid ${cssVar('borderColor')}`,

--- a/packages/frontend/core/src/modules/right-sidebar/view/container.css.ts
+++ b/packages/frontend/core/src/modules/right-sidebar/view/container.css.ts
@@ -36,14 +36,5 @@ export const sidebarContainer = style({
 export const sidebarBodyTarget = style({
   flex: 1,
   width: '100%',
-  minWidth: '320px',
   overflow: 'hidden',
-  selectors: {
-    [`&[data-client-border=true]`]: {
-      paddingLeft: 9,
-    },
-    [`&[data-client-border=false]`]: {
-      borderLeft: `1px solid ${cssVar('borderColor')}`,
-    },
-  },
 });


### PR DESCRIPTION
- before
    ![CleanShot%202024-05-22%20at%2018.18.15@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/4fe8f114-6471-4e28-8788-0d50b39efe7a.png)
    ![CleanShot%202024-05-22%20at%2018.27.18@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/95ff58d7-2f6b-42ae-85f2-6b026ad48c05.png)

- after
    ![CleanShot 2024-05-22 at 19.10.30@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/LakojjjzZNf6ogjOVwKE/920fc348-b53f-4e5e-aa85-3329372923b1.png)

