### PR TITLE
fix: support chat in different doc

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/_common/chat-actions-handle.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/_common/chat-actions-handle.ts
@@ -48,16 +48,16 @@ export type ChatAction = {
   ) => Promise<boolean>;
 };
 
-export async function queryHistoryMessages(doc: Doc, forkSessionId: string) {
+export async function queryHistoryMessages(
+  workspaceId: string,
+  docId: string,
+  forkSessionId: string
+) {
   // Get fork session messages
-  const histories = await AIProvider.histories?.chats(
-    doc.collection.id,
-    doc.id,
-    {
-      sessionId: forkSessionId,
-      messageOrder: ChatHistoryOrder.asc,
-    }
-  );
+  const histories = await AIProvider.histories?.chats(workspaceId, docId, {
+    sessionId: forkSessionId,
+    messageOrder: ChatHistoryOrder.asc,
+  });
 
   if (!histories || !histories.length) {
     return [];
@@ -98,7 +98,11 @@ export async function constructRootChatBlockMessages(
 ) {
   // Convert chat messages to AI chat block messages
   const userInfo = await AIProvider.userInfo;
-  const forkMessages = await queryHistoryMessages(doc, forkSessionId);
+  const forkMessages = await queryHistoryMessages(
+    doc.collection.id,
+    doc.id,
+    forkSessionId
+  );
   return constructUserInfoWithMessages(forkMessages, userInfo);
 }
 
@@ -163,6 +167,8 @@ function addAIChatBlock(
       messages: JSON.stringify(messages),
       index: layer.generateIndex('affine:embed-ai-chat'),
       sessionId,
+      rootWorkspaceId: doc.collection.id,
+      rootDocId: doc.id,
     },
     surfaceBlock.id
   );


### PR DESCRIPTION
fix:
[BS-990](https://linear.app/affine-design/issue/BS-990/避免centerpeek中发起的会话，等待ai返回时，页面失去响应)
[BS-1005](https://linear.app/affine-design/issue/BS-1005/chat-block无法被copy-paste到别的文档中，duplicate全篇文档后，可以center-peek)