### PR TITLE
fix(editor): inline latex editor should not be shown when doc is readonly

### DIFF
--- a/blocksuite/affine/components/src/rich-text/inline/presets/nodes/latex-node/latex-node.ts
+++ b/blocksuite/affine/components/src/rich-text/inline/presets/nodes/latex-node/latex-node.ts
@@ -161,6 +161,9 @@ export class AffineLatexNode extends SignalWatcher(
     this.disposables.addFromEvent(this, 'click', e => {
       e.preventDefault();
       e.stopPropagation();
+      if (this.readonly) {
+        return;
+      }
       this.toggleEditor();
     });
 
@@ -210,6 +213,10 @@ export class AffineLatexNode extends SignalWatcher(
       },
       { once: true }
     );
+  }
+
+  get readonly() {
+    return this.std.store.readonly;
   }
 
   @property({ attribute: false })


### PR DESCRIPTION
[BS-2442](https://linear.app/affine-design/issue/BS-2442/只读时-inline-latex-node-点击不应该弹出-modal)