### PR TITLE
fix: beginPath before drawing drag indicator

### DIFF
--- a/blocksuite/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/mind-map-ext/indicator-overlay.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/gfx-tool/default-tool-ext/mind-map-ext/indicator-overlay.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   NODE_HORIZONTAL_SPACING,
   NODE_VERTICAL_SPACING,
@@ -191,6 +190,7 @@ export class MindMapIndicatorOverlay extends Overlay {
     ctx.fillStyle = color;
     ctx.lineWidth = 3;
 
+    ctx.beginPath();
     ctx.roundRect(targetPos.x, targetPos.y, targetPos.w, targetPos.h, 4);
     ctx.fill();
 


### PR DESCRIPTION
Fixes [BS-2238](https://linear.app/affine-design/issue/BS-2238/frame-套一个-mindmap-，拖动行为不可用)