### PR TITLE
fix: should bring children to new doc created

### DIFF
--- a/blocksuite/affine/block-note/src/quick-action.ts
+++ b/blocksuite/affine/block-note/src/quick-action.ts
@@ -32,7 +32,7 @@ export const quickActionConfig: QuickActionConfig[] = [
         .chain()
         .getSelectedModels({
           types: ['block'],
-          mode: 'highest',
+          mode: 'flat',
         })
         .draftSelectedModels()
         .run();

--- a/blocksuite/blocks/src/root-block/widgets/format-bar/config.ts
+++ b/blocksuite/blocks/src/root-block/widgets/format-bar/config.ts
@@ -197,7 +197,7 @@ export function toolbarDefaultConfig(toolbar: AffineFormatBarWidget) {
         const [_, ctx] = chain
           .getSelectedModels({
             types: ['block', 'text'],
-            mode: 'highest',
+            mode: 'flat',
           })
           .draftSelectedModels()
           .run();

--- a/blocksuite/tests-legacy/format-bar.spec.ts
+++ b/blocksuite/tests-legacy/format-bar.spec.ts
@@ -965,6 +965,9 @@ test('create linked doc from block selection with format bar', async ({
   expect(await getPageSnapshot(page, true)).toMatchSnapshot(
     `${testInfo.title}.json`
   );
+
+  const paragraph = page.locator('affine-paragraph');
+  await expect(paragraph).toHaveCount(3);
 });
 
 test.describe('more menu button', () => {

--- a/blocksuite/tests-legacy/snapshots/format-bar.spec.ts/create-linked-doc-from-block-selection-with-format-bar.json
+++ b/blocksuite/tests-legacy/snapshots/format-bar.spec.ts/create-linked-doc-from-block-selection-with-format-bar.json
@@ -34,7 +34,7 @@
       "children": [
         {
           "type": "block",
-          "id": "11",
+          "id": "12",
           "flavour": "affine:embed-linked-doc",
           "version": 1,
           "props": {


### PR DESCRIPTION
Closes: [BS-2186](https://linear.app/affine-design/issue/BS-2186/created-linked-doc-%E6%97%B6%EF%BC%8C%E4%BC%9A%E6%B8%85%E9%99%A4list%E7%9A%84-children)