### PR TITLE
feat(editor): append note to page button

### DIFF
--- a/blocksuite/affine/shared/src/services/notification-service.ts
+++ b/blocksuite/affine/shared/src/services/notification-service.ts
@@ -29,6 +29,7 @@ export interface NotificationService {
   notify(options: {
     title: string | TemplateResult;
     message?: string | TemplateResult;
+    footer?: string | TemplateResult;
     accent?: 'info' | 'success' | 'warning' | 'error';
     duration?: number; // unit ms, give 0 to disable auto dismiss
     abort?: AbortSignal;

--- a/blocksuite/blocks/package.json
+++ b/blocksuite/blocks/package.json
@@ -47,6 +47,7 @@
     "@lit/context": "^1.1.2",
     "@preact/signals-core": "^1.8.0",
     "@toeverything/theme": "^1.1.6",
+    "@vanilla-extract/css": "^1.17.0",
     "date-fns": "^4.0.0",
     "dompurify": "^3.1.6",
     "fflate": "^0.8.2",

--- a/blocksuite/blocks/src/root-block/widgets/element-toolbar/styles.css.ts
+++ b/blocksuite/blocks/src/root-block/widgets/element-toolbar/styles.css.ts
@@ -1,0 +1,24 @@
+import { cssVar } from '@toeverything/theme';
+import { cssVarV2 } from '@toeverything/theme/v2';
+import { style } from '@vanilla-extract/css';
+
+export const viewInPageNotifyFooter = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '12px',
+});
+
+export const viewInPageNotifyFooterButton = style({
+  padding: '0px 6px',
+  borderRadius: '4px',
+  color: cssVarV2('text/primary'),
+
+  fontSize: cssVar('fontSm'),
+  lineHeight: '22px',
+  fontWeight: '500',
+  textAlign: 'center',
+
+  ':hover': {
+    background: cssVarV2('layer/background/hoverOverlay'),
+  },
+});

--- a/blocksuite/playground/package.json
+++ b/blocksuite/playground/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@tweakpane/core": "^2.0.4",
     "@types/micromatch": "^4.0.9",
+    "@vanilla-extract/vite-plugin": "^4.0.19",
     "graphql": "^16.9.0",
     "magic-string": "^0.30.11",
     "vite": "^6.0.3",

--- a/blocksuite/playground/vite.config.ts
+++ b/blocksuite/playground/vite.config.ts
@@ -4,6 +4,7 @@ import { cpus } from 'node:os';
 import path, { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import type { GetManualChunk } from 'rollup';
 import type { Plugin } from 'vite';
 import { defineConfig, loadEnv } from 'vite';
@@ -187,6 +188,7 @@ export default defineConfig(({ mode }) => {
           forceBuildInstrument: true,
         }),
       wasm(),
+      vanillaExtractPlugin(),
       clearSiteDataPlugin(),
     ],
     esbuild: {

--- a/blocksuite/presets/package.json
+++ b/blocksuite/presets/package.json
@@ -40,6 +40,7 @@
     "!dist/__tests__"
   ],
   "devDependencies": {
+    "@vanilla-extract/vite-plugin": "^4.0.19",
     "vitest": "^3.0.0"
   },
   "version": "0.19.0"

--- a/blocksuite/presets/src/__tests__/utils/setup.ts
+++ b/blocksuite/presets/src/__tests__/utils/setup.ts
@@ -77,6 +77,7 @@ async function createEditor(collection: TestWorkspace, mode: DocMode = 'page') {
 
   app.style.width = '100%';
   app.style.height = '1280px';
+  app.style.overflowY = 'auto';
 
   document.body.append(app);
   await editor.updateComplete;

--- a/blocksuite/presets/vitest.config.ts
+++ b/blocksuite/presets/vitest.config.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig(_configEnv =>
@@ -14,6 +15,7 @@ export default defineConfig(_configEnv =>
         target: 'es2022',
       },
     },
+    plugins: [vanillaExtractPlugin()],
     test: {
       include: ['src/__tests__/**/*.spec.ts'],
       browser: {

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/spec-patchers.tsx
@@ -225,6 +225,7 @@ export function patchNotificationService({
         {
           title: toReactNode(notification.title),
           message: toReactNode(notification.message),
+          footer: toReactNode(notification.footer),
           action: notification.action?.onClick
             ? {
                 label: toReactNode(notification.action?.label),

--- a/tests/kit/src/utils/keyboard.ts
+++ b/tests/kit/src/utils/keyboard.ts
@@ -70,6 +70,12 @@ export async function selectAllByKeyboard(page: Page) {
   await keyUpCtrlOrMeta(page);
 }
 
+export async function undoByKeyboard(page: Page) {
+  await keyDownCtrlOrMeta(page);
+  await page.keyboard.press('z', { delay: 50 });
+  await keyUpCtrlOrMeta(page);
+}
+
 export async function writeTextToClipboard(page: Page, text: string) {
   // paste the url
   await page.evaluate(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3910,6 +3910,7 @@ __metadata:
     "@toeverything/theme": "npm:^1.1.6"
     "@types/katex": "npm:^0.16.7"
     "@types/lodash.isequal": "npm:^4.5.8"
+    "@vanilla-extract/css": "npm:^1.17.0"
     date-fns: "npm:^4.0.0"
     dompurify: "npm:^3.1.6"
     fflate: "npm:^0.8.2"
@@ -4034,6 +4035,7 @@ __metadata:
     "@tweakpane/core": "npm:^2.0.4"
     "@types/katex": "npm:^0.16.7"
     "@types/micromatch": "npm:^4.0.9"
+    "@vanilla-extract/vite-plugin": "npm:^4.0.19"
     browser-fs-access: "npm:^0.35.0"
     graphql: "npm:^16.9.0"
     jszip: "npm:^3.10.1"
@@ -4068,6 +4070,7 @@ __metadata:
     "@lottiefiles/dotlottie-wc": "npm:^0.4.0"
     "@preact/signals-core": "npm:^1.8.0"
     "@toeverything/theme": "npm:^1.1.6"
+    "@vanilla-extract/vite-plugin": "npm:^4.0.19"
     lit: "npm:^3.2.0"
     vitest: "npm:^3.0.0"
     yjs: "npm:^13.6.21"
@@ -15530,7 +15533,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vanilla-extract/vite-plugin@npm:^4.0.18":
+"@vanilla-extract/vite-plugin@npm:^4.0.18, @vanilla-extract/vite-plugin@npm:^4.0.19":
   version: 4.0.19
   resolution: "@vanilla-extract/vite-plugin@npm:4.0.19"
   dependencies:


### PR DESCRIPTION
Close [BS-2310](https://linear.app/affine-design/issue/BS-2310/note-display-in-page-%E7%9A%84%E8%A1%8C%E4%B8%BA), [BS-2312](https://linear.app/affine-design/issue/BS-2312/edgeless-note-%E7%9A%84-element-toolbar-%E6%B7%BB%E5%8A%A0display-in-page%E6%8C%89%E9%92%AE) and [BS-2313](https://linear.app/affine-design/issue/BS-2313/添加display-in-page的toast提示，以及打开toc的按钮) 