### PR TITLE
fix: old document edgelessColorTheme shows auto but always render white

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/root-block.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/root-block.ts
@@ -107,7 +107,9 @@ function createThemeExtension(framework: FrameworkProvider) {
       if (cache) return cache;
 
       const appTheme$ = framework.get(AppThemeService).appTheme.theme$;
-      const docTheme$ = doc.properties$.map(props => props.edgelessColorTheme);
+      const docTheme$ = doc.properties$.map(
+        props => props.edgelessColorTheme || 'system'
+      );
       const theme$: Observable<ColorScheme> = combineLatest([
         appTheme$,
         docTheme$,


### PR DESCRIPTION
Fix issue [AF-1593](https://linear.app/affine-design/issue/AF-1593).