### PR TITLE
feat(core): emoji as doc icon support with feature flag

### DIFF
--- a/packages/common/infra/src/modules/feature-flag/constant.ts
+++ b/packages/common/infra/src/modules/feature-flag/constant.ts
@@ -104,6 +104,17 @@ export const AFFINE_FLAGS = {
     configurable: true,
     defaultState: true,
   },
+  enable_emoji_doc_icon: {
+    category: 'affine',
+    displayName: 'Emoji Doc Icon',
+    description:
+      'Once enabled, you can use an emoji as the page icon. When the first character of the folder name is an emoji, it will be extracted and used as its icon.',
+    feedbackType: 'discord',
+    feedbackLink:
+      'https://discord.com/channels/959027316334407691/1280014319865696351',
+    configurable: true,
+    defaultState: true,
+  },
   enable_editor_settings: {
     category: 'affine',
     displayName: 'Editor Settings',

--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -52,7 +52,9 @@ export function AffinePageReference({
       referenceToNode: linkToNode,
     })
   );
-  const title = useLiveData(docDisplayMetaService.title$(pageId));
+  const title = useLiveData(
+    docDisplayMetaService.title$(pageId, { reference: true })
+  );
 
   const el = (
     <>

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/linked.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/linked.ts
@@ -34,7 +34,9 @@ export function createLinkedWidgetConfig(
           return !meta.trash;
         })
         .map(meta => {
-          const title = docDisplayMetaService.title$(meta.id).value;
+          const title = docDisplayMetaService.title$(meta.id, {
+            reference: true,
+          }).value;
           return {
             ...meta,
             title: typeof title === 'string' ? title : I18n[title.key](),

--- a/packages/frontend/core/src/modules/doc-display-meta/index.ts
+++ b/packages/frontend/core/src/modules/doc-display-meta/index.ts
@@ -1,5 +1,6 @@
 import {
   DocsService,
+  FeatureFlagService,
   type Framework,
   WorkspaceScope,
 } from '@toeverything/infra';
@@ -12,5 +13,9 @@ export { DocDisplayMetaService };
 export function configureDocDisplayMetaModule(framework: Framework) {
   framework
     .scope(WorkspaceScope)
-    .service(DocDisplayMetaService, [WorkspacePropertiesAdapter, DocsService]);
+    .service(DocDisplayMetaService, [
+      WorkspacePropertiesAdapter,
+      DocsService,
+      FeatureFlagService,
+    ]);
 }

--- a/packages/frontend/core/src/modules/explorer/views/nodes/doc/index.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/nodes/doc/index.tsx
@@ -14,6 +14,7 @@ import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import {
   DocsService,
+  FeatureFlagService,
   GlobalContextService,
   LiveData,
   useLiveData,
@@ -47,11 +48,13 @@ export const ExplorerDocNode = ({
     docsService,
     globalContextService,
     docDisplayMetaService,
+    featureFlagService,
   } = useServices({
     DocsSearchService,
     DocsService,
     GlobalContextService,
     DocDisplayMetaService,
+    FeatureFlagService,
   });
   // const pageInfoAdapter = useCurrentWorkspacePropertiesAdapter();
 
@@ -67,6 +70,9 @@ export const ExplorerDocNode = ({
   );
   const docTitle = useLiveData(docDisplayMetaService.title$(docId));
   const isInTrash = useLiveData(docRecord?.trash$);
+  const enableEmojiIcon = useLiveData(
+    featureFlagService.flags.enable_emoji_doc_icon.$
+  );
 
   const Icon = useCallback(
     ({ className }: { className?: string }) => {
@@ -206,6 +212,7 @@ export const ExplorerDocNode = ({
       dndData={dndData}
       onDrop={handleDropOnDoc}
       renameable
+      extractEmojiAsIcon={enableEmojiIcon}
       collapsed={collapsed}
       setCollapsed={setCollapsed}
       canDrop={handleCanDrop}


### PR DESCRIPTION
close AF-1412

Adjusted the priority of the public doc icon:

1. block-reference
2. journal
3. page reference
4. **emoji** (*new)
5. default