### PR TITLE
ci: avoid twice by nx

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -296,8 +296,8 @@ jobs:
           path: ./packages/backend/native/server-native.node
           if-no-files-found: error
 
-  build-web:
-    name: Build @affine/web
+  build-electron-renderer:
+    name: Build @affine/electron renderer
     runs-on: ubuntu-latest
 
     steps:
@@ -307,9 +307,9 @@ jobs:
         with:
           electron-install: false
           full-cache: true
-      - name: Build Web
+      - name: Build Electron renderer
         # always skip cache because its fast, and cache configuration is always changing
-        run: yarn nx build @affine/web --skip-nx-cache
+        run: yarn build
         env:
           DISTRIBUTION: desktop
       - name: zip web

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   },
   "scripts": {
     "dev": "yarn workspace @affine/cli dev",
+    "build": "yarn workspace @affine/cli bundle",
     "dev:electron": "yarn workspace @affine/electron dev",
-    "build": "yarn nx build @affine/web",
     "build:electron": "yarn nx build @affine/electron",
     "build:server-native": "yarn nx run-many -t build -p @affine/server-native",
     "start:web-static": "yarn workspace @affine/web static-server",

--- a/packages/frontend/admin/package.json
+++ b/packages/frontend/admin/package.json
@@ -60,7 +60,7 @@
     "tailwindcss-animate": "^1.0.7"
   },
   "scripts": {
-    "build": "cross-env DISTRIBUTION=admin yarn workspace @affine/cli build",
+    "build": "cross-env DISTRIBUTION=admin yarn workspace @affine/cli bundle",
     "update-shadcn": "shadcn-ui add -p src/components/ui"
   },
   "exports": {

--- a/packages/frontend/apps/electron/scripts/generate-assets.ts
+++ b/packages/frontend/apps/electron/scripts/generate-assets.ts
@@ -47,12 +47,9 @@ process.env.DISTRIBUTION = 'desktop';
 
 const cwd = repoRootDir;
 
-const { SKIP_NX_CACHE } = process.env;
-const nxFlag = SKIP_NX_CACHE ? '--skip-nx-cache' : '';
-
 // step 1: build web dist
 if (!process.env.SKIP_WEB_BUILD) {
-  spawnSync('yarn', ['nx', 'build', '@affine/web', nxFlag], {
+  spawnSync('yarn', ['build'], {
     stdio: 'inherit',
     env: process.env,
     cwd,

--- a/packages/frontend/apps/mobile/package.json
+++ b/packages/frontend/apps/mobile/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "browser": "src/index.tsx",
   "scripts": {
-    "build": "cross-env DISTRIBUTION=mobile yarn workspace @affine/cli build",
+    "build": "cross-env DISTRIBUTION=mobile yarn workspace @affine/cli bundle",
     "dev": "yarn workspace @affine/cli dev",
     "static-server": "cross-env DISTRIBUTION=mobile yarn workspace @affine/cli dev --static"
   },

--- a/packages/frontend/apps/web/package.json
+++ b/packages/frontend/apps/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "browser": "src/index.tsx",
   "scripts": {
-    "build": "cross-env DISTRIBUTION=web yarn workspace @affine/cli build",
+    "build": "cross-env DISTRIBUTION=web yarn workspace @affine/cli bundle",
     "dev": "yarn workspace @affine/cli dev",
     "static-server": "yarn workspace @affine/cli dev --static"
   },

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -41,7 +41,7 @@
     "webpack-merge": "^6.0.0"
   },
   "scripts": {
-    "build": "node --loader ts-node/esm/transpile-only.mjs ./src/bin/build.ts",
+    "bundle": "node --loader ts-node/esm/transpile-only.mjs ./src/bin/build.ts",
     "dev": "node --loader ts-node/esm/transpile-only.mjs ./src/bin/dev.ts"
   },
   "version": "0.16.0"


### PR DESCRIPTION
Nx finds project dependencies like

`@affine/web => @affine/cli`

and when build with `yarn nx @affine/web build`, it requires all dependencies' `build` command to be finished first, so the actual commands would be 

```
# dependOn i18n:build
yarn workspace @affine/i18n build
# dependOn cli:build 
yarn workspace @affine/cli build

# web build
yarn workspace @affine/cli build
```