### PR TITLE
chore(cli): enable accessing dev server by host name

### DIFF
--- a/tools/cli/src/webpack/config.ts
+++ b/tools/cli/src/webpack/config.ts
@@ -347,6 +347,8 @@ export const createConfiguration: (
     optimization: OptimizeOptionOptions(buildFlags),
 
     devServer: {
+      host: '0.0.0.0',
+      allowedHosts: 'all',
       hot: buildFlags.static ? false : 'only',
       liveReload: !buildFlags.static,
       client: {


### PR DESCRIPTION
This PR is particularly useful for debugging mobile app (and any other personal devices for testing) via [Tailscale](https://tailscale.com/), since it allows accessing a stable hostname on phone, instead of typing in an unstable IP address.

Before:

![image](https://github.com/user-attachments/assets/6ca9edd5-11b1-449b-bf8d-0423cb8a53fe)

After:

![image](https://github.com/user-attachments/assets/9df7710f-f662-4a3c-83c4-cf5f28d7c64f)


