### PR TITLE
refactor(editor): highlight selected cards of TOC based on signal

### DIFF
--- a/blocksuite/affine/block-note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/block-note/src/note-edgeless-block.ts
@@ -245,10 +245,12 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
     }
   }
 
-  private _isFirstNote() {
+  private _isFirstVisibleNote() {
     return (
-      this.model.parent?.children.find(child =>
-        matchFlavours(child, ['affine:note'])
+      this.model.parent?.children.find(
+        child =>
+          matchFlavours(child, ['affine:note']) &&
+          child.displayMode !== NoteDisplayMode.EdgelessOnly
       ) === this.model
     );
   }
@@ -509,7 +511,8 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
           .editing=${this._editing}
         ></edgeless-note-mask>
 
-        ${isCollapsable && (!this._isFirstNote() || !this._enablePageHeader)
+        ${isCollapsable &&
+        (!this._isFirstVisibleNote() || !this._enablePageHeader)
           ? html`<div
               class="${classMap({
                 'edgeless-note-collapse-button': true,

--- a/blocksuite/presets/src/fragments/outline/card/outline-card.ts
+++ b/blocksuite/presets/src/fragments/outline/card/outline-card.ts
@@ -143,11 +143,13 @@ const styles = css`
     color: var(--affine-text-primary-color);
   }
 
-  .card-preview.edgeless .card-content:hover {
+  .card-preview .card-content:hover {
     cursor: pointer;
   }
 
-  .card-preview.edgeless .card-header-container:hover {
+  .card-container[data-invisible='false']
+    .card-preview
+    .card-header-container:hover {
     cursor: grab;
   }
 
@@ -156,11 +158,11 @@ const styles = css`
     opacity: 0.5;
   }
 
-  .card-container.selected .card-preview.edgeless {
+  .card-container.selected .card-preview {
     background: var(--affine-hover-color);
   }
 
-  .card-container.placeholder .card-preview.edgeless {
+  .card-container.placeholder .card-preview {
     background: var(--affine-hover-color);
     opacity: 0.9;
   }
@@ -178,7 +180,7 @@ const styles = css`
     pointer-events: none;
   }
 
-  .card-preview.page outline-block-preview:hover {
+  .card-preview outline-block-preview:hover {
     color: var(--affine-brand-color);
   }
 `;

--- a/blocksuite/presets/src/fragments/outline/outline-panel.ts
+++ b/blocksuite/presets/src/fragments/outline/outline-panel.ts
@@ -1,6 +1,7 @@
 import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
+import { effect } from '@preact/signals-core';
 import { baseTheme } from '@toeverything/theme';
-import { css, html, LitElement, unsafeCSS } from 'lit';
+import { css, html, LitElement, type PropertyValues, unsafeCSS } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 import type { AffineEditorContainer } from '../../editors/editor-container.js';
@@ -112,7 +113,25 @@ export class OutlinePanel extends SignalWatcher(WithDisposable(LitElement)) {
 
   override connectedCallback() {
     super.connectedCallback();
-    this._loadSettingsFromLocalStorage();
+    this.disposables.add(
+      effect(() => {
+        if (this.editor.mode === 'edgeless') {
+          this._enableNotesSorting = true;
+        } else {
+          this._loadSettingsFromLocalStorage();
+        }
+      })
+    );
+  }
+
+  override willUpdate(_changedProperties: PropertyValues): void {
+    if (_changedProperties.has('editor')) {
+      if (this.editor.mode === 'edgeless') {
+        this._enableNotesSorting = true;
+      } else {
+        this._loadSettingsFromLocalStorage();
+      }
+    }
   }
 
   override render() {

--- a/blocksuite/tests-legacy/fragments/outline/outline-panel.spec.ts
+++ b/blocksuite/tests-legacy/fragments/outline/outline-panel.spec.ts
@@ -44,20 +44,14 @@ test.describe('toc-panel', () => {
     return panel.locator(`affine-outline-panel-body .title`);
   }
 
-  async function toggleNoteSorting(page: Page) {
-    const enableSortingButton = page.locator(
-      '.outline-panel-header-container .note-sorting-button'
-    );
-    await enableSortingButton.click();
-  }
-
   async function dragNoteCard(page: Page, fromCard: Locator, toCard: Locator) {
     const fromRect = await fromCard.boundingBox();
     const toRect = await toCard.boundingBox();
 
     await page.mouse.move(fromRect!.x + 10, fromRect!.y + 10);
+    await page.mouse.click(fromRect!.x + 10, fromRect!.y + 10);
     await page.mouse.down();
-    await page.mouse.move(toRect!.x + 5, toRect!.y + 5, { steps: 10 });
+    await page.mouse.move(toRect!.x + 5, toRect!.y + 5, { steps: 20 });
     await page.mouse.up();
   }
 
@@ -267,7 +261,6 @@ test.describe('toc-panel', () => {
     await page.mouse.click(100, 100);
 
     await toggleTocPanel(page);
-    await toggleNoteSorting(page);
     const docVisibleCard = page.locator(
       '.card-container[data-invisible="false"]'
     );
@@ -311,7 +304,6 @@ test.describe('toc-panel', () => {
     );
 
     await toggleTocPanel(page);
-    await toggleNoteSorting(page);
     const docVisibleCard = page.locator(
       '.card-container[data-invisible="false"]'
     );
@@ -345,7 +337,6 @@ test.describe('toc-panel', () => {
     );
 
     await toggleTocPanel(page);
-    await toggleNoteSorting(page);
     const docVisibleCard = page.locator(
       '.card-container[data-invisible="false"]'
     );

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/edgeless-note-header.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/edgeless-note-header.tsx
@@ -8,7 +8,11 @@ import { WorkspaceService } from '@affine/core/modules/workspace';
 import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import { GfxControllerIdentifier } from '@blocksuite/affine/block-std/gfx';
-import { matchFlavours, type NoteBlockModel } from '@blocksuite/affine/blocks';
+import {
+  matchFlavours,
+  type NoteBlockModel,
+  NoteDisplayMode,
+} from '@blocksuite/affine/blocks';
 import { Bound } from '@blocksuite/affine/global/utils';
 import {
   ExpandFullIcon,
@@ -160,12 +164,14 @@ export const EdgelessNoteHeader = ({ note }: { note: NoteBlockModel }) => {
 
   if (!flags.enable_page_block_header) return null;
 
-  const isFirstNote =
-    note.parent?.children.find(child =>
-      matchFlavours(child, ['affine:note'])
+  const isFirstVisibleNote =
+    note.parent?.children.find(
+      child =>
+        matchFlavours(child, ['affine:note']) &&
+        child.displayMode === NoteDisplayMode.DocAndEdgeless
     ) === note;
 
-  if (!isFirstNote) return null;
+  if (!isFirstVisibleNote) return null;
 
   return (
     <div className={styles.header} data-testid="edgeless-page-block-header">

--- a/tests/affine-local/e2e/blocksuite/edgeless/note.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/edgeless/note.spec.ts
@@ -229,7 +229,11 @@ test.describe('edgeless note element toolbar', () => {
 
     await displayInPage.click();
     await viewTocButton.click();
-    await page.waitForSelector('affine-outline-panel');
-    expect(page.locator('affine-outline-panel')).toBeVisible();
+    const toc = page.locator('affine-outline-panel');
+    await toc.waitFor({ state: 'visible' });
+    const highlightNoteCards = toc.locator(
+      'affine-outline-note-card > .selected'
+    );
+    expect(highlightNoteCards).toHaveCount(1);
   });
 });

--- a/tests/kit/src/utils/sidebar.ts
+++ b/tests/kit/src/utils/sidebar.ts
@@ -19,3 +19,11 @@ export async function clickSideBarUseAvatar(page: Page) {
 export async function clickNewPageButton(page: Page) {
   return page.getByTestId('sidebar-new-page-button').click();
 }
+
+export async function openRightSideBar(
+  page: Page,
+  tab?: 'chat' | 'properties' | 'journal' | 'outline' | 'frame'
+) {
+  await page.getByTestId('right-sidebar-toggle').click();
+  tab && (await page.getByTestId(`sidebar-tab-${tab}`).click());
+}


### PR DESCRIPTION
Close [BS-2314](https://linear.app/affine-design/issue/BS-2314/添加打开toc时，将note-block-高亮), [BS-1868](https://linear.app/affine-design/issue/BS-1868/toc-里面-note之间顺序可拖动性，在page和edgeless里面是不同的，这个是设计的行为么？)

This PR refactor the highlight logic of note cards of TOC panel:
- notes block selected in edgeless note
- notes block covered by text or block selection in page mode
- note cards selected in TOC for dragging

Other changes:
- remove not used codes
- add tests for highlight note cards  