### PR TITLE
feat(electron): move @blocksuite/affine to peer dependences for package speed on windows

### DIFF
--- a/packages/common/env/package.json
+++ b/packages/common/env/package.json
@@ -3,7 +3,6 @@
   "private": true,
   "type": "module",
   "devDependencies": {
-    "@blocksuite/affine": "workspace:*",
     "vitest": "2.1.8"
   },
   "exports": {
@@ -16,7 +15,8 @@
     "./blocksuite": "./src/blocksuite/index.ts"
   },
   "peerDependencies": {
-    "@affine/templates": "workspace:*"
+    "@affine/templates": "workspace:*",
+    "@blocksuite/affine": "workspace:*"
   },
   "dependencies": {
     "zod": "^3.24.1"

--- a/packages/common/env/tsconfig.json
+++ b/packages/common/env/tsconfig.json
@@ -7,5 +7,5 @@
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },
   "include": ["./src"],
-  "references": [{ "path": "../../../blocksuite/affine/all" }]
+  "references": []
 }

--- a/packages/frontend/apps/electron/package.json
+++ b/packages/frontend/apps/electron/package.json
@@ -32,7 +32,6 @@
     "make-nsis": "node ./scripts/make-nsis.ts"
   },
   "devDependencies": {
-    "@affine-test/kit": "workspace:*",
     "@affine-tools/utils": "workspace:*",
     "@affine/native": "workspace:*",
     "@affine/nbstore": "workspace:*",

--- a/packages/frontend/apps/electron/test/db/ensure-db.spec.ts
+++ b/packages/frontend/apps/electron/test/db/ensure-db.spec.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { setTimeout } from 'node:timers/promises';
 
-import { removeWithRetry } from '@affine-test/kit/utils/utils';
+import fs from 'fs-extra';
 import { v4 } from 'uuid';
 import { afterAll, afterEach, beforeEach, expect, test, vi } from 'vitest';
 
@@ -44,7 +44,11 @@ beforeEach(() => {
 
 afterEach(async () => {
   existProcess();
-  await removeWithRetry(tmpDir);
+  try {
+    await fs.remove(tmpDir);
+  } catch (e) {
+    console.error(e);
+  }
   vi.useRealTimers();
 });
 

--- a/packages/frontend/apps/electron/test/db/workspace-db-adapter.spec.ts
+++ b/packages/frontend/apps/electron/test/db/workspace-db-adapter.spec.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 
-import { removeWithRetry } from '@affine-test/kit/utils/utils';
 import fs from 'fs-extra';
 import { v4 } from 'uuid';
 import { afterAll, afterEach, beforeAll, expect, test, vi } from 'vitest';
@@ -17,7 +16,11 @@ beforeAll(() => {
 });
 
 afterEach(async () => {
-  await removeWithRetry(tmpDir);
+  try {
+    await fs.remove(tmpDir);
+  } catch (e) {
+    console.error(e);
+  }
 });
 
 afterAll(() => {

--- a/packages/frontend/apps/electron/test/workspace/handlers.spec.ts
+++ b/packages/frontend/apps/electron/test/workspace/handlers.spec.ts
@@ -1,6 +1,5 @@
 import path from 'node:path';
 
-import { removeWithRetry } from '@affine-test/kit/utils/utils';
 import fs from 'fs-extra';
 import { v4 } from 'uuid';
 import { afterAll, afterEach, describe, expect, test, vi } from 'vitest';
@@ -21,7 +20,11 @@ vi.doMock('@affine/electron/helper/main-rpc', () => ({
 }));
 
 afterEach(async () => {
-  await removeWithRetry(tmpDir);
+  try {
+    await fs.remove(tmpDir);
+  } catch (e) {
+    console.error(e);
+  }
 });
 
 afterAll(() => {

--- a/packages/frontend/apps/electron/tsconfig.json
+++ b/packages/frontend/apps/electron/tsconfig.json
@@ -7,7 +7,6 @@
   },
   "include": ["./src"],
   "references": [
-    { "path": "../../../../tests/kit" },
     { "path": "../../../../tools/utils" },
     { "path": "../../native" },
     { "path": "../../../common/nbstore" },

--- a/tools/utils/src/workspace.gen.ts
+++ b/tools/utils/src/workspace.gen.ts
@@ -468,7 +468,7 @@ export const PackageList = [
   {
     location: 'packages/common/env',
     name: '@affine/env',
-    workspaceDependencies: ['blocksuite/affine/all'],
+    workspaceDependencies: [],
   },
   {
     location: 'packages/common/infra',
@@ -512,7 +512,6 @@ export const PackageList = [
     location: 'packages/frontend/apps/electron',
     name: '@affine/electron',
     workspaceDependencies: [
-      'tests/kit',
       'tools/utils',
       'packages/frontend/native',
       'packages/common/nbstore',

--- a/yarn.lock
+++ b/yarn.lock
@@ -498,7 +498,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@affine/electron@workspace:packages/frontend/apps/electron"
   dependencies:
-    "@affine-test/kit": "workspace:*"
     "@affine-tools/utils": "workspace:*"
     "@affine/native": "workspace:*"
     "@affine/nbstore": "workspace:*"
@@ -556,11 +555,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@affine/env@workspace:packages/common/env"
   dependencies:
-    "@blocksuite/affine": "workspace:*"
     vitest: "npm:2.1.8"
     zod: "npm:^3.24.1"
   peerDependencies:
     "@affine/templates": "workspace:*"
+    "@blocksuite/affine": "workspace:*"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`@blocksuite/affine` is indirectly depended by electron package. It has around 120k files in total and will greatly slow down forge package build speed.
Move them to peer dependencies to mitigate the issue.