### PR TITLE
refactor(electron): reduce the number of listeners for ipc

### DIFF
--- a/packages/frontend/electron/src/main/events.ts
+++ b/packages/frontend/electron/src/main/events.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, WebContentsView } from 'electron';
 
+import { AFFINE_EVENT_CHANNEL_NAME } from '../shared/type';
 import { applicationMenuEvents } from './application-menu';
 import { logger } from './logger';
 import { sharedStorageEvents } from './shared-storage';
@@ -39,14 +40,14 @@ export function registerEvents() {
             return;
           }
           // .webContents could be undefined if the window is destroyed
-          win.webContents?.send(chan, ...args);
+          win.webContents?.send(AFFINE_EVENT_CHANNEL_NAME, chan, ...args);
           win.contentView.children.forEach(child => {
             if (
               child instanceof WebContentsView &&
               child.webContents &&
               !child.webContents.isDestroyed()
             ) {
-              child.webContents?.send(chan, ...args);
+              child.webContents?.send(AFFINE_EVENT_CHANNEL_NAME, chan, ...args);
             }
           });
         });

--- a/packages/frontend/electron/src/preload/shared-storage.ts
+++ b/packages/frontend/electron/src/preload/shared-storage.ts
@@ -1,15 +1,19 @@
 import { MemoryMemento } from '@toeverything/infra';
 import { ipcRenderer } from 'electron';
 
+import { AFFINE_API_CHANNEL_NAME } from '../shared/type';
+
 const initialGlobalState = ipcRenderer.sendSync(
+  AFFINE_API_CHANNEL_NAME,
   'sharedStorage:getAllGlobalState'
 );
 const initialGlobalCache = ipcRenderer.sendSync(
+  AFFINE_API_CHANNEL_NAME,
   'sharedStorage:getAllGlobalCache'
 );
 
 function invokeWithCatch(key: string, ...args: any[]) {
-  ipcRenderer.invoke(key, ...args).catch(err => {
+  ipcRenderer.invoke(AFFINE_API_CHANNEL_NAME, key, ...args).catch(err => {
     console.error(`Failed to invoke ${key}`, err);
   });
 }

--- a/packages/frontend/electron/src/shared/type.ts
+++ b/packages/frontend/electron/src/shared/type.ts
@@ -27,3 +27,6 @@ export type MainToHelper = Pick<
   | 'showItemInFolder'
   | 'getPath'
 >;
+
+export const AFFINE_API_CHANNEL_NAME = 'affine-ipc-api';
+export const AFFINE_EVENT_CHANNEL_NAME = 'affine-ipc-event';


### PR DESCRIPTION
previously there are quite a lot of api/events handlers registered on ipcMain/ipcRenderer. After this PR, the number should be significantly reduced, which will benefit performance.