### PR TITLE
perf(editor): fix autoUpdate being continuously added when updating selections

### DIFF
--- a/blocksuite/blocks/src/root-block/widgets/format-bar/format-bar.ts
+++ b/blocksuite/blocks/src/root-block/widgets/format-bar/format-bar.ts
@@ -567,10 +567,12 @@ export class AffineFormatBarWidget extends WidgetComponent {
   }
 
   override updated() {
+    if (this._floatDisposables) {
+      this._floatDisposables.dispose();
+      this._floatDisposables = null;
+    }
+
     if (!this._shouldDisplay()) {
-      if (this._floatDisposables) {
-        this._floatDisposables.dispose();
-      }
       return;
     }
 


### PR DESCRIPTION
Since `updated` is triggered every time click or update the selection, `autoUpdate` will be continuously added.

Case: select text and `Shift+ArrowLeft/ArrowRight`