### PR TITLE
fix(electron): respect locale for spellchecker

### DIFF
--- a/packages/frontend/apps/electron/src/main/ui/handlers.ts
+++ b/packages/frontend/apps/electron/src/main/ui/handlers.ts
@@ -1,6 +1,7 @@
 import { app, nativeTheme, shell } from 'electron';
 import { getLinkPreview } from 'link-preview-js';
 
+import { isMacOS } from '../../shared/utils';
 import { persistentConfig } from '../config-storage/persist';
 import { logger } from '../logger';
 import type { WorkbenchViewMeta } from '../shared-state-schema';
@@ -219,5 +220,16 @@ export const uiHandlers = {
   restartApp: async () => {
     app.relaunch();
     app.quit();
+  },
+  onLanguageChange: async (e, language: string) => {
+    // only works for win/linux
+    // see https://www.electronjs.org/docs/latest/tutorial/spellchecker#how-to-set-the-languages-the-spellchecker-uses
+    if (isMacOS()) {
+      return;
+    }
+
+    if (e.sender.session.availableSpellCheckerLanguages.includes(language)) {
+      e.sender.session.setSpellCheckerLanguages([language, 'en-US']);
+    }
   },
 } satisfies NamespaceHandlers;

--- a/packages/frontend/core/src/modules/editor-setting/index.ts
+++ b/packages/frontend/core/src/modules/editor-setting/index.ts
@@ -4,6 +4,8 @@ import {
   GlobalStateService,
 } from '@toeverything/infra';
 
+import { DesktopApiService } from '../desktop-api';
+import { I18n } from '../i18n';
 import { UserDBService } from '../userspace';
 import { EditorSetting } from './entities/editor-setting';
 import { CurrentUserDBEditorSettingProvider } from './impls/user-db';
@@ -25,5 +27,9 @@ export function configureEditorSettingModule(framework: Framework) {
 }
 
 export function configureSpellCheckSettingModule(framework: Framework) {
-  framework.service(SpellCheckSettingService, [GlobalStateService]);
+  framework.service(SpellCheckSettingService, [
+    GlobalStateService,
+    I18n,
+    DesktopApiService,
+  ]);
 }

--- a/packages/frontend/core/src/modules/editor-setting/services/spell-check-setting.ts
+++ b/packages/frontend/core/src/modules/editor-setting/services/spell-check-setting.ts
@@ -2,14 +2,31 @@ import type {
   SpellCheckStateKey,
   SpellCheckStateSchema,
 } from '@affine/electron/main/shared-state-schema';
+import type { Language } from '@affine/i18n';
 import type { GlobalStateService } from '@toeverything/infra';
 import { LiveData, Service } from '@toeverything/infra';
+
+import type { DesktopApiService } from '../../desktop-api';
+import type { I18n } from '../../i18n';
 
 const SPELL_CHECK_SETTING_KEY: SpellCheckStateKey = 'spellCheckState';
 
 export class SpellCheckSettingService extends Service {
-  constructor(private readonly globalStateService: GlobalStateService) {
+  constructor(
+    private readonly globalStateService: GlobalStateService,
+    private readonly i18n: I18n,
+    private readonly desktopApiService: DesktopApiService
+  ) {
     super();
+
+    // this will be called even during initialization
+    this.i18n.i18next.on('languageChanged', (language: Language) => {
+      this.desktopApiService.handler.ui
+        .onLanguageChange(language)
+        .catch(err => {
+          console.error(err);
+        });
+    });
   }
 
   enabled$ = LiveData.from(


### PR DESCRIPTION
may fix #8837.
fix AF-1712

MacOS automatically do spellcheck based on given text. This only works for Win/Linux.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/25058395-d70a-42a4-b869-c69fa71bc418.png)

