### PR TITLE
fix(editor): too many digits after decimal point in table calculations

### DIFF
--- a/blocksuite/affine/data-view/src/core/statistics/number.ts
+++ b/blocksuite/affine/data-view/src/core/statistics/number.ts
@@ -30,7 +30,9 @@ export const numberStatsFunctions: StatisticsConfig[] = [
       if (numbers.length === 0) {
         return 'None';
       }
-      return (numbers.reduce((a, b) => a + b, 0) / numbers.length).toString();
+      return parseFloat(
+        (numbers.reduce((a, b) => a + b, 0) / numbers.length).toFixed(2)
+      ).toString();
     },
   }),
   createStatisticConfig({
@@ -49,7 +51,7 @@ export const numberStatsFunctions: StatisticsConfig[] = [
         const a = arr[index];
         const b = arr[index - 1];
         if (a == null || b == null) return 'None';
-        result = (a + b) / 2;
+        result = parseFloat(((a + b) / 2).toFixed(2));
       }
       return result?.toString() ?? 'None';
     },
@@ -120,7 +122,7 @@ export const numberStatsFunctions: StatisticsConfig[] = [
       if (min == null || max == null) {
         return 'None';
       }
-      return (max - min).toString();
+      return parseFloat((max - min).toFixed(2)).toString();
     },
   }),
 ];


### PR DESCRIPTION
Fixes **floating-point precision error**, when using **average, median, range functions**

# Changes
## Average
Before:
![Screenshot 2024-12-30 at 18 12 09](https://github.com/user-attachments/assets/c105c39b-33ba-4271-a711-49b8e22a412c)
After:
![Screenshot 2024-12-30 at 18 14 44](https://github.com/user-attachments/assets/347b660c-af08-4630-adb1-408a73d3a2f1)

## Median
Before:
![Screenshot 2024-12-31 at 15 18 55](https://github.com/user-attachments/assets/5755b896-1f58-4b45-8edb-ddc8576bcdfa)
After:
![Screenshot 2024-12-31 at 15 20 46](https://github.com/user-attachments/assets/c8457a0c-692b-437b-bb00-d60756f2d962)

## Range
Before:
![Screenshot 2024-12-30 at 18 20 33](https://github.com/user-attachments/assets/d72118a1-1781-48ad-b6fb-b15ae21efccb)
After:
![Screenshot 2024-12-30 at 18 21 36](https://github.com/user-attachments/assets/d43f9bd8-f0dd-4cb9-a9d0-0335a27d6fd4)
