### PR TITLE
fix(core): unexpected text overflow style in dialog

### DIFF
--- a/packages/frontend/component/src/ui/modal/styles.css.ts
+++ b/packages/frontend/component/src/ui/modal/styles.css.ts
@@ -53,7 +53,9 @@ export const modalHeader = style({
   marginBottom: '12px',
 });
 export const modalDescription = style({
-  // marginBottom: '20px',
+  wordBreak: 'break-word',
+  whiteSpace: 'pre-wrap',
+  overflowWrap: 'break-word',
 });
 export const modalFooter = style({
   display: 'flex',


### PR DESCRIPTION
close AF-967
before:
<img width="502" alt="image" src="https://github.com/toeverything/AFFiNE/assets/102217452/839096b2-62b1-4ca3-b410-99c478eeac53">

after:
<img width="496" alt="image" src="https://github.com/toeverything/AFFiNE/assets/102217452/9f02c305-e122-4c6c-a3c6-32647fa9e4c5">
