### PR TITLE
fix: remove useless padding css style

### DIFF
--- a/packages/frontend/core/src/components/page-detail-editor.css.ts
+++ b/packages/frontend/core/src/components/page-detail-editor.css.ts
@@ -1,4 +1,4 @@
-import { globalStyle, style } from '@vanilla-extract/css';
+import { style } from '@vanilla-extract/css';
 export const editor = style({
   flex: 1,
   selectors: {
@@ -22,9 +22,3 @@ export const editor = style({
     },
   },
 });
-globalStyle(
-  `${editor} .affine-page-viewport:not(.affine-embed-synced-doc-editor)`,
-  {
-    paddingBottom: '100px',
-  }
-);


### PR DESCRIPTION
Fix issue [BS-581](https://linear.app/affine-design/issue/BS-581).Remove the extra 100px padding of embed doc.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/14ef1f94-512f-4376-9498-03e21c8968d0.png)

