### PR TITLE
fix(server): only handle doc.snapshot.updated event on renderer

### DIFF
--- a/packages/backend/server/src/core/doc-renderer/event.ts
+++ b/packages/backend/server/src/core/doc-renderer/event.ts
@@ -1,0 +1,27 @@
+import { FactoryProvider } from '@nestjs/common';
+
+import { Config, OnEvent } from '../../base';
+import { DocContentService } from './service';
+
+class DocEventsListener {
+  constructor(private readonly doc: DocContentService) {}
+
+  @OnEvent('doc.snapshot.updated')
+  async handleDocSnapshotUpdated({
+    workspaceId,
+    docId,
+  }: Events['doc.snapshot.updated']) {
+    await this.doc.markDocContentCacheStale(workspaceId, docId);
+  }
+}
+
+export const DocEventsListenerProvider: FactoryProvider = {
+  provide: DocEventsListener,
+  useFactory: (config: Config, doc: DocContentService) => {
+    if (config.flavor.renderer) {
+      return new DocEventsListener(doc);
+    }
+    return;
+  },
+  inject: [Config, DocContentService],
+};

--- a/packages/backend/server/src/core/doc-renderer/index.ts
+++ b/packages/backend/server/src/core/doc-renderer/index.ts
@@ -3,11 +3,12 @@ import { Module } from '@nestjs/common';
 import { DocStorageModule } from '../doc';
 import { PermissionModule } from '../permission';
 import { DocRendererController } from './controller';
+import { DocEventsListenerProvider } from './event';
 import { DocContentService } from './service';
 
 @Module({
   imports: [DocStorageModule, PermissionModule],
-  providers: [DocContentService],
+  providers: [DocContentService, DocEventsListenerProvider],
   controllers: [DocRendererController],
   exports: [DocContentService],
 })

--- a/packages/backend/server/src/core/doc-renderer/service.ts
+++ b/packages/backend/server/src/core/doc-renderer/service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { applyUpdate, Doc } from 'yjs';
 
-import { Cache, OnEvent } from '../../base';
+import { Cache } from '../../base';
 import { DocReader } from '../doc';
 import {
   type PageDocContent,
@@ -78,11 +78,7 @@ export class DocContentService {
     return content;
   }
 
-  @OnEvent('doc.snapshot.updated')
-  async markDocContentCacheStale({
-    workspaceId,
-    docId,
-  }: Events['doc.snapshot.updated']) {
+  async markDocContentCacheStale(workspaceId: string, docId: string) {
     const key =
       workspaceId === docId
         ? `workspace:${workspaceId}:content`


### PR DESCRIPTION
before

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/hTwOityLamd4hitrae7M/0345e2e0-85fb-45a2-a917-be0cb1731907.png)

after

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/hTwOityLamd4hitrae7M/fd49d1b4-2970-4b86-aca1-4c40da3d0988.png)

