### PR TITLE
feat(core): add error notification for block not found

### DIFF
--- a/packages/frontend/core/src/modules/editor/utils/scroll-anchoring.ts
+++ b/packages/frontend/core/src/modules/editor/utils/scroll-anchoring.ts
@@ -1,3 +1,5 @@
+import { notify } from '@affine/component';
+import { I18n } from '@affine/i18n';
 import type { BlockStdScope, SelectionManager } from '@blocksuite/block-std';
 import type {
   DocMode,
@@ -38,7 +40,10 @@ function scrollAnchoringInEdgelessMode(
       bounds = Bound.fromXYWH(deserializeXYWH(model.xywh));
     }
 
-    if (!bounds) return;
+    if (!bounds) {
+      notify.error({ title: I18n['Block not found']() });
+      return;
+    }
 
     const { zoom, centerX, centerY } = service.getFitToScreenData(
       [20, 20, 100, 20],
@@ -72,7 +77,10 @@ function scrollAnchoringInEdgelessMode(
 
 function scrollAnchoringInPageMode(service: PageRootService, id: string) {
   const blockComponent = service.std.view.getBlock(id);
-  if (!blockComponent) return;
+  if (!blockComponent) {
+    notify.error({ title: I18n['Block not found']() });
+    return;
+  }
 
   blockComponent.scrollIntoView({
     behavior: 'instant',

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1613,5 +1613,6 @@
   "unnamed": "unnamed",
   "upgradeBrowser": "Please upgrade to the latest version of Chrome for the best experience.",
   "will be moved to Trash": "{{title}} will be moved to trash",
-  "will delete member": "will delete member"
+  "will delete member": "will delete member",
+  "Block not found": "Block not found"
 }


### PR DESCRIPTION
Closes [BS-1416](https://linear.app/affine-design/issue/BS-1416/被删除的白板或者-page-里的-block，访问其-link-to-block，跳转之后没有-toast-提示)

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/8ypiIKZXudF5a0tIgIzf/76e0e8d8-8685-41a2-abc8-79b330854a7e.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/8ypiIKZXudF5a0tIgIzf/76e0e8d8-8685-41a2-abc8-79b330854a7e.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/76e0e8d8-8685-41a2-abc8-79b330854a7e.mov">Screen Recording 2024-09-13 at 21.09.20.mov</video>

