### PR TITLE
feat(electron): add offline mode

### DIFF
--- a/packages/common/infra/src/modules/feature-flag/constant.ts
+++ b/packages/common/infra/src/modules/feature-flag/constant.ts
@@ -96,6 +96,13 @@ export const AFFINE_FLAGS = {
     configurable: isCanaryBuild,
     defaultState: isCanaryBuild,
   },
+  enable_offline_mode: {
+    category: 'affine',
+    displayName: 'Offline Mode',
+    description: 'Enables offline mode.',
+    configurable: isDesktopEnvironment,
+    defaultState: false,
+  },
 } satisfies { [key in string]: FlagInfo };
 
 export type AFFINE_FLAGS = typeof AFFINE_FLAGS;

--- a/packages/frontend/electron/src/main/updater/electron-updater.ts
+++ b/packages/frontend/electron/src/main/updater/electron-updater.ts
@@ -3,6 +3,7 @@ import { autoUpdater as defaultAutoUpdater } from 'electron-updater';
 
 import { buildType } from '../config';
 import { logger } from '../logger';
+import { isOfflineModeEnabled } from '../utils';
 import { AFFiNEUpdateProvider } from './affine-update-provider';
 import { updaterSubjects } from './event';
 import { WindowsUpdater } from './windows-updater';
@@ -54,7 +55,7 @@ export const setConfig = (newConfig: Partial<UpdaterConfig> = {}): void => {
 };
 
 export const checkForUpdates = async () => {
-  if (disabled || checkingUpdate) {
+  if (disabled || checkingUpdate || isOfflineModeEnabled()) {
     return;
   }
   checkingUpdate = true;


### PR DESCRIPTION
fix AF-1334

It seems `session.enableNetworkEmulation({ offline: true });` does not work - https://github.com/electron/electron/issues/21250

implemented using an in-house solution.

When turned on:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/6805735b-1006-4e51-be46-c047b0f1a82c.png)

