### PR TITLE
fix(server): Do not require scope field in access token

### DIFF
--- a/packages/backend/server/src/plugins/oauth/providers/oidc.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/oidc.ts
@@ -14,7 +14,6 @@ const OIDCTokenSchema = z.object({
   access_token: z.string(),
   expires_in: z.number(),
   refresh_token: z.string(),
-  scope: z.string(),
   token_type: z.string(),
 });
 

--- a/packages/backend/server/src/plugins/oauth/providers/oidc.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/oidc.ts
@@ -14,6 +14,7 @@ const OIDCTokenSchema = z.object({
   access_token: z.string(),
   expires_in: z.number(),
   refresh_token: z.string(),
+  scope: z.string().optional(),
   token_type: z.string(),
 });
 


### PR DESCRIPTION
Remove scope that should not be mandatory and is not used (#8752)