### PR TITLE
feat(admin): allow config unlimited copilot

### DIFF
--- a/packages/backend/server/src/core/features/resolver.ts
+++ b/packages/backend/server/src/core/features/resolver.ts
@@ -37,7 +37,7 @@ export class AvailableUserFeatureConfig {
 
   async availableUserFeatures() {
     return this.config.isSelfhosted
-      ? [FeatureType.Admin]
+      ? [FeatureType.Admin, FeatureType.UnlimitedCopilot]
       : [FeatureType.EarlyAccess, FeatureType.AIEarlyAccess, FeatureType.Admin];
   }
 }


### PR DESCRIPTION
If you configure copilot in your self host instance, it still has a limit: 10 quotas.