### PR TITLE
perf(editor): reduce frequency of native selection sync

### DIFF
--- a/blocksuite/framework/block-std/src/range/range-binding.ts
+++ b/blocksuite/framework/block-std/src/range/range-binding.ts
@@ -151,7 +151,7 @@ export class RangeBinding {
           });
       });
 
-      await nextTick();
+      await this.host.updateComplete;
 
       const selection = this.selectionManager.create('text', {
         from: {
@@ -170,7 +170,7 @@ export class RangeBinding {
     if (this.isComposing) return;
     if (!this.host) return; // Unstable when switching views, card <-> embed
 
-    await this.host.updateComplete;
+    await nextTick();
 
     const selection = document.getSelection();
     if (!selection) {

--- a/blocksuite/framework/block-std/src/range/range-binding.ts
+++ b/blocksuite/framework/block-std/src/range/range-binding.ts
@@ -312,7 +312,8 @@ export class RangeBinding {
     );
 
     this.host.disposables.addFromEvent(document, 'selectionchange', () => {
-      serialThrottle(() => this._onNativeSelectionChanged());
+      const throttled = serialThrottle(() => this._onNativeSelectionChanged());
+      throttled().catch(console.error);
     });
 
     this.host.disposables.add(

--- a/blocksuite/framework/block-std/src/range/range-binding.ts
+++ b/blocksuite/framework/block-std/src/range/range-binding.ts
@@ -1,4 +1,4 @@
-import { serialThrottle } from '@blocksuite/global/utils';
+import { nextTick, serialThrottle } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
 import type { BaseSelection, TextSelection } from '../selection/index.js';
@@ -151,7 +151,7 @@ export class RangeBinding {
           });
       });
 
-      await this.host.updateComplete;
+      await nextTick();
 
       const selection = this.selectionManager.create('text', {
         from: {

--- a/blocksuite/framework/block-std/src/range/range-binding.ts
+++ b/blocksuite/framework/block-std/src/range/range-binding.ts
@@ -1,4 +1,4 @@
-import { throttle } from '@blocksuite/global/utils';
+import { serialThrottle } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
 
 import type { BaseSelection, TextSelection } from '../selection/index.js';
@@ -311,13 +311,9 @@ export class RangeBinding {
       this.selectionManager.slots.changed.on(this._onStdSelectionChanged)
     );
 
-    this.host.disposables.addFromEvent(
-      document,
-      'selectionchange',
-      throttle(() => {
-        this._onNativeSelectionChanged().catch(console.error);
-      }, 10)
-    );
+    this.host.disposables.addFromEvent(document, 'selectionchange', () => {
+      serialThrottle(() => this._onNativeSelectionChanged());
+    });
 
     this.host.disposables.add(
       this.host.event.add('beforeInput', ctx => {

--- a/blocksuite/framework/global/src/__tests__/utils.unit.spec.ts
+++ b/blocksuite/framework/global/src/__tests__/utils.unit.spec.ts
@@ -73,11 +73,10 @@ describe('serialThrottle', () => {
     const mock = vi.fn().mockResolvedValue('result');
     const throttled = serialThrottle(mock);
 
-    const result = await throttled('test');
+    const result = await throttled();
 
     expect(result).toBe('result');
     expect(mock).toHaveBeenCalledTimes(1);
-    expect(mock).toHaveBeenCalledWith('test');
   });
 
   test('should only keep last call while running', async () => {
@@ -86,11 +85,11 @@ describe('serialThrottle', () => {
     const mock = vi.fn().mockReturnValue(promise);
     const throttled = serialThrottle(mock);
 
-    const firstCall = throttled('first');
+    const firstCall = throttled();
     // Queue multiple calls while running
-    throttled('second');
-    throttled('third');
-    const lastCall = throttled('fourth');
+    throttled();
+    throttled();
+    const lastCall = throttled();
 
     // Complete first execution
     resolve('done');
@@ -98,6 +97,5 @@ describe('serialThrottle', () => {
     await lastCall;
 
     expect(mock).toHaveBeenCalledTimes(2);
-    expect(mock.mock.calls).toEqual([['first'], ['fourth']]);
   });
 });

--- a/blocksuite/framework/global/src/utils/function.ts
+++ b/blocksuite/framework/global/src/utils/function.ts
@@ -125,23 +125,22 @@ export async function nextTick() {
   }
 }
 
-export function serialThrottle<T>(fn: (...args: any[]) => Promise<T>) {
+export function serialThrottle<T>(fn: () => Promise<T>) {
   let running = false;
-  let pending: { args: any[] } | null = null;
+  let pending = false;
 
-  return async (...args: any[]): Promise<T | undefined> => {
+  return async (): Promise<T | undefined> => {
     if (running) {
-      pending = { args };
+      pending = true;
       return;
     }
 
     running = true;
     try {
-      const result = await fn(...args);
+      const result = await fn();
       while (pending) {
-        const { args } = pending;
-        pending = null;
-        await fn(...args);
+        pending = false;
+        await fn();
       }
       return result;
     } finally {


### PR DESCRIPTION
Currently, the native selection sync logic is costly in large docs. While there is already a `throttle(10ms)` in place, the actual DOM querying cost can take several hundred milliseconds, leading to multiple redundant executions queuing up and high CPU usage.

This PR implements a custom `serialThrottle` that ensures only one execution runs at a time and processes only the latest selection state once the previous execution completes. This eliminates redundant DOM queries without affecting the selection sync accuracy, effectively reducing CPU usage while maintaining UI responsiveness.

Tested using a markdown novel with ~20k words (100k characters). 

[moby-dick-chap1-10.md](https://github.com/user-attachments/files/18298053/moby-dick-chap1-10.md)

Before:

<img width="1772" alt="image" src="https://github.com/user-attachments/assets/639a50ba-acb2-4d13-b8e1-aa58036114ac" />

After:

<img width="1772" alt="image" src="https://github.com/user-attachments/assets/41d18ad4-402e-40e7-b1b8-d9c296dd6a49" />
