### PR TITLE
fix(core): add synced doc block content to ai context

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/utils/markdown-utils.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/utils/markdown-utils.ts
@@ -5,6 +5,7 @@ import type {
 } from '@blocksuite/block-std';
 import {
   defaultImageProxyMiddleware,
+  embedSyncedDocMiddleware,
   MarkdownAdapter,
   MixTextAdapter,
   pasteMiddleware,
@@ -76,7 +77,7 @@ export async function getContentFromSlice(
 ) {
   const job = new Job({
     collection: host.std.doc.collection,
-    middlewares: [titleMiddleware],
+    middlewares: [titleMiddleware, embedSyncedDocMiddleware('content')],
   });
   const snapshot = await job.sliceToSnapshot(slice);
   processTextInSnapshot(snapshot, host);


### PR DESCRIPTION
Closes: [AF-955](https://linear.app/affine-design/issue/AF-955/synced-block-%E6%96%87%E6%A1%A3%E6%94%AF%E6%8C%81%EF%BC%9A%E8%AF%BB%E5%8F%96%E6%96%87%E6%A1%A3%E5%86%85%E5%AE%B9%E4%BD%9C%E4%B8%BA-ai-%E7%9A%84%E4%B8%8A%E4%B8%8B%E6%96%87-cotent)

Related PR: https://github.com/toeverything/blocksuite/pull/7405