### PR TITLE
chore: remove blocksuite local debug option

### DIFF
--- a/tools/cli/src/webpack/config.ts
+++ b/tools/cli/src/webpack/config.ts
@@ -91,7 +91,6 @@ export const createConfiguration: (
   buildFlags: BuildFlags,
   buildConfig: BUILD_CONFIG_TYPE
 ) => webpack.Configuration = (cwd, buildFlags, buildConfig) => {
-  const blocksuiteBaseDir = buildFlags.localBlockSuite;
   const config = {
     name: 'affine',
     // to set a correct base path for the source map
@@ -146,81 +145,9 @@ export const createConfiguration: (
         '.mjs': ['.mjs', '.mts'],
       },
       extensions: ['.js', '.ts', '.tsx'],
-      fallback:
-        blocksuiteBaseDir === undefined
-          ? undefined
-          : {
-              events: false,
-            },
       alias: {
         yjs: join(workspaceRoot, 'node_modules', 'yjs'),
         lit: join(workspaceRoot, 'node_modules', 'lit'),
-        '@blocksuite/affine/block-std': blocksuiteBaseDir
-          ? join(blocksuiteBaseDir, 'packages', 'framework', 'block-std', 'src')
-          : join(
-              workspaceRoot,
-              'node_modules',
-              '@blocksuite',
-              'block-std',
-              'dist'
-            ),
-        '@blocksuite/affine/blocks': blocksuiteBaseDir
-          ? join(blocksuiteBaseDir, 'packages', 'blocks', 'src')
-          : join(
-              workspaceRoot,
-              'node_modules',
-              '@blocksuite',
-              'blocks',
-              'dist'
-            ),
-        '@blocksuite/affine/presets': blocksuiteBaseDir
-          ? join(blocksuiteBaseDir, 'packages', 'presets', 'src')
-          : join(
-              workspaceRoot,
-              'node_modules',
-              '@blocksuite',
-              'presets',
-              'dist'
-            ),
-        '@blocksuite/affine/global': blocksuiteBaseDir
-          ? join(blocksuiteBaseDir, 'packages', 'framework', 'global', 'src')
-          : join(
-              workspaceRoot,
-              'node_modules',
-              '@blocksuite',
-              'global',
-              'dist'
-            ),
-        '@blocksuite/affine/store/providers/broadcast-channel':
-          blocksuiteBaseDir
-            ? join(
-                blocksuiteBaseDir,
-                'packages',
-                'framework',
-                'store',
-                'src/providers/broadcast-channel'
-              )
-            : join(
-                workspaceRoot,
-                'node_modules',
-                '@blocksuite',
-                'store',
-                'dist',
-                'providers',
-                'broadcast-channel.js'
-              ),
-        '@blocksuite/affine/store': blocksuiteBaseDir
-          ? join(blocksuiteBaseDir, 'packages', 'framework', 'store', 'src')
-          : join(workspaceRoot, 'node_modules', '@blocksuite', 'store', 'dist'),
-        '@blocksuite/inline': blocksuiteBaseDir
-          ? join(blocksuiteBaseDir, 'packages', 'framework', 'inline', 'src')
-          : join(
-              workspaceRoot,
-              'node_modules',
-              '@blocksuite',
-              'inline',
-              'dist'
-            ),
       },
     },
 


### PR DESCRIPTION
This PR removes the blocksuite local debug option when running `yarn dev`.

After this, to enable local debugging, simply run
```sh
yarn link <path-to-blocksuite> -A
yarn dev
```
You can disable local debugging by running 
```sh
yarn unlink <path-to-blocksuite> -A
```