### PR TITLE
fix(editor): add default value to progress column

### DIFF
--- a/blocksuite/affine/data-view/src/core/property/types.ts
+++ b/blocksuite/affine/data-view/src/core/property/types.ts
@@ -85,6 +85,7 @@ export type PropertyConfig<
       newValue: Value;
     }>
   ) => Value;
+  defaultValue?: Value;
 };
 
 export type DVJSON =

--- a/blocksuite/affine/data-view/src/property-presets/progress/define.ts
+++ b/blocksuite/affine/data-view/src/property-presets/progress/define.ts
@@ -21,4 +21,5 @@ export const progressPropertyModelConfig =
       return value;
     },
     isEmpty: () => false,
+    defaultValue: 0,
   });

--- a/blocksuite/affine/data-view/src/view-presets/table/table-view-manager.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/table-view-manager.ts
@@ -321,6 +321,14 @@ export class TableSingleView extends SingleViewBase<TableViewData> {
   ): string {
     const id = super.rowAdd(insertPosition);
 
+    this.properties$.value.forEach(column =>
+      this.cellValueSet(
+        id,
+        column.id,
+        this.propertyMetaGet(column.type$.value).config.defaultValue
+      )
+    );
+
     const filter = this.filter$.value;
     if (filter.conditions.length > 0) {
       const defaultValues = generateDefaultValues(filter, this.vars$.value);


### PR DESCRIPTION
Fixes #9624 

## What's the issue?


https://github.com/user-attachments/assets/bd622e28-5e68-4db0-95ef-5efb2969e377

1. Add a new column with the data type "progress"
2. Apply a filter to the "progress" column with the condition "= 0"
3. Observe that no rows are displayed in the filtered results
4. Modify the filter condition to "is empty"
5. Observe that all rows are now displayed in the filtered results
6. Change the value of each "progress" field to a non-zero value
7. Change the value of each "progress" field back to zero
8. Apply the filter to the "progress" column with the condition "= 0" again
9. Observe that all rows with a "progress" value of zero are now displayed, which contradicts the initial behavior where no rows were displayed with the same filter condition

## What's the root cause?

New rows are initialized to null by default, resulting in empty values.

## What's changed?

https://github.com/user-attachments/assets/d9e1c9c7-9a5c-4c16-a83c-7bb8d9067384


1. [In code] Added `defaultValue` field within the `PropertyConfig` type
2. [In code] Added `defaultValue` with zero at `progressPropertyModelConfig`
3. Automatically assigned the default value to cells when a new property is added.
4. Updated cell values to the default value whenever a property type is modified.
5. Set newly created rows to the default value for all properties
