### PR TITLE
feat(editor): add start-with-ai button for empty doc

### DIFF
--- a/blocksuite/blocks/src/root-block/page/page-root-block.ts
+++ b/blocksuite/blocks/src/root-block/page/page-root-block.ts
@@ -117,14 +117,16 @@ export class PageRootBlockComponent extends BlockComponent<
   /**
    * Focus the first paragraph in the default note block.
    * If there is no paragraph, create one.
+   * @return  { id: string, created: boolean }  id of the focused paragraph and whether it is created or not
    */
-  focusFirstParagraph = () => {
+  focusFirstParagraph = (): { id: string; created: boolean } => {
     const defaultNote = this._getDefaultNoteBlock();
     const firstText = defaultNote?.children.find(block =>
       matchFlavours(block, ['affine:paragraph', 'affine:list', 'affine:code'])
     );
     if (firstText) {
       focusTextModel(this.std, firstText.id);
+      return { id: firstText.id, created: false };
     } else {
       const newFirstParagraphId = this.doc.addBlock(
         'affine:paragraph',
@@ -133,6 +135,7 @@ export class PageRootBlockComponent extends BlockComponent<
         0
       );
       focusTextModel(this.std, newFirstParagraphId);
+      return { id: newFirstParagraphId, created: true };
     }
   };
 

--- a/tests/affine-cloud-copilot/e2e/copilot.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/copilot.spec.ts
@@ -431,6 +431,15 @@ test.describe('chat panel', () => {
     expect(history[1].name).toBe('AFFiNE AI');
     expect(await page.locator('chat-panel affine-link').count()).toBe(0);
   });
+
+  test('can trigger inline ai input and action panel by clicking Start with AI button', async ({
+    page,
+  }) => {
+    await clickNewPageButton(page);
+    await page.getByTestId('start-with-ai-badge').click();
+    await expect(page.locator('affine-ai-panel-widget')).toBeVisible();
+    await expect(page.locator('ask-ai-panel')).toBeVisible();
+  });
 });
 
 test.describe('chat with block', () => {


### PR DESCRIPTION
Close [BS-2391](https://linear.app/affine-design/issue/BS-2391/bs-ai-toolbar-空状态下添加-actions-列表)

https://github.com/user-attachments/assets/cbded517-2d3d-4a75-b144-644e2b03f68a

