### PR TITLE
fix: cannot read properties of undefined editor.host

### DIFF
--- a/packages/frontend/core/src/modules/peek-view/view/doc-peek-view.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/doc-peek-view.tsx
@@ -72,19 +72,21 @@ export function DocPeekPreview({
   const [resolvedMode, setResolvedMode] = useState<DocMode | undefined>(mode);
 
   useEffect(() => {
-    if (editor && resolvedMode === 'edgeless') {
-      editor.host
-        .closest('[data-testid="peek-view-modal-animation-container"]')
-        ?.addEventListener(
-          'animationend',
-          () => {
-            fitViewport(editor, xywh);
-          },
-          {
-            once: true,
-          }
-        );
-    }
+    requestAnimationFrame(() => {
+      if (editor && editor.host && resolvedMode === 'edgeless') {
+        editor.host
+          .closest('[data-testid="peek-view-modal-animation-container"]')
+          ?.addEventListener(
+            'animationend',
+            () => {
+              fitViewport(editor, xywh);
+            },
+            {
+              once: true,
+            }
+          );
+      }
+    });
     return;
   }, [editor, resolvedMode, xywh]);
 


### PR DESCRIPTION
Fix issue [BS-657](https://linear.app/affine-design/issue/BS-657).

Unable to obtain `editor.host` synchronously on `editor` reference callback. Maybe we should have a separate host reference callback. @pengx17 

![截屏2024-06-26 11.58.54.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/7d442ce3-86c9-4f4d-85c5-000d923702b6.png)

