### PR TITLE
feat(server): use x-cloud-trace-context instead of x-rpc-trace-id

### DIFF
--- a/packages/backend/server/src/app.module.ts
+++ b/packages/backend/server/src/app.module.ts
@@ -57,7 +57,7 @@ export const FunctionalityModules = [
       generateId: true,
       idGenerator(req: Request) {
         // make every request has a unique id to tracing
-        return req.get('x-rpc-trace-id') ?? genRequestId('req');
+        return req.get('x-cloud-trace-context') ?? genRequestId('req');
       },
       setup(cls, _req, res: Response) {
         res.setHeader('X-Request-Id', cls.getId());

--- a/packages/backend/server/src/core/doc-service/__tests__/controller.spec.ts
+++ b/packages/backend/server/src/core/doc-service/__tests__/controller.spec.ts
@@ -110,7 +110,7 @@ test('should return doc when found', async t => {
   const res = await app
     .GET(`/rpc/workspaces/${workspace.id}/docs/${docId}`)
     .set('x-access-token', t.context.crypto.sign(docId))
-    .set('x-rpc-trace-id', 'test-trace-id')
+    .set('x-cloud-trace-context', 'test-trace-id')
     .expect(200)
     .expect('x-request-id', 'test-trace-id')
     .expect('Content-Type', 'application/octet-stream');

--- a/packages/backend/server/src/core/doc/reader.ts
+++ b/packages/backend/server/src/core/doc/reader.ts
@@ -46,7 +46,7 @@ export class RpcDocReader extends DatabaseDocReader {
       const res = await fetch(url, {
         headers: {
           'x-access-token': this.crypto.sign(docId),
-          'x-rpc-trace-id': this.cls.getId(),
+          'x-cloud-trace-context': this.cls.getId(),
         },
       });
       if (!res.ok) {


### PR DESCRIPTION
x-cloud-trace-context will be overwritten by lb,
and cannot be fake from internet access request

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/hTwOityLamd4hitrae7M/6d3c47c1-ac9e-4bc9-a7f1-2be8f56dbf69.png)

