### PR TITLE
feat(editor): kanban mobile drag and drop

### DIFF
--- a/blocksuite/affine/block-database/src/data-source.ts
+++ b/blocksuite/affine/block-database/src/data-source.ts
@@ -16,7 +16,6 @@ import {
   type ViewMeta,
 } from '@blocksuite/data-view';
 import { propertyPresets } from '@blocksuite/data-view/property-presets';
-import { IS_MOBILE } from '@blocksuite/global/env';
 import { assertExists } from '@blocksuite/global/utils';
 import { type BlockModel, nanoid, Text } from '@blocksuite/store';
 import { computed, type ReadonlySignal } from '@preact/signals-core';
@@ -69,11 +68,7 @@ export class DatabaseBlockDataSource extends DataSourceBase {
   });
 
   readonly$: ReadonlySignal<boolean> = computed(() => {
-    return (
-      this._model.doc.readonly ||
-      // TODO(@L-Sun): use block level readonly
-      IS_MOBILE
-    );
+    return this._model.doc.readonly;
   });
 
   rows$: ReadonlySignal<string[]> = computed(() => {

--- a/blocksuite/affine/data-view/src/core/utils/drag.ts
+++ b/blocksuite/affine/data-view/src/core/utils/drag.ts
@@ -35,6 +35,7 @@ export const startDrag = <
   const clear = () => {
     window.removeEventListener('pointermove', move);
     window.removeEventListener('pointerup', up);
+    window.removeEventListener('pointercancel', up);
     window.removeEventListener('keydown', keydown);
     document.body.style.cursor = oldCursor;
     ops.onClear();
@@ -63,6 +64,7 @@ export const startDrag = <
   };
   window.addEventListener('pointermove', move);
   window.addEventListener('pointerup', up);
+  window.addEventListener('pointercancel', up);
   window.addEventListener('keydown', keydown);
 
   return result;

--- a/blocksuite/affine/data-view/src/view-presets/kanban/mobile/card.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/mobile/card.ts
@@ -22,6 +22,7 @@ const styles = css`
     box-shadow: 0px 2px 3px 0px rgba(0, 0, 0, 0.05);
     border-radius: 8px;
     background-color: var(--affine-background-kanban-card-color);
+    touch-action: none;
   }
 
   .mobile-card-header {

--- a/blocksuite/affine/data-view/src/view-presets/kanban/mobile/controller/drag.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/mobile/controller/drag.ts
@@ -4,15 +4,15 @@ import type { ReactiveController } from 'lit';
 import { assertExists, Point, Rect } from '@blocksuite/global/utils';
 import { computed } from '@preact/signals-core';
 
-import type { DataViewKanban } from '../kanban-view.js';
+import type { MobileDataViewKanban } from '../kanban-view.js';
 
 import { autoScrollOnBoundary } from '../../../../core/utils/auto-scroll.js';
 import { startDrag } from '../../../../core/utils/drag.js';
-import { KanbanCard } from '../card.js';
-import { KanbanGroup } from '../group.js';
+import { MobileKanbanCard } from '../card.js';
+import { MobileKanbanGroup } from '../group.js';
 
-export class KanbanDragController implements ReactiveController {
-  dragStart = (ele: KanbanCard, evt: PointerEvent) => {
+export class MobileKanbanDragController implements ReactiveController {
+  dragStart = (ele: MobileKanbanCard, evt: PointerEvent) => {
     const eleRect = ele.getBoundingClientRect();
     const offsetLeft = evt.x - eleRect.left;
     const offsetTop = evt.y - eleRect.top;
@@ -21,7 +21,7 @@ export class KanbanDragController implements ReactiveController {
       evt.x - offsetLeft,
       evt.y - offsetTop
     );
-    const currentGroup = ele.closest('affine-data-view-kanban-group');
+    const currentGroup = ele.closest('mobile-kanban-group');
     const drag = startDrag<
       | { type: 'out'; callback: () => void }
       | {
@@ -100,10 +100,10 @@ export class KanbanDragController implements ReactiveController {
   getInsertPosition = (
     evt: MouseEvent
   ):
-    | { group: KanbanGroup; card?: KanbanCard; position: InsertToPosition }
+    | { group: MobileKanbanGroup; card?: MobileKanbanCard; position: InsertToPosition }
     | undefined => {
     const eles = document.elementsFromPoint(evt.x, evt.y);
-    const target = eles.find(v => v instanceof KanbanGroup) as KanbanGroup;
+    const target = eles.find(v => v instanceof MobileKanbanGroup) as MobileKanbanGroup;
     if (target) {
       const card = getCardByPoint(target, evt.y);
       return {
@@ -123,8 +123,8 @@ export class KanbanDragController implements ReactiveController {
 
   shooIndicator = (
     evt: MouseEvent,
-    self: KanbanCard | undefined
-  ): { group: KanbanGroup; position: InsertToPosition } | undefined => {
+    self: MobileKanbanCard | undefined
+  ): { group: MobileKanbanGroup; position: InsertToPosition } | undefined => {
     const position = this.getInsertPosition(evt);
     if (position) {
       this.dropPreview.display(position.group, self, position.card);
@@ -136,13 +136,13 @@ export class KanbanDragController implements ReactiveController {
 
   get scrollContainer() {
     const scrollContainer = this.host.querySelector(
-      '.affine-data-view-kanban-groups'
+      '.mobile-kanban-groups'
     ) as HTMLElement;
     assertExists(scrollContainer);
     return scrollContainer;
   }
 
-  constructor(private host: DataViewKanban) {
+  constructor(private host: MobileDataViewKanban) {
     this.host.addController(this);
   }
 
@@ -155,12 +155,12 @@ export class KanbanDragController implements ReactiveController {
         const event = context.get('pointerState').raw;
         const target = event.target;
         if (target instanceof Element) {
-          const cell = target.closest('affine-data-view-kanban-cell');
-          if (cell?.editing) {
+          const cell = target.closest('mobile-kanban-cell');
+          if (cell?.isEditing) {
             return;
           }
           cell?.selectCurrentCell(false);
-          const card = target.closest('affine-data-view-kanban-card');
+          const card = target.closest('mobile-kanban-card');
           if (card) {
             this.dragStart(card, event);
           }
@@ -171,11 +171,11 @@ export class KanbanDragController implements ReactiveController {
   }
 }
 
-const createDragPreview = (card: KanbanCard, x: number, y: number) => {
+const createDragPreview = (card: MobileKanbanCard, x: number, y: number) => {
   const preOpacity = card.style.opacity;
   card.style.opacity = '0.5';
   const div = document.createElement('div');
-  const kanbanCard = new KanbanCard();
+  const kanbanCard = new MobileKanbanCard();
   kanbanCard.cardId = card.cardId;
   kanbanCard.view = card.view;
   kanbanCard.isFocus = true;
@@ -209,9 +209,9 @@ const createDropPreview = () => {
   div.style.boxShadow = '0px 0px 8px 0px rgba(30, 150, 235, 0.35)';
   return {
     display(
-      group: KanbanGroup,
-      self: KanbanCard | undefined,
-      card?: KanbanCard
+      group: MobileKanbanGroup,
+      self: MobileKanbanCard | undefined,
+      card?: MobileKanbanCard
     ) {
       const target = card ?? group.querySelector('.add-card');
       assertExists(target);
@@ -231,11 +231,11 @@ const createDropPreview = () => {
 };
 
 const getCardByPoint = (
-  group: KanbanGroup,
+  group: MobileKanbanGroup,
   y: number
-): KanbanCard | undefined => {
+): MobileKanbanCard | undefined => {
   const cards = Array.from(
-    group.querySelectorAll('affine-data-view-kanban-card')
+    group.querySelectorAll('mobile-kanban-card')
   );
   const positions = cards.map(v => {
     const rect = v.getBoundingClientRect();

--- a/blocksuite/affine/data-view/src/view-presets/kanban/mobile/controller/drag.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/mobile/controller/drag.ts
@@ -1,0 +1,246 @@
+import type { InsertToPosition } from '@blocksuite/affine-shared/utils';
+import type { ReactiveController } from 'lit';
+
+import { assertExists, Point, Rect } from '@blocksuite/global/utils';
+import { computed } from '@preact/signals-core';
+
+import type { DataViewKanban } from '../kanban-view.js';
+
+import { autoScrollOnBoundary } from '../../../../core/utils/auto-scroll.js';
+import { startDrag } from '../../../../core/utils/drag.js';
+import { KanbanCard } from '../card.js';
+import { KanbanGroup } from '../group.js';
+
+export class KanbanDragController implements ReactiveController {
+  dragStart = (ele: KanbanCard, evt: PointerEvent) => {
+    const eleRect = ele.getBoundingClientRect();
+    const offsetLeft = evt.x - eleRect.left;
+    const offsetTop = evt.y - eleRect.top;
+    const preview = createDragPreview(
+      ele,
+      evt.x - offsetLeft,
+      evt.y - offsetTop
+    );
+    const currentGroup = ele.closest('affine-data-view-kanban-group');
+    const drag = startDrag<
+      | { type: 'out'; callback: () => void }
+      | {
+          type: 'self';
+          key: string;
+          position: InsertToPosition;
+        }
+      | undefined,
+      PointerEvent
+    >(evt, {
+      onDrag: () => undefined,
+      onMove: evt => {
+        if (!(evt.target instanceof HTMLElement)) {
+          return;
+        }
+        preview.display(evt.x - offsetLeft, evt.y - offsetTop);
+        if (!Rect.fromDOM(this.host).isPointIn(Point.from(evt))) {
+          const callback = this.host.props.onDrag;
+          if (callback) {
+            this.dropPreview.remove();
+            return {
+              type: 'out',
+              callback: callback(evt, ele.cardId),
+            };
+          }
+          return;
+        }
+        const result = this.shooIndicator(evt, ele);
+        if (result) {
+          return {
+            type: 'self',
+            key: result.group.group.key,
+            position: result.position,
+          };
+        }
+        return;
+      },
+      onClear: () => {
+        preview.remove();
+        this.dropPreview.remove();
+        cancelScroll();
+      },
+      onDrop: result => {
+        if (!result) {
+          return;
+        }
+        if (result.type === 'out') {
+          result.callback();
+          return;
+        }
+        if (result && currentGroup) {
+          currentGroup.group.manager.moveCardTo(
+            ele.cardId,
+            currentGroup.group.key,
+            result.key,
+            result.position
+          );
+        }
+      },
+    });
+    const cancelScroll = autoScrollOnBoundary(
+      this.scrollContainer,
+      computed(() => {
+        return {
+          left: drag.mousePosition.value.x,
+          right: drag.mousePosition.value.x,
+          top: drag.mousePosition.value.y,
+          bottom: drag.mousePosition.value.y,
+        };
+      })
+    );
+  };
+
+  dropPreview = createDropPreview();
+
+  getInsertPosition = (
+    evt: MouseEvent
+  ):
+    | { group: KanbanGroup; card?: KanbanCard; position: InsertToPosition }
+    | undefined => {
+    const eles = document.elementsFromPoint(evt.x, evt.y);
+    const target = eles.find(v => v instanceof KanbanGroup) as KanbanGroup;
+    if (target) {
+      const card = getCardByPoint(target, evt.y);
+      return {
+        group: target,
+        card,
+        position: card
+          ? {
+              before: true,
+              id: card.cardId,
+            }
+          : 'end',
+      };
+    } else {
+      return;
+    }
+  };
+
+  shooIndicator = (
+    evt: MouseEvent,
+    self: KanbanCard | undefined
+  ): { group: KanbanGroup; position: InsertToPosition } | undefined => {
+    const position = this.getInsertPosition(evt);
+    if (position) {
+      this.dropPreview.display(position.group, self, position.card);
+    } else {
+      this.dropPreview.remove();
+    }
+    return position;
+  };
+
+  get scrollContainer() {
+    const scrollContainer = this.host.querySelector(
+      '.affine-data-view-kanban-groups'
+    ) as HTMLElement;
+    assertExists(scrollContainer);
+    return scrollContainer;
+  }
+
+  constructor(private host: DataViewKanban) {
+    this.host.addController(this);
+  }
+
+  hostConnected() {
+    if (this.host.props.view.readonly$.value) {
+      return;
+    }
+    this.host.disposables.add(
+      this.host.props.handleEvent('dragStart', context => {
+        const event = context.get('pointerState').raw;
+        const target = event.target;
+        if (target instanceof Element) {
+          const cell = target.closest('affine-data-view-kanban-cell');
+          if (cell?.editing) {
+            return;
+          }
+          cell?.selectCurrentCell(false);
+          const card = target.closest('affine-data-view-kanban-card');
+          if (card) {
+            this.dragStart(card, event);
+          }
+        }
+        return true;
+      })
+    );
+  }
+}
+
+const createDragPreview = (card: KanbanCard, x: number, y: number) => {
+  const preOpacity = card.style.opacity;
+  card.style.opacity = '0.5';
+  const div = document.createElement('div');
+  const kanbanCard = new KanbanCard();
+  kanbanCard.cardId = card.cardId;
+  kanbanCard.view = card.view;
+  kanbanCard.isFocus = true;
+  kanbanCard.style.backgroundColor = 'var(--affine-background-primary-color)';
+  div.append(kanbanCard);
+  div.className = 'with-data-view-css-variable';
+  div.style.width = `${card.getBoundingClientRect().width}px`;
+  div.style.position = 'fixed';
+  // div.style.pointerEvents = 'none';
+  div.style.transform = 'rotate(-3deg)';
+  div.style.left = `${x}px`;
+  div.style.top = `${y}px`;
+  div.style.zIndex = '9999';
+  document.body.append(div);
+  return {
+    display(x: number, y: number) {
+      div.style.left = `${Math.round(x)}px`;
+      div.style.top = `${Math.round(y)}px`;
+    },
+    remove() {
+      card.style.opacity = preOpacity;
+      div.remove();
+    },
+  };
+};
+const createDropPreview = () => {
+  const div = document.createElement('div');
+  div.style.height = '2px';
+  div.style.borderRadius = '1px';
+  div.style.backgroundColor = 'var(--affine-primary-color)';
+  div.style.boxShadow = '0px 0px 8px 0px rgba(30, 150, 235, 0.35)';
+  return {
+    display(
+      group: KanbanGroup,
+      self: KanbanCard | undefined,
+      card?: KanbanCard
+    ) {
+      const target = card ?? group.querySelector('.add-card');
+      assertExists(target);
+      if (target.previousElementSibling === self || target === self) {
+        div.remove();
+        return;
+      }
+      if (target.previousElementSibling === div) {
+        return;
+      }
+      target.insertAdjacentElement('beforebegin', div);
+    },
+    remove() {
+      div.remove();
+    },
+  };
+};
+
+const getCardByPoint = (
+  group: KanbanGroup,
+  y: number
+): KanbanCard | undefined => {
+  const cards = Array.from(
+    group.querySelectorAll('affine-data-view-kanban-card')
+  );
+  const positions = cards.map(v => {
+    const rect = v.getBoundingClientRect();
+    return (rect.top + rect.bottom) / 2;
+  });
+  const index = positions.findIndex(v => v > y);
+  return cards[index];
+};

--- a/blocksuite/affine/data-view/src/view-presets/kanban/mobile/controller/drag.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/mobile/controller/drag.ts
@@ -147,11 +147,11 @@ export class MobileKanbanDragController implements ReactiveController {
   }
 
   hostConnected() {
-    if (this.host.props.view.readonly$.value) {
-      return;
-    }
     this.host.disposables.add(
       this.host.props.handleEvent('dragStart', context => {
+        if (this.host.props.view.readonly$.value) {
+          return;
+        }
         const event = context.get('pointerState').raw;
         const target = event.target;
         if (target instanceof Element) {

--- a/blocksuite/affine/data-view/src/view-presets/kanban/mobile/kanban-view.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/mobile/kanban-view.ts
@@ -10,11 +10,13 @@ import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { html } from 'lit/static-html.js';
 
+import type { KanbanSingleView } from '../kanban-view-manager.js';
+import type { KanbanViewSelectionWithType } from '../types.js';
+
 import { type DataViewInstance, renderUniLit } from '../../../core/index.js';
 import { sortable } from '../../../core/utils/wc-dnd/sort/sort-context.js';
 import { DataViewBase } from '../../../core/view/data-view-base.js';
-import type { KanbanSingleView } from '../kanban-view-manager.js';
-import type { KanbanViewSelectionWithType } from '../types.js';
+import { MobileKanbanDragController } from './controller/drag.js';
 
 const styles = css`
   mobile-data-view-kanban {
@@ -50,6 +52,8 @@ export class MobileDataViewKanban extends DataViewBase<
   KanbanViewSelectionWithType
 > {
   static override styles = styles;
+
+  private dragController = new MobileKanbanDragController(this);
 
   renderAddGroup = () => {
     const addGroup = this.groupManager.addGroup;

--- a/blocksuite/affine/data-view/src/view-presets/kanban/mobile/kanban-view.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/mobile/kanban-view.ts
@@ -98,8 +98,8 @@ export class MobileDataViewKanban extends DataViewBase<
       },
       hideIndicator: () => {},
       moveTo: () => {},
-      showIndicator: () => {
-        return false;
+      showIndicator: evt => {
+        return this.dragController.shooIndicator(evt, undefined) != null;
       },
       view: this.props.view,
       eventTrace: this.props.eventTrace,

--- a/blocksuite/affine/data-view/src/view-presets/kanban/pc/card.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/pc/card.ts
@@ -10,6 +10,7 @@ import { html } from 'lit/static-html.js';
 
 import type { DataViewRenderer } from '../../../core/data-view.js';
 import type { KanbanColumn, KanbanSingleView } from '../kanban-view-manager.js';
+
 import { openDetail, popCardMenu } from './menu.js';
 
 const styles = css`
@@ -22,6 +23,7 @@ const styles = css`
     border-radius: 8px;
     transition: background-color 100ms ease-in-out;
     background-color: var(--affine-background-kanban-card-color);
+    touch-action: none;
   }
 
   affine-data-view-kanban-card:hover {
@@ -125,7 +127,7 @@ export class KanbanCard extends SignalWatcher(
 ) {
   static override styles = styles;
 
-  private readonly clickEdit = (e: MouseEvent) => {
+  private clickEdit = (e: MouseEvent) => {
     e.stopPropagation();
     const selection = this.getSelection();
     if (selection) {
@@ -133,7 +135,7 @@ export class KanbanCard extends SignalWatcher(
     }
   };
 
-  private readonly clickMore = (e: MouseEvent) => {
+  private clickMore = (e: MouseEvent) => {
     e.stopPropagation();
     const selection = this.getSelection();
     const ele = e.currentTarget as HTMLElement;
@@ -156,7 +158,7 @@ export class KanbanCard extends SignalWatcher(
     }
   };
 
-  private readonly contextMenu = (e: MouseEvent) => {
+  private contextMenu = (e: MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
     const selection = this.getSelection();

--- a/tests/affine-local/e2e/blocksuite/editor.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/editor.spec.ts
@@ -43,6 +43,9 @@ test('kanban drag and drop is useable', async ({ page }) => {
   await page.locator('[data-testid=page-editor-blank]').click();
   await addKanban(page);
 
+  // NOTE: the following code is the same as the test in
+  // tests/affine-mobile/e2e/kanban.spec.ts apart from the locator names
+
   const database = page.locator('affine-database');
   await expect(database).toBeVisible();
 

--- a/tests/affine-local/e2e/blocksuite/editor.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/editor.spec.ts
@@ -44,7 +44,7 @@ test('kanban drag and drop is useable', async ({ page }) => {
   await addKanban(page);
 
   // NOTE: the following code is the same as the test in
-  // tests/affine-mobile/e2e/kanban.spec.ts apart from the locator names
+  // tests/affine-mobile/e2e/kanban.spec.ts apart from the locator names and waiting for drag preview
 
   const database = page.locator('affine-database');
   await expect(database).toBeVisible();

--- a/tests/affine-local/e2e/blocksuite/editor.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/editor.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@affine-test/kit/playwright';
 import { openHomePage } from '@affine-test/kit/utils/load-page';
 import {
   addDatabase,
+  addKanban,
   clickNewPageButton,
   getBlockSuiteEditorTitle,
   waitForEditorLoad,
@@ -31,6 +32,38 @@ test('database is useable', async ({ page }) => {
   await addDatabase(page);
   const database2 = page.locator('affine-database');
   await expect(database2).toBeVisible();
+});
+
+
+test('kanban drag and drop is useable', async ({ page }) => {
+  await openHomePage(page);
+  await waitForEditorLoad(page);
+  await clickNewPageButton(page);
+
+  await page.locator('[data-testid=page-editor-blank]').click();
+  await addKanban(page);
+
+  const database = page.locator('affine-database');
+  await expect(database).toBeVisible();
+
+  // find the card in the 0th group
+  const cardId = await page.locator("affine-data-view-kanban-group").nth(0).locator('affine-data-view-kanban-card').getAttribute("data-card-id")
+  expect(cardId).toBeTruthy()
+
+  // drag the card across by one group
+  await page.locator(`[data-card-id="${cardId}"]`).hover()
+  await page.mouse.down();
+  await page.locator(".group-header").nth(1).hover()
+
+  // drag preview of card should be visible
+  await expect(page.locator(".with-data-view-css-variable .card-body")).toBeVisible()
+
+  // wiggle the card a bit and then drop it (not sure how to do this in a non-racey way)
+  await page.locator(".group-body").nth(1).hover({ force: true })
+  await page.mouse.up()
+
+  // assert that it is in the intended column
+  await expect(page.locator(".group-body").nth(1).locator(`[data-card-id="${cardId}"]`)).toBeVisible()
 });
 
 test('link page is useable', async ({ page }) => {

--- a/tests/affine-mobile/e2e/kanban.spec.ts
+++ b/tests/affine-mobile/e2e/kanban.spec.ts
@@ -27,7 +27,7 @@ test('kanban drag and drop', async ({ page }) => {
   }).getByRole('button').nth(1).click();
 
   // NOTE: the following code is the same as the test in
-  // tests/affine-local/e2e/blocksuite/editor.spec.ts apart from the locator names
+  // tests/affine-local/e2e/blocksuite/editor.spec.ts apart from the locator names and waiting for drag preview
 
   const database = page.locator('affine-database');
   await expect(database).toBeVisible();
@@ -39,9 +39,8 @@ test('kanban drag and drop', async ({ page }) => {
   // drag the card across by one group
   await page.locator(`[data-card-id="${cardId}"]`).hover()
   await page.mouse.down();
-  await page.locator(".mobile-group-header").nth(1).hover()
 
-  // drag preview of card should be visible
+  // wait for the drag preview to appear before moving
   await expect(page.locator(".with-data-view-css-variable .mobile-card-body")).toBeVisible()
 
   // wiggle the card a bit and then drop it (not sure how to do this in a non-racey way)

--- a/tests/affine-mobile/e2e/kanban.spec.ts
+++ b/tests/affine-mobile/e2e/kanban.spec.ts
@@ -1,0 +1,54 @@
+import { test } from '@affine-test/kit/mobile';
+import { expect } from '@playwright/test';
+
+import { openTab } from './utils';
+
+
+
+test('kanban drag and drop', async ({ page }) => {
+  // directly open new doc, should not show back
+  await openTab(page, 'New Page');
+
+  await page.locator('affine-paragraph').click();
+
+  await expect(page.locator('affine-keyboard-toolbar')).toBeVisible()
+  // Hack: force the toolbar to be visible (normally it is hidden behind the AppTabs widget),
+  // and we can only click it once the virtual keyboard pushes it up, but there is no virtual
+  // keyboard in playwright.
+  await page.evaluate(() => {
+    const el = document.getElementsByTagName("affine-keyboard-toolbar")[0];
+    // @ts-expect-error el is actually an AffineKeyboardToolbarWidget
+    el._panelHeight$.value = 260;
+  })
+  await page.locator('affine-keyboard-toolbar div').first().click();
+  await page.locator('icon-button').first().click();
+  await page.locator('affine-keyboard-tool-panel div').filter({
+    hasText: 'Database Table view Kanban'
+  }).getByRole('button').nth(1).click();
+
+  // NOTE: the following code is the same as the test in
+  // tests/affine-local/e2e/blocksuite/editor.spec.ts apart from the locator names
+
+  const database = page.locator('affine-database');
+  await expect(database).toBeVisible();
+
+  // find the card in the 0th group
+  const cardId = await page.locator("mobile-kanban-group").nth(0).locator('mobile-kanban-card').getAttribute("data-card-id")
+  expect(cardId).toBeTruthy()
+
+  // drag the card across by one group
+  await page.locator(`[data-card-id="${cardId}"]`).hover()
+  await page.mouse.down();
+  await page.locator(".mobile-group-header").nth(1).hover()
+
+  await page.pause()
+  // drag preview of card should be visible
+  await expect(page.locator(".with-data-view-css-variable .mobilecard-body")).toBeVisible()
+
+  // wiggle the card a bit and then drop it (not sure how to do this in a non-racey way)
+  await page.locator(".mobile-group-body").nth(1).hover({ force: true })
+  await page.mouse.up()
+
+  // assert that it is in the intended column
+  await expect(page.locator(".mobile-group-body").nth(1).locator(`[data-card-id="${cardId}"]`)).toBeVisible()
+});

--- a/tests/affine-mobile/e2e/kanban.spec.ts
+++ b/tests/affine-mobile/e2e/kanban.spec.ts
@@ -43,7 +43,7 @@ test('kanban drag and drop', async ({ page }) => {
 
   await page.pause()
   // drag preview of card should be visible
-  await expect(page.locator(".with-data-view-css-variable .mobilecard-body")).toBeVisible()
+  await expect(page.locator(".with-data-view-css-variable .mobile-card-body")).toBeVisible()
 
   // wiggle the card a bit and then drop it (not sure how to do this in a non-racey way)
   await page.locator(".mobile-group-body").nth(1).hover({ force: true })

--- a/tests/affine-mobile/e2e/kanban.spec.ts
+++ b/tests/affine-mobile/e2e/kanban.spec.ts
@@ -41,7 +41,6 @@ test('kanban drag and drop', async ({ page }) => {
   await page.mouse.down();
   await page.locator(".mobile-group-header").nth(1).hover()
 
-  await page.pause()
   // drag preview of card should be visible
   await expect(page.locator(".with-data-view-css-variable .mobile-card-body")).toBeVisible()
 

--- a/tests/kit/utils/page-logic.ts
+++ b/tests/kit/utils/page-logic.ts
@@ -217,3 +217,11 @@ export const addDatabaseRow = async (page: Page, databaseTitle: string) => {
   });
   await db.locator('.data-view-table-group-add-row-button').click();
 };
+
+
+export const addKanban = async (page: Page, title?: string) => {
+  await page.keyboard.press('/');
+  await expect(page.locator('affine-slash-menu .slash-menu')).toBeVisible();
+  await page.keyboard.type('kanban');
+  await page.getByTestId('Kanban View').click();
+}


### PR DESCRIPTION
this is based on https://github.com/toeverything/blocksuite/pull/9048

This PR includes:
* A fix for when the drag and drop can get into a bad state after the browser sends us a pointercancel event 
* An implementation of drag and drop for mobile
  - [ ] kanban/mobile/controller/drag.ts is mostly copy-paste from kanban/pc/controller/drag.ts . Do you want me to DRY it out at all?
  - [x] I have disabled the "mobile databases are readonly" logic from  https://github.com/toeverything/blocksuite/commit/d90ff22f3c0e21b074625a9a727bc3b7d687d08b until someone can give me a bit more context (I have asked in #technical-discussion on discord). If you have a suggested fix for this, please leave a comment (or just push your proposed fix to my branch).
- [x] I haven't worked out the best way to port my tests yet. Should I add the mobile configs to blocksuite/tests-legacy, or try to port them to tests/affine-mobile or somewhere? I've not worked out who to add a kanban view on affine yet, so this might take more time.

This is based on top of https://github.com/toeverything/blocksuite/pull/9044 so it included a basic playwright test. I'm happy to merge this as two separate PRs or close the other one if you prefer.

TODO/known bugs from QAing (some for now, and some for fixing in later issues/PRs):
- [ ] ignore drags if the user didn't stay in the same place for long enough (how long?) before moving
  - [ ] I guess I should display the tilted drag preview as soon as the timeout expires?
- [ ] (later) the horizontal blue drop position indicator doesn't show if you're dropping into an empty column (this is also a problem on desktop affine.fail)
- [ ] (later) it is possible to drop a card into the section below the kanban board and it turns it into a text card, losing information (I might split this out into its own issue though, because it is also a problem on desktop, and pressing undo will get it back where you started)
- [ ] (later) clicking and dragging on the T causes it to render the tilted drag preview, but it stays where it is rather than following your cursor (this is also a problem on desktop affine.fail: it renders the previews as if you're moving the card successfully, but when you release it silently doesn't do anything)
- [ ] (later?) sometimes after you've been playing about for a while, an invisible <affine-mobile-menu> shows up and blocks all interactions with the page. It does not go away when you refresh the page, so you have to open a new browser tab to continue working. (I think this happens when you click any of the 3 dot menus - are they implemented as a pushstate() with hidden data sessionstorage or something? I am tempted to split out a separate PR to enable editing of mobile data views, because the 3dot menus aren't visible on read-only data views)
- [ ] (later) sometimes after you've been playing around for a while, the drag-to-scroll behaviour breaks. It does not fix itself when you refresh the page, so you have to open a new browser tab to continue working. This feels like a chrome bug?
