### PR TITLE
fix(editor): wrap doc title by default

### DIFF
--- a/blocksuite/affine/components/src/doc-title/doc-title.ts
+++ b/blocksuite/affine/components/src/doc-title/doc-title.ts
@@ -219,5 +219,5 @@ export class DocTitle extends WithDisposable(ShadowlessElement) {
   accessor doc!: Store;
 
   @property({ attribute: false })
-  accessor wrapText = false;
+  accessor wrapText = true;
 }


### PR DESCRIPTION
Close [AF-2195](https://linear.app/affine-design/issue/AF-2195/editor-的-title-overflow-时没有换行)