### PR TITLE
chore(mobile): disable some toolbar widgets for mobile

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -54,6 +54,7 @@ import {
   patchDocModeService,
   patchEdgelessClipboard,
   patchEmbedLinkedDocBlockConfig,
+  patchForMobile,
   patchForSharedPage,
   patchNotificationService,
   patchParseDocUrlExtension,
@@ -149,6 +150,9 @@ const usePatchSpecs = (shared: boolean, mode: DocMode) => {
     patched = patched.concat(patchEmbedLinkedDocBlockConfig(framework));
     if (shared) {
       patched = patched.concat(patchForSharedPage());
+    }
+    if (BUILD_CONFIG.isMobileEdition) {
+      patched = patched.concat(patchForMobile());
     }
     patched = patched.concat(
       patchDocModeService(docService, docsService, editorService)

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/root-block.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/root-block.ts
@@ -42,7 +42,6 @@ import { combineLatest, map } from 'rxjs';
 
 import { getFontConfigExtension } from '../font-extension';
 import { createDatabaseOptionsConfig } from './database-block';
-import { createKeyboardToolbarConfig } from './widgets/keyboard-toolbar';
 import { createLinkedWidgetConfig } from './widgets/linked';
 import { createToolbarMoreMenuConfig } from './widgets/toolbar';
 
@@ -150,7 +149,6 @@ function getEditorConfigExtension(
       linkedWidget: createLinkedWidgetConfig(framework),
       toolbarMoreMenu: createToolbarMoreMenuConfig(framework),
       databaseOptions: createDatabaseOptionsConfig(framework),
-      keyboardToolbar: createKeyboardToolbarConfig(),
     } satisfies RootBlockConfig),
   ];
 }


### PR DESCRIPTION
This PR disable some toolbar widgets on mobile. Close [BS-1730](https://linear.app/affine-design/issue/BS-1730/%E7%A6%81%E7%94%A8-block-yuan%E7%B4%A0%E7%9A%84-toolbar)