### PR TITLE
chore(oxlint): configure rule categories in oxlint.json

### DIFF
--- a/oxlint.json
+++ b/oxlint.json
@@ -1,4 +1,8 @@
 {
+  "categories": {
+    "correctness": "error",
+    "perf": "error"
+  },
   "rules": {
     // allow
     "import/named": "allow",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lint:eslint:fix": "yarn lint:eslint --fix",
     "lint:prettier": "prettier --ignore-unknown --cache --check .",
     "lint:prettier:fix": "prettier --ignore-unknown --cache --write .",
-    "lint:ox": "oxlint -c oxlint.json --deny-warnings --import-plugin -D correctness -D perf",
+    "lint:ox": "oxlint -c oxlint.json --deny-warnings --import-plugin",
     "lint": "yarn lint:eslint && yarn lint:prettier",
     "lint:fix": "yarn lint:eslint:fix && yarn lint:prettier:fix",
     "test": "vitest --run",

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-cards.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-cards.ts
@@ -359,7 +359,7 @@ export class ChatCards extends WithDisposable(LitElement) {
           (
             this.host.doc.getBlock(data.currentImageSelections[0].blockId)
               ?.model as ImageBlockModel
-          ).caption ?? '';
+          )?.caption ?? '';
       }
 
       this._updateCards({


### PR DESCRIPTION
## What This PR Does

Moves category-based configuration from CLI args in `lint:ox` to `oxlint.json`.

We are adding support for the `plugins` field in the next release, and we ironed out how CLI-based rule configuration merges with file-based rule configuration (see: https://github.com/oxc-project/oxc/pull/6088). Rules that should have been enabled before will now be enabled, and due to this I also fixed a violation of `eslint/no-unsafe-optional-chaining` that was not caught before.

This is part of an ongoing effort to keep our ecosystem CI nice and green. Thank you for using oxlint ⚓ 