### PR TITLE
fix(electron): deep link handling in macos

### DIFF
--- a/packages/frontend/apps/electron/src/main/deep-link.ts
+++ b/packages/frontend/apps/electron/src/main/deep-link.ts
@@ -30,11 +30,15 @@ export function setupDeepLink(app: App) {
   }
 
   app.on('open-url', (event, url) => {
+    logger.log('open-url', url);
     if (url.startsWith(`${protocol}://`)) {
       event.preventDefault();
-      handleAffineUrl(url).catch(e => {
-        logger.error('failed to handle affine url', e);
-      });
+      app
+        .whenReady()
+        .then(() => handleAffineUrl(url))
+        .catch(e => {
+          logger.error('failed to handle affine url', e);
+        });
     }
   });
 


### PR DESCRIPTION
fix AF-1617
The issue is that handling deep link on opening new instance will access the screen module from electron too soon. Move the open call behind whenReady to mitigate the issue.