### PR TITLE
feat: patch edgeless clipboard to support cuntom block copy paste

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -37,6 +37,7 @@ import { BiDirectionalLinkPanel } from './bi-directional-link-panel';
 import { BlocksuiteEditorJournalDocTitle } from './journal-doc-title';
 import {
   patchDocModeService,
+  patchEdgelessClipboard,
   patchForSharedPage,
   patchNotificationService,
   patchPeekViewService,
@@ -102,6 +103,7 @@ const usePatchSpecs = (page: Doc, shared: boolean, mode: DocMode) => {
       confirmModal
     );
     patched = patchPeekViewService(patched, peekViewService);
+    patched = patchEdgelessClipboard(patched);
     if (!page.readonly) {
       patched = patchQuickSearchService(patched, framework);
     }


### PR DESCRIPTION
fix: [BS-1005](https://linear.app/affine-design/issue/BS-1005/chat-block无法被copy-paste到别的文档中，duplicate全篇文档后，可以center-peek)

related: https://github.com/toeverything/blocksuite/pull/7797