### PR TITLE
chore(editor): hide title of locked group

### DIFF
--- a/blocksuite/affine/model/src/elements/group/group.ts
+++ b/blocksuite/affine/model/src/elements/group/group.ts
@@ -90,6 +90,16 @@ export class GroupElementModel extends GfxGroupLikeElementModel<GroupElementProp
     return result as SerializedGroupElement;
   }
 
+  override lock(): void {
+    super.lock();
+    this.showTitle = false;
+  }
+
+  override unlock(): void {
+    super.unlock();
+    this.showTitle = true;
+  }
+
   @observe(
     // use `GroupElementModel` type in decorator will cause playwright error
     (_, instance: GfxGroupLikeElementModel<GroupElementProps>, transaction) => {


### PR DESCRIPTION
Close [BS-2188](https://linear.app/affine-design/issue/BS-2188/[improvement]-多个yuan素-lock-后不渲染标签)