### PR TITLE
refactor(editor): simplify TOC implementation with signal and context

### DIFF
--- a/blocksuite/presets/src/fragments/outline/card/outline-card.css.ts
+++ b/blocksuite/presets/src/fragments/outline/card/outline-card.css.ts
@@ -48,19 +48,23 @@ export const cardHeader = style({
   alignItems: 'center',
   gap: '8px',
   boxSizing: 'border-box',
+
+  ':hover': {
+    cursor: 'grab',
+  },
   selectors: {
     [`${outlineCard}[data-sortable="true"] &`]: {
       display: 'flex',
     },
-    [`${outlineCard}[data-invisible="false"] &:hover`]: {
-      cursor: 'grab',
+    [`${outlineCard}[data-visibility="edgeless"] &:hover`]: {
+      cursor: 'default',
     },
   },
 });
 
 const invisibleCard = style({
   selectors: {
-    [`${outlineCard}[data-invisible="true"] &`]: {
+    [`${outlineCard}[data-visibility="edgeless"] &`]: {
       color: cssVarV2('text/disable'),
       pointerEvents: 'none',
     },

--- a/blocksuite/presets/src/fragments/outline/config.ts
+++ b/blocksuite/presets/src/fragments/outline/config.ts
@@ -1,4 +1,4 @@
-import type { ParagraphBlockModel } from '@blocksuite/blocks';
+import type { ParagraphBlockModel, Signal } from '@blocksuite/blocks';
 import {
   AttachmentIcon,
   BlockIcon,
@@ -84,10 +84,11 @@ export const headingKeys = new Set(
 
 export const outlineSettingsKey = 'outlinePanelSettings';
 
-export type OutlineSettingsDataType = {
-  showIcons: boolean;
-  enableSorting: boolean;
+export type TocContext = {
+  editor$: Signal<AffineEditorContainer>;
+  enableSorting$: Signal<boolean>;
+  showIcons$: Signal<boolean>;
+  fitPadding$: Signal<number[]>;
 };
 
-export const editorContext =
-  createContext<AffineEditorContainer>('editorContext');
+export const tocContext = createContext<TocContext>('tocContext');

--- a/blocksuite/presets/src/fragments/outline/header/outline-panel-header.ts
+++ b/blocksuite/presets/src/fragments/outline/header/outline-panel-header.ts
@@ -1,45 +1,54 @@
 import { ShadowlessElement } from '@blocksuite/block-std';
 import { createButtonPopper } from '@blocksuite/blocks';
-import { WithDisposable } from '@blocksuite/global/utils';
+import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
 import { SettingsIcon, SortIcon } from '@blocksuite/icons/lit';
+import { consume } from '@lit/context';
+import { signal } from '@preact/signals-core';
 import { html } from 'lit';
-import { property, query, state } from 'lit/decorators.js';
+import { query } from 'lit/decorators.js';
 
+import { type TocContext, tocContext } from '../config';
 import * as styles from './outline-panel-header.css';
 
 export const AFFINE_OUTLINE_PANEL_HEADER = 'affine-outline-panel-header';
 
-export class OutlinePanelHeader extends WithDisposable(ShadowlessElement) {
+export class OutlinePanelHeader extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
   private _notePreviewSettingMenuPopper: ReturnType<
     typeof createButtonPopper
   > | null = null;
 
-  override firstUpdated() {
-    const _disposables = this._disposables;
+  private readonly _settingPopperShow$ = signal(false);
 
+  override firstUpdated() {
     this._notePreviewSettingMenuPopper = createButtonPopper(
       this._noteSettingButton,
       this._notePreviewSettingMenu,
       ({ display }) => {
-        this._settingPopperShow = display === 'show';
+        this._settingPopperShow$.value = display === 'show';
       },
       {
         mainAxis: 14,
         crossAxis: -30,
       }
     );
-    _disposables.add(this._notePreviewSettingMenuPopper);
+    this.disposables.add(this._notePreviewSettingMenuPopper);
   }
 
   override render() {
+    const sortingEnabled = this._context.enableSorting$.value;
+    const showSettingPopper = this._settingPopperShow$.value;
+
     return html`<div class=${styles.container}>
         <div class=${styles.noteSettingContainer}>
           <span class=${styles.label}>Table of Contents</span>
           <edgeless-tool-icon-button
-            class="${this._settingPopperShow ? 'active' : ''}"
-            .tooltip=${this._settingPopperShow ? '' : 'Preview Settings'}
+            data-testid="toggle-toc-setting-button"
+            class="${showSettingPopper ? 'active' : ''}"
+            .tooltip=${showSettingPopper ? '' : 'Preview Settings'}
             .tipPosition=${'bottom'}
-            .active=${this._settingPopperShow}
+            .active=${showSettingPopper}
             .activeMode=${'background'}
             @click=${() => this._notePreviewSettingMenuPopper?.toggle()}
           >
@@ -48,22 +57,21 @@ export class OutlinePanelHeader extends WithDisposable(ShadowlessElement) {
         </div>
         <edgeless-tool-icon-button
           data-testid="toggle-notes-sorting-button"
-          class="${this.enableNotesSorting ? 'active' : ''}"
+          class="${sortingEnabled ? 'active' : ''}"
           .tooltip=${'Visibility and sort'}
           .tipPosition=${'left'}
           .iconContainerPadding=${0}
-          .active=${this.enableNotesSorting}
+          .active=${sortingEnabled}
           .activeMode=${'color'}
-          @click=${() => this.toggleNotesSorting()}
+          @click=${() => {
+            this._context.enableSorting$.value = !sortingEnabled;
+          }}
         >
           ${SortIcon({ width: '20px', height: '20px' })}
         </edgeless-tool-icon-button>
       </div>
       <div class=${styles.notePreviewSettingContainer}>
-        <affine-outline-note-preview-setting-menu
-          .showPreviewIcon=${this.showPreviewIcon}
-          .toggleShowPreviewIcon=${this.toggleShowPreviewIcon}
-        ></affine-outline-note-preview-setting-menu>
+        <affine-outline-note-preview-setting-menu></affine-outline-note-preview-setting-menu>
       </div>`;
   }
 
@@ -73,20 +81,8 @@ export class OutlinePanelHeader extends WithDisposable(ShadowlessElement) {
   @query(`.${styles.noteSettingContainer}`)
   private accessor _noteSettingButton!: HTMLDivElement;
 
-  @state()
-  private accessor _settingPopperShow = false;
-
-  @property({ attribute: false })
-  accessor enableNotesSorting!: boolean;
-
-  @property({ attribute: false })
-  accessor showPreviewIcon!: boolean;
-
-  @property({ attribute: false })
-  accessor toggleNotesSorting!: () => void;
-
-  @property({ attribute: false })
-  accessor toggleShowPreviewIcon!: (on: boolean) => void;
+  @consume({ context: tocContext })
+  private accessor _context!: TocContext;
 }
 
 declare global {

--- a/blocksuite/presets/src/fragments/outline/header/outline-setting-menu.ts
+++ b/blocksuite/presets/src/fragments/outline/header/outline-setting-menu.ts
@@ -1,17 +1,20 @@
 import { ShadowlessElement } from '@blocksuite/block-std';
-import { WithDisposable } from '@blocksuite/global/utils';
+import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
+import { consume } from '@lit/context';
 import { html } from 'lit';
-import { property } from 'lit/decorators.js';
 
+import { type TocContext, tocContext } from '../config';
 import * as styles from './outline-setting-menu.css';
 
 export const AFFINE_OUTLINE_NOTE_PREVIEW_SETTING_MENU =
   'affine-outline-note-preview-setting-menu';
 
-export class OutlineNotePreviewSettingMenu extends WithDisposable(
-  ShadowlessElement
+export class OutlineNotePreviewSettingMenu extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
 ) {
   override render() {
+    const showPreviewIcon = this._context.showIcons$.value;
+
     return html`<div
       class=${styles.notePreviewSettingMenuContainer}
       @click=${(e: MouseEvent) => e.stopPropagation()}
@@ -23,19 +26,18 @@ export class OutlineNotePreviewSettingMenu extends WithDisposable(
         <div class=${styles.actionLabel}>Show type icon</div>
         <div class=${styles.toggleButton}>
           <toggle-switch
-            .on=${this.showPreviewIcon}
-            .onChange=${this.toggleShowPreviewIcon}
+            .on=${showPreviewIcon}
+            .onChange=${() => {
+              this._context.showIcons$.value = !showPreviewIcon;
+            }}
           ></toggle-switch>
         </div>
       </div>
     </div>`;
   }
 
-  @property({ attribute: false })
-  accessor showPreviewIcon!: boolean;
-
-  @property({ attribute: false })
-  accessor toggleShowPreviewIcon!: (on: boolean) => void;
+  @consume({ context: tocContext })
+  private accessor _context!: TocContext;
 }
 
 declare global {

--- a/blocksuite/presets/src/fragments/outline/outline-viewer.ts
+++ b/blocksuite/presets/src/fragments/outline/outline-viewer.ts
@@ -8,13 +8,13 @@ import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
 import { TocIcon } from '@blocksuite/icons/lit';
 import { provide } from '@lit/context';
 import { signal } from '@preact/signals-core';
-import { css, html, nothing } from 'lit';
+import { css, html, nothing, type PropertyValues } from 'lit';
 import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
 import type { AffineEditorContainer } from '../../editors/editor-container.js';
-import { editorContext } from './config.js';
+import { type TocContext, tocContext } from './config.js';
 import { getHeadingBlocksFromDoc } from './utils/query.js';
 import {
   observeActiveHeadingDuringScroll,
@@ -176,6 +176,15 @@ export class OutlineViewer extends SignalWatcher(
     }
   }
 
+  private _setContext() {
+    this._context = {
+      editor$: signal(this.editor),
+      showIcons$: signal<boolean>(false),
+      enableSorting$: signal<boolean>(false),
+      fitPadding$: signal<number[]>([]),
+    };
+  }
+
   override connectedCallback() {
     super.connectedCallback();
 
@@ -194,6 +203,14 @@ export class OutlineViewer extends SignalWatcher(
         this.requestUpdate();
       })
     );
+
+    this._setContext();
+  }
+
+  override willUpdate(changedProperties: PropertyValues<this>): void {
+    if (changedProperties.has('editor')) {
+      this._context.editor$.value = this.editor;
+    }
   }
 
   override disconnectedCallback() {
@@ -281,13 +298,15 @@ export class OutlineViewer extends SignalWatcher(
     `;
   }
 
+  @provide({ context: tocContext })
+  private accessor _context!: TocContext;
+
   @query('.outline-viewer-item.active')
   private accessor _activeItem: HTMLElement | null = null;
 
   @state()
   private accessor _showViewer: boolean = false;
 
-  @provide({ context: editorContext })
   @property({ attribute: false })
   accessor editor!: AffineEditorContainer;
 

--- a/blocksuite/presets/src/fragments/outline/utils/drag.ts
+++ b/blocksuite/presets/src/fragments/outline/utils/drag.ts
@@ -1,4 +1,4 @@
-import { on, once } from '@blocksuite/blocks';
+import { NoteDisplayMode, on, once } from '@blocksuite/blocks';
 import type { Store } from '@blocksuite/store';
 
 import type { OutlinePanelBody } from '../body/outline-panel-body.js';
@@ -52,13 +52,14 @@ export function startDragging(options: {
     }
 
     idx = 0;
-    for (const note of children) {
-      if (note.invisible || !note.note) break;
+    for (const card of children) {
+      if (!card.note || card.note.displayMode === NoteDisplayMode.EdgelessOnly)
+        break;
 
       const topBoundary =
-        listContainerRect.top + note.offsetTop - outlineListContainer.scrollTop;
-      const midBoundary = topBoundary + note.offsetHeight / 2;
-      const bottomBoundary = topBoundary + note.offsetHeight;
+        listContainerRect.top + card.offsetTop - outlineListContainer.scrollTop;
+      const midBoundary = topBoundary + card.offsetHeight / 2;
+      const bottomBoundary = topBoundary + card.offsetHeight;
 
       if (e.clientY >= topBoundary && e.clientY <= bottomBoundary) {
         idx = e.clientY > midBoundary ? idx + 1 : idx;

--- a/tests/kit/src/utils/editor.ts
+++ b/tests/kit/src/utils/editor.ts
@@ -52,6 +52,14 @@ export function locateEditorContainer(page: Page, editorIndex = 0) {
   return page.locator('[data-affine-editor-container]').nth(editorIndex);
 }
 
+export function locateDocTitle(page: Page, editorIndex = 0) {
+  return locateEditorContainer(page, editorIndex).locator('doc-title');
+}
+
+export async function focusDocTitle(page: Page, editorIndex = 0) {
+  await locateDocTitle(page, editorIndex).locator('.inline-editor').focus();
+}
+
 // ================== Page ==================
 export function locateFormatBar(page: Page, editorIndex = 0) {
   return locateEditorContainer(page, editorIndex).locator(

--- a/tests/kit/src/utils/page-logic.ts
+++ b/tests/kit/src/utils/page-logic.ts
@@ -199,6 +199,7 @@ export const dragTo = async (
 };
 
 // sometimes editor loses focus, this function is to focus the editor
+// FIXME: this function is not usable since the placeholder is not unstable
 export const focusInlineEditor = async (page: Page) => {
   await page
     .locator(


### PR DESCRIPTION
### What Changes
1. Used `@preact/signal` and `@lit/context` to simplify repetitive passing of properties of TOC components,
2. Fixed TOC invalid when editor changed, such as click new page button.