### PR TITLE
fix(docker-compose): missing redis server host env for self hosted yml

### DIFF
--- a/.docker/selfhost/compose.yaml
+++ b/.docker/selfhost/compose.yaml
@@ -20,6 +20,7 @@ services:
       - .env
     environment:
       - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
+      - REDIS_SERVER_HOST=redis
     restart: unless-stopped
 
   affine_migration:
@@ -34,6 +35,7 @@ services:
       - .env
     environment:
       - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
+      - REDIS_SERVER_HOST=redis
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
The redis clients of the AFFiNE containers try to connect to 127.0.0.1 instead of the redis container

```
affine_migration_job  | [ioredis] Unhandled error event: Error: connect ECONNREFUSED 127.0.0.1:6379
affine_migration_job  |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1611:16)
```

```
affine_server         | Error: connect ECONNREFUSED 127.0.0.1:6379
affine_server         |     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1611:16) {
affine_server         |   errno: -111,
affine_server         |   code: 'ECONNREFUSED',
affine_server         |   syscall: 'connect',
affine_server         |   address: '127.0.0.1',
affine_server         |   port: 6379
affine_server         | }
```




