### PR TITLE
feat(core): frame editor settings

### DIFF
--- a/blocksuite/affine/model/src/blocks/frame/frame-model.ts
+++ b/blocksuite/affine/model/src/blocks/frame/frame-model.ts
@@ -1,5 +1,6 @@
 import type {
   GfxBlockElementModel,
+  GfxCompatibleProps,
   GfxElementGeometry,
   GfxGroupCompatibleInterface,
   GfxModel,
@@ -10,7 +11,6 @@ import {
   descendantElementsImpl,
   generateKeyBetweenV2,
   GfxCompatible,
-  GfxCompatibleZodSchema,
   gfxGroupCompatibleSymbol,
   hasDescendantElementImpl,
 } from '@blocksuite/block-std/gfx';
@@ -18,33 +18,33 @@ import { Bound } from '@blocksuite/global/utils';
 import { BlockModel, defineBlockSchema, type Text } from '@blocksuite/store';
 import { z } from 'zod';
 
-import { ColorSchema, DefaultTheme } from '../../themes/index.js';
+import { type Color, ColorSchema, DefaultTheme } from '../../themes/index.js';
+
+export type FrameBlockProps = {
+  title: Text;
+  background: Color;
+  childElementIds?: Record<string, boolean>;
+  presentationIndex?: string;
+} & GfxCompatibleProps;
 
 export const FrameZodSchema = z
   .object({
     background: ColorSchema,
-    childElementIds: z.record(z.boolean()),
-    presentationIndex: z.string(),
   })
-  .and(GfxCompatibleZodSchema)
   .default({
     background: DefaultTheme.transparent,
-    xywh: `[0,0,100,100]`,
-    index: 'a0',
-    childElementIds: Object.create(null),
-    presentationIndex: generateKeyBetweenV2(null, null),
-    lockedBySelf: false,
   });
-
-export type FrameBlockProps = z.infer<typeof FrameZodSchema> & {
-  title: Text;
-};
 
 export const FrameBlockSchema = defineBlockSchema({
   flavour: 'affine:frame',
   props: (internal): FrameBlockProps => ({
     title: internal.Text(),
-    ...FrameZodSchema.parse(undefined),
+    background: 'transparent',
+    xywh: `[0,0,100,100]`,
+    index: 'a0',
+    childElementIds: Object.create(null),
+    presentationIndex: generateKeyBetweenV2(null, null),
+    lockedBySelf: false,
   }),
   metadata: {
     version: 1,

--- a/blocksuite/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -158,15 +158,12 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
     const { service, surfaceBlockModel } = edgeless;
     const frameMgr = service.frame;
     const frameIndex = service.frames.length + 1;
-    const id = this.crud.addBlock(
-      'affine:frame',
-      {
-        title: new Y.Text(`Frame ${frameIndex}`),
-        xywh: serializeXYWH(...xywh),
-        presentationIndex: frameMgr.generatePresentationIndex(),
-      },
-      surfaceBlockModel
-    );
+    const props = this.std.get(EditPropsStore).applyLastProps('affine:frame', {
+      title: new Y.Text(`Frame ${frameIndex}`),
+      xywh: serializeXYWH(...xywh),
+      presentationIndex: frameMgr.generatePresentationIndex(),
+    });
+    const id = this.crud.addBlock('affine:frame', props, surfaceBlockModel);
     edgeless.doc.captureSync();
     const frame = this.crud.getElementById(id);
     if (!frame) return;

--- a/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
@@ -206,12 +206,8 @@ export class EdgelessFrameManager extends GfxExtension {
         index: this.gfx.layer.generateIndex(true),
         presentationIndex: this.generatePresentationIndex(),
       });
-    const nProps = {
-      ...props,
-      index: this.gfx.layer.generateIndex(),
-    };
 
-    const id = this.gfx.doc.addBlock('affine:frame', nProps, surfaceModel);
+    const id = this.gfx.doc.addBlock('affine:frame', props, surfaceModel);
     const frameModel = this.gfx.getElementById(id);
 
     if (!frameModel || !isFrameBlock(frameModel)) {

--- a/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
@@ -1,5 +1,6 @@
 import type { SurfaceBlockModel } from '@blocksuite/affine-block-surface';
 import { Overlay } from '@blocksuite/affine-block-surface';
+import { EditPropsStore } from '@blocksuite/affine-shared/services';
 import {
   generateKeyBetweenV2,
   getTopElements,
@@ -23,11 +24,7 @@ import type { Store } from '@blocksuite/store';
 import { Text } from '@blocksuite/store';
 import * as Y from 'yjs';
 
-import {
-  EditPropsStore,
-  type FrameBlockModel,
-  type NoteBlockModel,
-} from '../../index.js';
+import { type FrameBlockModel, type NoteBlockModel } from '../../index.js';
 import { areSetsEqual } from './utils/misc.js';
 import { isFrameBlock } from './utils/query.js';
 

--- a/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
@@ -1,5 +1,6 @@
 import type { SurfaceBlockModel } from '@blocksuite/affine-block-surface';
 import { Overlay } from '@blocksuite/affine-block-surface';
+import type { FrameBlockModel, NoteBlockModel } from '@blocksuite/affine-model';
 import { EditPropsStore } from '@blocksuite/affine-shared/services';
 import {
   generateKeyBetweenV2,
@@ -24,7 +25,6 @@ import type { Store } from '@blocksuite/store';
 import { Text } from '@blocksuite/store';
 import * as Y from 'yjs';
 
-import { type FrameBlockModel, type NoteBlockModel } from '../../index.js';
 import { areSetsEqual } from './utils/misc.js';
 import { isFrameBlock } from './utils/query.js';
 

--- a/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/frame-manager.ts
@@ -23,7 +23,11 @@ import type { Store } from '@blocksuite/store';
 import { Text } from '@blocksuite/store';
 import * as Y from 'yjs';
 
-import type { FrameBlockModel, NoteBlockModel } from '../../index.js';
+import {
+  EditPropsStore,
+  type FrameBlockModel,
+  type NoteBlockModel,
+} from '../../index.js';
 import { areSetsEqual } from './utils/misc.js';
 import { isFrameBlock } from './utils/query.js';
 
@@ -194,16 +198,20 @@ export class EdgelessFrameManager extends GfxExtension {
 
   private _addFrameBlock(bound: Bound) {
     const surfaceModel = this.gfx.surface as SurfaceBlockModel;
-    const id = this.gfx.doc.addBlock(
-      'affine:frame',
-      {
+    const props = this.gfx.std
+      .get(EditPropsStore)
+      .applyLastProps('affine:frame', {
         title: new Text(new Y.Text(`Frame ${this.frames.length + 1}`)),
         xywh: bound.serialize(),
         index: this.gfx.layer.generateIndex(true),
         presentationIndex: this.generatePresentationIndex(),
-      },
-      surfaceModel
-    );
+      });
+    const nProps = {
+      ...props,
+      index: this.gfx.layer.generateIndex(),
+    };
+
+    const id = this.gfx.doc.addBlock('affine:frame', nProps, surfaceModel);
     const frameModel = this.gfx.getElementById(id);
 
     if (!frameModel || !isFrameBlock(frameModel)) {

--- a/blocksuite/blocks/src/root-block/edgeless/gfx-tool/frame-tool.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/gfx-tool/frame-tool.ts
@@ -1,6 +1,9 @@
 import { OverlayIdentifier } from '@blocksuite/affine-block-surface';
 import type { FrameBlockModel } from '@blocksuite/affine-model';
-import { TelemetryProvider } from '@blocksuite/affine-shared/services';
+import {
+  EditPropsStore,
+  TelemetryProvider,
+} from '@blocksuite/affine-shared/services';
 import type { PointerEventState } from '@blocksuite/block-std';
 import {
   BaseTool,
@@ -70,16 +73,21 @@ export class FrameTool extends BaseTool {
       const frames = this.gfx.layer.blocks.filter(
         block => block.flavour === 'affine:frame'
       ) as FrameBlockModel[];
-      const id = this.doc.addBlock(
-        'affine:frame',
-        {
+
+      const props = this.std
+        .get(EditPropsStore)
+        .applyLastProps('affine:frame', {
           title: new Text(new Y.Text(`Frame ${frames.length + 1}`)),
           xywh: Bound.fromPoints([this._startPoint, currentPoint]).serialize(),
           index: this.gfx.layer.generateIndex(true),
           presentationIndex: this.frameManager.generatePresentationIndex(),
-        },
-        this.gfx.surface
-      );
+        });
+      const nProps = {
+        ...props,
+        index: this.gfx.layer.generateIndex(),
+      };
+
+      const id = this.doc.addBlock('affine:frame', nProps, this.gfx.surface);
 
       this.std.getOptional(TelemetryProvider)?.track('CanvasElementAdded', {
         control: 'canvas:draw',

--- a/blocksuite/blocks/src/root-block/edgeless/gfx-tool/frame-tool.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/gfx-tool/frame-tool.ts
@@ -82,12 +82,8 @@ export class FrameTool extends BaseTool {
           index: this.gfx.layer.generateIndex(true),
           presentationIndex: this.frameManager.generatePresentationIndex(),
         });
-      const nProps = {
-        ...props,
-        index: this.gfx.layer.generateIndex(),
-      };
 
-      const id = this.doc.addBlock('affine:frame', nProps, this.gfx.surface);
+      const id = this.doc.addBlock('affine:frame', props, this.gfx.surface);
 
       this.std.getOptional(TelemetryProvider)?.track('CanvasElementAdded', {
         control: 'canvas:draw',

--- a/blocksuite/framework/block-std/src/gfx/index.ts
+++ b/blocksuite/framework/block-std/src/gfx/index.ts
@@ -29,10 +29,8 @@ export {
 export {
   GfxBlockElementModel,
   type GfxCommonBlockProps,
-  GfxCommonBlockZodSchema,
   GfxCompatibleBlockModel as GfxCompatible,
   type GfxCompatibleProps,
-  GfxCompatibleZodSchema,
 } from './model/gfx-block-model.js';
 export { type GfxModel } from './model/model.js';
 export {

--- a/blocksuite/framework/block-std/src/gfx/model/gfx-block-model.ts
+++ b/blocksuite/framework/block-std/src/gfx/model/gfx-block-model.ts
@@ -15,10 +15,8 @@ import {
   polygonGetPointTangent,
   polygonNearestPoint,
   rotatePoints,
-  SerializedXYWHZodSchema,
 } from '@blocksuite/global/utils';
 import { BlockModel } from '@blocksuite/store';
-import { z } from 'zod';
 
 import {
   isLockedByAncestorImpl,
@@ -35,24 +33,20 @@ import type { SurfaceBlockModel } from './surface/surface-model.js';
 /**
  * The props that a graphics block model should have.
  */
-export const GfxCompatibleZodSchema = z.object({
-  xywh: SerializedXYWHZodSchema,
-  index: z.string(),
-  lockedBySelf: z.boolean().optional(),
-});
-export type GfxCompatibleProps = z.infer<typeof GfxCompatibleZodSchema>;
+export type GfxCompatibleProps = {
+  xywh: SerializedXYWH;
+  index: string;
+  lockedBySelf?: boolean;
+};
 
 /**
  * This type include the common props for the graphic block model.
  * You can use this type with Omit to define the props of a graphic block model.
  */
-export const GfxCommonBlockZodSchema = GfxCompatibleZodSchema.and(
-  z.object({
-    rotate: z.number(),
-    scale: z.number(),
-  })
-);
-export type GfxCommonBlockProps = z.infer<typeof GfxCommonBlockZodSchema>;
+export type GfxCommonBlockProps = GfxCompatibleProps & {
+  rotate: number;
+  scale: number;
+};
 
 /**
  * The graphic block model that can be rendered in the graphics mode.

--- a/blocksuite/framework/global/src/utils/index.ts
+++ b/blocksuite/framework/global/src/utils/index.ts
@@ -16,5 +16,4 @@ export * from './slot.js';
 export * from './types.js';
 export * from './with-disposable.js';
 export type { SerializedXYWH, XYWH } from './xywh.js';
-export { SerializedXYWHZodSchema } from './xywh.js';
 export { deserializeXYWH, serializeXYWH } from './xywh.js';

--- a/blocksuite/framework/global/src/utils/xywh.ts
+++ b/blocksuite/framework/global/src/utils/xywh.ts
@@ -1,5 +1,3 @@
-import { z } from 'zod';
-
 /**
  * XYWH represents the x, y, width, and height of an element or block.
  */
@@ -9,30 +7,6 @@ export type XYWH = [number, number, number, number];
  * SerializedXYWH is a string that represents the x, y, width, and height of a block.
  */
 export type SerializedXYWH = `[${number},${number},${number},${number}]`;
-
-export const SerializedXYWHZodSchema = z.custom<SerializedXYWH>((val: any) => {
-  if (typeof val !== 'string') {
-    throw new Error('SerializedXYWH should be a string');
-  }
-
-  if (!val.startsWith('[') || !val.endsWith(']')) {
-    throw new Error('SerializedXYWH should be wrapped in square brackets');
-  }
-
-  const parts = val.slice(1, -1).split(',');
-
-  if (parts.length !== 4) {
-    throw new Error('SerializedXYWH should have 4 parts');
-  }
-
-  for (const part of parts) {
-    if (!/^\d+$/.test(part)) {
-      throw new Error('Each part of SerializedXYWH should be a number');
-    }
-  }
-
-  return val as SerializedXYWH;
-});
 
 export function serializeXYWH(
   x: number,

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/docs/frame.json
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/docs/frame.json
@@ -1,14 +1,14 @@
 {
   "type": "page",
   "meta": {
-    "id": "ArQikchA-L",
+    "id": "gIUEIHL42k",
     "title": "FrameDoc",
-    "createDate": 1737997265443,
+    "createDate": 1738858597791,
     "tags": []
   },
   "blocks": {
     "type": "block",
-    "id": "qq7mI8nDLZ",
+    "id": "MCYCDPz_QH",
     "flavour": "affine:page",
     "version": 2,
     "props": {
@@ -24,7 +24,7 @@
     "children": [
       {
         "type": "block",
-        "id": "6rh1ghlYSo",
+        "id": "I_s0rS2Pbl",
         "flavour": "affine:surface",
         "version": 5,
         "props": {
@@ -33,7 +33,7 @@
         "children": [
           {
             "type": "block",
-            "id": "yCrarAaUqW",
+            "id": "mHE8GI9UWx",
             "flavour": "affine:frame",
             "version": 1,
             "props": {
@@ -41,41 +41,16 @@
                 "$blocksuite:internal:text$": true,
                 "delta": [
                   {
-                    "insert": "Frame1"
+                    "insert": "Frame 1"
                   }
                 ]
               },
               "background": "transparent",
-              "xywh": "[-36.618320239403886,-43.02477852444463,532.468488236992,205.78063789944463]",
-              "index": "a3",
-              "childElementIds": {
-                "SQi7VaLNb8": true
-              },
-              "presentationIndex": "a004uIjqqu985M8JGnXKGPW2dwa7u69rSbw",
+              "xywh": "[-186.37939453125,-68.03814697265625,375.8616943359375,114.787109375]",
+              "index": "Zz",
+              "childElementIds": {},
+              "presentationIndex": "a00zHdtY37OLhj7JOhCr9ywYQXy1SbAI6kM",
               "lockedBySelf": false
-            },
-            "children": []
-          },
-          {
-            "type": "block",
-            "id": "SQi7VaLNb8",
-            "flavour": "affine:frame",
-            "version": 1,
-            "props": {
-              "title": {
-                "$blocksuite:internal:text$": true,
-                "delta": [
-                  {
-                    "insert": "Frame2"
-                  }
-                ]
-              },
-              "index": "a4",
-              "presentationIndex": "a10GuoRJBEkSB8jqIxcQwO2hrujfAkhek8m",
-              "lockedBySelf": false,
-              "background": "transparent",
-              "xywh": "[60.759284076779295,-11.016554724217983,336.97560870618815,117.92243767863903]",
-              "childElementIds": {}
             },
             "children": []
           }

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/docs/frame.json
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/docs/frame.json
@@ -1,0 +1,86 @@
+{
+  "type": "page",
+  "meta": {
+    "id": "ArQikchA-L",
+    "title": "FrameDoc",
+    "createDate": 1737997265443,
+    "tags": []
+  },
+  "blocks": {
+    "type": "block",
+    "id": "qq7mI8nDLZ",
+    "flavour": "affine:page",
+    "version": 2,
+    "props": {
+      "title": {
+        "$blocksuite:internal:text$": true,
+        "delta": [
+          {
+            "insert": "FrameDoc"
+          }
+        ]
+      }
+    },
+    "children": [
+      {
+        "type": "block",
+        "id": "6rh1ghlYSo",
+        "flavour": "affine:surface",
+        "version": 5,
+        "props": {
+          "elements": {}
+        },
+        "children": [
+          {
+            "type": "block",
+            "id": "yCrarAaUqW",
+            "flavour": "affine:frame",
+            "version": 1,
+            "props": {
+              "title": {
+                "$blocksuite:internal:text$": true,
+                "delta": [
+                  {
+                    "insert": "Frame1"
+                  }
+                ]
+              },
+              "background": "transparent",
+              "xywh": "[-36.618320239403886,-43.02477852444463,532.468488236992,205.78063789944463]",
+              "index": "a3",
+              "childElementIds": {
+                "SQi7VaLNb8": true
+              },
+              "presentationIndex": "a004uIjqqu985M8JGnXKGPW2dwa7u69rSbw",
+              "lockedBySelf": false
+            },
+            "children": []
+          },
+          {
+            "type": "block",
+            "id": "SQi7VaLNb8",
+            "flavour": "affine:frame",
+            "version": 1,
+            "props": {
+              "title": {
+                "$blocksuite:internal:text$": true,
+                "delta": [
+                  {
+                    "insert": "Frame2"
+                  }
+                ]
+              },
+              "index": "a4",
+              "presentationIndex": "a10GuoRJBEkSB8jqIxcQwO2hrujfAkhek8m",
+              "lockedBySelf": false,
+              "background": "transparent",
+              "xywh": "[60.759284076779295,-11.016554724217983,336.97560870618815,117.92243767863903]",
+              "childElementIds": {}
+            },
+            "children": []
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/docs/index.ts
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/docs/index.ts
@@ -24,7 +24,8 @@ export type DocName =
   | 'flow'
   | 'text'
   | 'connector'
-  | 'mindmap';
+  | 'mindmap'
+  | 'frame';
 
 const docMap = new Map<DocName, Promise<Store | undefined>>();
 
@@ -38,6 +39,10 @@ async function loadPen() {
 
 async function loadShape() {
   return (await import('./shape.json')).default;
+}
+
+async function loadFrame() {
+  return (await import('./frame.json')).default;
 }
 
 async function loadFlow() {
@@ -60,6 +65,7 @@ const loaders = {
   note: loadNote,
   pen: loadPen,
   shape: loadShape,
+  frame: loadFrame,
   flow: loadFlow,
   text: loadText,
   connector: loadConnector,

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/edgeless.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/edgeless.tsx
@@ -2,6 +2,7 @@ import { SettingWrapper } from '@affine/component/setting-components';
 import { useI18n } from '@affine/i18n';
 
 import { ConnectorSettings } from './connector';
+import { FrameSettings } from './frame';
 import { GeneralEdgelessSetting } from './general';
 import { MindMapSettings } from './mind-map';
 import { NoteSettings } from './note';
@@ -17,6 +18,7 @@ export const Edgeless = () => {
       <NoteSettings />
       <TextSettings />
       <ShapeSettings />
+      <FrameSettings />
       <ConnectorSettings />
       <PenSettings />
       <MindMapSettings />

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/frame.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/frame.tsx
@@ -1,0 +1,88 @@
+import { MenuItem, MenuTrigger } from '@affine/component';
+import { SettingRow } from '@affine/component/setting-components';
+import { EditorSettingService } from '@affine/core/modules/editor-setting';
+import { useI18n } from '@affine/i18n';
+import { DefaultTheme } from '@blocksuite/affine/blocks';
+import type { Store } from '@blocksuite/affine/store';
+import { useFramework, useLiveData } from '@toeverything/infra';
+import { isEqual } from 'lodash-es';
+import { useCallback, useMemo } from 'react';
+
+import { DropdownMenu } from '../menu';
+import { menuTrigger } from '../style.css';
+import { usePalettes } from '../utils';
+import { Point } from './point';
+import { EdgelessSnapshot } from './snapshot';
+
+export const FrameSettings = () => {
+  const t = useI18n();
+  const framework = useFramework();
+  const { editorSetting } = framework.get(EditorSettingService);
+  const settings = useLiveData(editorSetting.settings$);
+  const { palettes, getCurrentColor } = usePalettes(
+    [
+      { key: 'Transparent', value: DefaultTheme.transparent },
+      ...DefaultTheme.FillColorPalettes,
+    ],
+    DefaultTheme.transparent
+  );
+
+  const { background } = settings['affine:frame'];
+  const currentColor = useMemo(() => {
+    return getCurrentColor(background);
+  }, [getCurrentColor, background]);
+
+  const colorItems = useMemo(() => {
+    return palettes.map(({ key, value, resolvedValue }) => {
+      const handler = () => {
+        editorSetting.set('affine:frame', { background: value });
+      };
+      const isSelected = isEqual(background, value);
+      return (
+        <MenuItem
+          key={key}
+          onSelect={handler}
+          selected={isSelected}
+          prefix={<Point color={resolvedValue} />}
+        >
+          {key}
+        </MenuItem>
+      );
+    });
+  }, [editorSetting, background, palettes]);
+
+  const getElements = useCallback((doc: Store) => {
+    return doc.getBlocksByFlavour('affine:frame') || [];
+  }, []);
+
+  return (
+    <>
+      <EdgelessSnapshot
+        title={t['com.affine.settings.editorSettings.edgeless.frame']()}
+        docName="frame"
+        keyName="affine:frame"
+        getElements={getElements}
+      />
+      <SettingRow
+        name={t[
+          'com.affine.settings.editorSettings.edgeless.frame.background'
+        ]()}
+        desc={''}
+      >
+        {currentColor ? (
+          <DropdownMenu
+            items={colorItems}
+            trigger={
+              <MenuTrigger
+                className={menuTrigger}
+                prefix={<Point color={currentColor.resolvedValue} />}
+              >
+                {currentColor.key}
+              </MenuTrigger>
+            }
+          />
+        ) : null}
+      </SettingRow>
+    </>
+  );
+};

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/snapshot.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/snapshot.tsx
@@ -115,7 +115,8 @@ export const EdgelessSnapshot = (props: Props) => {
       doc.readonly = false;
       edgelessBlock.editorViewportSelector = 'ref-viewport';
       const frame = getFrameBlock(doc);
-      if (frame) {
+      if (frame && frame.id !== 'SQi7VaLNb8') {
+        // frame with id 'SQi7VaLNb8' shouldn't be deleted, it is a part of frame settings
         boundMap.set(docName, Bound.deserialize(frame.xywh));
         doc.deleteBlock(frame);
       }

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/snapshot.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/snapshot.tsx
@@ -115,8 +115,8 @@ export const EdgelessSnapshot = (props: Props) => {
       doc.readonly = false;
       edgelessBlock.editorViewportSelector = 'ref-viewport';
       const frame = getFrameBlock(doc);
-      if (frame && frame.id !== 'SQi7VaLNb8') {
-        // frame with id 'SQi7VaLNb8' shouldn't be deleted, it is a part of frame settings
+      if (frame && docName !== 'frame') {
+        // docName with value 'frame' shouldn't be deleted, it is a part of frame settings
         boundMap.set(docName, Bound.deserialize(frame.xywh));
         doc.deleteBlock(frame);
       }

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1212,6 +1212,8 @@
   "com.affine.settings.editorSettings.edgeless.shape.text-alignment": "Text alignment",
   "com.affine.settings.editorSettings.edgeless.shape.text-color": "Text color",
   "com.affine.settings.editorSettings.edgeless.shape.triangle": "Triangle",
+  "com.affine.settings.editorSettings.edgeless.frame": "Frame",
+  "com.affine.settings.editorSettings.edgeless.frame.background": "Background",
   "com.affine.settings.editorSettings.edgeless.style": "Style",
   "com.affine.settings.editorSettings.edgeless.style.general": "General",
   "com.affine.settings.editorSettings.edgeless.style.scribbled": "Scribbled",


### PR DESCRIPTION
Fixes #9646
# Demo

https://github.com/user-attachments/assets/b7cf983d-dbfd-4f6d-8206-d9a4f02a36e6

## Design Decisions 
- `frame-tools.ts`: other blocks update their props using one of the extensions in `surface` block. Since `frame` block is not a part of the `surface`, this extension wasn't called. I decided to update the props directly in the `frame-tool.ts` instead of writing an extension for entire `frame` block
- `snapshot.tsx`: whenever editor settings are opened, one frame in each block preview area is deleted. This behavior deleted the preview frame that shows the selected color of frame settings. I decided to exclude this frame from deletion process 