### PR TITLE
feat(nbstore): remove async on connection api

### DIFF
--- a/packages/common/nbstore/src/__tests__/frontend.spec.ts
+++ b/packages/common/nbstore/src/__tests__/frontend.spec.ts
@@ -23,7 +23,9 @@ test('doc', async () => {
     type: 'workspace',
   });
 
-  await docStorage.connect();
+  docStorage.connect();
+
+  await docStorage.waitForConnected();
 
   const frontend1 = new DocFrontend(docStorage, null);
   frontend1.start();
@@ -66,8 +68,11 @@ test('awareness', async () => {
     type: 'workspace',
   });
 
-  await storage1.connect();
-  await storage2.connect();
+  storage1.connect();
+  storage2.connect();
+
+  await storage1.waitForConnected();
+  await storage2.waitForConnected();
 
   // peer a
   const docA = new YDoc({ guid: 'test-doc' });

--- a/packages/common/nbstore/src/__tests__/sync.spec.ts
+++ b/packages/common/nbstore/src/__tests__/sync.spec.ts
@@ -44,9 +44,13 @@ test('doc', async () => {
   const peerB = new SpaceStorage([peerBDoc]);
   const peerC = new SpaceStorage([peerCDoc]);
 
-  await peerA.connect();
-  await peerB.connect();
-  await peerC.connect();
+  peerA.connect();
+  peerB.connect();
+  peerC.connect();
+
+  await peerA.waitForConnected();
+  await peerB.waitForConnected();
+  await peerC.waitForConnected();
 
   await peerA.get('doc').pushDocUpdate({
     docId: 'doc1',
@@ -121,6 +125,18 @@ test('blob', async () => {
     type: 'workspace',
   });
 
+  const peerA = new SpaceStorage([a]);
+  const peerB = new SpaceStorage([b]);
+  const peerC = new SpaceStorage([c]);
+
+  peerA.connect();
+  peerB.connect();
+  peerC.connect();
+
+  await peerA.waitForConnected();
+  await peerB.waitForConnected();
+  await peerC.waitForConnected();
+
   await a.set({
     key: 'test',
     data: new Uint8Array([1, 2, 3, 4]),
@@ -134,14 +150,6 @@ test('blob', async () => {
     mime: 'text/plain',
     createdAt: new Date(100),
   });
-
-  const peerA = new SpaceStorage([a]);
-  const peerB = new SpaceStorage([b]);
-  const peerC = new SpaceStorage([c]);
-
-  await peerA.connect();
-  await peerB.connect();
-  await peerC.connect();
 
   const sync = new Sync(peerA, [peerB, peerC]);
   sync.start();

--- a/packages/common/nbstore/src/connection/shared-connection.ts
+++ b/packages/common/nbstore/src/connection/shared-connection.ts
@@ -11,12 +11,10 @@ export function share<T extends Connection<any>>(conn: T): T {
   const existing = CONNECTIONS.get(conn.shareId);
 
   if (existing) {
-    existing.ref();
     return existing as T;
   }
 
   CONNECTIONS.set(conn.shareId, conn);
-  conn.ref();
 
   return conn;
 }

--- a/packages/common/nbstore/src/impls/broadcast-channel/channel.ts
+++ b/packages/common/nbstore/src/impls/broadcast-channel/channel.ts
@@ -12,7 +12,7 @@ export class BroadcastChannelConnection extends Connection<BroadcastChannel> {
     return new BroadcastChannel(this.channelName);
   }
 
-  override async doDisconnect() {
+  override doDisconnect() {
     this.close();
   }
 

--- a/packages/common/nbstore/src/impls/cloud/awareness.ts
+++ b/packages/common/nbstore/src/impls/cloud/awareness.ts
@@ -25,10 +25,6 @@ export class CloudAwarenessStorage extends AwarenessStorage<CloudAwarenessStorag
     return this.connection.inner;
   }
 
-  override async connect(): Promise<void> {
-    await super.connect();
-  }
-
   override async update(record: AwarenessRecord): Promise<void> {
     const encodedUpdate = await uint8ArrayToBase64(record.bin);
     this.socket.emit('space:update-awareness', {
@@ -44,6 +40,7 @@ export class CloudAwarenessStorage extends AwarenessStorage<CloudAwarenessStorag
     onUpdate: (update: AwarenessRecord, origin?: string) => void,
     onCollect: () => AwarenessRecord
   ): () => void {
+    // TODO: handle disconnect
     // leave awareness
     const leave = () => {
       this.socket.emit('space:leave-awareness', {

--- a/packages/common/nbstore/src/impls/cloud/socket.ts
+++ b/packages/common/nbstore/src/impls/cloud/socket.ts
@@ -184,7 +184,7 @@ export class SocketConnection extends Connection<Socket> {
     return conn;
   }
 
-  override async doDisconnect(conn: Socket) {
+  override doDisconnect(conn: Socket) {
     conn.close();
   }
 

--- a/packages/common/nbstore/src/impls/idb/db.ts
+++ b/packages/common/nbstore/src/impls/idb/db.ts
@@ -25,7 +25,8 @@ export class IDBConnection extends Connection<{
         blocking: () => {
           // if, for example, an tab with newer version is opened, this function will be called.
           // we should close current connection to allow the new version to upgrade the db.
-          this.close(
+          this.setStatus(
+            'closed',
             new Error('Blocking a new version. Closing the connection.')
           );
         },
@@ -38,13 +39,11 @@ export class IDBConnection extends Connection<{
     };
   }
 
-  override async doDisconnect() {
-    this.close();
-  }
-
-  private close(error?: Error) {
-    this.maybeConnection?.channel.close();
-    this.maybeConnection?.db.close();
-    this.setStatus('closed', error);
+  override doDisconnect(db: {
+    db: IDBPDatabase<DocStorageSchema>;
+    channel: BroadcastChannel;
+  }) {
+    db.channel.close();
+    db.db.close();
   }
 }

--- a/packages/common/nbstore/src/impls/idb/doc.ts
+++ b/packages/common/nbstore/src/impls/idb/doc.ts
@@ -1,4 +1,3 @@
-import { share } from '../../connection';
 import {
   type DocClock,
   type DocClocks,
@@ -17,7 +16,7 @@ interface ChannelMessage {
 }
 
 export class IndexedDBDocStorage extends DocStorage {
-  readonly connection = share(new IDBConnection(this.options));
+  readonly connection = new IDBConnection(this.options);
 
   get db() {
     return this.connection.inner.db;

--- a/packages/common/nbstore/src/impls/idb/v1/db.ts
+++ b/packages/common/nbstore/src/impls/idb/v1/db.ts
@@ -28,7 +28,7 @@ export class DocIDBConnection extends Connection<IDBPDatabase<DocDBSchema>> {
     });
   }
 
-  override async doDisconnect(conn: IDBPDatabase<DocDBSchema>) {
+  override doDisconnect(conn: IDBPDatabase<DocDBSchema>) {
     conn.close();
   }
 }
@@ -57,7 +57,7 @@ export class BlobIDBConnection extends Connection<IDBPDatabase<BlobDBSchema>> {
     });
   }
 
-  override async doDisconnect(conn: IDBPDatabase<BlobDBSchema>) {
+  override doDisconnect(conn: IDBPDatabase<BlobDBSchema>) {
     conn.close();
   }
 }

--- a/packages/common/nbstore/src/op/consumer.ts
+++ b/packages/common/nbstore/src/op/consumer.ts
@@ -42,15 +42,6 @@ export class SpaceStorageConsumer extends SpaceStorage {
     });
     this.consumer.register('connect', this.connect.bind(this));
     this.consumer.register('disconnect', this.disconnect.bind(this));
-    this.consumer.register('connection', () => {
-      return new Observable(subscriber => {
-        subscriber.add(
-          this.on('connection', payload => {
-            subscriber.next(payload);
-          })
-        );
-      });
-    });
     this.consumer.register('destroy', this.destroy.bind(this));
   }
 

--- a/packages/common/nbstore/src/storage/storage.ts
+++ b/packages/common/nbstore/src/storage/storage.ts
@@ -102,11 +102,15 @@ export abstract class Storage<Opts extends StorageOptions = StorageOptions> {
 
   constructor(public readonly options: Opts) {}
 
-  async connect() {
-    await this.connection.connect();
+  connect() {
+    this.connection.connect();
   }
 
-  async disconnect() {
-    await this.connection.disconnect();
+  disconnect() {
+    this.connection.disconnect();
+  }
+
+  async waitForConnected() {
+    await this.connection.waitForConnected();
   }
 }

--- a/packages/frontend/apps/electron/src/helper/exposed.ts
+++ b/packages/frontend/apps/electron/src/helper/exposed.ts
@@ -1,10 +1,5 @@
 import { dialogHandlers } from './dialog';
-import {
-  dbEventsV1,
-  dbHandlersV1,
-  nbstoreEvents,
-  nbstoreHandlers,
-} from './nbstore';
+import { dbEventsV1, dbHandlersV1, nbstoreHandlers } from './nbstore';
 import { provideExposed } from './provide';
 import { workspaceEvents, workspaceHandlers } from './workspace';
 
@@ -18,7 +13,6 @@ export const handlers = {
 export const events = {
   db: dbEventsV1,
   workspace: workspaceEvents,
-  nbstore: nbstoreEvents,
 };
 
 const getExposedMeta = () => {

--- a/packages/frontend/apps/electron/src/helper/nbstore/db.ts
+++ b/packages/frontend/apps/electron/src/helper/nbstore/db.ts
@@ -33,8 +33,14 @@ export class NativeDBConnection extends Connection<NativeDocStorage> {
     return conn;
   }
 
-  override async doDisconnect(conn: NativeDocStorage) {
-    await conn.close();
-    logger.info('[nbstore] connection closed', this.shareId);
+  override doDisconnect(conn: NativeDocStorage) {
+    conn
+      .close()
+      .then(() => {
+        logger.info('[nbstore] connection closed', this.shareId);
+      })
+      .catch(err => {
+        logger.error('[nbstore] connection close failed', this.shareId, err);
+      });
   }
 }

--- a/packages/frontend/apps/electron/src/helper/nbstore/handlers.ts
+++ b/packages/frontend/apps/electron/src/helper/nbstore/handlers.ts
@@ -4,13 +4,7 @@ import {
   type DocUpdate,
 } from '@affine/nbstore';
 
-import type { MainEventRegister } from '../type';
-import {
-  type ConnectionStatus,
-  ensureStorage,
-  getStorage,
-  onConnectionChanged,
-} from './storage';
+import { ensureStorage, getStorage } from './storage';
 
 export const nbstoreHandlers = {
   connect: async (id: string) => {
@@ -21,7 +15,7 @@ export const nbstoreHandlers = {
     const store = getStorage(id);
 
     if (store) {
-      await store.disconnect();
+      store.disconnect();
       // The store may be shared with other tabs, so we don't delete it from cache
       // the underlying connection will handle the close correctly
       // STORE_CACHE.delete(`${spaceType}:${spaceId}`);
@@ -132,12 +126,3 @@ export const nbstoreHandlers = {
     return store.get('sync').clearClocks();
   },
 };
-
-export const nbstoreEvents = {
-  onConnectionStatusChanged: (fn: (payload: ConnectionStatus) => void) => {
-    const sub = onConnectionChanged(fn);
-    return () => {
-      sub.unsubscribe();
-    };
-  },
-} satisfies Record<string, MainEventRegister>;

--- a/packages/frontend/apps/electron/src/helper/nbstore/index.ts
+++ b/packages/frontend/apps/electron/src/helper/nbstore/index.ts
@@ -1,4 +1,4 @@
-export { nbstoreEvents, nbstoreHandlers } from './handlers';
+export { nbstoreHandlers } from './handlers';
 export * from './storage';
 export { dbEvents as dbEventsV1, dbHandlers as dbHandlersV1 } from './v1';
 export { universalId } from '@affine/nbstore';


### PR DESCRIPTION
We should not use async on `connect` and `disconnect`, for `WebSocketConnection` will never connect when offline.

We should handle the connection status of each storage in sync, using the `connection.waitForConnect`

This PR also puts the connection reference count on the `connect` and disconnect`