### PR TITLE
fix(core): reference link icon

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -97,12 +97,11 @@ const usePatchSpecs = (page: Doc, shared: boolean, mode: DocMode) => {
         <AffinePageReference
           docCollection={page.collection}
           pageId={pageId}
-          mode={mode}
           params={params}
         />
       );
     };
-  }, [mode, page.collection]);
+  }, [page.collection]);
 
   const specs = useMemo(() => {
     const enableAI = featureFlagService.flags.enable_ai.value;


### PR DESCRIPTION
Closes [AF-1384](https://linear.app/affine-design/issue/AF-1384/edgeless-reference-icon-在fail版本中显示不正确)