### PR TITLE
chore: base url for mobile debug

### DIFF
--- a/packages/frontend/core/src/modules/cloud/constant.ts
+++ b/packages/frontend/core/src/modules/cloud/constant.ts
@@ -33,7 +33,7 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
       ? [
           {
             id: 'affine-cloud',
-            baseUrl: 'http://localhost:8080',
+            baseUrl: location.origin,
             config: {
               serverName: 'Affine Cloud',
               features: [


### PR DESCRIPTION
Without this PR, the login requests on mobile devices will be sent to `localhost:8080`, which is incorrect.