### PR TITLE
fix(electron): cmd+num not working on mac

### DIFF
--- a/packages/frontend/electron/src/main/application-menu/create.ts
+++ b/packages/frontend/electron/src/main/application-menu/create.ts
@@ -139,22 +139,19 @@ export function createApplicationMenu() {
             undoCloseTab().catch(console.error);
           },
         },
-        {
-          label: 'Switch to tab',
-          acceleratorWorksWhenHidden: true,
-          visible: false,
-          submenu: [1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => {
-            const shortcut = `CommandOrControl+${n}`;
-            const listener = () => {
-              switchTab(n);
-            };
-            return {
-              label: `Switch to tab ${n}`,
-              accelerator: shortcut,
-              click: listener,
-            };
-          }),
-        },
+        ...[1, 2, 3, 4, 5, 6, 7, 8, 9].map(n => {
+          const shortcut = `CommandOrControl+${n}`;
+          const listener = () => {
+            switchTab(n);
+          };
+          return {
+            acceleratorWorksWhenHidden: true,
+            label: `Switch to tab ${n}`,
+            accelerator: shortcut,
+            click: listener,
+            visible: false,
+          };
+        }),
       ],
     },
     {

--- a/tests/affine-desktop/e2e/tabs.spec.ts
+++ b/tests/affine-desktop/e2e/tabs.spec.ts
@@ -154,7 +154,9 @@ async function enableSplitView(page: Page) {
       })
     );
   });
-  await page.reload();
+  await page.reload({
+    timeout: 30000,
+  });
 }
 
 test('open new tab via cmd+click page link', async ({ page }) => {


### PR DESCRIPTION
fix AF-1248
hidden menu group + acceleratorWorksWhenHidden does not work on mac

