### PR TITLE
fix: ai slide render initialize error

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/messages/slides-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/messages/slides-renderer.ts
@@ -214,6 +214,7 @@ export class AISlidesRenderer extends WithDisposable(LitElement) {
 
     const schema = new Schema().register(AffineSchemas);
     const collection = new DocCollection({ schema, id: 'SLIDES_PREVIEW' });
+    collection.meta.initialize();
     collection.start();
     const doc = collection.createDoc();
 


### PR DESCRIPTION
Need add `collection.meta.initialize()` in AI slide render. 
Similar codes:
https://github.com/toeverything/AFFiNE/blob/b3ec3a2b3efc0a88770c855e25e7f21ef8142d9c/packages/frontend/core/src/blocksuite/presets/ai/utils/markdown-utils.ts#L177-L195