### PR TITLE
fix(core): downward arrow is visible when message panel is not scrollable

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
@@ -205,17 +205,11 @@ export class ChatPanel extends WithDisposable(ShadowlessElement) {
     if (
       !this.isLoading &&
       _changedProperties.has('chatContextValue') &&
-      this.chatContextValue.status !== 'idle'
-    ) {
-      if (this.chatContextValue.status === 'transmitting') {
-        this._scrollToEnd();
-      } else if (
-        this.chatContextValue.status === 'loading' ||
+      (this.chatContextValue.status === 'loading' ||
         this.chatContextValue.status === 'error' ||
-        this.chatContextValue.status === 'success'
-      ) {
-        setTimeout(this._scrollToEnd, 500);
-      }
+        this.chatContextValue.status === 'success')
+    ) {
+      setTimeout(this._scrollToEnd, 500);
     }
   }
 


### PR DESCRIPTION
Fix issue [AF-2056](https://linear.app/affine-design/issue/AF-2056).

### What changed?
- Check both `showDownIndicator` and `filteredItems.length` when rendering `DownArrowIcon`.
- Use `scrollIntoView` instead of `scrollToEnd` during AI result transmission.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/9810856c-04fe-4381-8a9b-a87a0d8931d6.png)