### PR TITLE
fix(electron): active view sometimes does not get focused

### DIFF
--- a/packages/frontend/apps/electron/src/main/application-menu/create.ts
+++ b/packages/frontend/apps/electron/src/main/application-menu/create.ts
@@ -172,22 +172,6 @@ export function createApplicationMenu() {
           },
         },
         {
-          label: 'Switch to next tab (mac)',
-          accelerator: 'Command+]',
-          visible: false,
-          click: () => {
-            switchToNextTab();
-          },
-        },
-        {
-          label: 'Switch to previous tab (mac)',
-          accelerator: 'Command+[',
-          visible: false,
-          click: () => {
-            switchToPreviousTab();
-          },
-        },
-        {
           label: 'Switch to next tab (mac 2)',
           accelerator: 'Alt+Command+]',
           visible: false,

--- a/packages/frontend/apps/electron/src/main/windows-manager/tab-views.ts
+++ b/packages/frontend/apps/electron/src/main/windows-manager/tab-views.ts
@@ -734,6 +734,33 @@ export class WebContentViewsManager {
     app.on('before-quit', () => {
       disposables.forEach(d => d.unsubscribe());
     });
+
+    const focusActiveView = () => {
+      if (
+        !this.activeWorkbenchView ||
+        this.activeWorkbenchView.webContents.isFocused()
+      ) {
+        return;
+      }
+      this.activeWorkbenchView?.webContents.focus();
+      setTimeout(() => {
+        focusActiveView();
+      }, 100);
+    };
+
+    app.on('browser-window-focus', () => {
+      focusActiveView();
+    });
+
+    combineLatest([
+      this.activeWorkbenchId$,
+      this.mainWindowManager.mainWindow$,
+    ]).subscribe(([_, window]) => {
+      // makes sure the active view is always focused
+      if (window?.isFocused()) {
+        focusActiveView();
+      }
+    });
   };
 
   getViewById = (id: string) => {


### PR DESCRIPTION
fix AF-1602
also remove CMD+[ or ] for changing active tabs.

If the active tab is not being correctly focuesed, the other active focus will swallow some of the keybindings. 