### PR TITLE
fix(editor): should focus the textarea will clicking the chat input box

### DIFF
--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-input.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-input.ts
@@ -376,7 +376,14 @@ export class ChatPanelInput extends SignalWatcher(WithDisposable(LitElement)) {
           user-select: none;
         }
       </style>
-      <div class="chat-panel-input">
+      <div
+        class="chat-panel-input"
+        @pointerdown=${(e: MouseEvent) => {
+          // by default the div will be focused and will blur the textarea
+          e.preventDefault();
+          this.textarea.focus();
+        }}
+      >
         ${hasImages ? this._renderImages(images) : nothing}
         ${this.chatContextValue.quote
           ? html`<div class="chat-selection-quote">


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/0fc4ec8d-85ba-486b-9d1e-854eff3c0dfc.png)

Clicking outside of the textarea should also focuses the textarea