### PR TITLE
fix: tab label overflow style when there is only one tab

### DIFF
--- a/packages/frontend/core/src/modules/app-tabs-header/views/app-tabs-header.tsx
+++ b/packages/frontend/core/src/modules/app-tabs-header/views/app-tabs-header.tsx
@@ -125,8 +125,8 @@ const WorkbenchTab = ({
           </Fragment>
         );
       })}
-      {!workbench.pinned && tabsLength > 1 ? (
-        <div className={styles.tabCloseButtonWrapper}>
+      <div className={styles.tabCloseButtonWrapper}>
+        {!workbench.pinned && tabsLength > 1 ? (
           <button
             data-testid="close-tab-button"
             className={styles.tabCloseButton}
@@ -134,8 +134,8 @@ const WorkbenchTab = ({
           >
             <CloseIcon />
           </button>
-        </div>
-      ) : null}
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/packages/frontend/core/src/modules/app-tabs-header/views/styles.css.ts
+++ b/packages/frontend/core/src/modules/app-tabs-header/views/styles.css.ts
@@ -148,7 +148,7 @@ export const tabCloseButtonWrapper = style({
   paddingRight: 4,
   justifyContent: 'flex-end',
   selectors: {
-    [`${tab}:is([data-active=true], :hover) &`]: {
+    [`${tab}:is([data-active=true], :hover) &:not(:empty)`]: {
       width: 40,
     },
     [`${tab}[data-active=true] &`]: {


### PR DESCRIPTION
before
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/d610e543-db1d-4671-a9f4-a31480f26dd7.png)

after
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/ab1c53b7-8cdd-443b-9371-fdf9bb6c85ae.png)

