### PR TITLE
fix: render ai chat block in embed doc and surface ref

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/index.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/index.tsx
@@ -1,3 +1,4 @@
 export * from './blocksuite-editor';
 
 import './ai/setup-provider';
+import './specs/preview';

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/preview.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/preview.ts
@@ -1,0 +1,13 @@
+import type { BlockSpec } from '@blocksuite/block-std';
+import { SpecProvider } from '@blocksuite/blocks';
+import { AIChatBlockSpec, EdgelessAIChatBlockSpec } from '@blocksuite/presets';
+
+const CustomSpecs: BlockSpec[] = [AIChatBlockSpec, EdgelessAIChatBlockSpec];
+
+function patchPreviewSpec(id: string, specs: BlockSpec[]) {
+  const specProvider = SpecProvider.getInstance();
+  specProvider.extendSpec(id, specs);
+}
+
+// Patch edgeless preview spec for blocksuite surface-ref and embed-synced-doc
+patchPreviewSpec('edgeless:preview', CustomSpecs);


### PR DESCRIPTION
[BS-1017](https://linear.app/affine-design/issue/BS-1017/含有chat-block的页面被embed时，embed预览不会渲染chatblock)

related: https://github.com/toeverything/blocksuite/pull/7845