### PR TITLE
fix(core): selected content should not be activated when executing open in chat

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-cards.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-cards.ts
@@ -2,6 +2,7 @@ import type { EditorHost } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/block-std';
 import {
   type ImageBlockModel,
+  isInsidePageEditor,
   type NoteBlockModel,
   NoteDisplayMode,
 } from '@blocksuite/blocks';
@@ -463,6 +464,18 @@ export class ChatCards extends WithDisposable(LitElement) {
           if (card.type === CardType.Doc) return;
 
           await this._selectCard(card);
+        }
+      })
+    );
+
+    this._disposables.add(
+      AIProvider.slots.requestContinueInChat.on(async ({ host, show }) => {
+        if (show) {
+          if (isInsidePageEditor(host)) {
+            await this._extract();
+          } else {
+            await this._extractOnEdgeless();
+          }
         }
       })
     );

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
@@ -212,19 +212,6 @@ export class ChatPanel extends WithDisposable(ShadowlessElement) {
         this._resetItems();
       }
     });
-
-    AIProvider.slots.requestContinueInChat.on(async ({ show }) => {
-      if (show) {
-        const text = await getSelectedTextContent(this.host, 'plain-text');
-        const markdown = await getSelectedTextContent(this.host, 'markdown');
-        const images = await getSelectedImagesAsBlobs(this.host);
-        this.updateContext({
-          quote: text,
-          markdown: markdown,
-          images: images,
-        });
-      }
-    });
   }
 
   updateContext = (context: Partial<ChatContextValue>) => {


### PR DESCRIPTION
Closes: [AF-949](https://linear.app/affine-design/issue/AF-949/执行-open-in-chat-时，不应该激活选中内容)