### PR TITLE
fix(core): disable append paragraph in shared page editor

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor-container.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/blocksuite-editor-container.tsx
@@ -164,11 +164,12 @@ export const BlocksuiteEditorContainer = forwardRef<
   ]);
 
   const handleClickPageModeBlank = useCallback(() => {
+    if (shared || page.readonly) return;
     affineEditorContainerProxy.host?.std.command.exec(
       'appendParagraph' as never,
       {}
     );
-  }, [affineEditorContainerProxy]);
+  }, [affineEditorContainerProxy, page, shared]);
 
   return (
     <div

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -223,7 +223,11 @@ export const BlocksuiteDocEditor = forwardRef<
           specs={specs}
           hasViewport={false}
         />
-        <div className={styles.docEditorGap} onClick={onClickBlank}></div>
+        <div
+          className={styles.docEditorGap}
+          data-testid="page-editor-blank"
+          onClick={onClickBlank}
+        ></div>
         {!shared && displayBiDirectionalLink ? (
           <BiDirectionalLinkPanel />
         ) : null}


### PR DESCRIPTION
Disable append paragraph function for readonly or shared page editor.

### Before

![CleanShot 2024-09-10 at 22.26.04@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/3ab206a2-8e30-4212-9d5d-3073ec489644.png)

