### PR TITLE
fix  #5813

### DIFF
--- a/packages/frontend/component/src/ui/modal/confirm-modal.tsx
+++ b/packages/frontend/component/src/ui/modal/confirm-modal.tsx
@@ -10,7 +10,7 @@ import { Modal } from './modal';
 import * as styles from './styles.css';
 
 export interface ConfirmModalProps extends ModalProps {
-  confirmButtonOptions?: ButtonProps;
+  confirmButtonOptions?: ButtonProps & { autoFocus?: boolean }; // Add autoFocus here
   onConfirm?: (() => void) | (() => Promise<void>);
   onCancel?: () => void;
   cancelText?: string;
@@ -35,6 +35,7 @@ export const ConfirmModal = ({
       console.error(err);
     });
   }, [onConfirm]);
+
   return (
     <Modal
       contentOptions={{
@@ -64,7 +65,7 @@ export const ConfirmModal = ({
             {cancelText}
           </Button>
         </DialogTrigger>
-        <Button onClick={onConfirmClick} {...confirmButtonOptions}></Button>
+        <Button onClick={onConfirmClick} autoFocus={confirmButtonOptions?.autoFocus} {...confirmButtonOptions}></Button>
       </div>
     </Modal>
   );
@@ -142,7 +143,7 @@ export const ConfirmModalProvider = ({ children }: PropsWithChildren) => {
       value={{ openConfirmModal, closeConfirmModal, modalProps }}
     >
       {children}
-      {/* TODO(@catsjuice): multi-instance support(unnecessary for now) */}
+      {/* TODO: multi-instance support (unnecessary for now) */}
       <ConfirmModal {...modalProps} onOpenChange={onOpenChange} />
     </ConfirmModalContext.Provider>
   );


### PR DESCRIPTION
Changes Made
### 1. Added autoFocus Property to ConfirmModalProps:

Enhanced the ConfirmModalProps interface to include an optional autoFocus property within the confirmButtonOptions. This allows the confirm button to be auto-focused when the modal is opened.

```
export interface ConfirmModalProps extends ModalProps {
  confirmButtonOptions?: ButtonProps & { autoFocus?: boolean }; // Added autoFocus here
  ...
}
```
### 2. Set autoFocus Attribute on the Confirm Button in ConfirmModal Component:

Updated the ConfirmModal component to pass the autoFocus attribute to the Button component used for the confirm action. This ensures the confirm button is focused automatically, allowing users to press the Enter key to confirm.

`<Button onClick={onConfirmClick} autoFocus={confirmButtonOptions?.autoFocus} {...confirmButtonOptions}></Button>`

Summary

These changes improve the user experience by allowing the delete (confirm) button in the confirmation modal to be auto-focused. As a result, users can now press the Enter key to activate the confirm button without needing to manually click it.

