### PR TITLE
fix: ensure exact tag matching with enter key behavior refinement

### DIFF
--- a/packages/frontend/core/src/components/affine/page-properties/tags-inline-editor.tsx
+++ b/packages/frontend/core/src/components/affine/page-properties/tags-inline-editor.tsx
@@ -197,7 +197,8 @@ export const TagsEditor = ({ pageId, readonly }: TagsEditorProps) => {
     [setOpen, setSelectedTagIds]
   );
 
-  const exactMatch = useLiveData(tagList.tagByTagValue$(inputValue));
+  const match = useLiveData(tagList.tagByTagValue$(inputValue));
+  const exactMatch = useLiveData(tagList.excactTagByValue$(inputValue));
 
   const filteredTags = useLiveData(
     inputValue ? tagList.filterTagsByName$(inputValue) : tagList.tags$
@@ -266,7 +267,7 @@ export const TagsEditor = ({ pageId, readonly }: TagsEditorProps) => {
         tags.find(tag => tag.id === lastTagId)?.untag(pageId);
       }
     },
-    [exactMatch, inputValue, onAddTag, onCreateTag, pageId, tagIds, tags]
+    [match, inputValue, onAddTag, onCreateTag, pageId, tagIds, tags]
   );
 
   return (
@@ -320,7 +321,7 @@ export const TagsEditor = ({ pageId, readonly }: TagsEditorProps) => {
                 </div>
               );
             })}
-            {exactMatch || !inputValue ? null : (
+            {match || !inputValue ? null : (
               <div
                 data-testid="tag-selector-item"
                 className={styles.tagSelectorItem}

--- a/packages/frontend/core/src/components/affine/page-properties/tags-inline-editor.tsx
+++ b/packages/frontend/core/src/components/affine/page-properties/tags-inline-editor.tsx
@@ -267,7 +267,7 @@ export const TagsEditor = ({ pageId, readonly }: TagsEditorProps) => {
         tags.find(tag => tag.id === lastTagId)?.untag(pageId);
       }
     },
-    [match, inputValue, onAddTag, onCreateTag, pageId, tagIds, tags]
+    [inputValue, tagIds, exactMatch, onAddTag, onCreateTag, tags, pageId]
   );
 
   return (

--- a/packages/frontend/core/src/modules/tag/entities/tag-list.ts
+++ b/packages/frontend/core/src/modules/tag/entities/tag-list.ts
@@ -63,6 +63,12 @@ export class TagList extends Entity {
     return trimmedValue.includes(trimmedQuery);
   }
 
+  private findfn(value: string, query?: string) {
+    const trimmedTagValue = query?.trim().toLowerCase();
+    const trimmedInputValue = value.trim().toLowerCase();
+    return trimmedTagValue === trimmedInputValue;
+  }
+
   filterTagsByName$(name: string) {
     return LiveData.computed(get => {
       return get(this.tags$).filter(tag =>
@@ -74,6 +80,12 @@ export class TagList extends Entity {
   tagByTagValue$(value: string) {
     return LiveData.computed(get => {
       return get(this.tags$).find(tag => this.filterFn(get(tag.value$), value));
+    });
+  }
+
+  excactTagByValue$(value: string) {
+    return LiveData.computed(get => {
+      return get(this.tags$).find(tag => this.findfn(get(tag.value$), value));
     });
   }
 }


### PR DESCRIPTION
Fixes #7385
Refined the tag matching logic to ensure that only tags with exact matches are considered for selection  when the Enter key is pressed. Created a new method for exact matching of tag.