### PR TITLE
fix(core): should show block link icon first

### DIFF
--- a/packages/frontend/core/src/modules/doc-display-meta/services/doc-display-meta.ts
+++ b/packages/frontend/core/src/modules/doc-display-meta/services/doc-display-meta.ts
@@ -82,6 +82,12 @@ export class DocDisplayMetaService extends Service {
       const doc = get(this.docsService.list.doc$(docId));
       const mode = doc ? get(doc.primaryMode$) : undefined;
       const finalMode = options?.mode ?? mode ?? 'page';
+      const referenceToNode = !!(options?.reference && options.referenceToNode);
+
+      // increases block link priority
+      if (referenceToNode) {
+        return iconSet.BlockLinkIcon;
+      }
 
       const journalDate = this._toDayjs(
         this.propertiesAdapter.getJournalPageDateString(docId)
@@ -98,11 +104,9 @@ export class DocDisplayMetaService extends Service {
       }
 
       return options?.reference
-        ? options?.referenceToNode
-          ? iconSet.BlockLinkIcon
-          : finalMode === 'edgeless'
-            ? iconSet.LinkedEdgelessIcon
-            : iconSet.LinkedPageIcon
+        ? finalMode === 'edgeless'
+          ? iconSet.LinkedEdgelessIcon
+          : iconSet.LinkedPageIcon
         : finalMode === 'edgeless'
           ? iconSet.EdgelessIcon
           : iconSet.PageIcon;


### PR DESCRIPTION
Closes [PD-1715](https://linear.app/affine-design/issue/PD-1715/journal-里的-block-link-在识别之后不显示为-link-to-block-的效果)



![Screenshot 2024-09-20 at 15.31.16.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/c2f59e11-44ca-4f3f-85f3-ed8bec6d06a9.png)

