### PR TITLE
fix(core): avoid shaking when center-peek opened

### DIFF
--- a/packages/frontend/core/src/modules/peek-view/view/modal-container.css.ts
+++ b/packages/frontend/core/src/modules/peek-view/view/modal-container.css.ts
@@ -48,7 +48,6 @@ export const modalContentContainer = style({
     [`${modalContentWrapper}[data-mode="max"] &`]: {
       width: 'calc(100% - 64px)',
       height: 'calc(100% - 64px)',
-      paddingRight: 48,
     },
     [`${modalContentWrapper}[data-mode="full"] &`]: {
       width: '100%',
@@ -57,7 +56,6 @@ export const modalContentContainer = style({
     [`${modalContentWrapper}[data-mode="fit"] &`]: {
       width: '90%',
       height: '90%',
-      paddingRight: 48,
       maxWidth: 1248,
     },
     '&[data-anime-state="animating"]': {
@@ -96,7 +94,7 @@ export const modalContent = style({
 
 export const modalControls = style({
   position: 'absolute',
-  right: 0,
+  right: -48,
   top: 0,
   zIndex: -1,
   minWidth: '48px',


### PR DESCRIPTION
close AF-1668;

We calculate the final width through ﻿modalContent at the start of the animation, so the calculated width is unexpected when there is a `padding`.