### PR TITLE
fix(core): reference node word break

### DIFF
--- a/packages/frontend/core/src/components/affine/reference-link/styles.css.ts
+++ b/packages/frontend/core/src/components/affine/reference-link/styles.css.ts
@@ -9,5 +9,6 @@ export const pageReferenceIcon = style({
 export const pageReferenceLink = style({
   textDecoration: 'none',
   color: 'inherit',
-  wordBreak: 'break-all',
+  wordBreak: 'break-word',
+  hyphens: 'auto',
 });


### PR DESCRIPTION
before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/2320279b-9986-46a9-b3cf-d0272f2656aa.png)

---

after:
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/8869024b-92fd-4afe-aa87-af730224a0d3.png)

