### PR TITLE
refactor(editor): mount worker renderer in editor host

### DIFF
--- a/blocksuite/affine/shared/package.json
+++ b/blocksuite/affine/shared/package.json
@@ -46,6 +46,7 @@
     "remark-math": "^6.0.0",
     "remark-parse": "^11.0.0",
     "remark-stringify": "^11.0.0",
+    "tweakpane": "^4.0.5",
     "unified": "^11.0.5",
     "yjs": "^13.6.21",
     "zod": "^3.23.8"

--- a/blocksuite/playground/examples/renderer/editor.ts
+++ b/blocksuite/playground/examples/renderer/editor.ts
@@ -12,10 +12,11 @@ presetsEffects();
 
 export const doc = createEmptyDoc().init();
 export const editor = new AffineEditorContainer();
-editor.pageSpecs = editor.pageSpecs.concat([ViewportTurboRendererExtension]);
-editor.edgelessSpecs = editor.edgelessSpecs.concat([
+editor.pageSpecs = [...editor.pageSpecs, ViewportTurboRendererExtension];
+editor.edgelessSpecs = [
+  ...editor.edgelessSpecs,
   ViewportTurboRendererExtension,
-]);
+];
 
 editor.doc = doc;
 editor.mode = 'edgeless';

--- a/blocksuite/playground/examples/renderer/index.html
+++ b/blocksuite/playground/examples/renderer/index.html
@@ -15,45 +15,15 @@
         background-color: var(--affine-white-90);
         transition: background-color 0.3s;
       }
-
       #container {
-        display: flex;
+        position: relative;
         width: 100%;
         height: 100%;
-      }
-
-      #left-column {
-        flex: 1;
-        padding: 20px;
-        border-right: 1px solid #e0e0e0;
-      }
-
-      #right-column {
-        flex: 1;
-        padding: 20px;
-        position: relative;
-        display: flex;
-        align-items: flex-end;
-        justify-content: center;
-      }
-
-      .top-bar {
-        position: absolute;
-        top: 0;
-        left: 0;
-        padding: 5px;
       }
     </style>
   </head>
   <body>
-    <div id="container">
-      <div id="left-column"></div>
-      <div id="right-column">
-        <div class="top-bar">
-          <div id="tweakpane-container"></div>
-        </div>
-      </div>
-    </div>
+    <div id="container"></div>
     <script type="module" src="./main.ts"></script>
   </body>
 </html>

--- a/blocksuite/playground/examples/renderer/main.ts
+++ b/blocksuite/playground/examples/renderer/main.ts
@@ -1,58 +1,6 @@
-import { ViewportTurboRendererIdentifier } from '@blocksuite/affine-shared/viewport-renderer';
-import { GfxControllerIdentifier } from '@blocksuite/block-std/gfx';
-import { nextTick } from '@blocksuite/global/utils';
 import { Text } from '@blocksuite/store';
-import { Pane } from 'tweakpane';
 
 import { doc, editor } from './editor.js';
-
-type DocMode = 'page' | 'edgeless';
-
-async function handleToCanvasClick() {
-  const renderer = editor.std.get(ViewportTurboRendererIdentifier);
-  await renderer.render();
-  const viewport = editor.std.get(GfxControllerIdentifier).viewport;
-  viewport.viewportUpdated.on(async () => {
-    await renderer.render();
-  });
-}
-
-async function handleModeChange(mode: DocMode) {
-  editor.mode = mode;
-  await nextTick();
-
-  const renderer = editor.std.get(ViewportTurboRendererIdentifier);
-  await renderer.render();
-}
-
-function initUI() {
-  const pane = new Pane({
-    container: document.querySelector('#tweakpane-container') as HTMLElement,
-  });
-
-  const params = {
-    mode: 'edgeless' as DocMode,
-  };
-
-  pane
-    .addButton({
-      title: 'To Canvas',
-    })
-    .on('click', () => {
-      handleToCanvasClick().catch(console.error);
-    });
-  pane
-    .addBinding(params, 'mode', {
-      label: 'Editor Mode',
-      options: {
-        Doc: 'page',
-        Edgeless: 'edgeless',
-      },
-    })
-    .on('change', ({ value }) => {
-      handleModeChange(value as DocMode).catch(console.error);
-    });
-}
 
 function addParagraph(content: string) {
   const note = doc.getBlocksByFlavour('affine:note')[0];
@@ -63,9 +11,7 @@ function addParagraph(content: string) {
 }
 
 function main() {
-  initUI();
-
-  document.querySelector('#left-column')?.append(editor);
+  document.querySelector('#container')?.append(editor);
   const firstParagraph = doc.getBlockByFlavour('affine:paragraph')[0];
   doc.updateBlock(firstParagraph, { text: new Text('Renderer') });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3754,6 +3754,7 @@ __metadata:
     remark-math: "npm:^6.0.0"
     remark-parse: "npm:^11.0.0"
     remark-stringify: "npm:^11.0.0"
+    tweakpane: "npm:^4.0.5"
     unified: "npm:^11.0.5"
     vitest: "npm:3.0.5"
     yjs: "npm:^13.6.21"
@@ -32935,7 +32936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tweakpane@npm:^4.0.4":
+"tweakpane@npm:^4.0.4, tweakpane@npm:^4.0.5":
   version: 4.0.5
   resolution: "tweakpane@npm:4.0.5"
   checksum: 10/7719a15ce96dd2b936b277239ccb18ee6a75ed2416a6bdacfc537515d909da6edd50161b12e91441ace5243efad3a14a98fe6e5475cae2617d7647a197117e64


### PR DESCRIPTION
This would allow for easier integration with current test runner, since the two column layout is removed.

The `ViewportTurboRender` canvas and its debug UI are only enabled if the extension is added, which won't affect the AFFiNE entry.

<img width="945" alt="image" src="https://github.com/user-attachments/assets/dc82daa4-cbed-4eb9-9660-28c3f7d35722" />
