### PR TITLE
fix: menu in peek view content not scrollable issue

### DIFF
--- a/packages/frontend/core/src/modules/peek-view/view/modal-container.css.ts
+++ b/packages/frontend/core/src/modules/peek-view/view/modal-container.css.ts
@@ -100,6 +100,7 @@ export const modalOverlay = style({
   zIndex: cssVar('zIndexModal'),
   backgroundColor: cssVar('black30'),
   viewTransitionName: vtOverlayFade,
+  pointerEvents: 'auto',
 });
 
 export const modalContentWrapper = style({

--- a/packages/frontend/core/src/modules/peek-view/view/modal-container.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/modal-container.tsx
@@ -18,7 +18,11 @@ const contentOptions: Dialog.DialogContentProps = {
   ['data-testid' as string]: 'peek-view-modal',
   onPointerDownOutside: e => {
     const el = e.target as HTMLElement;
-    if (el.closest('[data-peek-view-wrapper]')) {
+    if (
+      el.closest('[data-peek-view-wrapper]') ||
+      // workaround for slash menu click outside issue
+      el.closest('affine-slash-menu')
+    ) {
       e.preventDefault();
     }
   },
@@ -82,6 +86,8 @@ export type PeekViewModalContainerProps = PropsWithChildren<{
   animation?: 'fade' | 'zoom';
   testId?: string;
 }>;
+
+const PeekViewModalOverlay = 'div';
 
 export const PeekViewModalContainer = forwardRef<
   HTMLDivElement,
@@ -149,7 +155,7 @@ export const PeekViewModalContainer = forwardRef<
     <PeekViewContext.Provider value={emptyContext}>
       <Dialog.Root modal open={vtOpen} onOpenChange={onOpenChange}>
         <Dialog.Portal>
-          <Dialog.Overlay
+          <PeekViewModalOverlay
             className={styles.modalOverlay}
             onAnimationStart={onAnimationStart}
             onAnimationEnd={onAnimateEnd}


### PR DESCRIPTION
when using [dialog.overlay](https://github.com/radix-ui/primitives/blob/main/packages/react/dialog/src/Dialog.tsx#L203-L211), whole app is affected by [react-scroll library](https://github.com/theKashey/react-remove-scroll/blob/8923c513d269190162eb4678c1b80137f5998679/src/SideEffect.tsx#L131-L134):

In the current implementation, only the contents in the dialog content will be scrollable and cannot be configured in current API.

This PR introduces a simple div overlay to get rid of this issue.

fix BS-696
