### PR TITLE
build: enable new decorator for swc

### DIFF
--- a/tools/cli/src/webpack/config.ts
+++ b/tools/cli/src/webpack/config.ts
@@ -273,6 +273,7 @@ export const createConfiguration: (
                       },
                     },
                     useDefineForClassFields: false,
+                    decoratorVersion: '2022-03',
                   },
                 },
                 sourceMaps: true,


### PR DESCRIPTION
bs now has migrated to stage 3 decorators. to enable running affine locally with debugging blocksuite, we need to [turn this on](https://swc.rs/docs/configuration/compilation#jsctransformdecoratorversion).

Question:
It seems affine core code already uses stage 3 decorators, however we do not have an issue without this flag since we haven't used class field decorators that uses the `accessor` keyword?