### PR TITLE
refactor(core): improve editor gap appendParagraph function

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/styles.css.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/styles.css.ts
@@ -1,6 +1,8 @@
 import { cssVar } from '@toeverything/theme';
 import { style, type StyleRule } from '@vanilla-extract/css';
 
+const editorBottomPadding = 32;
+
 export const docEditorRoot = style({
   display: 'block',
   background: cssVar('backgroundPrimaryColor'),
@@ -29,10 +31,13 @@ export const docEditorGap = style({
   display: 'block',
   width: '100%',
   margin: '0 auto',
-  paddingTop: 50,
+  // hack to cover the bottom padding of the editor
+  marginTop: -editorBottomPadding,
+  paddingTop: 50 + editorBottomPadding,
   paddingBottom: 50,
   cursor: 'text',
   flexGrow: 1,
+  zIndex: 1,
 });
 
 const titleTagBasic = style({

--- a/tests/affine-local/e2e/blocksuite/editor.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/editor.spec.ts
@@ -64,3 +64,25 @@ test('link page is useable', async ({ page }) => {
     page.locator('.doc-title-container:has-text("page1")')
   ).toBeVisible();
 });
+
+test('append paragraph when click editor gap', async ({ page }) => {
+  await openHomePage(page);
+  await waitForEditorLoad(page);
+  await clickNewPageButton(page);
+  await waitForEditorLoad(page);
+
+  const title = getBlockSuiteEditorTitle(page);
+  await title.pressSequentially('test title');
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.insertText('test content');
+
+  const paragraph = page.locator('affine-paragraph');
+  const numParagraphs = await paragraph.count();
+
+  await page.locator('[data-testid=page-editor-blank]').click();
+  expect(await paragraph.count()).toBe(numParagraphs + 1);
+
+  // click the gap again, should not append another paragraph
+  await page.locator('[data-testid=page-editor-blank]').click();
+  expect(await paragraph.count()).toBe(numParagraphs + 1);
+});


### PR DESCRIPTION
close AF-1257

Every time we clicked on an empty space at the bottom, a new Paragraph block was created. 
Now we change it so that if there is already an empty Paragraph block at the bottom, we focus it instead of creating a new one.