### PR TITLE
fix(server): end_session_endpoint is not required for oidc

### DIFF
--- a/packages/backend/server/src/plugins/oauth/providers/oidc.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/oidc.ts
@@ -34,7 +34,6 @@ const OIDCConfigurationSchema = z.object({
   authorization_endpoint: z.string().url(),
   token_endpoint: z.string().url(),
   userinfo_endpoint: z.string().url(),
-  end_session_endpoint: z.string().url(),
 });
 
 type OIDCConfiguration = z.infer<typeof OIDCConfigurationSchema>;


### PR DESCRIPTION
closes #9380
