### PR TITLE
fix(core): redudant drop target register

### DIFF
--- a/packages/frontend/component/src/ui/dnd/drop-target.ts
+++ b/packages/frontend/component/src/ui/dnd/drop-target.ts
@@ -231,9 +231,13 @@ export const useDropTarget = <D extends DNDData = DNDData>(
 
   const dropTargetOptions = useMemo(() => {
     const wrappedCanDrop = dropTargetGet(options.canDrop, options);
+    let _element: HTMLElement | null = null;
     return {
       get element() {
-        return dropTargetRef.current;
+        if (!_element) {
+          _element = dropTargetRef.current;
+        }
+        return _element;
       },
       canDrop: wrappedCanDrop
         ? (args: DropTargetGetFeedback<D>) => {


### PR DESCRIPTION
fix the following issue.
root cause is that options.element is being reused when cleaning up, but if its value comes from a ref, it might be null at that point.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/1739c4e0-9ba8-4e27-8944-c6022644b40d.png)

