### PR TITLE
fix(core): unexpected autofill style in dark mode

### DIFF
--- a/packages/frontend/component/src/ui/input/style.css.ts
+++ b/packages/frontend/component/src/ui/input/style.css.ts
@@ -69,5 +69,8 @@ export const input = style({
     '&:disabled': {
       color: cssVar('textDisableColor'),
     },
+    '&:-webkit-autofill': {
+      WebkitBoxShadow: `0 0 0 1000px ${cssVar('white')} inset`,
+    },
   },
 });


### PR DESCRIPTION
before:
<img width="395" alt="image" src="https://github.com/toeverything/AFFiNE/assets/102217452/028a6dcf-2b8f-465a-99e7-5ef147079b5c">

after:
<img width="420" alt="image" src="https://github.com/toeverything/AFFiNE/assets/102217452/1ae1b75d-bb64-4b2c-9021-8fb7bb41460b">
