### PR TITLE
fix: auto focus and select the input when notification modal prompt

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -189,6 +189,7 @@ export function patchNotificationService(
                 placeholder={placeholder}
                 defaultValue={value}
                 onChange={e => (value = e)}
+                ref={input => input?.select()}
               />
             </div>
           );


### PR DESCRIPTION
- Use `autofill` attribute instead of `input.focus()` on ref
- Auto focus and select all content of the input when prompt