### PR TITLE
chore(docs): update server start script

### DIFF
--- a/docs/developing-server.md
+++ b/docs/developing-server.md
@@ -45,7 +45,8 @@ yarn data-migration run
 ## Start server
 
 ```sh
-yarn dev
+# at project root
+yarn affine server dev
 ```
 
 when server started, it will created a default user for testing:


### PR DESCRIPTION
Currently, directly running `yarn dev` in `packages/backend/server` (following `developing-server.md`) instead of `yarn affine server dev` would raise following error:

``` sh
server git:(canary) ✗ yarn dev
[nodemon] 3.1.9
[nodemon] to restart at any time, enter `rs`
[nodemon] watching path(s): *.*
[nodemon] watching extensions: ts,json
[nodemon] starting `node ./src/index.ts`
node:internal/modules/esm/get_format:160
  throw new ERR_UNKNOWN_FILE_EXTENSION(ext, filepath);
        ^

TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/ewind/code/AFFiNE/packages/backend/server/src/index.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:160:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:203:36)
    at defaultLoad (node:internal/modules/esm/load:141:22)
    at async ModuleLoader.load (node:internal/modules/esm/loader:409:7)
    at async ModuleLoader.moduleProvider (node:internal/modules/esm/loader:291:45)
    at async link (node:internal/modules/esm/module_job:76:21) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}

Node.js v20.10.0
[nodemon] app crashed - waiting for file changes before starting...
```