### PR TITLE
test(core): update outline viewer test in shared page

### DIFF
--- a/tests/affine-cloud/e2e/share-page.spec.ts
+++ b/tests/affine-cloud/e2e/share-page.spec.ts
@@ -118,6 +118,11 @@ test('share page should have toc', async ({ page, browser }) => {
     const viewer = page2.locator('affine-outline-viewer');
     await tocIndicators.first().hover({ force: true });
     await expect(viewer).toBeVisible();
+
+    const toggleButton = viewer.locator(
+      '[data-testid="toggle-outline-panel-button"]'
+    );
+    await expect(toggleButton).toHaveCount(0);
   }
 });
 


### PR DESCRIPTION
Close [BS-1573](https://linear.app/affine-design/issue/BS-1537/share-page-中-toc-不应该有-[open-in-sidebar]-选项), Related PR: https://github.com/toeverything/blocksuite/pull/8493