### PR TITLE
feat(core): allow keyboard navigation in tags inline editor

### DIFF
--- a/packages/frontend/core/src/components/affine/page-properties/tags-inline-editor.css.ts
+++ b/packages/frontend/core/src/components/affine/page-properties/tags-inline-editor.css.ts
@@ -90,8 +90,10 @@ export const tagSelectorItem = style({
   gap: 8,
   cursor: 'pointer',
   borderRadius: '4px',
-  ':hover': {
-    backgroundColor: cssVar('hoverColor'),
+  selectors: {
+    '&[data-focused=true]': {
+      backgroundColor: cssVar('hoverColor'),
+    },
   },
 });
 

--- a/packages/frontend/core/src/components/page-list/docs/page-tags.css.ts
+++ b/packages/frontend/core/src/components/page-list/docs/page-tags.css.ts
@@ -78,6 +78,12 @@ export const tagInnerWrapper = style({
   justifyContent: 'space-between',
   padding: '0 8px',
   color: cssVar('textPrimaryColor'),
+  borderColor: cssVar('borderColor'),
+  selectors: {
+    '&[data-focused=true]': {
+      borderColor: cssVar('primaryColor'),
+    },
+  },
 });
 export const tagInline = style([
   tagInnerWrapper,
@@ -85,7 +91,8 @@ export const tagInline = style([
     fontSize: 'inherit',
     borderRadius: '10px',
     columnGap: '4px',
-    border: `1px solid ${cssVar('borderColor')}`,
+    borderWidth: '1px',
+    borderStyle: 'solid',
     background: cssVar('backgroundPrimaryColor'),
     maxWidth: '128px',
     height: '100%',

--- a/packages/frontend/core/src/components/page-list/docs/page-tags.tsx
+++ b/packages/frontend/core/src/components/page-list/docs/page-tags.tsx
@@ -22,6 +22,7 @@ interface TagItemProps {
   idx?: number;
   maxWidth?: number | string;
   mode: 'inline' | 'list-item';
+  focused?: boolean;
   onRemoved?: () => void;
   style?: React.CSSProperties;
 }
@@ -54,6 +55,7 @@ export const TagItem = ({
   tag,
   idx,
   mode,
+  focused,
   onRemoved,
   style,
   maxWidth,
@@ -79,6 +81,7 @@ export const TagItem = ({
     >
       <div
         style={{ maxWidth: maxWidth }}
+        data-focused={focused}
         className={mode === 'inline' ? styles.tagInline : styles.tagListItem}
       >
         <div

--- a/packages/frontend/core/src/modules/tag/entities/tag-list.ts
+++ b/packages/frontend/core/src/modules/tag/entities/tag-list.ts
@@ -63,29 +63,11 @@ export class TagList extends Entity {
     return trimmedValue.includes(trimmedQuery);
   }
 
-  private findfn(value: string, query?: string) {
-    const trimmedTagValue = query?.trim().toLowerCase();
-    const trimmedInputValue = value.trim().toLowerCase();
-    return trimmedTagValue === trimmedInputValue;
-  }
-
   filterTagsByName$(name: string) {
     return LiveData.computed(get => {
       return get(this.tags$).filter(tag =>
         this.filterFn(get(tag.value$), name)
       );
-    });
-  }
-
-  tagByTagValue$(value: string) {
-    return LiveData.computed(get => {
-      return get(this.tags$).find(tag => this.filterFn(get(tag.value$), value));
-    });
-  }
-
-  excactTagByValue$(value: string) {
-    return LiveData.computed(get => {
-      return get(this.tags$).find(tag => this.findfn(get(tag.value$), value));
     });
   }
 }

--- a/tests/affine-local/e2e/page-properties.spec.ts
+++ b/tests/affine-local/e2e/page-properties.spec.ts
@@ -45,6 +45,24 @@ test('allow create tag', async ({ page }) => {
   await expectTagsVisible(page, ['Test2']);
 });
 
+test('allow using keyboard to navigate tags', async ({ page }) => {
+  await openTagsEditor(page);
+  await searchAndCreateTag(page, 'Test1');
+  await searchAndCreateTag(page, 'Test2');
+
+  await page.keyboard.press('ArrowLeft');
+  await page.keyboard.press('Backspace');
+  await closeTagsEditor(page);
+  await expectTagsVisible(page, ['Test1']);
+
+  await openTagsEditor(page);
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await closeTagsEditor(page);
+  await expectTagsVisible(page, ['Test1', 'Test2']);
+});
+
 test('allow create tag on journals page', async ({ page }) => {
   await openJournalsPage(page);
   await waitForEditorLoad(page);


### PR DESCRIPTION
fix AF-966

- Allow using arrowup/down to navigate the tag list candidates; press enter to add the currently focused tag option;
- Allow using arrowleft/right to navigate the inline tag list (selected) and use backspace to delete focused tag.


