### PR TITLE
fix(core): can't enter presentation again in share page

### DIFF
--- a/packages/frontend/core/src/components/cloud/share-header-right-item/present.tsx
+++ b/packages/frontend/core/src/components/cloud/share-header-right-item/present.tsx
@@ -45,13 +45,9 @@ export const PresentButton = () => {
     const edgelessPage = editorHost?.querySelector('affine-edgeless-root');
     if (!edgelessPage) return;
 
-    edgelessPage.slots.edgelessToolUpdated.on(() => {
+    return edgelessPage.slots.edgelessToolUpdated.on(() => {
       setIsPresent(edgelessPage.edgelessTool.type === 'frameNavigator');
-    });
-
-    return () => {
-      edgelessPage.slots.edgelessToolUpdated.dispose();
-    };
+    }).dispose;
   }, [editor?.host, isPresent]);
 
   return (

--- a/packages/frontend/electron/renderer/app.tsx
+++ b/packages/frontend/electron/renderer/app.tsx
@@ -35,6 +35,7 @@ const desktopWhiteList = [
   '/open-app/url',
   '/upgrade-success',
   '/ai-upgrade-success',
+  '/share',
 ];
 if (
   !environment.isDesktop &&


### PR DESCRIPTION
Fix [TOV-916](https://linear.app/affine-design/issue/TOV-916/分享页面的-present-按钮在第二次进入演示模式时未生效)