### PR TITLE
fix(editor): prevent errors from isStrictUrl

### DIFF
--- a/blocksuite/affine/shared/src/utils/url.ts
+++ b/blocksuite/affine/shared/src/utils/url.ts
@@ -130,14 +130,17 @@ function isCommonTLD(url: URL) {
  * Assuming the user will input anything, we need to check rigorously.
  */
 export function isStrictUrl(str: string) {
-  if (!isValidUrl(str)) {
+  try {
+    if (!isValidUrl(str)) {
+      return false;
+    }
+
+    const url = new URL(normalizeUrl(str));
+
+    return isCommonTLD(url);
+  } catch {
     return false;
   }
-  const url = new URL(normalizeUrl(str));
-  if (isCommonTLD(url)) {
-    return true;
-  }
-  return false;
 }
 
 export function isUrlInClipboard(clipboardData: DataTransfer) {


### PR DESCRIPTION
Closes: [BS-2277](https://linear.app/affine-design/issue/BS-2277/typeerror-failed-to-construct-url-invalid-url)