### PR TITLE
feat(core): add tag field to ai messages

### DIFF
--- a/packages/backend/server/schema.prisma
+++ b/packages/backend/server/schema.prisma
@@ -333,6 +333,11 @@ enum AiPromptRole {
   user
 }
 
+enum AiMessageTag {
+  invisible
+  retrieval
+}
+
 model AiPromptMessage {
   promptId    Int          @map("prompt_id") @db.Integer
   // if a group of prompts contains multiple sentences, idx specifies the order of each sentence
@@ -344,6 +349,7 @@ model AiPromptMessage {
   attachments Json?        @db.Json
   params      Json?        @db.Json
   createdAt   DateTime     @default(now()) @map("created_at") @db.Timestamptz(3)
+  tag         AiMessageTag?
 
   prompt AiPrompt @relation(fields: [promptId], references: [id], onDelete: Cascade)
 
@@ -379,6 +385,7 @@ model AiSessionMessage {
   params      Json?        @db.Json
   createdAt   DateTime     @default(now()) @map("created_at") @db.Timestamptz(3)
   updatedAt   DateTime     @updatedAt @map("updated_at") @db.Timestamptz(3)
+  tag         AiMessageTag?
 
   session AiSession @relation(fields: [sessionId], references: [id], onDelete: Cascade)
 

--- a/packages/backend/server/src/__tests__/copilot.spec.ts
+++ b/packages/backend/server/src/__tests__/copilot.spec.ts
@@ -253,13 +253,15 @@ test('should be able to manage chat session', async t => {
     s1
       .finish(params)
       // @ts-expect-error
-      .map(({ id: _, attachments: __, createdAt: ___, ...m }) => m),
+      .map(({ id: _, attachments: __, createdAt: ___, tag: _tag, ...m }) => m),
     finalMessages,
     'should same as before message'
   );
   t.deepEqual(
-    // @ts-expect-error
-    s1.finish({}).map(({ id: _, attachments: __, createdAt: ___, ...m }) => m),
+    s1
+      .finish({})
+      // @ts-expect-error
+      .map(({ id: _, attachments: __, createdAt: ___, tag: _tag, ...m }) => m),
     [
       { content: 'hello ', params: {}, role: 'system' },
       { content: 'hello', role: 'user' },
@@ -365,8 +367,9 @@ test('should be able to fork chat session', async t => {
     const s2 = (await session.get(forkedSessionId1))!;
 
     const finalMessages = s2
-      .finish(params) // @ts-expect-error
-      .map(({ id: _, attachments: __, createdAt: ___, ...m }) => m);
+      .finish(params)
+      // @ts-expect-error
+      .map(({ id: _, attachments: __, createdAt: ___, tag: _tag, ...m }) => m);
     t.deepEqual(
       finalMessages,
       [
@@ -386,8 +389,9 @@ test('should be able to fork chat session', async t => {
     t.is(s2.config.userId, newUser.id, 'should have same user id');
 
     const finalMessages = s2
-      .finish(params) // @ts-expect-error
-      .map(({ id: _, attachments: __, createdAt: ___, ...m }) => m);
+      .finish(params)
+      // @ts-expect-error
+      .map(({ id: _, attachments: __, createdAt: ___, tag: _tag, ...m }) => m);
     t.deepEqual(
       finalMessages,
       [
@@ -404,8 +408,9 @@ test('should be able to fork chat session', async t => {
     const s3 = (await session.get(sessionId))!;
 
     const finalMessages = s3
-      .finish(params) // @ts-expect-error
-      .map(({ id: _, attachments: __, createdAt: ___, ...m }) => m);
+      .finish(params)
+      // @ts-expect-error
+      .map(({ id: _, attachments: __, createdAt: ___, tag: _tag, ...m }) => m);
     t.deepEqual(
       finalMessages,
       [

--- a/packages/backend/server/src/__tests__/utils/copilot.ts
+++ b/packages/backend/server/src/__tests__/utils/copilot.ts
@@ -320,6 +320,7 @@ type ChatMessage = {
   content: string;
   attachments: string[] | null;
   createdAt: string;
+  tag?: string | null;
 };
 
 type History = {
@@ -366,6 +367,7 @@ export async function getHistories(
               content
               attachments
               createdAt
+              tag
             }
           }
         }

--- a/packages/backend/server/src/plugins/copilot/prompt/chat-prompt.ts
+++ b/packages/backend/server/src/plugins/copilot/prompt/chat-prompt.ts
@@ -133,7 +133,7 @@ export class ChatPrompt {
     const paramsAttach = Array.isArray(attach) ? attach : [];
 
     return this.messages.map(
-      ({ attachments: attach, content, params: _, ...rest }) => {
+      ({ attachments: attach, content, params: _, tag, ...rest }) => {
         const result: PromptMessage = {
           ...rest,
           params,
@@ -146,6 +146,9 @@ export class ChatPrompt {
         ];
         if (attachments.length && rest.role === 'user') {
           result.attachments = attachments;
+        }
+        if (tag) {
+          result.tag = tag;
         }
         return result;
       }

--- a/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
+++ b/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
@@ -947,8 +947,12 @@ const chat: Prompt[] = [
     messages: [
       {
         role: 'system',
-        content: `You are AFFiNE AI, a professional and humorous copilot within AFFiNE. You are powered by latest GPT model from OpenAI and AFFiNE. AFFiNE is an open source general purposed productivity tool that contains unified building blocks that users can use on any interfaces, including block-based docs editor, infinite canvas based edgeless graphic mode, or multi-dimensional table with multiple transformable views. Your mission is always to try your very best to assist users to use AFFiNE to write docs, draw diagrams or plan things with these abilities. You always think step-by-step and describe your plan for what to build, using well-structured and clear markdown, written out in great detail. Unless otherwise specified, where list, JSON, or code blocks are required for giving the output. Minimize any other prose so that your responses can be directly used and inserted into the docs. You are able to access to API of AFFiNE to finish your job. You always respect the users' privacy and would not leak their info to anyone else. AFFiNE is made by Toeverything .Pte .Ltd, a company registered in Singapore with a diverse and international team. The company also open sourced blocksuite and octobase for building tools similar to Affine. The name AFFiNE comes from the idea of AFFiNE transform, as blocks in affine can all transform in page, edgeless or database mode. AFFiNE team is now having 25 members, an open source company driven by engineers.
-# Context Documents
+        content: `You are AFFiNE AI, a professional and humorous copilot within AFFiNE. You are powered by latest GPT model from OpenAI and AFFiNE. AFFiNE is an open source general purposed productivity tool that contains unified building blocks that users can use on any interfaces, including block-based docs editor, infinite canvas based edgeless graphic mode, or multi-dimensional table with multiple transformable views. Your mission is always to try your very best to assist users to use AFFiNE to write docs, draw diagrams or plan things with these abilities. You always think step-by-step and describe your plan for what to build, using well-structured and clear markdown, written out in great detail. Unless otherwise specified, where list, JSON, or code blocks are required for giving the output. Minimize any other prose so that your responses can be directly used and inserted into the docs. You are able to access to API of AFFiNE to finish your job. You always respect the users' privacy and would not leak their info to anyone else. AFFiNE is made by Toeverything .Pte .Ltd, a company registered in Singapore with a diverse and international team. The company also open sourced blocksuite and octobase for building tools similar to Affine. The name AFFiNE comes from the idea of AFFiNE transform, as blocks in affine can all transform in page, edgeless or database mode. AFFiNE team is now having 25 members, an open source company driven by engineers.`,
+      },
+      {
+        role: 'user',
+        tag: 'invisible',
+        content: `# Context Documents
 The following documents provide relevant context and background information for your reference. 
 If the provided documents are relevant to the user's query:
 - Use them to enrich and support your response
@@ -1025,6 +1029,7 @@ export async function refreshPrompts(db: PrismaClient) {
             role: message.role,
             content: message.content,
             params: message.params || undefined,
+            tag: message.tag || undefined,
           })),
         },
       },
@@ -1040,6 +1045,7 @@ export async function refreshPrompts(db: PrismaClient) {
             role: message.role,
             content: message.content,
             params: message.params || undefined,
+            tag: message.tag || undefined,
           })),
         },
       },

--- a/packages/backend/server/src/plugins/copilot/prompt/service.ts
+++ b/packages/backend/server/src/plugins/copilot/prompt/service.ts
@@ -39,7 +39,7 @@ export class PromptService implements OnModuleInit {
         model: true,
         config: true,
         messages: {
-          select: { role: true, content: true, params: true },
+          select: { role: true, content: true, params: true, tag: true },
           orderBy: { idx: 'asc' },
         },
       },
@@ -70,6 +70,7 @@ export class PromptService implements OnModuleInit {
             role: true,
             content: true,
             params: true,
+            tag: true,
           },
           orderBy: {
             idx: 'asc',
@@ -110,6 +111,7 @@ export class PromptService implements OnModuleInit {
               ...m,
               attachments: m.attachments || undefined,
               params: m.params || undefined,
+              tag: m.tag || undefined,
             })),
           },
         },
@@ -137,6 +139,7 @@ export class PromptService implements OnModuleInit {
             ...m,
             attachments: m.attachments || undefined,
             params: m.params || undefined,
+            tag: m.tag || undefined,
           })),
         },
       },

--- a/packages/backend/server/src/plugins/copilot/resolver.ts
+++ b/packages/backend/server/src/plugins/copilot/resolver.ts
@@ -15,7 +15,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import { AiPromptRole } from '@prisma/client';
+import { AiMessageTag, AiPromptRole } from '@prisma/client';
 import { GraphQLJSON, SafeIntResolver } from 'graphql-scalars';
 import GraphQLUpload from 'graphql-upload/GraphQLUpload.mjs';
 
@@ -155,14 +155,16 @@ class QueryChatHistoriesInput implements Partial<ListHistoriesOptions> {
 
 // ================== Return Types ==================
 
+registerEnumType(AiMessageTag, { name: 'AiMessageTag' });
+
 @ObjectType('ChatMessage')
 class ChatMessageType implements Partial<ChatMessage> {
   // id will be null if message is a prompt message
   @Field(() => ID, { nullable: true })
   id!: string;
 
-  @Field(() => String)
-  role!: 'system' | 'assistant' | 'user';
+  @Field(() => AiPromptRole)
+  role!: AiPromptRole;
 
   @Field(() => String)
   content!: string;
@@ -175,6 +177,9 @@ class ChatMessageType implements Partial<ChatMessage> {
 
   @Field(() => Date)
   createdAt!: Date;
+
+  @Field(() => AiMessageTag, { nullable: true })
+  tag!: AiMessageTag | undefined;
 }
 
 @ObjectType('CopilotHistories')

--- a/packages/backend/server/src/plugins/copilot/session.ts
+++ b/packages/backend/server/src/plugins/copilot/session.ts
@@ -257,6 +257,7 @@ export class ChatSessionService {
               attachments: m.attachments || undefined,
               params: m.params || undefined,
               sessionId,
+              tag: m.tag || undefined,
             })),
           });
 
@@ -312,6 +313,7 @@ export class ChatSessionService {
               content: true,
               attachments: true,
               createdAt: true,
+              tag: true,
             },
             orderBy: { createdAt: 'asc' },
           },
@@ -463,6 +465,7 @@ export class ChatSessionService {
               attachments: true,
               params: true,
               createdAt: true,
+              tag: true,
             },
             orderBy: {
               // message order is asc by default

--- a/packages/backend/server/src/plugins/copilot/types.ts
+++ b/packages/backend/server/src/plugins/copilot/types.ts
@@ -1,5 +1,5 @@
 import { type Tokenizer } from '@affine/server-native';
-import { AiPromptRole } from '@prisma/client';
+import { AiMessageTag, AiPromptRole } from '@prisma/client';
 import { z } from 'zod';
 
 import { fromModelName } from '../../native';
@@ -41,20 +41,19 @@ export function getTokenEncoder(model?: string | null): Tokenizer | null {
 
 // ======== ChatMessage ========
 
-export const ChatMessageRole = Object.values(AiPromptRole) as [
-  'system',
-  'assistant',
-  'user',
-];
+export const ChatMessageRole = Object.values(AiPromptRole);
+
+export const ChatMessageTag = Object.values(AiMessageTag);
 
 const PureMessageSchema = z.object({
   content: z.string(),
   attachments: z.array(z.string()).optional().nullable(),
   params: z.record(z.any()).optional().nullable(),
+  tag: z.nativeEnum(AiMessageTag).optional().nullable(),
 });
 
 export const PromptMessageSchema = PureMessageSchema.extend({
-  role: z.enum(ChatMessageRole),
+  role: z.nativeEnum(AiPromptRole),
 }).strict();
 
 export type PromptMessage = z.infer<typeof PromptMessageSchema>;

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -2,6 +2,11 @@
 # THIS FILE WAS AUTOMATICALLY GENERATED (DO NOT MODIFY)
 # ------------------------------------------------------
 
+enum AiMessageTag {
+  invisible
+  retrieval
+}
+
 type AlreadyInSpaceDataType {
   spaceId: String!
 }
@@ -22,7 +27,8 @@ type ChatMessage {
   createdAt: DateTime!
   id: ID
   params: JSON
-  role: String!
+  role: CopilotPromptMessageRole!
+  tag: AiMessageTag
 }
 
 type Copilot {

--- a/packages/frontend/core/src/blocksuite/blocks/ai-chat-block/types.ts
+++ b/packages/frontend/core/src/blocksuite/blocks/ai-chat-block/types.ts
@@ -1,15 +1,17 @@
+import { CopilotMessageTag, CopilotPromptMessageRole } from '@affine/graphql';
 import { z } from 'zod';
 
 // Define the Zod schema
 const ChatMessageSchema = z.object({
   id: z.string(),
   content: z.string(),
-  role: z.union([z.literal('user'), z.literal('assistant')]),
+  role: z.nativeEnum(CopilotPromptMessageRole),
   createdAt: z.string(),
   attachments: z.array(z.string()).optional(),
   userId: z.string().optional(),
   userName: z.string().optional(),
   avatarUrl: z.string().optional(),
+  tag: z.nativeEnum(CopilotMessageTag).optional(),
 });
 
 export const ChatMessagesSchema = z.array(ChatMessageSchema);
@@ -17,7 +19,6 @@ export const ChatMessagesSchema = z.array(ChatMessageSchema);
 // Derive the TypeScript type from the Zod schema
 export type ChatMessage = z.infer<typeof ChatMessageSchema>;
 
-export type MessageRole = 'user' | 'assistant';
 export type MessageUserInfo = {
   userId?: string;
   userName?: string;

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
@@ -1,4 +1,8 @@
-import type { getCopilotHistoriesQuery, RequestOptions } from '@affine/graphql';
+import type {
+  CopilotPromptMessageRole,
+  getCopilotHistoriesQuery,
+  RequestOptions,
+} from '@affine/graphql';
 import type { EditorHost } from '@blocksuite/affine/block-std';
 import type { BlockModel } from '@blocksuite/affine/store';
 
@@ -241,12 +245,10 @@ declare global {
         id: string; // message id
         content: string;
         createdAt: string;
-        role: MessageRole;
+        role: CopilotPromptMessageRole;
         attachments?: string[];
       }[];
     }
-
-    type MessageRole = 'user' | 'assistant';
 
     type AIHistoryIds = Pick<AIHistory, 'sessionId' | 'messages'> & {
       messages: Pick<

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-context.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-context.ts
@@ -1,12 +1,17 @@
+import type {
+  CopilotMessageTag,
+  CopilotPromptMessageRole,
+} from '@affine/graphql';
 import type { AIError } from '@blocksuite/affine/blocks';
 import type { Signal } from '@preact/signals-core';
 
 export type ChatMessage = {
   id: string;
   content: string;
-  role: 'user' | 'assistant';
+  role: CopilotPromptMessageRole;
   attachments?: string[];
   createdAt: string;
+  tag?: CopilotMessageTag | null;
 };
 
 export type ChatAction = {

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-input.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-input.ts
@@ -1,4 +1,5 @@
 import { stopPropagation } from '@affine/core/utils';
+import { CopilotPromptMessageRole } from '@affine/graphql';
 import type { EditorHost } from '@blocksuite/affine/block-std';
 import {
   type AIError,
@@ -545,14 +546,14 @@ export class ChatPanelInput extends SignalWatcher(WithDisposable(LitElement)) {
         ...this.chatContextValue.items,
         {
           id: '',
-          role: 'user',
+          role: CopilotPromptMessageRole.user,
           content: userInput,
           createdAt: new Date().toISOString(),
           attachments,
         },
         {
           id: '',
-          role: 'assistant',
+          role: CopilotPromptMessageRole.assistant,
           content: '',
           createdAt: new Date().toISOString(),
         },

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-messages.ts
@@ -1,3 +1,4 @@
+import { CopilotMessageTag } from '@affine/graphql';
 import type { EditorHost } from '@blocksuite/affine/block-std';
 import { ShadowlessElement } from '@blocksuite/affine/block-std';
 import {
@@ -193,12 +194,15 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
     const { items } = this.chatContextValue;
     const { isLoading } = this;
     const filteredItems = items.filter(item => {
-      return (
-        'role' in item ||
-        item.messages?.length === 3 ||
-        (HISTORY_IMAGE_ACTIONS.includes(item.action) &&
-          item.messages?.length === 2)
-      );
+      if ('role' in item) {
+        return item.tag !== CopilotMessageTag.invisible;
+      } else {
+        return (
+          item.messages?.length === 3 ||
+          (HISTORY_IMAGE_ACTIONS.includes(item.action) &&
+            item.messages?.length === 2)
+        );
+      }
     });
 
     return html`<style>
@@ -215,7 +219,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
         class="chat-panel-messages"
         @scroll=${() => this._debouncedOnScroll()}
       >
-        ${items.length === 0
+        ${filteredItems.length === 0
           ? html`<div class="chat-panel-messages-placeholder">
               ${AffineIcon(
                 isLoading

--- a/packages/frontend/core/src/blocksuite/presets/ai/peek-view/chat-block-input.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/peek-view/chat-block-input.ts
@@ -1,3 +1,4 @@
+import { CopilotPromptMessageRole } from '@affine/graphql';
 import type { EditorHost } from '@blocksuite/affine/block-std';
 import { type AIError, openFileOrFiles } from '@blocksuite/affine/blocks';
 import { css, html, LitElement, nothing } from 'lit';
@@ -379,7 +380,7 @@ export class ChatBlockInput extends LitElement {
         {
           id: '',
           content: text,
-          role: 'user',
+          role: CopilotPromptMessageRole.user,
           createdAt: new Date().toISOString(),
           attachments,
           userId: userInfo?.id,
@@ -389,7 +390,7 @@ export class ChatBlockInput extends LitElement {
         {
           id: '',
           content: '',
-          role: 'assistant',
+          role: CopilotPromptMessageRole.assistant,
           createdAt: new Date().toISOString(),
         },
       ],

--- a/packages/frontend/core/src/blocksuite/presets/blocks/ai-chat-block/components/ai-chat-messages.ts
+++ b/packages/frontend/core/src/blocksuite/presets/blocks/ai-chat-block/components/ai-chat-messages.ts
@@ -1,3 +1,4 @@
+import type { CopilotPromptMessageRole } from '@affine/graphql';
 import type { EditorHost } from '@blocksuite/affine/block-std';
 import type { AffineAIPanelState } from '@blocksuite/affine/blocks';
 import { css, html, LitElement } from 'lit';
@@ -5,11 +6,7 @@ import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type {
-  ChatMessage,
-  MessageRole,
-  MessageUserInfo,
-} from '../../../../blocks';
+import type { ChatMessage, MessageUserInfo } from '../../../../blocks';
 import type { TextRendererOptions } from '../../../_common/components/text-renderer';
 import { UserInfoTemplate } from './user-info';
 
@@ -79,7 +76,7 @@ export class AIChatMessage extends LitElement {
   accessor host!: EditorHost;
 
   @property({ attribute: false })
-  accessor messageRole: MessageRole | undefined = undefined;
+  accessor messageRole: CopilotPromptMessageRole | undefined = undefined;
 
   @property({ attribute: false })
   accessor state: AffineAIPanelState = 'finished';

--- a/packages/frontend/core/src/blocksuite/presets/blocks/ai-chat-block/components/user-info.ts
+++ b/packages/frontend/core/src/blocksuite/presets/blocks/ai-chat-block/components/user-info.ts
@@ -1,8 +1,9 @@
+import type { CopilotPromptMessageRole } from '@affine/graphql';
 import { baseTheme } from '@toeverything/theme';
 import { css, html, LitElement, type TemplateResult, unsafeCSS } from 'lit';
 import { property } from 'lit/decorators.js';
 
-import type { MessageRole, MessageUserInfo } from '../../../../blocks';
+import type { MessageUserInfo } from '../../../../blocks';
 import { AffineAIIcon } from '../../_common/icon';
 
 export class UserInfo extends LitElement {
@@ -96,7 +97,7 @@ declare global {
 
 export function UserInfoTemplate(
   userInfo: MessageUserInfo,
-  messageRole?: MessageRole
+  messageRole?: CopilotPromptMessageRole
 ) {
   const isUser = !!messageRole && messageRole === 'user';
 

--- a/packages/frontend/graphql/src/graphql/index.ts
+++ b/packages/frontend/graphql/src/graphql/index.ts
@@ -389,6 +389,7 @@ query getCopilotHistories($workspaceId: String!, $docId: String, $options: Query
           content
           attachments
           createdAt
+          tag
         }
       }
     }

--- a/packages/frontend/graphql/src/schema.ts
+++ b/packages/frontend/graphql/src/schema.ts
@@ -53,6 +53,11 @@ export enum ChatHistoryOrder {
   desc = 'desc',
 }
 
+export enum CopilotMessageTag {
+  invisible = 'invisible',
+  retrieval = 'retrieval',
+}
+
 export interface ChatMessage {
   __typename?: 'ChatMessage';
   attachments: Maybe<Array<Scalars['String']['output']>>;
@@ -60,7 +65,8 @@ export interface ChatMessage {
   createdAt: Scalars['DateTime']['output'];
   id: Maybe<Scalars['ID']['output']>;
   params: Maybe<Scalars['JSON']['output']>;
-  role: Scalars['String']['output'];
+  role: CopilotPromptMessageRole;
+  tag?: CopilotMessageTag | null;
 }
 
 export interface Copilot {


### PR DESCRIPTION
Fix issue [BS-2522](https://linear.app/affine-design/issue/BS-2522).

### Why make this change?
If the user data contains illegal content, carrying the user data in the system prompt will run the risk of having the account banned.

### What Changed?
- Add a `tag` field to AI messages.
- Move the `Context Documents` to the user prompt and mark it with a special tag.
- If the tag value is `invisible`, do not render it in the view component.
- Remove duplicate ts definitions.
- Add e2e test.
