### PR TITLE
chore: pin postgresql version in  self-host compose.yaml

### DIFF
--- a/.github/deployment/self-host/compose.yaml
+++ b/.github/deployment/self-host/compose.yaml
@@ -43,7 +43,7 @@ services:
       timeout: 5s
       retries: 5
   postgres:
-    image: postgres
+    image: postgres:16
     container_name: affine_postgres
     restart: unless-stopped
     volumes:


### PR DESCRIPTION
As PostgresSQL released v17 old database files are incompatible with this version.


upd. logs:
```
affine_postgres  | PostgreSQL Database directory appears to contain a database; Skipping initialization
affine_postgres  | 
affine_postgres  | 2024-09-30 10:33:21.268 UTC [1] FATAL:  database files are incompatible with server
affine_postgres  | 2024-09-30 10:33:21.268 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.0 (Debian 17.0-1.pgdg120+1).
```