### PR TITLE
fix: doc update time outdated

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor.tsx
@@ -89,6 +89,17 @@ const BlockSuiteEditorImpl = forwardRef<AffineEditorContainer, EditorProps>(
     );
 
     useEffect(() => {
+      const disposable = page.slots.blockUpdated.once(() => {
+        page.collection.setDocMeta(page.id, {
+          updatedDate: Date.now(),
+        });
+      });
+      return () => {
+        disposable.dispose();
+      };
+    }, [page]);
+
+    useEffect(() => {
       return () => {
         editorDisposeRef.current();
       };

--- a/packages/frontend/core/src/components/page-detail-editor.tsx
+++ b/packages/frontend/core/src/components/page-detail-editor.tsx
@@ -75,13 +75,6 @@ const PageDetailEditorMain = memo(function PageDetailEditorMain({
       // debug current detail editor
       globalThis.currentEditor = editor;
       const disposableGroup = new DisposableGroup();
-      disposableGroup.add(
-        page.slots.blockUpdated.once(() => {
-          page.collection.setDocMeta(page.id, {
-            updatedDate: Date.now(),
-          });
-        })
-      );
       localStorage.setItem('last_page_id', page.id);
 
       if (onLoad) {

--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
@@ -67,7 +67,6 @@ const DetailPageImpl = memo(function DetailPageImpl() {
   const activeTabName = useLiveData(rightSidebar.activeTabName$);
 
   const doc = useService(DocService).doc;
-  const docRecordList = useService(DocsService).list;
   const { openPage, jumpToPageBlock, jumpToTag } = useNavigateHelper();
   const [editor, setEditor] = useState<AffineEditorContainer | null>(null);
   const workspace = useService(WorkspaceService).workspace;
@@ -200,15 +199,6 @@ const DetailPageImpl = memo(function DetailPageImpl() {
         editorHost.std.spec.getService<PageRootService>('affine:page');
       const disposable = new DisposableGroup();
 
-      pageService.getDocUpdatedAt = (pageId: string) => {
-        const linkedPage = docRecordList.doc$(pageId).value;
-        if (!linkedPage) return new Date();
-
-        const updatedDate = linkedPage.meta$.value.updatedDate;
-        const createDate = linkedPage.meta$.value.createDate;
-        return new Date(updatedDate || createDate || Date.now());
-      };
-
       doc.setMode(mode);
       disposable.add(
         pageService.slots.docLinkClicked.on(({ docId, blockId }) => {
@@ -232,7 +222,6 @@ const DetailPageImpl = memo(function DetailPageImpl() {
     [
       doc,
       mode,
-      docRecordList,
       jumpToPageBlock,
       docCollection.id,
       openPage,


### PR DESCRIPTION
Fix issue [BS-603](https://linear.app/affine-design/issue/BS-603).

- Move observe `blockUpdated` logic in `blocksuite-editor` component, so it can be excuted on both page-detail and center-peek mode.
- Remove useless `getDocUpdatedAt` service, because blocksuite can get `docMeta` directly.

https://github.com/toeverything/blocksuite/pull/7434

https://github.com/toeverything/AFFiNE/assets/12724894/e01e3f97-f1d0-4d1d-a8ed-e70e27e39bdb



