### PR TITLE
fix(editor): re-init after yText change in inline editor

### DIFF
--- a/blocksuite/affine/components/src/rich-text/rich-text.ts
+++ b/blocksuite/affine/components/src/rich-text/rich-text.ts
@@ -360,6 +360,12 @@ export class RichText extends WithDisposable(ShadowlessElement) {
   }
 
   override updated(changedProperties: Map<string | number | symbol, unknown>) {
+    const inlineEditor = this.inlineEditor;
+    if (inlineEditor && this._yText && this._yText !== inlineEditor.yText) {
+      this._unmount();
+      this._init();
+      return;
+    }
     if (this._inlineEditor && changedProperties.has('readonly')) {
       this._inlineEditor.setReadonly(this.readonly);
     }


### PR DESCRIPTION
Closes: [BS-2143](https://linear.app/affine-design/issue/BS-2143/block通过drag-handle拖动位置后，无法输入)