### PR TITLE
fix(electron): potential crash on quit

### DIFF
--- a/packages/frontend/apps/electron/src/main/helper-process.ts
+++ b/packages/frontend/apps/electron/src/main/helper-process.ts
@@ -78,8 +78,12 @@ class HelperProcessManager {
     renderer.postMessage('helper-connection', null, [rendererPort]);
 
     return () => {
-      helperPort.close();
-      rendererPort.close();
+      try {
+        helperPort.close();
+        rendererPort.close();
+      } catch (err) {
+        logger.error('[helper] close port error', err);
+      }
     };
   }
 

--- a/packages/frontend/apps/electron/src/preload/electron-api.ts
+++ b/packages/frontend/apps/electron/src/preload/electron-api.ts
@@ -157,7 +157,11 @@ const createMessagePortChannel = (port: MessagePort): EventBasedChannel => {
       port.start();
       return () => {
         port.onmessage = null;
-        port.close();
+        try {
+          port.close();
+        } catch (err) {
+          console.error('[helper] close port error', err);
+        }
       };
     },
     send(data) {


### PR DESCRIPTION
fix AF-1696

Related log:
```
Thread 0 Crashed:: CrBrowserMain Dispatch queue: com.apple.main-thread
0   Electron Framework            	       0x10c3bb09c electron::MessagePort::Close()
1   Electron Framework            	       0x10c3bcb78 gin::internal::Dispatcher<void (electron::MessagePort*)>::DispatchToCallbackImpl(gin::Arguments*)
2   Electron Framework            	       0x10c3bc984 gin::internal::Dispatcher<void (electron::MessagePort*)>::DispatchToCallback(v8::FunctionCallbackInfo<v8::Value> const&)
3   ???                           	       0x147e0f58c ???
4   ???                           	       0x147e0d45c ???
5   ???                           	       0x147e0d45c ???
6   ???                           	       0x147e0d45c ???
7   ???                           	       0x1401743b8 ???
8   ???                           	       0x147e0b088 ???
9   ???                           	       0x147e0acd4 ???
10  Electron Framework            	       0x10d657578 v8::internal::Execution::Call(v8::internal::Isolate*, v8::internal::Handle<v8::internal::Object>, v8::internal::Handle<v8::internal::Object>, int, v8::internal::Handle<v8::internal::Object>*)
11  Electron Framework            	       0x10d53e478 v8::Function::Call(v8::Isolate*, v8::Local<v8::Context>, v8::Local<v8::Value>, int, v8::Local<v8::Value>*)
12  Electron Framework            	       0x11337ad34 node::InternalMakeCallback(node::Environment*, v8::Local<v8::Object>, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context)
13  Electron Framework            	       0x11337b0b0 node::MakeCallback(v8::Isolate*, v8::Local<v8::Object>, v8::Local<v8::Function>, int, v8::Local<v8::Value>*, node::async_context)
14  Electron Framework            	       0x10c46d9dc gin_helper::internal::CallMethodWithArgs(v8::Isolate*, v8::Local<v8::Object>, char const*, base::span<v8::Local<v8::Value>, 18446744073709551615ul, v8::Local<v8::Value>*>)
15  Electron Framework            	       0x10c3833b0 bool gin_helper::EventEmitterMixin<electron::api::WebContents>::Emit<>(std::__Cr::basic_string_view<char, std::__Cr::char_traits<char>>)
16  Electron Framework            	       0x10c38324c electron::api::WebContents::WebContentsDestroyed()
17  Electron Framework            	       0x10ebc2ee8 void content::WebContentsImpl::WebContentsObserverList::NotifyObservers<void (content::WebContentsObserver::*)()>(void (content::WebContentsObserver::*)())
18  Electron Framework            	       0x10ebc229c content::WebContentsImpl::~WebContentsImpl()
19  Electron Framework            	       0x10ebc32b0 content::WebContentsImpl::~WebContentsImpl()
20  Electron Framework            	       0x10c4212dc electron::InspectableWebContents::~InspectableWebContents()
21  Electron Framework            	       0x10c4213ac electron::InspectableWebContents::~InspectableWebContents()
22  Electron Framework            	       0x10c382ffc electron::api::WebContents::~WebContents()
23  Electron Framework            	       0x10c383498 non-virtual thunk to electron::api::WebContents::~WebContents()
24  Electron Framework            	       0x10c46cb80 gin_helper::CleanedUpAtExit::DoCleanup()
25  Electron Framework            	       0x10c3ec994 electron::JavascriptEnvironment::DestroyMicrotasksRunner()
26  Electron Framework            	       0x10c3d2828 electron::ElectronBrowserMainParts::PostMainMessageLoopRun()
27  Electron Framework            	       0x10e663458 content::BrowserMainLoop::ShutdownThreadsAndCleanUp()
28  Electron Framework            	       0x10e664a80 content::BrowserMainRunnerImpl::Shutdown()
29  Electron Framework            	       0x10e661098 content::BrowserMain(content::MainFunctionParams)
30  Electron Framework            	       0x10c6339a4 content::RunBrowserProcessMain(content::MainFunctionParams, content::ContentMainDelegate*)
31  Electron Framework            	       0x10c634968 content::ContentMainRunnerImpl::RunBrowser(content::MainFunctionParams, bool)
32  Electron Framework            	       0x10c6347e8 content::ContentMainRunnerImpl::Run()
33  Electron Framework            	       0x10c633208 content::RunContentProcess(content::ContentMainParams, content::ContentMainRunner*)
34  Electron Framework            	       0x10c6332f0 content::ContentMain(content::ContentMainParams)
35  Electron Framework            	       0x10c2e98c0 ElectronMain
36  dyld                          	       0x18b5a8274 start
```