### PR TITLE
fix: ai generation of mindmap fail from note text context

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/_common/config.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/_common/config.ts
@@ -6,14 +6,12 @@ import type {
 import {
   type AIItemGroupConfig,
   type AISubItemConfig,
-  type CopilotTool,
   EDGELESS_ELEMENT_TOOLBAR_WIDGET,
   type EdgelessElementToolbarWidget,
   matchFlavours,
 } from '@blocksuite/affine/blocks';
 import type { TemplateResult } from 'lit';
 
-import { TOGGLE_EMPTY_INPUT_ACTIONS } from '../actions/consts';
 import { actionToHandler } from '../actions/doc-handler';
 import { actionToHandler as edgelessActionToHandler } from '../actions/edgeless-handler';
 import {
@@ -255,17 +253,6 @@ function edgelessHandler<T extends keyof BlockSuitePresets.AIActions>(
       const selectedElements = edgeless.service.selection.selectedElements;
       if (!selectedElements.length) return;
 
-      edgeless.gfx.tool.setTool({ type: 'copilot' });
-      const currentController =
-        edgeless.gfx.tool.currentTool$.peek() as CopilotTool;
-      if (!currentController) {
-        edgeless.gfx.tool.setTool({ type: 'default' });
-        return;
-      }
-
-      currentController.updateDragPointsWith(selectedElements, 10);
-      currentController.draggingAreaUpdated.emit(false); // do not show edgeless panel
-
       return edgelessActionToHandler(
         id,
         generatingIcon,
@@ -281,11 +268,10 @@ function edgelessHandler<T extends keyof BlockSuitePresets.AIActions>(
             selections?.selectedBlocks?.length === 1 && attachments.length > 0;
           return {
             attachments: sendAttachments ? attachments : undefined,
-            content: sendAttachments ? '' : markdown,
+            input: sendAttachments ? '' : markdown,
           };
         },
-        trackerOptions,
-        TOGGLE_EMPTY_INPUT_ACTIONS.includes(id)
+        trackerOptions
       )(host);
     }
   };

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/consts.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/consts.ts
@@ -27,4 +27,3 @@ export const generatingStages: {
 };
 
 export const INSERT_ABOVE_ACTIONS = ['createHeadings'];
-export const TOGGLE_EMPTY_INPUT_ACTIONS = ['createImage', 'makeItReal'];

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/edgeless-handler.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/edgeless-handler.ts
@@ -67,7 +67,8 @@ function actionToRenderer<T extends keyof BlockSuitePresets.AIActions>(
     ] as BlockSuite.EdgelessModel[];
 
     if (
-      isMindMapRoot(selectedElements[0] || isMindmapChild(selectedElements[0]))
+      isMindMapRoot(selectedElements[0]) ||
+      isMindmapChild(selectedElements[0])
     ) {
       const mindmap = selectedElements[0].group as MindmapElementModel;
 
@@ -426,8 +427,7 @@ export function actionToHandler<T extends keyof BlockSuitePresets.AIActions>(
     attachments?: (string | Blob)[];
     seed?: string;
   } | void>,
-  trackerOptions?: BlockSuitePresets.TrackerOptions,
-  toggleEmptyInput?: boolean
+  trackerOptions?: BlockSuitePresets.TrackerOptions
 ) {
   return (host: EditorHost) => {
     const aiPanel = getAIPanel(host);
@@ -490,7 +490,7 @@ export function actionToHandler<T extends keyof BlockSuitePresets.AIActions>(
 
     if (isCreateImageAction || isMakeItRealAction) {
       togglePanel = async () => {
-        if (isEmpty || toggleEmptyInput) return true;
+        if (isEmpty) return true;
         const { notes, shapes, images, edgelessTexts, embedSyncedDocs } =
           BlocksUtils.splitElements(selectedElements);
         const blocks = [

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
@@ -87,7 +87,6 @@ declare global {
     }
 
     interface AIImageActionOptions extends AITextActionOptions {
-      content?: string;
       seed?: string;
     }
 

--- a/packages/frontend/core/src/blocksuite/presets/ai/entries/edgeless/actions-config.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/entries/edgeless/actions-config.ts
@@ -288,7 +288,7 @@ const generateGroup: AIItemGroupConfig = {
             const content = aiPanel.inputText?.trim();
             if (!content) return;
             return {
-              content,
+              input: content,
             };
           }
 
@@ -317,7 +317,7 @@ const generateGroup: AIItemGroupConfig = {
           // text to image
           if (content.length && images.length + pureShapes.length === 0) {
             return {
-              content,
+              input: content,
             };
           }
 
@@ -337,7 +337,7 @@ const generateGroup: AIItemGroupConfig = {
           const png = await canvasToBlob(canvas);
           if (!png) return;
           return {
-            content,
+            input: content,
             attachments: [png],
             seed: String(randomSeed()),
           };
@@ -418,7 +418,7 @@ const generateGroup: AIItemGroupConfig = {
             const content = aiPanel.inputText?.trim();
             if (!content) return;
             return {
-              content,
+              input: content,
             };
           }
 
@@ -444,7 +444,7 @@ const generateGroup: AIItemGroupConfig = {
               (s === 1 && shapes[0] instanceof TextElementModel))
           ) {
             return {
-              content,
+              input: content,
             };
           }
 
@@ -472,7 +472,7 @@ const generateGroup: AIItemGroupConfig = {
           });
 
           return {
-            content,
+            input: content,
             attachments: [png],
           };
         }

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/setup-provider.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/setup-provider.tsx
@@ -296,7 +296,7 @@ export function setupAIProvider(client: CopilotClient) {
 
   AIProvider.provide('makeItReal', options => {
     let promptName: PromptKey = 'Make it real';
-    let content = options.content || '';
+    let content = options.input || '';
 
     // wireframes
     if (options.attachments?.length) {
@@ -374,6 +374,7 @@ Could you make a new website based on these notes and send back just the html fi
     return toImage({
       ...options,
       client,
+      content: options.input,
       promptName,
     });
   });
@@ -384,6 +385,7 @@ Could you make a new website based on these notes and send back just the html fi
     return toImage({
       ...options,
       client,
+      content: options.input,
       timeout: 120000,
       promptName: promptName as PromptKey,
       workflow: !!promptName?.startsWith('workflow:'),
@@ -398,6 +400,7 @@ Could you make a new website based on these notes and send back just the html fi
     return toImage({
       ...options,
       client,
+      content: options.input,
       timeout: 120000,
       promptName,
     });


### PR DESCRIPTION
Fix issue [AF-1632](https://linear.app/affine-design/issue/AF-1632).

### What Changed?
- Keep the note selection and do not set the widget tool to copilot if asking AI from selection in a note in edgeless mode.
- Remove `content` from `AIImageActionOptions`, using `input` as AI context like other actions.