### PR TITLE
refactor(core): remove scroll anchoring from AffinePageReference

### DIFF
--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -141,7 +141,7 @@ export function AffinePageReference({
     } else {
       setAnchor(null);
     }
-  }, [std, isSameDoc, mode, blockIds, elementIds]);
+  }, [isSameDoc, mode, blockIds, elementIds]);
 
   const onClick = useCallback(
     (e: React.MouseEvent) => {

--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -6,7 +6,6 @@ import {
 } from '@affine/core/modules/peek-view';
 import { WorkbenchLink } from '@affine/core/modules/workbench';
 import { useI18n } from '@affine/i18n';
-import type { BlockStdScope } from '@blocksuite/block-std';
 import type { DocMode } from '@blocksuite/blocks';
 import {
   BlockLinkIcon,
@@ -17,16 +16,9 @@ import {
 } from '@blocksuite/icons/rc';
 import type { DocCollection } from '@blocksuite/store';
 import { useService } from '@toeverything/infra';
-import {
-  type PropsWithChildren,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import { type PropsWithChildren, useCallback, useRef } from 'react';
 
 import * as styles from './styles.css';
-import { scrollAnchoring } from './utils';
 
 export interface PageReferenceRendererOptions {
   pageId: string;
@@ -90,8 +82,6 @@ export function AffinePageReference({
   wrapper: Wrapper,
   mode = 'page',
   params = {},
-  isSameDoc = false,
-  std,
 }: {
   pageId: string;
   docCollection: DocCollection;
@@ -102,16 +92,10 @@ export function AffinePageReference({
     blockIds?: string[];
     elementIds?: string[];
   };
-  isSameDoc?: boolean;
-  std?: BlockStdScope;
 }) {
   const pageMetaHelper = useDocMetaHelper(docCollection);
   const journalHelper = useJournalHelper(docCollection);
   const t = useI18n();
-  const [anchor, setAnchor] = useState<{
-    mode: DocMode;
-    id: string;
-  } | null>(null);
 
   const { mode: linkedWithMode, blockIds, elementIds } = params;
 
@@ -131,18 +115,6 @@ export function AffinePageReference({
   const peekView = useService(PeekViewService).peekView;
   const isInPeekView = useInsidePeekView();
 
-  useEffect(() => {
-    if (isSameDoc) {
-      if (mode === 'edgeless' && elementIds?.length) {
-        setAnchor({ mode, id: elementIds[0] });
-      } else if (blockIds?.length) {
-        setAnchor({ mode, id: blockIds[0] });
-      }
-    } else {
-      setAnchor(null);
-    }
-  }, [isSameDoc, mode, blockIds, elementIds]);
-
   const onClick = useCallback(
     (e: React.MouseEvent) => {
       if (e.shiftKey && ref.current) {
@@ -150,19 +122,13 @@ export function AffinePageReference({
         e.stopPropagation();
         peekView.open(ref.current).catch(console.error);
       }
-
-      if (std && anchor) {
-        e.preventDefault();
-        e.stopPropagation();
-        const { mode, id } = anchor;
-        scrollAnchoring(std, mode, id);
-      } else if (isInPeekView) {
+      if (isInPeekView) {
         peekView.close();
       }
 
       return;
     },
-    [isInPeekView, peekView, anchor, std]
+    [isInPeekView, peekView]
   );
 
   // A block/element reference link

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -77,20 +77,16 @@ const usePatchSpecs = (page: Doc, shared: boolean, mode: DocMode) => {
       const pageId = data.pageId;
       if (!pageId) return <span />;
 
-      const isSameDoc = pageId === page.id;
-
       return (
         <AffinePageReference
           docCollection={page.collection}
           pageId={pageId}
           mode={mode}
           params={data.params}
-          std={reference.std}
-          isSameDoc={isSameDoc}
         />
       );
     };
-  }, [mode, page.collection, page.id]);
+  }, [mode, page.collection]);
 
   const specs = useMemo(() => {
     return mode === 'edgeless'

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/database-block.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/database-block.ts
@@ -3,6 +3,7 @@ import {
   generateUrl,
   type UseSharingUrl,
 } from '@affine/core/hooks/affine/use-share-url';
+import { track } from '@affine/core/mixpanel';
 import { getAffineCloudBaseUrl } from '@affine/core/modules/cloud/services/fetch';
 import { EditorService } from '@affine/core/modules/editor';
 import { I18n } from '@affine/i18n';
@@ -70,6 +71,8 @@ function createCopyLinkToBlockMenuItem(
 
       const str = generateUrl(options);
       if (!str) return;
+
+      track.doc.editor.toolbar.copyBlockToLink({ type: model.flavour });
 
       navigator.clipboard
         .writeText(str)

--- a/packages/frontend/core/src/mixpanel/events.ts
+++ b/packages/frontend/core/src/mixpanel/events.ts
@@ -44,7 +44,8 @@ type DocEvents =
   | 'restoreDoc'
   | 'switchPageMode'
   | 'openDocOptionsMenu'
-  | 'openDocInfo';
+  | 'openDocInfo'
+  | 'copyBlockToLink';
 type EditorEvents = 'bold' | 'italic' | 'underline' | 'strikeThrough';
 // END SECTION
 
@@ -263,6 +264,7 @@ const PageEvents = {
       slashMenu: ['linkDoc', 'createDoc'],
       atMenu: ['linkDoc'],
       formatToolbar: ['bold'],
+      toolbar: ['copyBlockToLink'],
     },
     inlineDocInfo: {
       $: ['toggle'],
@@ -380,6 +382,9 @@ export type EventArgs = {
     type: 'default' | 'doc' | 'whiteboard' | 'block' | 'element';
   };
   export: { type: string };
+  copyBlockToLink: {
+    type: string;
+  };
 };
 
 // for type checking

--- a/packages/frontend/core/src/modules/editor/entities/editor.ts
+++ b/packages/frontend/core/src/modules/editor/entities/editor.ts
@@ -36,6 +36,10 @@ export class Editor extends Entity<{
     this.editorContainer$.next(editorContainer);
   }
 
+  setSelector(selector?: EditorSelector) {
+    this.selector$.next(selector);
+  }
+
   constructor(
     private readonly docService: DocService,
     private readonly workspaceService: WorkspaceService

--- a/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/pages/workspace/detail-page/detail-page.tsx
@@ -32,7 +32,7 @@ import {
   WorkspaceService,
 } from '@toeverything/infra';
 import clsx from 'clsx';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import type { Map as YMap } from 'yjs';
 
@@ -91,7 +91,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
   const isInTrash = useLiveData(doc.meta$.map(meta => meta.trash));
   const { openPage, jumpToPageBlock, jumpToTag } = useNavigateHelper();
   const editorContainer = useLiveData(editor.editorContainer$);
-  const [defaultSelector] = useState(() => editor.selector$.value);
+  const defaultSelector = useLiveData(editor.selector$);
 
   const isSideBarOpen = useLiveData(workbench.sidebarOpen$);
   const { appSettings } = useAppSettingHelper();


### PR DESCRIPTION
* click the same address multiple times can also automatically scroll to the target
* cache `blockIds` or `elementids` in selector
* remove `scrollAnchoring` from `AffinePageReference`