### PR TITLE
fix(core): override LinkedDocBlockComponent initial state

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -484,10 +484,12 @@ export function patchEdgelessClipboard() {
 }
 
 @customElement('affine-linked-doc-ref-block')
-// @ts-expect-error ignore private warning for overriding _load
 export class LinkedDocBlockComponent extends EmbedLinkedDocBlockComponent {
-  override async _load() {
-    this.isBannerEmpty = true;
+  override getInitialState() {
+    return {
+      loading: false,
+      isBannerEmpty: true,
+    };
   }
 }
 


### PR DESCRIPTION
Upstreams: https://github.com/toeverything/blocksuite/pull/8354

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/8ypiIKZXudF5a0tIgIzf/f8214c18-2fb7-4cbe-9d0d-5302f520b676.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/8ypiIKZXudF5a0tIgIzf/f8214c18-2fb7-4cbe-9d0d-5302f520b676.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/f8214c18-2fb7-4cbe-9d0d-5302f520b676.mov">Screen Recording 2024-09-13 at 20.27.38.mov</video>

