### PR TITLE
fix: chat panel ai onboarding title wrap

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-messages.ts
@@ -210,7 +210,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
                   display: 'flex',
                   height: '28px',
                   gap: '8px',
-                  width: '85%',
+                  width: '88%',
                   alignItems: 'center',
                   justifyContent: 'start',
                   cursor: 'pointer',


### PR DESCRIPTION
[BS-896](https://linear.app/affine-design/issue/BS-896/ai-chat-onboarding-ui-折行-bug)