### PR TITLE
fix(core): incorrect icon of initial reference

### DIFF
--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -44,7 +44,7 @@ export function pageReferenceRenderer({
   let title =
     referencedPage?.title ?? t['com.affine.editor.reference-not-found']();
   let icon =
-    docMode === 'page' ? (
+    docMode === 'page' || docMode === null ? (
       <LinkedPageIcon className={styles.pageReferenceIcon} />
     ) : (
       <LinkedEdgelessIcon className={styles.pageReferenceIcon} />


### PR DESCRIPTION
Closes: [AF-940](https://linear.app/affine-design/issue/AF-940/doc-created-with-%5B-%5B-syntax-are-by-default-in-doc-mode-but-shown-as)