### PR TITLE
feat(core): dnd support external types

### DIFF
--- a/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch
+++ b/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch
@@ -1,0 +1,19 @@
+diff --git a/dist/esm/adapter/external-adapter.js b/dist/esm/adapter/external-adapter.js
+index ef7a963d91f08c9e70c8ed9c6b41972bec349319..e682841ec10a4a8a9ce7a79642e58de5c9e664d5 100644
+--- a/dist/esm/adapter/external-adapter.js
++++ b/dist/esm/adapter/external-adapter.js
+@@ -54,9 +54,11 @@ var adapter = makeAdapter({
+       type: 'dragenter',
+       listener: function listener(event) {
+         // drag operation was started within the document, it won't be an "external" drag
+-        if (didDragStartLocally) {
+-          return;
+-        }
++
++        // we will handle all events actually
++        // if (didDragStartLocally) {
++        //   return;
++        // }
+ 
+         // Note: not checking if event was cancelled (`event.defaultPrevented`) as
+         // cancelling a "dragenter" accepts the drag operation (not prevent it)

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "macos-alias": "npm:@napi-rs/macos-alias@0.0.4",
     "fs-xattr": "npm:@napi-rs/xattr@latest",
     "vite": "6.0.2",
-    "decode-named-character-reference@npm:^1.0.0": "patch:decode-named-character-reference@npm%3A1.0.2#~/.yarn/patches/decode-named-character-reference-npm-1.0.2-db17a755fd.patch"
+    "decode-named-character-reference@npm:^1.0.0": "patch:decode-named-character-reference@npm%3A1.0.2#~/.yarn/patches/decode-named-character-reference-npm-1.0.2-db17a755fd.patch",
+    "@atlaskit/pragmatic-drag-and-drop@npm:^1.1.0": "patch:@atlaskit/pragmatic-drag-and-drop@npm%3A1.4.0#~/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch"
   }
 }

--- a/packages/frontend/component/package.json
+++ b/packages/frontend/component/package.json
@@ -22,7 +22,7 @@
     "@affine/electron-api": "workspace:*",
     "@affine/graphql": "workspace:*",
     "@affine/i18n": "workspace:*",
-    "@atlaskit/pragmatic-drag-and-drop": "^1.2.1",
+    "@atlaskit/pragmatic-drag-and-drop": "patch:@atlaskit/pragmatic-drag-and-drop@npm%3A1.4.0#~/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.0.3",
     "@blocksuite/icons": "2.1.75",
     "@emotion/react": "^11.11.4",

--- a/packages/frontend/component/src/ui/dnd/dnd.stories.tsx
+++ b/packages/frontend/component/src/ui/dnd/dnd.stories.tsx
@@ -86,11 +86,16 @@ export const DropTarget: StoryFn<{ canDrop: boolean }> = ({ canDrop }) => {
     }),
     []
   );
-  const { dropTargetRef } = useDropTarget(
+  const { dropTargetRef } = useDropTarget<DNDData<{ text: string }>>(
     () => ({
       canDrop,
       onDrop(data) {
         setDropData(prev => prev + data.source.data.text);
+      },
+      externalDataAdapter(args) {
+        return {
+          text: args.source.getStringData(args.source.types[0]) || 'no value',
+        };
       },
     }),
     [canDrop]
@@ -115,6 +120,8 @@ export const DropTarget: StoryFn<{ canDrop: boolean }> = ({ canDrop }) => {
         }`}
       </style>
       <div ref={dragRef}>👉 hello</div>
+      <a href="https://www.google.com">https://www.google.com</a>
+      <p>Some random texts</p>
       <div className="drop-target" ref={dropTargetRef}>
         {dropData || 'Drop here'}
       </div>

--- a/packages/frontend/component/src/ui/dnd/draggable.ts
+++ b/packages/frontend/component/src/ui/dnd/draggable.ts
@@ -103,6 +103,8 @@ export const useDraggable = <D extends DNDData = DNDData>(
       },
     };
 
+    dragRef.current.dataset.affineDraggable = 'true';
+
     const cleanupDraggable = draggable({
       element: dragRef.current,
       dragHandle: dragHandleRef.current ?? undefined,

--- a/packages/frontend/core/src/modules/dnd/index.ts
+++ b/packages/frontend/core/src/modules/dnd/index.ts
@@ -1,0 +1,14 @@
+import {
+  DocsService,
+  type Framework,
+  WorkspaceScope,
+  WorkspaceService,
+} from '@toeverything/infra';
+
+import { DndService } from './services';
+
+export function configureDndModule(framework: Framework) {
+  framework
+    .scope(WorkspaceScope)
+    .service(DndService, [DocsService, WorkspaceService]);
+}

--- a/packages/frontend/core/src/modules/dnd/services/index.ts
+++ b/packages/frontend/core/src/modules/dnd/services/index.ts
@@ -1,0 +1,89 @@
+import type { ExternalGetDataFeedbackArgs } from '@affine/component';
+import type { AffineDNDData } from '@affine/core/types/dnd';
+import type { DocsService, WorkspaceService } from '@toeverything/infra';
+import { Service } from '@toeverything/infra';
+
+import { resolveLinkToDoc } from '../../navigation';
+
+type EntityResolver = (
+  data: string
+) => AffineDNDData['draggable']['entity'] | null;
+
+export class DndService extends Service {
+  constructor(
+    private readonly docsService: DocsService,
+    private readonly workspaceService: WorkspaceService
+  ) {
+    super();
+
+    // order matters
+    this.resolvers.set('text/html', this.resolveHTML);
+    this.resolvers.set('text/uri-list', this.resolveUriList);
+  }
+
+  private readonly resolvers = new Map<string, EntityResolver>();
+
+  externalDataAdapter = (args: ExternalGetDataFeedbackArgs) => {
+    const from: AffineDNDData['draggable']['from'] = {
+      at: 'external',
+    };
+    let entity: AffineDNDData['draggable']['entity'];
+
+    // in the order of the resolvers instead of the order of the types
+    for (const [type, resolver] of this.resolvers) {
+      if (args.source.types.includes(type)) {
+        const stringData = args.source.getStringData(type);
+        if (stringData) {
+          const candidate = resolver(stringData);
+          if (candidate) {
+            entity = candidate;
+            break;
+          }
+        }
+      }
+    }
+
+    return {
+      from,
+      entity,
+    };
+  };
+
+  private readonly resolveUriList: EntityResolver = urls => {
+    // only deal with the first url
+    const url = urls
+      ?.split('\n')
+      .filter(u => u.trim() && !u.trim().startsWith('#'))[0];
+
+    if (url) {
+      const maybeDocLink = resolveLinkToDoc(url);
+
+      // check if the doc is in the current workspace
+      if (
+        maybeDocLink?.workspaceId === this.workspaceService.workspace.id &&
+        this.docsService.list.doc$(maybeDocLink.docId).value &&
+        // skip for block references for now
+        !maybeDocLink.blockIds?.length
+      ) {
+        return {
+          type: 'doc',
+          id: maybeDocLink.docId,
+        };
+      }
+    }
+    return null;
+  };
+
+  // todo: implement this
+  private readonly resolveHTML: EntityResolver = _html => {
+    try {
+      // const parser = new DOMParser();
+      // const doc = parser.parseFromString(html, 'text/html');
+      // return doc.body.innerText;
+    } catch {
+      // ignore the error
+      return null;
+    }
+    return null;
+  };
+}

--- a/packages/frontend/core/src/modules/explorer/views/nodes/collection/index.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/nodes/collection/index.tsx
@@ -189,9 +189,10 @@ export const ExplorerCollectionNode = ({
   const handleCanDrop = useMemo<DropTargetOptions<AffineDNDData>['canDrop']>(
     () => args => {
       const entityType = args.source.data.entity?.type;
+      const isExternalDrop = args.source.data.from?.at === 'external';
       return args.treeInstruction?.type !== 'make-child'
         ? ((typeof canDrop === 'function' ? canDrop(args) : canDrop) ?? true)
-        : entityType === 'doc';
+        : entityType === 'doc' || isExternalDrop;
     },
     [canDrop]
   );

--- a/packages/frontend/core/src/modules/explorer/views/nodes/doc/index.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/nodes/doc/index.tsx
@@ -180,9 +180,10 @@ export const ExplorerDocNode = ({
   const handleCanDrop = useMemo<DropTargetOptions<AffineDNDData>['canDrop']>(
     () => args => {
       const entityType = args.source.data.entity?.type;
+      const isExternalDrop = args.source.data.from?.at === 'external';
       return args.treeInstruction?.type !== 'make-child'
         ? ((typeof canDrop === 'function' ? canDrop(args) : canDrop) ?? true)
-        : entityType === 'doc';
+        : entityType === 'doc' || isExternalDrop;
     },
     [canDrop]
   );

--- a/packages/frontend/core/src/modules/explorer/views/sections/favorites/dnd.ts
+++ b/packages/frontend/core/src/modules/explorer/views/sections/favorites/dnd.ts
@@ -16,8 +16,10 @@ export const favoriteChildrenDropEffect: ExplorerTreeNodeDropEffect = data => {
     ) {
       return 'move';
     } else if (
-      data.source.data.entity?.type &&
-      isFavoriteSupportType(data.source.data.entity.type)
+      (data.source.data.entity?.type &&
+        isFavoriteSupportType(data.source.data.entity.type)) ||
+      // always allow external drop
+      data.source.data.from?.at === 'external'
     ) {
       return 'link';
     }
@@ -37,7 +39,7 @@ export const favoriteRootCanDrop: DropTargetOptions<AffineDNDData>['canDrop'] =
   data => {
     return data.source.data.entity?.type
       ? isFavoriteSupportType(data.source.data.entity.type)
-      : false;
+      : data.source.data.from?.at === 'external'; // always allow external drop
   };
 
 export const favoriteChildrenCanDrop: DropTargetOptions<AffineDNDData>['canDrop'] =

--- a/packages/frontend/core/src/modules/explorer/views/sections/favorites/empty.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/sections/favorites/empty.tsx
@@ -3,9 +3,11 @@ import {
   Skeleton,
   useDropTarget,
 } from '@affine/component';
+import { DndService } from '@affine/core/modules/dnd/services';
 import type { AffineDNDData } from '@affine/core/types/dnd';
 import { useI18n } from '@affine/i18n';
 import { FavoriteIcon } from '@blocksuite/icons/rc';
+import { useService } from '@toeverything/infra';
 
 import { ExplorerEmptySection } from '../../layouts/empty-section';
 import { DropEffect } from '../../tree';
@@ -21,6 +23,7 @@ const RootEmptyLoading = () => {
 };
 const RootEmptyReady = ({ onDrop }: Omit<RootEmptyProps, 'isLoading'>) => {
   const t = useI18n();
+  const dndService = useService(DndService);
 
   const { dropTargetRef, draggedOverDraggable, draggedOverPosition } =
     useDropTarget<AffineDNDData>(
@@ -30,8 +33,9 @@ const RootEmptyReady = ({ onDrop }: Omit<RootEmptyProps, 'isLoading'>) => {
         },
         onDrop: onDrop,
         canDrop: favoriteRootCanDrop,
+        externalDataAdapter: dndService.externalDataAdapter,
       }),
-      [onDrop]
+      [dndService.externalDataAdapter, onDrop]
     );
 
   return (

--- a/packages/frontend/core/src/modules/explorer/views/sections/favorites/index.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/sections/favorites/index.tsx
@@ -4,6 +4,7 @@ import {
   useDropTarget,
 } from '@affine/component';
 import { usePageHelper } from '@affine/core/components/blocksuite/block-suite-page-list/utils';
+import { DndService } from '@affine/core/modules/dnd/services';
 import {
   DropEffect,
   ExplorerTreeRoot,
@@ -20,6 +21,7 @@ import { track } from '@affine/track';
 import { PlusIcon } from '@blocksuite/icons/rc';
 import {
   useLiveData,
+  useService,
   useServices,
   WorkspaceService,
 } from '@toeverything/infra';
@@ -149,6 +151,8 @@ export const ExplorerFavorites = () => {
     [favoriteService]
   );
 
+  const dndService = useService(DndService);
+
   const { dropTargetRef, draggedOverDraggable, draggedOverPosition } =
     useDropTarget<AffineDNDData>(
       () => ({
@@ -157,8 +161,9 @@ export const ExplorerFavorites = () => {
         },
         onDrop: handleDrop,
         canDrop: favoriteRootCanDrop,
+        externalDataAdapter: dndService.externalDataAdapter,
       }),
-      [handleDrop]
+      [dndService.externalDataAdapter, handleDrop]
     );
 
   return (

--- a/packages/frontend/core/src/modules/explorer/views/tree/node.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/tree/node.tsx
@@ -11,6 +11,7 @@ import {
 } from '@affine/component';
 import { RenameModal } from '@affine/component/rename-modal';
 import { AppSidebarService } from '@affine/core/modules/app-sidebar';
+import { DndService } from '@affine/core/modules/dnd/services';
 import { WorkbenchLink } from '@affine/core/modules/workbench';
 import type { AffineDNDData } from '@affine/core/types/dnd';
 import { extractEmojiIcon } from '@affine/core/utils';
@@ -185,6 +186,8 @@ export const ExplorerTreeNode = ({
     },
     [canDrop, reorderable]
   );
+  const dndService = useService(DndService);
+
   const {
     dropTargetRef,
     treeInstruction,
@@ -221,6 +224,9 @@ export const ExplorerTreeNode = ({
         }
       },
       canDrop: handleCanDrop,
+      externalDataAdapter(args) {
+        return dndService.externalDataAdapter(args) as any;
+      },
     }),
     [
       dndData?.dropTarget,
@@ -232,6 +238,7 @@ export const ExplorerTreeNode = ({
       cid,
       onDrop,
       setCollapsed,
+      dndService,
     ]
   );
   const isSelfDraggedOver = draggedOverDraggable?.data.__cid === cid;

--- a/packages/frontend/core/src/modules/index.ts
+++ b/packages/frontend/core/src/modules/index.ts
@@ -6,6 +6,7 @@ import { configAtMenuConfigModule } from './at-menu-config';
 import { configureCloudModule } from './cloud';
 import { configureCollectionModule } from './collection';
 import { configureDialogModule } from './dialogs';
+import { configureDndModule } from './dnd';
 import { configureDocDisplayMetaModule } from './doc-display-meta';
 import { configureDocInfoModule } from './doc-info';
 import { configureDocLinksModule } from './doc-link';
@@ -69,4 +70,5 @@ export function configureCommonModules(framework: Framework) {
   configureDocInfoModule(framework);
   configureOpenInApp(framework);
   configAtMenuConfigModule(framework);
+  configureDndModule(framework);
 }

--- a/packages/frontend/core/src/types/dnd.ts
+++ b/packages/frontend/core/src/types/dnd.ts
@@ -74,6 +74,9 @@ export interface AffineDNDData extends DNDData {
       | {
           at: 'doc-property:manager';
           workspaceId: string;
+        }
+      | {
+          at: 'external'; // for blocksuite or external apps
         };
   };
   dropTarget:

--- a/yarn.lock
+++ b/yarn.lock
@@ -316,7 +316,7 @@ __metadata:
     "@affine/electron-api": "workspace:*"
     "@affine/graphql": "workspace:*"
     "@affine/i18n": "workspace:*"
-    "@atlaskit/pragmatic-drag-and-drop": "npm:^1.2.1"
+    "@atlaskit/pragmatic-drag-and-drop": "patch:@atlaskit/pragmatic-drag-and-drop@npm%3A1.4.0#~/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch"
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "npm:^1.0.3"
     "@blocksuite/affine": "npm:0.18.4"
     "@blocksuite/icons": "npm:2.1.75"
@@ -1209,7 +1209,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@atlaskit/pragmatic-drag-and-drop@npm:^1.1.0, @atlaskit/pragmatic-drag-and-drop@npm:^1.2.1":
+"@atlaskit/pragmatic-drag-and-drop@npm:1.4.0":
   version: 1.4.0
   resolution: "@atlaskit/pragmatic-drag-and-drop@npm:1.4.0"
   dependencies:
@@ -1217,6 +1217,17 @@ __metadata:
     bind-event-listener: "npm:^3.0.0"
     raf-schd: "npm:^4.0.3"
   checksum: 10/fff053f94428fbb6fc6e7ce6b7a0a0d469c7f33dd726e8705245ca517c9224a0d08d972cf739a095c96580c5221514b3c80a04ac5222d2c91a28a8c346d3a7e5
+  languageName: node
+  linkType: hard
+
+"@atlaskit/pragmatic-drag-and-drop@patch:@atlaskit/pragmatic-drag-and-drop@npm%3A1.4.0#~/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch":
+  version: 1.4.0
+  resolution: "@atlaskit/pragmatic-drag-and-drop@patch:@atlaskit/pragmatic-drag-and-drop@npm%3A1.4.0#~/.yarn/patches/@atlaskit-pragmatic-drag-and-drop-npm-1.4.0-75c45f52d3.patch::version=1.4.0&hash=9e529b"
+  dependencies:
+    "@babel/runtime": "npm:^7.0.0"
+    bind-event-listener: "npm:^3.0.0"
+    raf-schd: "npm:^4.0.3"
+  checksum: 10/4376cd2dfe2771081b601ce33d79ec2d2f412739bfa096b6f7bc098cca73659e2ae84ef69f4632f03708b814ed920794fbf9e1826c92c042d397597098de1f6b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
fix AF-1847

two issues:
1. original `dropTargetForExternal` only works if dragging target is from another window context. patched the library to bypass this issue
2. `dataTransfer`'s content is only available on `drop` event. This means we cannot have `canDrop` checks for external elements (like blocksuite links).