### PR TITLE
fix: remove unused variables

### DIFF
--- a/packages/backend/server/src/core/auth/service.ts
+++ b/packages/backend/server/src/core/auth/service.ts
@@ -83,7 +83,7 @@ export class AuthService implements OnApplicationBootstrap {
         await this.quota.switchUserQuota(devUser.id, QuotaType.ProPlanV1);
         await this.feature.addAdmin(devUser.id);
         await this.feature.addCopilot(devUser.id);
-      } catch (e) {
+      } catch {
         // ignore
       }
     }

--- a/packages/backend/server/src/core/quota/service.ts
+++ b/packages/backend/server/src/core/quota/service.ts
@@ -69,7 +69,7 @@ export class QuotaService {
             ...quota,
             feature: await QuotaConfig.get(this.prisma, quota.featureId),
           };
-        } catch (_) {}
+        } catch {}
         return null as unknown as typeof quota & {
           feature: QuotaConfig;
         };

--- a/packages/backend/server/src/core/utils/doc.ts
+++ b/packages/backend/server/src/core/utils/doc.ts
@@ -21,7 +21,7 @@ export class DocID {
   static parse(raw: string): DocID | null {
     try {
       return new DocID(raw);
-    } catch (e) {
+    } catch {
       return null;
     }
   }

--- a/packages/backend/server/src/core/workspaces/controller.ts
+++ b/packages/backend/server/src/core/workspaces/controller.ts
@@ -140,7 +140,7 @@ export class WorkspacesController {
     let ts;
     try {
       ts = new Date(timestamp);
-    } catch (e) {
+    } catch {
       throw new InvalidHistoryTimestamp({ timestamp });
     }
 

--- a/packages/backend/server/src/fundamentals/helpers/url.ts
+++ b/packages/backend/server/src/fundamentals/helpers/url.ts
@@ -89,7 +89,7 @@ export class URLHelper {
       if (!['http:', 'https:'].includes(url.protocol)) return false;
       if (!url.hostname) return false;
       return true;
-    } catch (_) {
+    } catch {
       return false;
     }
   }

--- a/packages/backend/server/src/fundamentals/storage/providers/fs.ts
+++ b/packages/backend/server/src/fundamentals/storage/providers/fs.ts
@@ -123,7 +123,7 @@ export class FsStorageProvider implements StorageProvider {
             });
           }
         }
-      } catch (e) {
+      } catch {
         // failed to read dir, stop recursion
       }
     }

--- a/packages/backend/server/src/fundamentals/storage/providers/utils.ts
+++ b/packages/backend/server/src/fundamentals/storage/providers/utils.ts
@@ -42,7 +42,7 @@ export async function autoMetadata(
     }
 
     return metadata;
-  } catch (e) {
+  } catch {
     return metadata;
   }
 }

--- a/packages/backend/server/src/plugins/copilot/workflow/executor/check-html.ts
+++ b/packages/backend/server/src/plugins/copilot/workflow/executor/check-html.ts
@@ -43,7 +43,7 @@ export class CopilotCheckHtmlExecutor extends AutoRegisteredWorkflowExecutor {
         }
       }
       return false;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/packages/backend/server/src/plugins/copilot/workflow/executor/check-json.ts
+++ b/packages/backend/server/src/plugins/copilot/workflow/executor/check-json.ts
@@ -34,7 +34,7 @@ export class CopilotCheckJsonExecutor extends AutoRegisteredWorkflowExecutor {
         return true;
       }
       return false;
-    } catch (e) {
+    } catch {
       return false;
     }
   }

--- a/packages/common/infra/src/app-config-storage.ts
+++ b/packages/common/infra/src/app-config-storage.ts
@@ -64,7 +64,7 @@ class Storage<T extends object> {
           return this._options.config;
         }
         return cfg;
-      } catch (err) {
+      } catch {
         return this._cfg;
       }
     } else {

--- a/packages/common/infra/src/framework/core/framework.ts
+++ b/packages/common/infra/src/framework/core/framework.ts
@@ -521,7 +521,7 @@ function isConstructor(cls: any) {
   try {
     Reflect.construct(function () {}, [], cls);
     return true;
-  } catch (error) {
+  } catch {
     return false;
   }
 }

--- a/packages/frontend/component/src/components/auth-components/onboarding-page.tsx
+++ b/packages/frontend/component/src/components/auth-components/onboarding-page.tsx
@@ -45,7 +45,7 @@ function getCallbackUrl(location: Location) {
       const parsedUrl = new URL(url);
       return parsedUrl.pathname + parsedUrl.search;
     }
-  } catch (_) {}
+  } catch {}
   return null;
 }
 

--- a/packages/frontend/core/src/hooks/affine/use-share-url.ts
+++ b/packages/frontend/core/src/hooks/affine/use-share-url.ts
@@ -49,7 +49,7 @@ const generateUrl = ({
       url.searchParams.append('xywh', xywh);
     }
     return url.toString();
-  } catch (e) {
+  } catch {
     return null;
   }
 };

--- a/packages/frontend/core/src/modules/cloud/services/fetch.ts
+++ b/packages/frontend/core/src/modules/cloud/services/fetch.ts
@@ -72,7 +72,7 @@ export class FetchService extends Service {
       if (res.headers.get('Content-Type')?.includes('application/json')) {
         try {
           reason = await res.json();
-        } catch (err) {
+        } catch {
           // ignore
         }
       }

--- a/packages/frontend/core/src/pages/magic-link.tsx
+++ b/packages/frontend/core/src/pages/magic-link.tsx
@@ -24,7 +24,7 @@ export const loader: LoaderFunction = async ({ request }) => {
     try {
       const { message } = await res.json();
       error = message;
-    } catch (e) {
+    } catch {
       error = 'failed to verify sign-in token';
     }
     return redirect(`/signIn?error=${encodeURIComponent(error)}`);

--- a/packages/frontend/core/src/utils/navigable-history.ts
+++ b/packages/frontend/core/src/utils/navigable-history.ts
@@ -187,7 +187,7 @@ function warning(cond: any, message: string) {
       // enabling "pause on exceptions" in your JavaScript debugger.
       throw new Error(message);
       // eslint-disable-next-line no-empty
-    } catch (e) {}
+    } catch {}
   }
 }
 

--- a/packages/frontend/electron/scripts/generate-yml.js
+++ b/packages/frontend/electron/scripts/generate-yml.js
@@ -32,7 +32,7 @@ const generateYml = platform => {
         sha512: hash,
         size: size,
       });
-    } catch (e) {}
+    } catch {}
   });
   // path & sha512 are deprecated
   yml.path = yml.files[0].url;

--- a/packages/frontend/i18n/src/scripts/download.ts
+++ b/packages/frontend/i18n/src/scripts/download.ts
@@ -49,7 +49,7 @@ const getBaseTranslations = async (baseLanguage: { tag: string }) => {
 const main = async () => {
   try {
     await fs.access(RES_DIR);
-  } catch (error) {
+  } catch {
     fs.mkdir(RES_DIR).catch(console.error);
     console.log('Create directory', RES_DIR);
   }


### PR DESCRIPTION
## What This PR Does

Removes all declared, but unused, variables. This is part of an effort to keep Oxlint's CI pipelines green, as we are in the process of promoting [`no-unused-vars`](https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html) to correctness. Thank you for using Oxlint ❤️ 

> Note: I am the product manager of Oxlint