### PR TITLE
build(electron): deb distro support

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -160,7 +160,7 @@ jobs:
           mkdir -p builds
           mv packages/frontend/apps/electron/out/*/make/zip/linux/x64/*.zip ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-linux-x64.zip
           mv packages/frontend/apps/electron/out/*/make/*.AppImage ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-linux-x64.appimage
-
+          mv packages/frontend/apps/electron/out/*/make/deb/x64/*.deb ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-linux-x64.deb
       - uses: actions/attest-build-provenance@v1
         if: ${{ matrix.spec.platform == 'darwin' }}
         with:
@@ -174,7 +174,7 @@ jobs:
           subject-path: |
             ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-linux-x64.zip
             ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-linux-x64.appimage
-
+            ./builds/affine-${{ needs.before-make.outputs.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-linux-x64.deb
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -411,6 +411,7 @@ jobs:
             ./*.dmg
             ./*.exe
             ./*.appimage
+            ./*.deb
             ./*.apk
             ./*.yml
       - name: Create Nightly Release Draft
@@ -433,5 +434,6 @@ jobs:
             ./*.dmg
             ./*.exe
             ./*.appimage
+            ./*.deb
             ./*.apk
             ./*.yml

--- a/packages/frontend/apps/electron/forge.config.mjs
+++ b/packages/frontend/apps/electron/forge.config.mjs
@@ -88,6 +88,18 @@ const makers = [
       ],
     },
   },
+  !process.env.SKIP_BUNDLE && {
+    name: '@electron-forge/maker-deb',
+    config: {
+      bin: productName,
+      options: {
+        name: productName,
+        productName,
+        icon: iconX64PngPath,
+        mimeType: ['x-scheme-handler/affine'],
+      },
+    },
+  },
 ].filter(Boolean);
 
 /**
@@ -119,6 +131,7 @@ export default {
         schemes: [productName.toLowerCase()],
       },
     ],
+    executableName: productName,
     asar: true,
   },
   makers,

--- a/packages/frontend/apps/electron/package.json
+++ b/packages/frontend/apps/electron/package.json
@@ -32,7 +32,7 @@
     "@electron-forge/cli": "^7.3.0",
     "@electron-forge/core": "^7.3.0",
     "@electron-forge/core-utils": "^7.3.0",
-    "@electron-forge/maker-deb": "^7.3.0",
+    "@electron-forge/maker-deb": "^7.5.0",
     "@electron-forge/maker-dmg": "^7.3.0",
     "@electron-forge/maker-squirrel": "^7.3.0",
     "@electron-forge/maker-zip": "^7.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -474,7 +474,7 @@ __metadata:
     "@electron-forge/cli": "npm:^7.3.0"
     "@electron-forge/core": "npm:^7.3.0"
     "@electron-forge/core-utils": "npm:^7.3.0"
-    "@electron-forge/maker-deb": "npm:^7.3.0"
+    "@electron-forge/maker-deb": "npm:^7.5.0"
     "@electron-forge/maker-dmg": "npm:^7.3.0"
     "@electron-forge/maker-squirrel": "npm:^7.3.0"
     "@electron-forge/maker-zip": "npm:^7.3.0"
@@ -3353,7 +3353,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@electron-forge/maker-deb@npm:^7.3.0":
+"@electron-forge/maker-deb@npm:^7.5.0":
   version: 7.5.0
   resolution: "@electron-forge/maker-deb@npm:7.5.0"
   dependencies:


### PR DESCRIPTION
Add simple .deb support.

Note:
1. auto updater not tested
2. no wayland support
3. may requires --no-sandbox to run

related to https://github.com/toeverything/AFFiNE/issues/3272

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/279f031d-070a-43ef-be67-9acf2134355d.png)

