### PR TITLE
fix(editor): chat panel render warning

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
@@ -191,8 +191,10 @@ export class ChatPanel extends WithDisposable(ShadowlessElement) {
 
   protected override updated(_changedProperties: PropertyValues) {
     if (_changedProperties.has('doc')) {
-      this.chatContextValue.chatSessionId = null;
-      this._resetItems();
+      requestAnimationFrame(() => {
+        this.chatContextValue.chatSessionId = null;
+        this._resetItems();
+      });
     }
 
     if (


### PR DESCRIPTION
Fixed the updated warning of both `chat-panel` and `chat-panel-messages`

![image](https://github.com/user-attachments/assets/73f30e45-119a-4899-bf05-84f8f64b944b)
