### PR TITLE
fix(core): should wrap link text

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/database-block.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/database-block.ts
@@ -73,14 +73,13 @@ function createCopyLinkToBlockMenuItem(
       if (!str) return;
 
       const type = model.flavour;
-      const title = editor.doc.title$.value;
       const page = editor.editorContainer$.value;
 
       page?.host?.std.clipboard
         .writeToClipboard(items => {
           items['text/plain'] = str;
           // wrap a link
-          items['text/html'] = `<a title="${title}" href="${str}">${title}</a>`;
+          items['text/html'] = `<a href="${str}">${str}</a>`;
           return items;
         })
         .then(() => {

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/toolbar.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/toolbar.ts
@@ -114,13 +114,11 @@ function createCopyLinkToBlockMenuItem(
         return;
       }
 
-      const title = editor.doc.title$.value;
-
       ctx.std.clipboard
         .writeToClipboard(items => {
           items['text/plain'] = str;
           // wrap a link
-          items['text/html'] = `<a title="${title}" href="${str}">${title}</a>`;
+          items['text/html'] = `<a href="${str}">${str}</a>`;
           return items;
         })
         .then(() => {


### PR DESCRIPTION
Closes [BS-1418](https://linear.app/affine-design/issue/BS-1418/link-to-block-粘贴识别后，使用-undo-来撤销操作的效果不一样)


https://github.com/user-attachments/assets/537cf8f4-cf13-466f-b68e-fc213891c548

