### PR TITLE
fix(component): workaround for storybook startup

### DIFF
--- a/packages/frontend/component/.storybook/main.ts
+++ b/packages/frontend/component/.storybook/main.ts
@@ -70,9 +70,9 @@ export default {
     });
   },
 
-  typescript: {
-    reactDocgen: 'react-docgen-typescript',
-  },
+  // typescript: {
+  //   reactDocgen: 'react-docgen-typescript',
+  // },
 } satisfies StorybookConfig;
 
 function getAbsolutePath(value: string): any {


### PR DESCRIPTION
It seems starting up storybook throws error when parsing doc using typescript.
Temporarily remove reactDocgen for now.
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/db54c528-2b37-4a91-b980-4fe6c07240b7.png)

