### PR TITLE
feat(core): impl doc display meta extension

### DIFF
--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -3,7 +3,6 @@ import { JournalService } from '@affine/core/modules/journal';
 import { PeekViewService } from '@affine/core/modules/peek-view/services/peek-view';
 import { useInsidePeekView } from '@affine/core/modules/peek-view/view/modal-container';
 import { WorkbenchLink } from '@affine/core/modules/workbench';
-import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import type { DocMode } from '@blocksuite/affine/blocks';
 import type { DocCollection } from '@blocksuite/affine/store';
@@ -30,7 +29,7 @@ import * as styles from './styles.css';
 interface AffinePageReferenceProps {
   pageId: string;
   params?: URLSearchParams;
-  title?: string | null; // title alias
+  title?: string; // title alias
   className?: string;
   Icon?: ComponentType;
   onClick?: (e: MouseEvent) => void;
@@ -44,7 +43,6 @@ function AffinePageReferenceInner({
 }: AffinePageReferenceProps) {
   const docDisplayMetaService = useService(DocDisplayMetaService);
   const docsService = useService(DocsService);
-  const i18n = useI18n();
 
   let referenceWithMode: DocMode | null = null;
   let referenceToNode = false;
@@ -74,17 +72,9 @@ function AffinePageReferenceInner({
 
   const notFound = !useLiveData(docsService.list.doc$(pageId));
 
-  const docTitle = useLiveData(
-    docDisplayMetaService.title$(pageId, { reference: true })
+  title = useLiveData(
+    docDisplayMetaService.title$(pageId, { title, reference: true })
   );
-
-  if (notFound) {
-    title = i18n.t('com.affine.notFoundPage.title');
-  }
-
-  if (!title) {
-    title = i18n.t(docTitle);
-  }
 
   return (
     <span className={notFound ? styles.notFound : ''}>

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -312,7 +312,6 @@ export function patchDocModeService(
       return (mode || DEFAULT_MODE) as DocMode;
     };
     onPrimaryModeChange = (handler: (mode: DocMode) => void, id?: string) => {
-      // eslint-disable-next-line rxjs/finnish
       const mode$ = id
         ? docsService.list.primaryMode$(id)
         : docService.doc.primaryMode$;

--- a/packages/frontend/core/src/mobile/components/doc-card/index.tsx
+++ b/packages/frontend/core/src/mobile/components/doc-card/index.tsx
@@ -8,7 +8,6 @@ import {
   WorkbenchLink,
   type WorkbenchLinkProps,
 } from '@affine/core/modules/workbench';
-import { useI18n } from '@affine/i18n';
 import type { DocMeta } from '@blocksuite/affine/store';
 import { useLiveData, useService } from '@toeverything/infra';
 import clsx from 'clsx';
@@ -48,13 +47,9 @@ export const DocCard = forwardRef<HTMLAnchorElement, DocCardProps>(
     outerRef
   ) {
     const containerRef = useRef<HTMLAnchorElement | null>(null);
-    const t = useI18n();
     const favAdapter = useService(CompatibleFavoriteItemsAdapter);
     const docDisplayService = useService(DocDisplayMetaService);
-    const titleInfo = useLiveData(docDisplayService.title$(meta.id));
-    const title =
-      typeof titleInfo === 'string' ? titleInfo : t[titleInfo.i18nKey]();
-
+    const title = useLiveData(docDisplayService.title$(meta.id));
     const favorited = useLiveData(favAdapter.isFavorite$(meta.id, 'doc'));
 
     const toggleFavorite = useCatchEventCallback(

--- a/packages/frontend/core/src/mobile/dialogs/selectors/doc-selector.tsx
+++ b/packages/frontend/core/src/mobile/dialogs/selectors/doc-selector.tsx
@@ -19,11 +19,9 @@ const DocIcon = ({ docId }: { docId: string }) => {
 };
 
 const DocLabel = ({ docId }: { docId: string }) => {
-  const t = useI18n();
   const docDisplayMetaService = useService(DocDisplayMetaService);
   const label = useLiveData(docDisplayMetaService.title$(docId));
-
-  return typeof label === 'string' ? label : t[label.i18nKey]();
+  return label;
 };
 
 export const DocSelectorDialog = ({

--- a/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
@@ -15,7 +15,7 @@ import { EditorService } from '@affine/core/modules/editor';
 import { JournalService } from '@affine/core/modules/journal';
 import { WorkbenchService } from '@affine/core/modules/workbench';
 import { ViewService } from '@affine/core/modules/workbench/services/view';
-import { i18nTime, useI18n } from '@affine/i18n';
+import { i18nTime } from '@affine/i18n';
 import {
   BookmarkBlockService,
   customImageProxyMiddleware,
@@ -240,14 +240,11 @@ const MobileDetailPage = ({
   pageId: string;
   date?: string;
 }) => {
-  const t = useI18n();
   const docDisplayMetaService = useService(DocDisplayMetaService);
   const journalService = useService(JournalService);
   const workbench = useService(WorkbenchService).workbench;
   const [showTitle, setShowTitle] = useState(checkShowTitle);
-  const titleInfo = useLiveData(docDisplayMetaService.title$(pageId));
-  const title =
-    typeof titleInfo === 'string' ? titleInfo : t[titleInfo.i18nKey]();
+  const title = useLiveData(docDisplayMetaService.title$(pageId));
 
   const allJournalDates = useLiveData(journalService.allJournalDates$);
 

--- a/packages/frontend/core/src/modules/doc-display-meta/index.ts
+++ b/packages/frontend/core/src/modules/doc-display-meta/index.ts
@@ -5,6 +5,7 @@ import {
   WorkspaceScope,
 } from '@toeverything/infra';
 
+import { I18nService } from '../i18n';
 import { JournalService } from '../journal';
 import { DocDisplayMetaService } from './services/doc-display-meta';
 
@@ -17,5 +18,6 @@ export function configureDocDisplayMetaModule(framework: Framework) {
       JournalService,
       DocsService,
       FeatureFlagService,
+      I18nService,
     ]);
 }


### PR DESCRIPTION
Closes: [BS-2111](https://linear.app/affine-design/issue/BS-2111/定义和实现-docdisplaymetaextension)
Upstreams: https://github.com/toeverything/blocksuite/pull/8953


https://github.com/user-attachments/assets/008d7433-efef-47c4-8189-9bc288e61199

