### PR TITLE
fix(core): temporarily make AI functions not follow server configuration

### DIFF
--- a/packages/frontend/core/src/components/affine/ai-onboarding/index.tsx
+++ b/packages/frontend/core/src/components/affine/ai-onboarding/index.tsx
@@ -1,9 +1,4 @@
-import { ServerConfigService } from '@affine/core/modules/cloud';
-import {
-  FeatureFlagService,
-  useLiveData,
-  useService,
-} from '@toeverything/infra';
+import { FeatureFlagService, useService } from '@toeverything/infra';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 
 import { AIOnboardingEdgeless } from './edgeless.dialog';
@@ -35,12 +30,7 @@ export const WorkspaceAIOnboarding = () => {
   const [dismissGeneral] = useDismiss(AIOnboardingType.GENERAL);
   const [dismissLocal] = useDismiss(AIOnboardingType.LOCAL);
   const featureFlagService = useService(FeatureFlagService);
-  const serverConfigService = useService(ServerConfigService);
-  const serverFeatures = useLiveData(
-    serverConfigService.serverConfig.features$
-  );
-  const enableAI =
-    serverFeatures?.copilot && featureFlagService.flags.enable_ai.value;
+  const enableAI = featureFlagService.flags.enable_ai.value;
 
   return (
     <Suspense>
@@ -53,12 +43,7 @@ export const WorkspaceAIOnboarding = () => {
 export const PageAIOnboarding = () => {
   const [dismissEdgeless] = useDismiss(AIOnboardingType.EDGELESS);
   const featureFlagService = useService(FeatureFlagService);
-  const serverConfigService = useService(ServerConfigService);
-  const serverFeatures = useLiveData(
-    serverConfigService.serverConfig.features$
-  );
-  const enableAI =
-    serverFeatures?.copilot && featureFlagService.flags.enable_ai.value;
+  const enableAI = featureFlagService.flags.enable_ai.value;
 
   return (
     <Suspense>

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -3,7 +3,6 @@ import {
   useConfirmModal,
   useLitPortalFactory,
 } from '@affine/component';
-import { ServerConfigService } from '@affine/core/modules/cloud';
 import { EditorService } from '@affine/core/modules/editor';
 import { EditorSettingService } from '@affine/core/modules/editor-setting';
 import { JournalService } from '@affine/core/modules/journal';
@@ -91,7 +90,6 @@ const usePatchSpecs = (shared: boolean, mode: DocMode) => {
     editorService,
     workspaceService,
     featureFlagService,
-    serverConfigService,
   } = useServices({
     PeekViewService,
     DocService,
@@ -99,12 +97,8 @@ const usePatchSpecs = (shared: boolean, mode: DocMode) => {
     WorkspaceService,
     EditorService,
     FeatureFlagService,
-    ServerConfigService,
   });
   const framework = useFramework();
-  const serverFeatures = useLiveData(
-    serverConfigService.serverConfig.features$
-  );
   const referenceRenderer: ReferenceReactRenderer = useMemo(() => {
     return function customReference(reference) {
       const data = reference.delta.attributes?.reference;
@@ -130,17 +124,11 @@ const usePatchSpecs = (shared: boolean, mode: DocMode) => {
   }, [workspaceService]);
 
   const specs = useMemo(() => {
-    const enableAI =
-      serverFeatures?.copilot && featureFlagService.flags.enable_ai.value;
+    const enableAI = featureFlagService.flags.enable_ai.value;
     return mode === 'edgeless'
       ? createEdgelessModeSpecs(framework, !!enableAI)
       : createPageModeSpecs(framework, !!enableAI);
-  }, [
-    serverFeatures?.copilot,
-    featureFlagService.flags.enable_ai.value,
-    mode,
-    framework,
-  ]);
+  }, [featureFlagService.flags.enable_ai.value, mode, framework]);
 
   const confirmModal = useConfirmModal();
   const patchedSpecs = useMemo(() => {

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
@@ -7,7 +7,6 @@ import { EditorOutlineViewer } from '@affine/core/components/blocksuite/outline-
 import { DocPropertySidebar } from '@affine/core/components/doc-properties/sidebar';
 import { useAppSettingHelper } from '@affine/core/components/hooks/affine/use-app-setting-helper';
 import { useDocMetaHelper } from '@affine/core/components/hooks/use-block-suite-page-meta';
-import { ServerConfigService } from '@affine/core/modules/cloud';
 import { EditorService } from '@affine/core/modules/editor';
 import { RecentDocsService } from '@affine/core/modules/quicksearch';
 import { ViewService } from '@affine/core/modules/workbench/services/view';
@@ -70,7 +69,6 @@ const DetailPageImpl = memo(function DetailPageImpl() {
     workspaceService,
     globalContextService,
     featureFlagService,
-    serverConfigService,
   } = useServices({
     WorkbenchService,
     ViewService,
@@ -79,7 +77,6 @@ const DetailPageImpl = memo(function DetailPageImpl() {
     WorkspaceService,
     GlobalContextService,
     FeatureFlagService,
-    ServerConfigService,
   });
   const workbench = workbenchService.workbench;
   const editor = editorService.editor;
@@ -106,12 +103,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
   const [_, setActiveBlockSuiteEditor] = useActiveBlocksuiteEditor();
 
   const t = useI18n();
-
-  const serverFeatures = useLiveData(
-    serverConfigService.serverConfig.features$
-  );
-  const enableAI =
-    serverFeatures?.copilot && featureFlagService.flags.enable_ai.value;
+  const enableAI = featureFlagService.flags.enable_ai.value;
 
   useEffect(() => {
     if (isActiveView) {


### PR DESCRIPTION
Since the switch of the AI ​​function in Blocksuite cannot be hot-updated, the editor will not be able to use the AI ​​function when it is not connected to the server at the beginning, so this code is temporarily removed.