### PR TITLE
fix(core): use doc mode enum type

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/_common/chat-actions-handle.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/_common/chat-actions-handle.ts
@@ -5,12 +5,11 @@ import type {
   TextSelection,
 } from '@blocksuite/block-std';
 import type {
-  DocMode,
   EdgelessRootService,
   ImageSelection,
   PageRootService,
 } from '@blocksuite/blocks';
-import { BlocksUtils, NoteDisplayMode } from '@blocksuite/blocks';
+import { BlocksUtils, DocMode, NoteDisplayMode } from '@blocksuite/blocks';
 import {
   Bound,
   getElementsBound,
@@ -111,7 +110,7 @@ function getViewportCenter(
   rootService: PageRootService | EdgelessRootService
 ) {
   const center = { x: 400, y: 50 };
-  if (mode === 'page') {
+  if (mode === DocMode.Page) {
     const viewport = rootService.editPropsStore.getStorage('viewport');
     if (viewport) {
       if ('xywh' in viewport) {
@@ -310,9 +309,9 @@ const SAVE_CHAT_TO_BLOCK_ACTION: ChatAction = {
     );
     const newBlockIndex = layer.generateIndex('affine:embed-ai-chat');
     // If current mode is not edgeless, switch to edgeless mode first
-    if (curMode !== 'edgeless') {
+    if (curMode !== DocMode.Edgeless) {
       // Set mode to edgeless
-      docModeService.setMode('edgeless');
+      docModeService.setMode(DocMode.Edgeless);
       // Notify user to switch to edgeless mode
       notificationService?.notify({
         title: 'Save chat to a block',
@@ -462,7 +461,7 @@ const CREATE_AS_LINKED_DOC = {
 
     const service = host.spec.getService<EdgelessRootService>('affine:page');
     const mode = service.docModeService.getMode();
-    if (mode !== 'edgeless') {
+    if (mode !== DocMode.Edgeless) {
       return false;
     }
 

--- a/packages/frontend/core/src/blocksuite/presets/ai/entries/edgeless/index.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/entries/edgeless/index.ts
@@ -4,7 +4,7 @@ import type {
   EdgelessElementToolbarWidget,
   EdgelessRootBlockComponent,
 } from '@blocksuite/blocks';
-import { EdgelessCopilotToolbarEntry } from '@blocksuite/blocks';
+import { DocMode, EdgelessCopilotToolbarEntry } from '@blocksuite/blocks';
 import { noop } from '@blocksuite/global/utils';
 import { html } from 'lit';
 
@@ -27,7 +27,7 @@ export function setupEdgelessElementToolbarEntry(
       const chain = edgeless.service.std.command.chain();
       const filteredGroups = edgelessActionGroups.reduce((pre, group) => {
         const filtered = group.items.filter(item =>
-          item.showWhen?.(chain, 'edgeless', edgeless.host)
+          item.showWhen?.(chain, DocMode.Edgeless, edgeless.host)
         );
 
         if (filtered.length > 0) pre.push({ ...group, items: filtered });

--- a/packages/frontend/core/src/bootstrap/first-app-data.ts
+++ b/packages/frontend/core/src/bootstrap/first-app-data.ts
@@ -2,7 +2,7 @@ import { DebugLogger } from '@affine/debug';
 import { DEFAULT_WORKSPACE_NAME } from '@affine/env/constant';
 import { WorkspaceFlavour } from '@affine/env/workspace';
 import onboardingUrl from '@affine/templates/onboarding.zip';
-import { ZipTransformer } from '@blocksuite/blocks';
+import { DocMode, ZipTransformer } from '@blocksuite/blocks';
 import type { WorkspacesService } from '@toeverything/infra';
 import { DocsService, initEmptyPage } from '@toeverything/infra';
 
@@ -31,7 +31,7 @@ export async function buildShowcaseWorkspace(
   );
 
   if (defaultDoc) {
-    defaultDoc.setPrimaryMode('edgeless');
+    defaultDoc.setPrimaryMode(DocMode.Edgeless);
   }
 
   dispose();

--- a/packages/frontend/core/src/commands/affine-creation.tsx
+++ b/packages/frontend/core/src/commands/affine-creation.tsx
@@ -1,4 +1,5 @@
 import type { useI18n } from '@affine/i18n';
+import { DocMode } from '@blocksuite/blocks';
 import { ImportIcon, PlusIcon } from '@blocksuite/icons/rc';
 
 import type { usePageHelper } from '../components/blocksuite/block-suite-page-list/utils';
@@ -31,7 +32,7 @@ export function registerAffineCreationCommands({
       run() {
         track.$.cmdk.creation.createDoc({ mode: 'page' });
 
-        pageHelper.createPage('page');
+        pageHelper.createPage(DocMode.Page);
       },
     })
   );

--- a/packages/frontend/core/src/components/affine/page-history-modal/history-modal.tsx
+++ b/packages/frontend/core/src/components/affine/page-history-modal/history-modal.tsx
@@ -9,16 +9,12 @@ import { EditorService } from '@affine/core/modules/editor';
 import { WorkspacePermissionService } from '@affine/core/modules/permissions';
 import { WorkspaceQuotaService } from '@affine/core/modules/quota';
 import { i18nTime, Trans, useI18n } from '@affine/i18n';
+import type { DocMode } from '@blocksuite/blocks';
 import { CloseIcon, ToggleCollapseIcon } from '@blocksuite/icons/rc';
 import type { Doc as BlockSuiteDoc, DocCollection } from '@blocksuite/store';
 import * as Collapsible from '@radix-ui/react-collapsible';
 import type { DialogContentProps } from '@radix-ui/react-dialog';
-import {
-  type DocMode,
-  useLiveData,
-  useService,
-  WorkspaceService,
-} from '@toeverything/infra';
+import { useLiveData, useService, WorkspaceService } from '@toeverything/infra';
 import { atom, useAtom, useSetAtom } from 'jotai';
 import type { PropsWithChildren } from 'react';
 import {

--- a/packages/frontend/core/src/components/affine/setting-modal/general-setting/editor/general.tsx
+++ b/packages/frontend/core/src/components/affine/setting-modal/general-setting/editor/general.tsx
@@ -23,8 +23,9 @@ import {
   SystemFontFamilyService,
 } from '@affine/core/modules/system-font-family';
 import { useI18n } from '@affine/i18n';
+import type { DocMode } from '@blocksuite/blocks';
 import { DoneIcon, SearchIcon } from '@blocksuite/icons/rc';
-import { type DocMode, useLiveData, useServices } from '@toeverything/infra';
+import { useLiveData, useServices } from '@toeverything/infra';
 import clsx from 'clsx';
 import {
   type ChangeEvent,

--- a/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-page.tsx
+++ b/packages/frontend/core/src/components/affine/share-page-modal/share-menu/share-page.tsx
@@ -10,8 +10,8 @@ import { EditorService } from '@affine/core/modules/editor';
 import { WorkspacePermissionService } from '@affine/core/modules/permissions';
 import { ShareInfoService } from '@affine/core/modules/share-doc';
 import { WorkspaceFlavour } from '@affine/env/workspace';
-import { PublicPageMode } from '@affine/graphql';
 import { useI18n } from '@affine/i18n';
+import { DocMode } from '@blocksuite/blocks';
 import {
   BlockIcon,
   CollaborationIcon,
@@ -93,7 +93,7 @@ export const AFFiNESharePage = (props: ShareMenuProps) => {
     }
     try {
       // TODO(@JimmFly): remove mode when we have a better way to handle it
-      await shareInfoService.shareInfo.enableShare(PublicPageMode.Page);
+      await shareInfoService.shareInfo.enableShare(DocMode.Page);
       track.$.sharePanel.$.createShareLink();
       notify.success({
         title:
@@ -158,10 +158,10 @@ export const AFFiNESharePage = (props: ShareMenuProps) => {
   });
 
   const onCopyPageLink = useCallback(() => {
-    onClickCopyLink('page');
+    onClickCopyLink(DocMode.Page);
   }, [onClickCopyLink]);
   const onCopyEdgelessLink = useCallback(() => {
-    onClickCopyLink('edgeless');
+    onClickCopyLink(DocMode.Edgeless);
   }, [onClickCopyLink]);
   const onCopyBlockLink = useCallback(() => {
     // TODO(@JimmFly): handle frame

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor-container.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor-container.tsx
@@ -121,7 +121,7 @@ export const BlocksuiteEditorContainer = forwardRef<
         return page;
       },
       get host() {
-        return mode === 'page'
+        return mode === DocMode.Page
           ? docRef.current?.host
           : edgelessRef.current?.host;
       },
@@ -129,7 +129,7 @@ export const BlocksuiteEditorContainer = forwardRef<
         return page.root as any;
       },
       get updateComplete() {
-        return mode === 'page'
+        return mode === DocMode.Page
           ? docRef.current?.updateComplete
           : edgelessRef.current?.updateComplete;
       },
@@ -214,7 +214,7 @@ export const BlocksuiteEditorContainer = forwardRef<
       style={style}
       ref={rootRef}
     >
-      {mode === 'page' ? (
+      {mode === DocMode.Page ? (
         <BlocksuiteDocEditor shared={shared} page={page} ref={docRef} />
       ) : (
         <BlocksuiteEdgelessEditor

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor.tsx
@@ -1,4 +1,5 @@
 import { EditorLoading } from '@affine/component/page-detail-skeleton';
+import type { DocMode } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import type { AffineEditorContainer } from '@blocksuite/presets';
 import type { Doc } from '@blocksuite/store';
@@ -22,7 +23,7 @@ export type ErrorBoundaryProps = {
 
 export type EditorProps = {
   page: Doc;
-  mode: 'page' | 'edgeless';
+  mode: DocMode;
   shared?: boolean;
   // on Editor instance instantiated
   onLoadEditor?: (editor: AffineEditorContainer) => () => void;

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -24,6 +24,7 @@ import type { BlockSpec, WidgetComponent } from '@blocksuite/block-std';
 import {
   type AffineReference,
   AffineSlashMenuWidget,
+  DocMode,
   EdgelessRootBlockComponent,
   EmbedLinkedDocBlockComponent,
   type ParagraphBlockService,
@@ -33,7 +34,6 @@ import { LinkIcon } from '@blocksuite/icons/rc';
 import { AIChatBlockSchema } from '@blocksuite/presets';
 import type { BlockSnapshot } from '@blocksuite/store';
 import {
-  type DocMode,
   type DocService,
   DocsService,
   type FrameworkProvider,
@@ -275,7 +275,7 @@ export function patchDocModeService(
   }
 
   patchSpecService(rootSpec, pageService => {
-    const DEFAULT_MODE = 'page';
+    const DEFAULT_MODE = DocMode.Page;
     pageService.docModeService = {
       setMode: (mode: DocMode, id?: string) => {
         if (id) {
@@ -409,8 +409,8 @@ export function patchQuickSearchService(
                     const docsService = framework.get(DocsService);
                     const mode =
                       result.id === 'creation:create-edgeless'
-                        ? 'edgeless'
-                        : 'page';
+                        ? DocMode.Edgeless
+                        : DocMode.Page;
                     const newDoc = docsService.createDoc({
                       primaryMode: mode,
                       title: result.payload.title,

--- a/packages/frontend/core/src/components/blocksuite/block-suite-mode-switch/index.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-mode-switch/index.tsx
@@ -3,8 +3,9 @@ import { registerAffineCommand } from '@affine/core/commands';
 import { track } from '@affine/core/mixpanel';
 import { EditorService } from '@affine/core/modules/editor';
 import { useI18n } from '@affine/i18n';
+import { DocMode } from '@blocksuite/blocks';
 import { EdgelessIcon, PageIcon } from '@blocksuite/icons/rc';
-import { type DocMode, useLiveData, useService } from '@toeverything/infra';
+import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback, useEffect, useMemo } from 'react';
 
 import { switchItem } from './style.css';
@@ -37,24 +38,24 @@ export const EditorModeSwitch = () => {
   const currentMode = useLiveData(editor.mode$);
 
   const togglePage = useCallback(() => {
-    if (currentMode === 'page' || isSharedMode || trash) return;
-    editor.setMode('page');
-    editor.doc.setPrimaryMode('page');
+    if (currentMode === DocMode.Page || isSharedMode || trash) return;
+    editor.setMode(DocMode.Page);
+    editor.doc.setPrimaryMode(DocMode.Page);
     toast(t['com.affine.toastMessage.pageMode']());
     track.$.header.actions.switchPageMode({ mode: 'page' });
   }, [currentMode, editor, isSharedMode, t, trash]);
 
   const toggleEdgeless = useCallback(() => {
-    if (currentMode === 'edgeless' || isSharedMode || trash) return;
-    editor.setMode('edgeless');
-    editor.doc.setPrimaryMode('edgeless');
+    if (currentMode === DocMode.Edgeless || isSharedMode || trash) return;
+    editor.setMode(DocMode.Edgeless);
+    editor.doc.setPrimaryMode(DocMode.Edgeless);
     toast(t['com.affine.toastMessage.edgelessMode']());
     track.$.header.actions.switchPageMode({ mode: 'edgeless' });
   }, [currentMode, editor, isSharedMode, t, trash]);
 
   const onModeChange = useCallback(
     (mode: DocMode) => {
-      mode === 'page' ? togglePage() : toggleEdgeless();
+      mode === DocMode.Page ? togglePage() : toggleEdgeless();
     },
     [toggleEdgeless, togglePage]
   );
@@ -78,7 +79,10 @@ export const EditorModeSwitch = () => {
         binding: 'Alt+KeyS',
         capture: true,
       },
-      run: () => onModeChange(currentMode === 'edgeless' ? 'page' : 'edgeless'),
+      run: () =>
+        onModeChange(
+          currentMode === DocMode.Edgeless ? DocMode.Page : DocMode.Edgeless
+        ),
     });
   }, [currentMode, isSharedMode, onModeChange, t, trash]);
 
@@ -93,8 +97,8 @@ export const EditorModeSwitch = () => {
         <PureEditorModeSwitch
           mode={currentMode}
           setMode={onModeChange}
-          hidePage={shouldHide('page')}
-          hideEdgeless={shouldHide('edgeless')}
+          hidePage={shouldHide(DocMode.Page)}
+          hideEdgeless={shouldHide(DocMode.Edgeless)}
         />
       </div>
     </Tooltip>

--- a/packages/frontend/core/src/components/blocksuite/block-suite-page-list/utils.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-page-list/utils.tsx
@@ -2,8 +2,8 @@ import { toast } from '@affine/component';
 import { useDocCollectionHelper } from '@affine/core/hooks/use-block-suite-workspace-helper';
 import { EditorSettingService } from '@affine/core/modules/editor-settting';
 import { WorkbenchService } from '@affine/core/modules/workbench';
+import { DocMode } from '@blocksuite/blocks';
 import {
-  type DocMode,
   DocsService,
   initEmptyPage,
   useLiveData,
@@ -41,7 +41,7 @@ export const usePageHelper = (docCollection: DocCollection) => {
 
   const createEdgelessAndOpen = useCallback(
     (open?: boolean | 'new-tab') => {
-      return createPageAndOpen('edgeless', open);
+      return createPageAndOpen(DocMode.Edgeless, open);
     },
     [createPageAndOpen]
   );

--- a/packages/frontend/core/src/components/cloud/share-header-right-item/index.tsx
+++ b/packages/frontend/core/src/components/cloud/share-header-right-item/index.tsx
@@ -1,5 +1,6 @@
 import { AuthService } from '@affine/core/modules/cloud';
-import { type DocMode, useLiveData, useService } from '@toeverything/infra';
+import type { DocMode } from '@blocksuite/blocks';
+import { useLiveData, useService } from '@toeverything/infra';
 
 import { PresentButton } from './present';
 import { SignIn } from './sign-in';

--- a/packages/frontend/core/src/components/page-list/docs/page-list-header.tsx
+++ b/packages/frontend/core/src/components/page-list/docs/page-list-header.tsx
@@ -13,6 +13,7 @@ import { TagService } from '@affine/core/modules/tag';
 import { isNewTabTrigger } from '@affine/core/utils';
 import type { Collection } from '@affine/env/filter';
 import { useI18n } from '@affine/i18n';
+import { DocMode } from '@blocksuite/blocks';
 import {
   ArrowDownSmallIcon,
   SearchIcon,
@@ -79,7 +80,7 @@ export const PageListHeader = () => {
           createEdgeless(isNewTabTrigger(e) ? 'new-tab' : true)
         }
         onCreatePage={e =>
-          createPage('page', isNewTabTrigger(e) ? 'new-tab' : true)
+          createPage(DocMode.Page, isNewTabTrigger(e) ? 'new-tab' : true)
         }
         onCreateDoc={e =>
           createPage(undefined, isNewTabTrigger(e) ? 'new-tab' : true)
@@ -144,7 +145,10 @@ export const CollectionPageListHeader = ({
     [openConfirmModal, t, createAndAddDocument]
   );
 
-  const createPageModeDoc = useCallback(() => createPage('page'), [createPage]);
+  const createPageModeDoc = useCallback(
+    () => createPage(DocMode.Page),
+    [createPage]
+  );
 
   const onCreateEdgeless = useCallback(
     () => onConfirmAddDocument(createEdgeless),

--- a/packages/frontend/core/src/hooks/affine/use-block-suite-meta-helper.ts
+++ b/packages/frontend/core/src/hooks/affine/use-block-suite-meta-helper.ts
@@ -2,6 +2,7 @@ import { useAsyncCallback } from '@affine/core/hooks/affine-async-hooks';
 import { useDocMetaHelper } from '@affine/core/hooks/use-block-suite-page-meta';
 import { useDocCollectionHelper } from '@affine/core/hooks/use-block-suite-workspace-helper';
 import { CollectionService } from '@affine/core/modules/collection';
+import { DocMode } from '@blocksuite/blocks';
 import { DocsService, useService } from '@toeverything/infra';
 import { useCallback } from 'react';
 import { applyUpdate, encodeStateAsUpdate } from 'yjs';
@@ -102,7 +103,7 @@ export function useBlockSuiteMetaHelper(docCollection: DocCollection) {
 
       pageRecordList
         .doc$(newPage.id)
-        .value?.setPrimaryMode(currentPagePrimaryMode || 'page');
+        .value?.setPrimaryMode(currentPagePrimaryMode || DocMode.Page);
       setDocTitle(newPage.id, newPageTitle);
       openPageAfterDuplication && openPage(docCollection.id, newPage.id);
     },

--- a/packages/frontend/core/src/hooks/affine/use-is-shared-page.tsx
+++ b/packages/frontend/core/src/hooks/affine/use-is-shared-page.tsx
@@ -7,8 +7,9 @@ import {
   revokePublicPageMutation,
 } from '@affine/graphql';
 import { type I18nKeys, useI18n } from '@affine/i18n';
+import { DocMode } from '@blocksuite/blocks';
 import { SingleSelectSelectSolidIcon } from '@blocksuite/icons/rc';
-import type { DocMode, Workspace } from '@toeverything/infra';
+import type { Workspace } from '@toeverything/infra';
 import { cssVar } from '@toeverything/theme';
 import { useCallback, useMemo } from 'react';
 
@@ -84,18 +85,24 @@ export function useIsSharedPage(
     );
     const isPageShared = !!publicPage;
 
-    const currentShareMode: DocMode =
-      publicPage?.mode === PublicPageMode.Edgeless ? 'edgeless' : 'page';
+    const currentShareMode =
+      publicPage?.mode === PublicPageMode.Edgeless
+        ? DocMode.Edgeless
+        : DocMode.Page;
 
     return [isPageShared, currentShareMode];
   }, [data?.workspace.publicPages, pageId]);
 
   const enableShare = useCallback(
     (mode: DocMode) => {
-      const publishMode =
-        mode === 'edgeless' ? PublicPageMode.Edgeless : PublicPageMode.Page;
-
-      enableSharePage({ workspaceId, pageId, mode: publishMode })
+      enableSharePage({
+        workspaceId,
+        pageId,
+        mode:
+          mode === DocMode.Edgeless
+            ? PublicPageMode.Edgeless
+            : PublicPageMode.Page,
+      })
         .then(() => {
           notify.success({
             title: t[notificationToI18nKey['enableSuccessTitle']](),
@@ -120,10 +127,14 @@ export function useIsSharedPage(
 
   const changeShare = useCallback(
     (mode: DocMode) => {
-      const publishMode =
-        mode === 'edgeless' ? PublicPageMode.Edgeless : PublicPageMode.Page;
-
-      enableSharePage({ workspaceId, pageId, mode: publishMode })
+      enableSharePage({
+        workspaceId,
+        pageId,
+        mode:
+          mode === DocMode.Edgeless
+            ? PublicPageMode.Edgeless
+            : PublicPageMode.Page,
+      })
         .then(() => {
           notify.success({
             title: t[notificationToI18nKey['changeSuccessTitle']](),
@@ -131,13 +142,9 @@ export function useIsSharedPage(
               'com.affine.share-menu.confirm-modify-mode.notification.success.message'
             ]({
               preMode:
-                publishMode === PublicPageMode.Edgeless
-                  ? t['Page']()
-                  : t['Edgeless'](),
+                mode === DocMode.Edgeless ? t['Page']() : t['Edgeless'](),
               currentMode:
-                publishMode === PublicPageMode.Edgeless
-                  ? t['Edgeless']()
-                  : t['Page'](),
+                mode === DocMode.Edgeless ? t['Edgeless']() : t['Page'](),
             }),
             style: 'normal',
             icon: (
@@ -210,7 +217,8 @@ export function usePublicPages(workspace: Workspace) {
     () =>
       maybeData?.workspace.publicPages.map(i => ({
         id: i.id,
-        mode: i.mode === PublicPageMode.Edgeless ? 'edgeless' : 'page',
+        mode:
+          i.mode === PublicPageMode.Edgeless ? DocMode.Edgeless : DocMode.Page,
       })) ?? [],
     [maybeData?.workspace.publicPages]
   );

--- a/packages/frontend/core/src/hooks/affine/use-share-url.ts
+++ b/packages/frontend/core/src/hooks/affine/use-share-url.ts
@@ -3,7 +3,7 @@ import { track } from '@affine/core/mixpanel';
 import { getAffineCloudBaseUrl } from '@affine/core/modules/cloud/services/fetch';
 import { useI18n } from '@affine/i18n';
 import type { BaseSelection } from '@blocksuite/block-std';
-import { type DocMode } from '@toeverything/infra';
+import type { DocMode } from '@blocksuite/blocks';
 import { useCallback } from 'react';
 
 import { useActiveBlocksuiteEditor } from '../use-block-suite-editor';

--- a/packages/frontend/core/src/hooks/use-navigate-helper.ts
+++ b/packages/frontend/core/src/hooks/use-navigate-helper.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceSubPath } from '@affine/core/shared';
-import type { DocMode } from '@toeverything/infra';
+import type { DocMode } from '@blocksuite/blocks';
 import { createContext, useCallback, useContext, useMemo } from 'react';
 import type { NavigateFunction, NavigateOptions } from 'react-router-dom';
 

--- a/packages/frontend/core/src/layouts/workspace-layout.tsx
+++ b/packages/frontend/core/src/layouts/workspace-layout.tsx
@@ -4,9 +4,8 @@ import {
   resolveGlobalLoadingEventAtom,
 } from '@affine/component/global-loading';
 import { useI18n } from '@affine/i18n';
-import { ZipTransformer } from '@blocksuite/blocks';
+import { type DocMode, ZipTransformer } from '@blocksuite/blocks';
 import {
-  type DocMode,
   DocsService,
   effect,
   fromPromise,

--- a/packages/frontend/core/src/modules/editor-settting/schema.ts
+++ b/packages/frontend/core/src/modules/editor-settting/schema.ts
@@ -1,3 +1,4 @@
+import { DocMode } from '@blocksuite/blocks';
 import { z } from 'zod';
 
 export type FontFamily = 'Sans' | 'Serif' | 'Mono' | 'Custom';
@@ -29,7 +30,7 @@ const BSEditorSettingSchema = z.object({
 const AffineEditorSettingSchema = z.object({
   fontFamily: z.enum(['Sans', 'Serif', 'Mono', 'Custom']).default('Sans'),
   customFontFamily: z.string().default(''),
-  newDocDefaultMode: z.enum(['edgeless', 'page']).default('page'),
+  newDocDefaultMode: z.nativeEnum(DocMode).default(DocMode.Page),
   spellCheck: z.boolean().default(false),
   fullWidthLayout: z.boolean().default(false),
   displayDocInfo: z.boolean().default(true),

--- a/packages/frontend/core/src/modules/peek-view/view/peek-view-controls.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/peek-view-controls.tsx
@@ -1,12 +1,13 @@
 import { IconButton } from '@affine/component';
 import { useI18n } from '@affine/i18n';
+import type { DocMode } from '@blocksuite/blocks';
 import {
   CloseIcon,
   ExpandFullIcon,
   OpenInNewIcon,
   SplitViewIcon,
 } from '@blocksuite/icons/rc';
-import { type DocMode, useService } from '@toeverything/infra';
+import { useService } from '@toeverything/infra';
 import { clsx } from 'clsx';
 import {
   type HTMLAttributes,

--- a/packages/frontend/core/src/modules/peek-view/view/utils.ts
+++ b/packages/frontend/core/src/modules/peek-view/view/utils.ts
@@ -1,4 +1,5 @@
-import type { Doc, DocMode } from '@toeverything/infra';
+import type { DocMode } from '@blocksuite/blocks';
+import type { Doc } from '@toeverything/infra';
 import {
   DocsService,
   useLiveData,

--- a/packages/frontend/core/src/modules/quicksearch/impls/commands.ts
+++ b/packages/frontend/core/src/modules/quicksearch/impls/commands.ts
@@ -4,7 +4,8 @@ import {
   type CommandCategory,
   PreconditionStrategy,
 } from '@affine/core/commands';
-import type { DocMode, GlobalContextService } from '@toeverything/infra';
+import { DocMode } from '@blocksuite/blocks';
+import type { GlobalContextService } from '@toeverything/infra';
 import { Entity, LiveData } from '@toeverything/infra';
 import Fuse from 'fuse.js';
 
@@ -100,17 +101,17 @@ const categories = {
 function filterCommandByContext(
   command: AffineCommand,
   context: {
-    docMode: DocMode | undefined;
+    docMode?: DocMode;
   }
 ) {
   if (command.preconditionStrategy === PreconditionStrategy.Always) {
     return true;
   }
   if (command.preconditionStrategy === PreconditionStrategy.InEdgeless) {
-    return context.docMode === 'edgeless';
+    return context.docMode === DocMode.Edgeless;
   }
   if (command.preconditionStrategy === PreconditionStrategy.InPaper) {
-    return context.docMode === 'page';
+    return context.docMode === DocMode.Page;
   }
   if (command.preconditionStrategy === PreconditionStrategy.InPaperOrEdgeless) {
     return !!context.docMode;

--- a/packages/frontend/core/src/modules/quicksearch/impls/creation.ts
+++ b/packages/frontend/core/src/modules/quicksearch/impls/creation.ts
@@ -1,5 +1,6 @@
+import { DocMode } from '@blocksuite/blocks';
 import { EdgelessIcon, PageIcon } from '@blocksuite/icons/rc';
-import { type DocMode, Entity, LiveData } from '@toeverything/infra';
+import { Entity, LiveData } from '@toeverything/infra';
 
 import type { QuickSearchSession } from '../providers/quick-search-provider';
 import type { QuickSearchGroup } from '../types/group';
@@ -34,7 +35,7 @@ export class CreationQuickSearchSession
         },
         group,
         icon: PageIcon,
-        payload: { mode: 'edgeless', title: query },
+        payload: { mode: DocMode.Edgeless, title: query },
       },
       {
         id: 'creation:create-edgeless',
@@ -45,7 +46,7 @@ export class CreationQuickSearchSession
         },
         group,
         icon: EdgelessIcon,
-        payload: { mode: 'edgeless', title: query },
+        payload: { mode: DocMode.Edgeless, title: query },
       },
     ] as QuickSearchItem<'creation', { title: string; mode: DocMode }>[];
   });

--- a/packages/frontend/core/src/modules/quicksearch/services/cmdk.ts
+++ b/packages/frontend/core/src/modules/quicksearch/services/cmdk.ts
@@ -1,4 +1,5 @@
 import { track } from '@affine/core/mixpanel';
+import { DocMode } from '@blocksuite/blocks';
 import type { DocsService } from '@toeverything/infra';
 import { Service } from '@toeverything/infra';
 
@@ -67,13 +68,13 @@ export class CMDKQuickSearchService extends Service {
           } else if (result.source === 'creation') {
             if (result.id === 'creation:create-page') {
               const newDoc = this.docsService.createDoc({
-                primaryMode: 'page',
+                primaryMode: DocMode.Page,
                 title: result.payload.title,
               });
               this.workbenchService.workbench.openDoc(newDoc.id);
             } else if (result.id === 'creation:create-edgeless') {
               const newDoc = this.docsService.createDoc({
-                primaryMode: 'edgeless',
+                primaryMode: DocMode.Edgeless,
                 title: result.payload.title,
               });
               this.workbenchService.workbench.openDoc(newDoc.id);

--- a/packages/frontend/core/src/modules/share-doc/entities/share-info.ts
+++ b/packages/frontend/core/src/modules/share-doc/entities/share-info.ts
@@ -1,7 +1,5 @@
-import type {
-  GetWorkspacePublicPageByIdQuery,
-  PublicPageMode,
-} from '@affine/graphql';
+import type { GetWorkspacePublicPageByIdQuery } from '@affine/graphql';
+import type { DocMode } from '@blocksuite/blocks';
 import type { DocService, WorkspaceService } from '@toeverything/infra';
 import {
   backoffRetry,
@@ -69,7 +67,7 @@ export class ShareInfo extends Entity {
     return this.isRevalidating$.waitFor(v => v === false, signal);
   }
 
-  async enableShare(mode: PublicPageMode) {
+  async enableShare(mode: DocMode) {
     await this.store.enableSharePage(
       this.workspaceService.workspace.id,
       this.docService.doc.id,
@@ -78,7 +76,7 @@ export class ShareInfo extends Entity {
     await this.waitForRevalidation();
   }
 
-  async changeShare(mode: PublicPageMode) {
+  async changeShare(mode: DocMode) {
     await this.enableShare(mode);
   }
 

--- a/packages/frontend/core/src/modules/share-doc/entities/share-reader.ts
+++ b/packages/frontend/core/src/modules/share-doc/entities/share-reader.ts
@@ -1,6 +1,6 @@
 import { UserFriendlyError } from '@affine/graphql';
+import type { DocMode } from '@blocksuite/blocks';
 import {
-  type DocMode,
   effect,
   Entity,
   fromPromise,

--- a/packages/frontend/core/src/modules/share-doc/stores/share-reader.ts
+++ b/packages/frontend/core/src/modules/share-doc/stores/share-reader.ts
@@ -1,5 +1,6 @@
 import { ErrorNames, UserFriendlyError } from '@affine/graphql';
-import { type DocMode, Store } from '@toeverything/infra';
+import type { DocMode } from '@blocksuite/blocks';
+import { Store } from '@toeverything/infra';
 
 import { type FetchService, isBackendError } from '../../cloud';
 

--- a/packages/frontend/core/src/modules/share-doc/stores/share.ts
+++ b/packages/frontend/core/src/modules/share-doc/stores/share.ts
@@ -1,9 +1,10 @@
-import type { PublicPageMode } from '@affine/graphql';
 import {
   getWorkspacePublicPageByIdQuery,
+  PublicPageMode,
   publishPageMutation,
   revokePublicPageMutation,
 } from '@affine/graphql';
+import { DocMode } from '@blocksuite/blocks';
 import { Store } from '@toeverything/infra';
 
 import type { GraphQLService } from '../../cloud';
@@ -34,7 +35,7 @@ export class ShareStore extends Store {
   async enableSharePage(
     workspaceId: string,
     pageId: string,
-    docMode?: PublicPageMode,
+    docMode?: DocMode,
     signal?: AbortSignal
   ) {
     await this.gqlService.gql({
@@ -42,7 +43,10 @@ export class ShareStore extends Store {
       variables: {
         pageId,
         workspaceId,
-        mode: docMode,
+        mode:
+          docMode === DocMode.Edgeless
+            ? PublicPageMode.Edgeless
+            : PublicPageMode.Page,
       },
       context: {
         signal,

--- a/packages/frontend/core/src/pages/workspace/all-page/all-page-header.tsx
+++ b/packages/frontend/core/src/pages/workspace/all-page/all-page-header.tsx
@@ -10,6 +10,7 @@ import { useAsyncCallback } from '@affine/core/hooks/affine-async-hooks';
 import { track } from '@affine/core/mixpanel';
 import { isNewTabTrigger } from '@affine/core/utils';
 import type { Filter } from '@affine/env/filter';
+import { DocMode } from '@blocksuite/blocks';
 import { PlusIcon } from '@blocksuite/icons/rc';
 import { useServices, WorkspaceService } from '@toeverything/infra';
 import clsx from 'clsx';
@@ -67,7 +68,7 @@ export const AllPageHeader = ({
               createEdgeless(isNewTabTrigger(e) ? 'new-tab' : true)
             }
             onCreatePage={e =>
-              createPage('page', isNewTabTrigger(e) ? 'new-tab' : true)
+              createPage(DocMode.Page, isNewTabTrigger(e) ? 'new-tab' : true)
             }
             onCreateDoc={e =>
               createPage(undefined, isNewTabTrigger(e) ? 'new-tab' : true)

--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page-wrapper.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page-wrapper.tsx
@@ -2,7 +2,7 @@ import { PageDetailSkeleton } from '@affine/component/page-detail-skeleton';
 import type { Editor } from '@affine/core/modules/editor';
 import { EditorsService } from '@affine/core/modules/editor';
 import { ViewService } from '@affine/core/modules/workbench/services/view';
-import { type DocMode, DocModes } from '@blocksuite/blocks';
+import { DocMode, DocModes } from '@blocksuite/blocks';
 import type { Doc } from '@toeverything/infra';
 import {
   DocsService,

--- a/packages/frontend/core/src/pages/workspace/share/share-header.tsx
+++ b/packages/frontend/core/src/pages/workspace/share/share-header.tsx
@@ -2,8 +2,8 @@ import { BlocksuiteHeaderTitle } from '@affine/core/components/blocksuite/block-
 import { EditorModeSwitch } from '@affine/core/components/blocksuite/block-suite-mode-switch';
 import ShareHeaderRightItem from '@affine/core/components/cloud/share-header-right-item';
 import { AuthModal } from '@affine/core/providers/modal-provider';
+import type { DocMode } from '@blocksuite/blocks';
 import type { DocCollection } from '@blocksuite/store';
-import type { DocMode } from '@toeverything/infra';
 
 import * as styles from './share-header.css';
 

--- a/packages/frontend/core/src/pages/workspace/share/share-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/share/share-page.tsx
@@ -12,7 +12,7 @@ import { ShareReaderService } from '@affine/core/modules/share-doc';
 import { CloudBlobStorage } from '@affine/core/modules/workspace-engine';
 import { WorkspaceFlavour } from '@affine/env/workspace';
 import { useI18n } from '@affine/i18n';
-import { type DocMode, DocModes } from '@blocksuite/blocks';
+import { DocMode, DocModes } from '@blocksuite/blocks';
 import { noop } from '@blocksuite/global/utils';
 import { Logo1Icon } from '@blocksuite/icons/rc';
 import type { AffineEditorContainer } from '@blocksuite/presets';
@@ -97,7 +97,7 @@ const SharePageInner = ({
   docId,
   workspaceBinary,
   docBinary,
-  publishMode = 'page',
+  publishMode = DocMode.Page,
 }: {
   workspaceId: string;
   docId: string;


### PR DESCRIPTION
Need to wait for the latest blocksuite release.

Use `DocMode` enum type uniformly

https://github.com/toeverything/blocksuite/blob/d9964057b5e3bed9ef0251cf8887e4a605eba952/packages/affine/model/src/consts/doc.ts#L1-L22