### PR TITLE
fix(core): update chat session after session created or reused

### DIFF
--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/setup-provider.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/setup-provider.tsx
@@ -80,6 +80,12 @@ export function setupAIProvider(
           workspaceId,
           docId,
           promptName,
+        }).then(sessionId => {
+          return updateChatSession({
+            sessionId,
+            client,
+            promptName,
+          });
         }),
         promptName,
       });


### PR DESCRIPTION
For an existing AI chat session, the prompt will not be updated when the front-end calls the `createChatSession` gql interface. Thus update it manually here.

In the future, the architecture needs to be adjusted to support multiple LLM model calls in one chat session.