### PR TITLE
fix(mobile): typo of identifier when override config

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -557,7 +557,7 @@ export function patchForMobile() {
       // page configs
       {
         const pageConfigIdentifier = ConfigIdentifier('affine:page');
-        const prev = di.getFactory(ConfigIdentifier);
+        const prev = di.getFactory(pageConfigIdentifier);
 
         di.override(pageConfigIdentifier, provider => {
           return {


### PR DESCRIPTION
Fixed a typo in the mobile patches where the wrong identifier was being used to override `affine:page` configs.