### PR TITLE
chore(core): improve scroll anchoring

### DIFF
--- a/packages/frontend/core/src/modules/editor/entities/editor.ts
+++ b/packages/frontend/core/src/modules/editor/entities/editor.ts
@@ -169,11 +169,10 @@ export class Editor extends Entity {
         get(this.mode$) === 'edgeless' && selector?.elementIds?.length
           ? selector?.elementIds?.[0]
           : selector?.blockIds?.[0];
-      if (id) {
-        return { id, refreshKey: selector?.refreshKey };
-      } else {
-        return null;
-      }
+
+      if (!id) return null;
+
+      return { id, refreshKey: selector?.refreshKey };
     });
     if (focusAt$.value === null && docTitle) {
       const title = docTitle.querySelector<


### PR DESCRIPTION
Upstreams: https://github.com/toeverything/blocksuite/pull/8335
* set `padding` to `[20,20,100,20]` 
* cancel smooth movement and scaling
* focus and zoom in on elements/blocks