### PR TITLE
refactor(core): remove abort event error on init

### DIFF
--- a/packages/frontend/core/src/desktop/pages/root/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/root/index.tsx
@@ -19,15 +19,9 @@ export const RootWrapper = () => {
     const abortController = new AbortController();
     defaultServerService.server
       .waitForConfigRevalidation(abortController.signal)
-      .then(() => {
-        setIsServerReady(true);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-    return () => {
-      abortController.abort();
-    };
+      .then(() => setIsServerReady(true))
+      .catch(console.error);
+    return () => abortController.abort();
   }, [defaultServerService, isServerReady]);
 
   return (

--- a/packages/frontend/core/src/mobile/pages/root/index.tsx
+++ b/packages/frontend/core/src/mobile/pages/root/index.tsx
@@ -17,15 +17,9 @@ export const RootWrapper = () => {
     const abortController = new AbortController();
     defaultServerService.server
       .waitForConfigRevalidation(abortController.signal)
-      .then(() => {
-        setIsServerReady(true);
-      })
-      .catch(error => {
-        console.error(error);
-      });
-    return () => {
-      abortController.abort();
-    };
+      .then(() => setIsServerReady(true))
+      .catch(console.error);
+    return () => abortController.abort();
   }, [defaultServerService, isServerReady]);
 
   return (

--- a/packages/frontend/core/src/modules/cloud/entities/server.ts
+++ b/packages/frontend/core/src/modules/cloud/entities/server.ts
@@ -100,11 +100,16 @@ export class Server extends Entity<{
   );
 
   async waitForConfigRevalidation(signal?: AbortSignal) {
-    this.revalidateConfig();
-    await this.isConfigRevalidating$.waitFor(
-      isRevalidating => !isRevalidating,
-      signal
-    );
+    try {
+      this.revalidateConfig();
+      await this.isConfigRevalidating$.waitFor(
+        isRevalidating => !isRevalidating,
+        signal
+      );
+    } catch (error) {
+      if (error instanceof Event && error.type === 'abort') return;
+      console.error('Config revalidation failed:', error);
+    }
   }
 
   override dispose(): void {


### PR DESCRIPTION
Following error always throw on Affine init, which is actually an `Event` from abort controller that can be handled in upstream.

![image](https://github.com/user-attachments/assets/50c25e5e-4a9c-45e0-b756-6b0f47390733)
