### PR TITLE
refactor(core): refactor editor query string selector

### DIFF
--- a/packages/common/infra/src/utils/shallow-equal.ts
+++ b/packages/common/infra/src/utils/shallow-equal.ts
@@ -1,0 +1,34 @@
+// credit: https://github.com/facebook/fbjs/blob/main/packages/fbjs/src/core/shallowEqual.js
+export function shallowEqual(objA: any, objB: any) {
+  if (Object.is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (const key of keysA) {
+    if (
+      !Object.prototype.hasOwnProperty.call(objB, key) ||
+      !Object.is(objA[key], objB[key])
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor.tsx
@@ -1,4 +1,5 @@
 import { EditorLoading } from '@affine/component/page-detail-skeleton';
+import type { EditorSelector } from '@affine/core/modules/editor';
 import type { DocMode } from '@blocksuite/blocks';
 import { assertExists } from '@blocksuite/global/utils';
 import type { AffineEditorContainer } from '@blocksuite/presets';
@@ -29,8 +30,7 @@ export type EditorProps = {
   onLoadEditor?: (editor: AffineEditorContainer) => () => void;
   style?: CSSProperties;
   className?: string;
-  blockIds?: string[];
-  elementIds?: string[];
+  defaultEditorSelector?: EditorSelector;
 };
 
 function usePageRoot(page: Doc) {
@@ -64,8 +64,7 @@ const BlockSuiteEditorImpl = forwardRef<AffineEditorContainer, EditorProps>(
       onLoadEditor,
       shared,
       style,
-      blockIds,
-      elementIds,
+      defaultEditorSelector,
     },
     ref
   ) {
@@ -116,8 +115,7 @@ const BlockSuiteEditorImpl = forwardRef<AffineEditorContainer, EditorProps>(
         ref={onRefChange}
         className={className}
         style={style}
-        blockIds={blockIds}
-        elementIds={elementIds}
+        defaultEditorSelector={defaultEditorSelector}
       />
     );
   }

--- a/packages/frontend/core/src/modules/editor/entities/editor.ts
+++ b/packages/frontend/core/src/modules/editor/entities/editor.ts
@@ -4,13 +4,20 @@ import type { DocService, WorkspaceService } from '@toeverything/infra';
 import { Entity, LiveData } from '@toeverything/infra';
 
 import { EditorScope } from '../scopes/editor';
+import type { EditorSelector } from '../types';
 
-export class Editor extends Entity<{ defaultMode: DocMode }> {
+export class Editor extends Entity<{
+  defaultMode: DocMode;
+  defaultEditorSelector?: EditorSelector;
+}> {
   readonly scope = this.framework.createScope(EditorScope, {
     editor: this as Editor,
   });
 
   readonly mode$ = new LiveData(this.props.defaultMode);
+  readonly selector$ = new LiveData<EditorSelector | undefined>(
+    this.props.defaultEditorSelector
+  );
   readonly doc = this.docService.doc;
   readonly isSharedMode =
     this.workspaceService.workspace.openOptions.isSharedMode;

--- a/packages/frontend/core/src/modules/editor/index.ts
+++ b/packages/frontend/core/src/modules/editor/index.ts
@@ -15,6 +15,7 @@ export { Editor } from './entities/editor';
 export { EditorScope } from './scopes/editor';
 export { EditorService } from './services/editor';
 export { EditorsService } from './services/editors';
+export type { EditorSelector } from './types';
 
 export function configureEditorModule(framework: Framework) {
   framework

--- a/packages/frontend/core/src/modules/editor/services/editors.ts
+++ b/packages/frontend/core/src/modules/editor/services/editors.ts
@@ -2,9 +2,13 @@ import type { DocMode } from '@blocksuite/blocks';
 import { Service } from '@toeverything/infra';
 
 import { Editor } from '../entities/editor';
+import type { EditorSelector } from '../types';
 
 export class EditorsService extends Service {
-  createEditor(defaultMode: DocMode) {
-    return this.framework.createEntity(Editor, { defaultMode });
+  createEditor(defaultMode: DocMode, defaultEditorSelector?: EditorSelector) {
+    return this.framework.createEntity(Editor, {
+      defaultMode,
+      defaultEditorSelector,
+    });
   }
 }

--- a/packages/frontend/core/src/modules/editor/types.ts
+++ b/packages/frontend/core/src/modules/editor/types.ts
@@ -1,0 +1,4 @@
+export type EditorSelector = {
+  blockIds?: string[];
+  elementIds?: string[];
+};

--- a/packages/frontend/core/src/modules/peek-view/view/utils.ts
+++ b/packages/frontend/core/src/modules/peek-view/view/utils.ts
@@ -8,15 +8,20 @@ import {
 } from '@toeverything/infra';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
-import { type Editor, EditorsService } from '../../editor';
+import { type Editor, type EditorSelector, EditorsService } from '../../editor';
 
-export const useEditor = (pageId: string, preferMode?: DocMode) => {
+export const useEditor = (
+  pageId: string,
+  preferMode?: DocMode,
+  preferSelector?: EditorSelector
+) => {
   const currentWorkspace = useService(WorkspaceService).workspace;
   const docsService = useService(DocsService);
   const docRecordList = docsService.list;
   const docListReady = useLiveData(docRecordList.isReady$);
   const docRecord = docRecordList.doc$(pageId).value;
   const preferModeRef = useRef(preferMode);
+  const preferSelectorRef = useRef(preferSelector);
 
   const [doc, setDoc] = useState<Doc | null>(null);
   const [editor, setEditor] = useState<Editor | null>(null);
@@ -38,7 +43,10 @@ export const useEditor = (pageId: string, preferMode?: DocMode) => {
     }
     const editor = doc.scope
       .get(EditorsService)
-      .createEditor(preferModeRef.current || doc.primaryMode$.value);
+      .createEditor(
+        preferModeRef.current || doc.primaryMode$.value,
+        preferSelectorRef.current
+      );
     setEditor(editor);
     return () => {
       editor.dispose();

--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
@@ -32,7 +32,7 @@ import {
   WorkspaceService,
 } from '@toeverything/infra';
 import clsx from 'clsx';
-import { memo, useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import type { Map as YMap } from 'yjs';
 
@@ -91,6 +91,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
   const isInTrash = useLiveData(doc.meta$.map(meta => meta.trash));
   const { openPage, jumpToPageBlock, jumpToTag } = useNavigateHelper();
   const editorContainer = useLiveData(editor.editorContainer$);
+  const [defaultSelector] = useState(() => editor.selector$.value);
 
   const isSideBarOpen = useLiveData(workbench.sidebarOpen$);
   const { appSettings } = useAppSettingHelper();
@@ -287,6 +288,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
                   pageId={doc.id}
                   onLoad={onLoad}
                   docCollection={docCollection}
+                  defaultEditorSelector={defaultSelector}
                 />
               </Scrollable.Viewport>
               <Scrollable.Scrollbar


### PR DESCRIPTION
The editor selector is the information for locating a block, which can automatically focus on a certain content when a user opens a document.


```
export type EditorSelector = {
  blockIds?: string[];
  elementIds?: string[];
};
```

The selector can be set from multiple places, such as passing it in the center peek parameter, or passing it in the query part of the URL.

This pr decoupled the selector from the query string and now available at `editorService.editor.selector$`
