### PR TITLE
fix(editor): block selection error when unloaded

### DIFF
--- a/blocksuite/affine/components/src/block-selection/index.ts
+++ b/blocksuite/affine/components/src/block-selection/index.ts
@@ -54,7 +54,9 @@ export class BlockSelection extends SignalWatcher(LitElement) {
 
   protected override updated(_changedProperties: PropertyValues): void {
     super.updated(_changedProperties);
-    this.style.display = this.block.selected?.is('block') ? 'block' : 'none';
+    if (this.block) {
+      this.style.display = this.block.selected?.is('block') ? 'block' : 'none';
+    }
   }
 
   @property({ attribute: false })


### PR DESCRIPTION
Closes: [BS-2305](https://linear.app/affine-design/issue/BS-2305/typeerror-thisblock-is-null)