### PR TITLE
chore(mobile): disable reference popup on mobile

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -40,6 +40,7 @@ import type {
   PeekOptions,
   PeekViewService as BSPeekViewService,
   QuickSearchResult,
+  ReferenceNodeConfig,
   RootBlockConfig,
   RootService,
 } from '@blocksuite/affine/blocks';
@@ -57,6 +58,7 @@ import {
   PeekViewExtension,
   QuickSearchExtension,
   ReferenceNodeConfigExtension,
+  ReferenceNodeConfigIdentifier,
 } from '@blocksuite/affine/blocks';
 import { type BlockSnapshot, Text } from '@blocksuite/affine/store';
 import {
@@ -564,6 +566,17 @@ export function patchForMobile() {
             ...prev?.(provider),
             keyboardToolbar: createKeyboardToolbarConfig(),
           } satisfies RootBlockConfig;
+        });
+      }
+
+      // Hide reference popup on mobile.
+      {
+        const prev = di.getFactory(ReferenceNodeConfigIdentifier);
+        di.override(ReferenceNodeConfigIdentifier, provider => {
+          return {
+            ...prev?.(provider),
+            hidePopup: true,
+          } satisfies ReferenceNodeConfig;
         });
       }
 


### PR DESCRIPTION
This PR disable reference node popup on mobile. Close [BS-1730](https://linear.app/affine-design/issue/BS-1730/%E7%A6%81%E7%94%A8-block-yuan%E7%B4%A0%E7%9A%84-toolbar)