### PR TITLE
chore: not allowed to open pdf files on mobile

### DIFF
--- a/packages/frontend/core/src/modules/peek-view/view/peek-view-controls.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/peek-view-controls.tsx
@@ -169,7 +169,8 @@ export const AttachmentPeekViewControls = ({
         name: t['com.affine.peek-view-controls.close'](),
         onClick: () => peekView.close(),
       },
-      {
+      // TODO(@fundon): needs to be implemented on mobile
+      BUILD_CONFIG.isDesktopEdition && {
         icon: <ExpandFullIcon />,
         name: t['com.affine.peek-view-controls.open-attachment'](),
         nameKey: 'open',


### PR DESCRIPTION
Related to [BS-1919](https://linear.app/affine-design/issue/BS-1919/pdf-block-适配).

First remove the expand button on the mobile side.
