### PR TITLE
feat(core): support block links on Bi-Directional Links

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/bi-directional-link-panel.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/bi-directional-link-panel.tsx
@@ -63,10 +63,14 @@ export const BiDirectionalLinkPanel = () => {
               {t['com.affine.page-properties.outgoing-links']()} ·{' '}
               {links.length}
             </div>
-            {links.map(link => (
-              <div key={link.docId} className={styles.link}>
+            {links.map((link, i) => (
+              <div
+                key={`${link.docId}-${link.params?.toString()}-${i}`}
+                className={styles.link}
+              >
                 <AffinePageReference
                   pageId={link.docId}
+                  params={link.params}
                   docCollection={workspaceService.workspace.docCollection}
                 />
               </div>

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -7,6 +7,7 @@ import { useJournalInfoHelper } from '@affine/core/hooks/use-journal';
 import { EditorService } from '@affine/core/modules/editor';
 import { EditorSettingService } from '@affine/core/modules/editor-settting';
 import { PeekViewService } from '@affine/core/modules/peek-view';
+import { toURLSearchParams } from '@affine/core/utils';
 import type { DocMode } from '@blocksuite/blocks';
 import { DocTitle, EdgelessEditor, PageEditor } from '@blocksuite/presets';
 import type { Doc } from '@blocksuite/store';
@@ -90,12 +91,14 @@ const usePatchSpecs = (page: Doc, shared: boolean, mode: DocMode) => {
       const pageId = data.pageId;
       if (!pageId) return <span />;
 
+      const params = toURLSearchParams(data.params);
+
       return (
         <AffinePageReference
           docCollection={page.collection}
           pageId={pageId}
           mode={mode}
-          params={data.params}
+          params={params}
         />
       );
     };

--- a/packages/frontend/core/src/modules/doc-link/entities/doc-links.ts
+++ b/packages/frontend/core/src/modules/doc-link/entities/doc-links.ts
@@ -6,6 +6,7 @@ import type { DocsSearchService } from '../../docs-search';
 export interface Link {
   docId: string;
   title: string;
+  params?: URLSearchParams;
 }
 
 export class DocLinks extends Entity {

--- a/packages/frontend/core/src/modules/docs-search/entities/docs-indexer.ts
+++ b/packages/frontend/core/src/modules/docs-search/entities/docs-indexer.ts
@@ -36,7 +36,7 @@ export class DocsIndexer extends Entity {
   /**
    * increase this number to re-index all docs
    */
-  static INDEXER_VERSION = 1;
+  static INDEXER_VERSION = 2;
 
   private readonly jobQueue: JobQueue<IndexerJobPayload> =
     new IndexedDBJobQueue<IndexerJobPayload>(

--- a/packages/frontend/core/src/modules/docs-search/schema.ts
+++ b/packages/frontend/core/src/modules/docs-search/schema.ts
@@ -11,8 +11,13 @@ export const blockIndexSchema = defineSchema({
   blockId: 'String',
   content: 'FullText',
   flavour: 'String',
-  ref: 'String',
   blob: 'String',
+  // reference doc id
+  // ['xxx','yyy']
+  refDocId: 'String',
+  // reference info
+  // [{"docId":"xxx","mode":"page","blockIds":["gt5Yfq1maYvgNgpi13rIq"]},{"docId":"yyy","mode":"edgeless","blockIds":["k5prpOlDF-9CzfatmO0W7"]}]
+  ref: 'String',
 });
 
 export type BlockIndexSchema = typeof blockIndexSchema;

--- a/packages/frontend/core/src/modules/docs-search/services/docs-search.ts
+++ b/packages/frontend/core/src/modules/docs-search/services/docs-search.ts
@@ -1,3 +1,4 @@
+import { toURLSearchParams } from '@affine/core/utils';
 import type { WorkspaceService } from '@toeverything/infra';
 import {
   fromPromise,
@@ -5,6 +6,7 @@ import {
   Service,
   WorkspaceEngineBeforeStart,
 } from '@toeverything/infra';
+import { isEmpty, omit } from 'lodash-es';
 import { type Observable, switchMap } from 'rxjs';
 
 import { DocsIndexer } from '../entities/docs-indexer';
@@ -250,36 +252,64 @@ export class DocsSearchService extends Service {
             field: 'docId',
             match: docId,
           },
+          // Ignore if it is a link to the current document.
+          {
+            type: 'boolean',
+            occur: 'must_not',
+            queries: [
+              {
+                type: 'match',
+                field: 'refDocId',
+                match: docId,
+              },
+            ],
+          },
           {
             type: 'exists',
-            field: 'ref',
+            field: 'refDocId',
           },
         ],
       },
       {
-        fields: ['ref'],
+        fields: ['refDocId', 'ref'],
         pagination: {
           limit: 100,
         },
       }
     );
 
-    const docIds = new Set(
-      nodes.flatMap(node => {
-        const refs = node.fields.ref;
-        return typeof refs === 'string' ? [refs] : refs;
-      })
+    const refs: {
+      docId: string;
+      mode?: string;
+      blockIds?: string[];
+      elementIds?: string[];
+    }[] = nodes.flatMap(node => {
+      const { ref } = node.fields;
+      return typeof ref === 'string'
+        ? [JSON.parse(ref)]
+        : ref.map(item => JSON.parse(item));
+    });
+
+    const docData = await this.indexer.docIndex.getAll(
+      Array.from(new Set(refs.map(ref => ref.docId)))
     );
 
-    const docData = await this.indexer.docIndex.getAll(Array.from(docIds));
+    return refs
+      .flatMap(ref => {
+        const doc = docData.find(doc => doc.id === ref.docId);
+        if (!doc) return null;
 
-    return docData.map(doc => {
-      const title = doc.get('title');
-      return {
-        docId: doc.id,
-        title: title ? (typeof title === 'string' ? title : title[0]) : '',
-      };
-    });
+        const titles = doc.get('title');
+        const title = (Array.isArray(titles) ? titles[0] : titles) ?? '';
+        const params = omit(ref, ['docId']);
+
+        return {
+          title,
+          docId: doc.id,
+          params: isEmpty(params) ? undefined : toURLSearchParams(params),
+        };
+      })
+      .filter(ref => !!ref);
   }
 
   watchRefsFrom(docId: string) {
@@ -294,14 +324,26 @@ export class DocsSearchService extends Service {
               field: 'docId',
               match: docId,
             },
+            // Ignore if it is a link to the current document.
+            {
+              type: 'boolean',
+              occur: 'must_not',
+              queries: [
+                {
+                  type: 'match',
+                  field: 'refDocId',
+                  match: docId,
+                },
+              ],
+            },
             {
               type: 'exists',
-              field: 'ref',
+              field: 'refDocId',
             },
           ],
         },
         {
-          fields: ['ref'],
+          fields: ['refDocId', 'ref'],
           pagination: {
             limit: 100,
           },
@@ -310,28 +352,41 @@ export class DocsSearchService extends Service {
       .pipe(
         switchMap(({ nodes }) => {
           return fromPromise(async () => {
-            const docIds = new Set(
-              nodes.flatMap(node => {
-                const refs = node.fields.ref;
-                return typeof refs === 'string' ? [refs] : refs;
-              })
-            );
+            const refs: {
+              docId: string;
+              mode?: string;
+              blockIds?: string[];
+              elementIds?: string[];
+            }[] = nodes.flatMap(node => {
+              const { ref } = node.fields;
+              return typeof ref === 'string'
+                ? [JSON.parse(ref)]
+                : ref.map(item => JSON.parse(item));
+            });
 
             const docData = await this.indexer.docIndex.getAll(
-              Array.from(docIds)
+              Array.from(new Set(refs.map(ref => ref.docId)))
             );
 
-            return docData.map(doc => {
-              const title = doc.get('title');
-              return {
-                docId: doc.id,
-                title: title
-                  ? typeof title === 'string'
-                    ? title
-                    : title[0]
-                  : '',
-              };
-            });
+            return refs
+              .flatMap(ref => {
+                const doc = docData.find(doc => doc.id === ref.docId);
+                if (!doc) return null;
+
+                const titles = doc.get('title');
+                const title =
+                  (Array.isArray(titles) ? titles[0] : titles) ?? '';
+                const params = omit(ref, ['docId']);
+
+                return {
+                  title,
+                  docId: doc.id,
+                  params: isEmpty(params)
+                    ? undefined
+                    : toURLSearchParams(params),
+                };
+              })
+              .filter(ref => !!ref);
           });
         })
       );
@@ -346,9 +401,27 @@ export class DocsSearchService extends Service {
   > {
     const { buckets } = await this.indexer.blockIndex.aggregate(
       {
-        type: 'match',
-        field: 'ref',
-        match: docId,
+        type: 'boolean',
+        occur: 'must',
+        queries: [
+          {
+            type: 'match',
+            field: 'refDocId',
+            match: docId,
+          },
+          // Ignore if it is a link to the current document.
+          {
+            type: 'boolean',
+            occur: 'must_not',
+            queries: [
+              {
+                type: 'match',
+                field: 'docId',
+                match: docId,
+              },
+            ],
+          },
+        ],
       },
       'docId',
       {
@@ -384,9 +457,27 @@ export class DocsSearchService extends Service {
     return this.indexer.blockIndex
       .aggregate$(
         {
-          type: 'match',
-          field: 'ref',
-          match: docId,
+          type: 'boolean',
+          occur: 'must',
+          queries: [
+            {
+              type: 'match',
+              field: 'refDocId',
+              match: docId,
+            },
+            // Ignore if it is a link to the current document.
+            {
+              type: 'boolean',
+              occur: 'must_not',
+              queries: [
+                {
+                  type: 'match',
+                  field: 'docId',
+                  match: docId,
+                },
+              ],
+            },
+          ],
         },
         'docId',
         {

--- a/packages/frontend/core/src/modules/quicksearch/impls/docs.ts
+++ b/packages/frontend/core/src/modules/quicksearch/impls/docs.ts
@@ -55,25 +55,28 @@ export class DocsQuickSearchSession
       if (!query) {
         out = of([] as QuickSearchItem<'docs', DocsPayload>[]);
       } else {
+        const resolvedDoc = resolveLinkToDoc(query);
+        const resolvedDocId = resolvedDoc?.docId;
+        const resolvedBlockId = resolvedDoc?.blockIds?.[0];
+
         out = this.docsSearchService.search$(query).pipe(
           map(docs => {
-            const resolvedDoc = resolveLinkToDoc(query);
             if (
-              resolvedDoc &&
-              !docs.some(doc => doc.docId === resolvedDoc.docId)
+              resolvedDocId &&
+              !docs.some(doc => doc.docId === resolvedDocId)
             ) {
               return [
                 {
-                  docId: resolvedDoc.docId,
+                  docId: resolvedDocId,
                   score: 100,
-                  blockId: resolvedDoc.blockIds?.[0],
+                  blockId: resolvedBlockId,
                   blockContent: '',
                 },
                 ...docs,
               ];
-            } else {
-              return docs;
             }
+
+            return docs;
           }),
           map(docs =>
             docs

--- a/packages/frontend/core/src/utils/url.ts
+++ b/packages/frontend/core/src/utils/url.ts
@@ -31,3 +31,13 @@ export function buildAppUrl(path: string, opts: AppUrlOptions = {}) {
     return new URL(path, webBase).toString();
   }
 }
+
+export function toURLSearchParams(params?: Record<string, string | string[]>) {
+  if (!params) return;
+  return new URLSearchParams(
+    Object.entries(params).map(([k, v]) => [
+      k,
+      Array.isArray(v) ? v.join(',') : v,
+    ])
+  );
+}


### PR DESCRIPTION
Clsoes [AF-1348](https://linear.app/affine-design/issue/AF-1348/修复-bi-directional-links-里面的链接地址)

* Links to the current document should be ignored on `Backlinks`
* Links to the current document should be ignored on `Outgoing links`


https://github.com/user-attachments/assets/dbc43cea-5aca-4c6f-886a-356e3a91c1f1


