### PR TITLE
chore(editor): ignore debug zip snapshots

### DIFF
--- a/blocksuite/playground/.gitignore
+++ b/blocksuite/playground/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+apps/starter/data/snapshots/*.zip
+


### PR DESCRIPTION
Put snapshot zips in `blocksuite/playground/apps/starter/data/snapshots/`