### PR TITLE
fix(core): clear op history when create a new doc

### DIFF
--- a/packages/common/infra/src/initialization/index.ts
+++ b/packages/common/infra/src/initialization/index.ts
@@ -23,5 +23,6 @@ export function initEmptyPage(page: Doc, title?: string) {
       {},
       noteBlockId
     );
+    page.history.clear();
   });
 }


### PR DESCRIPTION
Closes: [AF-969](https://linear.app/affine-design/issue/AF-969/%E5%9C%A8%E6%96%B0%E5%BB%BA%E7%9A%84%E6%96%87%E6%A1%A3undo%E6%8A%A5%E9%94%99-%E4%B8%94%E6%97%A0%E6%B3%95%E9%87%8D%E6%96%B0%E6%89%93%E5%BC%80%E6%96%87%E6%A1%A3)

## Bug Description
When creating a new document, the user can undo directly inside the document, which will make the blocks of document empty and unable to render after opening this document again.

## What changed
Clear operation history of doc initialization. 