### PR TITLE
fix(editor): white-space should be set to normal in tooltip

### DIFF
--- a/blocksuite/affine/components/src/toolbar/tooltip.ts
+++ b/blocksuite/affine/components/src/toolbar/tooltip.ts
@@ -26,7 +26,7 @@ const styles = css`
     background: var(--affine-tooltip);
 
     overflow-wrap: anywhere;
-    white-space: pre-wrap;
+    white-space: normal;
     word-break: break-all;
   }
 


### PR DESCRIPTION
Closes: [BS-2288](https://linear.app/affine-design/issue/BS-2288/tooltip-多余换行问题)

### Before

![Screenshot 2024-12-31 at 14.19.52.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/c0e9c46b-a8cf-4473-bd0d-89d6c82d890f.png)

### After

![Screenshot 2024-12-31 at 14.20.33.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/8ypiIKZXudF5a0tIgIzf/5d26f452-f7fd-4fc8-8b0f-ba1686cb6505.png)

