### PR TITLE
fix(core): menu shaking on boundary

### DIFF
--- a/packages/frontend/component/src/ui/menu/desktop/controller.ts
+++ b/packages/frontend/component/src/ui/menu/desktop/controller.ts
@@ -18,7 +18,25 @@ export const useMenuContentController = ({
   const [open, setOpen] = useState(defaultOpen ?? false);
   const actualOpen = controlledOpen ?? open;
   const contentSide = side ?? 'bottom';
-  const [contentOffset, setContentOffset] = useState<number>(0);
+  const [contentOffset, setContentOffsetO] = useState<number>(0);
+
+  const setContentOffset = useCallback(
+    (offsetOrFn: number | ((prev: number) => number)) => {
+      const setter =
+        typeof offsetOrFn !== 'function' ? () => offsetOrFn : offsetOrFn;
+
+      setContentOffsetO(prev => {
+        const newVal = setter(prev);
+
+        const diff = newVal - prev;
+        if (Math.abs(diff) < 1) {
+          return prev;
+        }
+        return newVal;
+      });
+    },
+    []
+  );
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -82,7 +100,7 @@ export const useMenuContentController = ({
         cancelAnimationFrame(animationFrame);
       };
     },
-    [actualOpen, contentSide]
+    [actualOpen, contentSide, setContentOffset]
   );
 
   return {


### PR DESCRIPTION
fix this issue

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/T2klNLEk0wxLh4NRDzhk/93991fee-9beb-46f5-95de-5353a4160b96.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/T2klNLEk0wxLh4NRDzhk/93991fee-9beb-46f5-95de-5353a4160b96.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/93991fee-9beb-46f5-95de-5353a4160b96.mp4">20240909-1450-02.9186816.mp4</video>

