### PR TITLE
fix(editor): stop paste-copy event bubbling on bookmark modal

### DIFF
--- a/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-caption-edit-modal.ts
+++ b/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-caption-edit-modal.ts
@@ -1,3 +1,4 @@
+import { stopPropagation } from '@blocksuite/affine-shared/utils';
 import { type BlockComponent, ShadowlessElement } from '@blocksuite/block-std';
 import { WithDisposable } from '@blocksuite/global/utils';
 import type { BlockModel } from '@blocksuite/store';
@@ -48,6 +49,9 @@ export class EmbedCardEditCaptionEditModal extends WithDisposable(
       .catch(console.error);
 
     this.disposables.addFromEvent(this, 'keydown', this._onKeydown);
+    this.disposables.addFromEvent(this, 'cup', stopPropagation);
+    this.disposables.addFromEvent(this, 'copy', stopPropagation);
+    this.disposables.addFromEvent(this, 'paste', stopPropagation);
   }
 
   override render() {

--- a/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-create-modal.ts
+++ b/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-create-modal.ts
@@ -6,7 +6,7 @@ import {
   EMBED_CARD_WIDTH,
 } from '@blocksuite/affine-shared/consts';
 import { EmbedOptionProvider } from '@blocksuite/affine-shared/services';
-import { isValidUrl } from '@blocksuite/affine-shared/utils';
+import { isValidUrl, stopPropagation } from '@blocksuite/affine-shared/utils';
 import type { EditorHost } from '@blocksuite/block-std';
 import { ShadowlessElement } from '@blocksuite/block-std';
 import { GfxControllerIdentifier } from '@blocksuite/block-std/gfx';
@@ -122,6 +122,9 @@ export class EmbedCardCreateModal extends WithDisposable(ShadowlessElement) {
       })
       .catch(console.error);
     this.disposables.addFromEvent(this, 'keydown', this._onDocumentKeydown);
+    this.disposables.addFromEvent(this, 'cup', stopPropagation);
+    this.disposables.addFromEvent(this, 'copy', stopPropagation);
+    this.disposables.addFromEvent(this, 'paste', stopPropagation);
   }
 
   override render() {

--- a/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-edit-modal.ts
+++ b/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-edit-modal.ts
@@ -305,6 +305,9 @@ export class EmbedCardEditModal extends SignalWatcher(
     this.disposables.add(listenClickAway(this, this._hide));
     this.disposables.addFromEvent(this, 'keydown', this._onKeydown);
     this.disposables.addFromEvent(this, 'pointerdown', stopPropagation);
+    this.disposables.addFromEvent(this, 'cup', stopPropagation);
+    this.disposables.addFromEvent(this, 'copy', stopPropagation);
+    this.disposables.addFromEvent(this, 'paste', stopPropagation);
 
     this.titleInput.focus();
     this.titleInput.select();


### PR DESCRIPTION
Closes: [BS-2402](https://linear.app/affine-design/issue/BS-2402/bookmark-没法粘贴修改标题，会跑到下一行)