### PR TITLE
fix: surface-ref peek view

### DIFF
--- a/packages/frontend/core/src/modules/peek-view/view/modal-container.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/modal-container.tsx
@@ -75,11 +75,6 @@ export const PeekViewModalContainer = ({
 }>) => {
   const [{ status }, toggle] = useTransition({
     timeout: animationTimeout,
-    onStateChange(event) {
-      if (event.current.status === 'exited' && onAnimateEnd) {
-        onAnimateEnd();
-      }
-    },
   });
   const [transformOrigin, setTransformOrigin] = useState<string | null>(null);
   useEffect(() => {
@@ -105,6 +100,9 @@ export const PeekViewModalContainer = ({
               [styles.transformOrigin]: transformOrigin,
               [styles.animationTimeout]: `${animationTimeout}ms`,
             })}
+            onAnimationEnd={() => {
+              onAnimateEnd?.();
+            }}
           />
           <div
             data-peek-view-wrapper


### PR DESCRIPTION
### Change
Add ref to `SurfaceRefPeekView`. It provide `fitViewportToTarget` method to fit the `surface-ref` content.

Related to [AFF-1200](https://linear.app/affine-design/issue/AFF-1200/center-peek-frame-rendering-issue).