### PR TITLE
refactor(editor): migrate viewport renderer to extension

### DIFF
--- a/blocksuite/playground/examples/renderer/editor.ts
+++ b/blocksuite/playground/examples/renderer/editor.ts
@@ -1,5 +1,6 @@
 import '../../style.css';
 
+import { ViewportTurboRendererExtension } from '@blocksuite/affine-shared/viewport-renderer';
 import { effects as blocksEffects } from '@blocksuite/blocks/effects';
 import { AffineEditorContainer } from '@blocksuite/presets';
 import { effects as presetsEffects } from '@blocksuite/presets/effects';
@@ -11,6 +12,10 @@ presetsEffects();
 
 export const doc = createEmptyDoc().init();
 export const editor = new AffineEditorContainer();
+editor.pageSpecs = editor.pageSpecs.concat([ViewportTurboRendererExtension]);
+editor.edgelessSpecs = editor.edgelessSpecs.concat([
+  ViewportTurboRendererExtension,
+]);
 
 editor.doc = doc;
 editor.mode = 'edgeless';

--- a/blocksuite/playground/examples/renderer/main.ts
+++ b/blocksuite/playground/examples/renderer/main.ts
@@ -1,4 +1,4 @@
-import { ViewportTurboRenderer } from '@blocksuite/affine-shared/viewport-renderer';
+import { ViewportTurboRendererIdentifier } from '@blocksuite/affine-shared/viewport-renderer';
 import { GfxControllerIdentifier } from '@blocksuite/block-std/gfx';
 import { nextTick } from '@blocksuite/global/utils';
 import { Text } from '@blocksuite/store';
@@ -8,11 +8,8 @@ import { doc, editor } from './editor.js';
 
 type DocMode = 'page' | 'edgeless';
 
-const rightColumn = document.querySelector('#right-column') as HTMLElement;
-const renderer = new ViewportTurboRenderer(rightColumn);
-
 async function handleToCanvasClick() {
-  renderer.setHost(editor.host!);
+  const renderer = editor.std.get(ViewportTurboRendererIdentifier);
   await renderer.render();
   const viewport = editor.std.get(GfxControllerIdentifier).viewport;
   viewport.viewportUpdated.on(async () => {
@@ -23,7 +20,8 @@ async function handleToCanvasClick() {
 async function handleModeChange(mode: DocMode) {
   editor.mode = mode;
   await nextTick();
-  renderer.setHost(editor.host!);
+
+  const renderer = editor.std.get(ViewportTurboRendererIdentifier);
   await renderer.render();
 }
 


### PR DESCRIPTION
This removes `renderer.setHost(host)`