### PR TITLE
chore(core): update inline reference icon

### DIFF
--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -7,6 +7,7 @@ import {
 import { WorkbenchLink } from '@affine/core/modules/workbench';
 import { useI18n } from '@affine/i18n';
 import {
+  DeleteIcon,
   LinkedEdgelessIcon,
   LinkedPageIcon,
   TodayIcon,
@@ -43,12 +44,15 @@ export function pageReferenceRenderer({
   const referencedPage = pageMetaHelper.getDocMeta(pageId);
   let title =
     referencedPage?.title ?? t['com.affine.editor.reference-not-found']();
-  let icon =
-    docMode === 'page' || docMode === null ? (
-      <LinkedPageIcon className={styles.pageReferenceIcon} />
-    ) : (
-      <LinkedEdgelessIcon className={styles.pageReferenceIcon} />
-    );
+
+  let icon = !referencedPage ? (
+    <DeleteIcon className={styles.pageReferenceIcon} />
+  ) : docMode === 'page' || docMode === null ? (
+    <LinkedPageIcon className={styles.pageReferenceIcon} />
+  ) : (
+    <LinkedEdgelessIcon className={styles.pageReferenceIcon} />
+  );
+
   const isJournal = isPageJournal(pageId);
   const localizedJournalDate = getLocalizedJournalDateString(pageId);
   if (isJournal && localizedJournalDate) {


### PR DESCRIPTION
Close [BS-659](https://linear.app/affine-design/issue/BS-659/deleted-doc%E7%8A%B6%E6%80%81%E7%BC%BA%E5%A4%B1)
Related PR: https://github.com/toeverything/blocksuite/pull/7433

Before:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/aa74cb3f-5eca-4456-992c-a04e58760edd.png)

After:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/0e2c437c-7317-47fb-8d90-07d32efe53df.png)

