### PR TITLE
fix(core): can not get chrome version in desktop mode in iOS

### DIFF
--- a/packages/common/env/src/ua-helper.ts
+++ b/packages/common/env/src/ua-helper.ts
@@ -1,5 +1,3 @@
-import { assertExists } from '@blocksuite/global/utils';
-
 export class UaHelper {
   private readonly uaMap;
   public isLinux = false;
@@ -12,8 +10,14 @@ export class UaHelper {
   public isIOS = false;
 
   getChromeVersion = (): number => {
-    const raw = this.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
-    assertExists(raw);
+    let raw = this.navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
+    if (!raw) {
+      raw = this.navigator.userAgent.match(/(CriOS)\/([0-9]+)/);
+    }
+    if (!raw) {
+      console.error('Cannot get chrome version');
+      return 0;
+    }
     return parseInt(raw[2], 10);
   };
 


### PR DESCRIPTION
When set iOS chrome to desktop mode, the ua will be like:
```
Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/127 Version/11.1.1 Safari/605.1.15
```

The `CriOS/127` can not be tested by the following code, which make app crash

https://github.com/toeverything/AFFiNE/blob/fd6e19829550d983cb4a3640f05a8dd8f50c92b6/packages/common/env/src/ua-helper.ts#L14-L18