### PR TITLE
fix(editor): close embed edit modal on editor unmount

### DIFF
--- a/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-edit-modal.ts
+++ b/blocksuite/affine/block-bookmark/src/components/embed-card-modal/embed-card-edit-modal.ts
@@ -279,6 +279,7 @@ export class EmbedCardEditModal extends SignalWatcher(
   override connectedCallback() {
     super.connectedCallback();
 
+    this.disposables.add(this.host.slots.unmounted.on(this._hide));
     this._updateInfo();
   }
 

--- a/tests/affine-local/e2e/blocksuite/edgeless/embed.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/edgeless/embed.spec.ts
@@ -1,0 +1,42 @@
+import { test } from '@affine-test/kit/playwright';
+import {
+  clickEdgelessModeButton,
+  locateEditorContainer,
+  locateElementToolbar,
+} from '@affine-test/kit/utils/editor';
+import { openHomePage } from '@affine-test/kit/utils/load-page';
+import {
+  clickNewPageButton,
+  waitForEditorLoad,
+} from '@affine-test/kit/utils/page-logic';
+import { expect } from '@playwright/test';
+
+const title = 'Edgeless Note Header Test';
+
+test.beforeEach(async ({ page }) => {
+  await openHomePage(page);
+  await waitForEditorLoad(page);
+  await clickNewPageButton(page, title);
+  await clickEdgelessModeButton(page);
+  const container = locateEditorContainer(page);
+  await container.click();
+});
+
+test('should close embed editing modal when editor switching to page mode by short cut', async ({
+  page,
+}) => {
+  await page.keyboard.press('@');
+  await page
+    .getByTestId('cmdk-label')
+    .getByText('Write, Draw, Plan all at Once.')
+    .click();
+  const toolbar = locateElementToolbar(page);
+  await toolbar.getByLabel('Edit').click();
+
+  const editingModal = page.locator('embed-card-edit-modal');
+  expect(editingModal).toBeVisible();
+
+  await page.keyboard.press('Alt+s');
+  await waitForEditorLoad(page);
+  expect(editingModal).toBeHidden();
+});


### PR DESCRIPTION
Close [BS-2436](https://linear.app/affine-design/issue/BS-2436/should-close-embed-card-edit-modal-after-editor-unmount)

### What Changes:
- fix(editor): close embed edit modal on editor unmount
- test(editor): add test to embed edit modal when switching mode