### PR TITLE
fix: button tooltip should not show on showing image preview

### DIFF
--- a/packages/frontend/core/src/modules/peek-view/view/image-preview/index.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/image-preview/index.tsx
@@ -308,6 +308,7 @@ const ImagePreviewModalImpl = ({
               data-testid="image-content"
               src={url}
               alt={caption}
+              tabIndex={0}
               ref={imageRef}
               draggable={isZoomedBigger}
               onMouseDown={handleDragStart}


### PR DESCRIPTION
when showing image preview in modal, the following code
https://github.com/radix-ui/primitives/blob/660060a765634e9cc7bf4513f41e8dabc9824d74/packages/react/focus-scope/src/FocusScope.tsx#L143 will find the first tabbable element and focus, which will trigger the button's tooltip

Adding tabIndex to the image to fix this issue