### PR TITLE
feat: add doc copilot context api

### DIFF
--- a/packages/backend/server/src/plugins/copilot/context/resolver.ts
+++ b/packages/backend/server/src/plugins/copilot/context/resolver.ts
@@ -36,12 +36,12 @@ class AddContextDocInput {
 }
 
 @InputType()
-class RemoveContextFileInput {
+class RemoveContextDocInput {
   @Field(() => String)
   contextId!: string;
 
   @Field(() => String)
-  fileId!: string;
+  docId!: string;
 }
 
 @ObjectType('CopilotContext')
@@ -227,8 +227,8 @@ export class CopilotContextResolver {
   })
   @CallMetric('ai', 'context_doc_remove')
   async removeContextDoc(
-    @Args({ name: 'options', type: () => RemoveContextFileInput })
-    options: RemoveContextFileInput
+    @Args({ name: 'options', type: () => RemoveContextDocInput })
+    options: RemoveContextDocInput
   ) {
     const lockFlag = `${COPILOT_LOCKER}:context:${options.contextId}`;
     await using lock = await this.mutex.acquire(lockFlag);
@@ -238,7 +238,7 @@ export class CopilotContextResolver {
     const session = await this.context.get(options.contextId);
 
     try {
-      return await session.removeDocRecord(options.fileId);
+      return await session.removeDocRecord(options.docId);
     } catch (e: any) {
       throw new CopilotFailedToModifyContext({
         contextId: options.contextId,

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -713,7 +713,7 @@ type Mutation {
   removeAvatar: RemoveAvatar!
 
   """remove a doc from context"""
-  removeContextDoc(options: RemoveContextFileInput!): Boolean!
+  removeContextDoc(options: RemoveContextDocInput!): Boolean!
   removeWorkspaceFeature(feature: FeatureType!, workspaceId: String!): Boolean!
   resumeSubscription(idempotencyKey: String @deprecated(reason: "use header `Idempotency-Key`"), plan: SubscriptionPlan = Pro, workspaceId: String): SubscriptionType!
   revoke(userId: String!, workspaceId: String!): Boolean!
@@ -891,9 +891,9 @@ type RemoveAvatar {
   success: Boolean!
 }
 
-input RemoveContextFileInput {
+input RemoveContextDocInput {
   contextId: String!
-  fileId: String!
+  docId: String!
 }
 
 input RevokeDocUserRoleInput {

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/doc-handler.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/doc-handler.ts
@@ -236,9 +236,14 @@ export function handleInlineAskAIAction(
     host.selection.set([selection]);
 
     selectAboveBlocks(host)
-      .then(context => {
-        assertExists(AIProvider.actions.chat);
+      .then(async context => {
+        if (!AIProvider.session || !AIProvider.actions.chat) return;
+        const sessionId = await AIProvider.session.createSession(
+          host.doc.workspace.id,
+          host.doc.id
+        );
         const stream = AIProvider.actions.chat({
+          sessionId,
           input: `${context}\n${input}`,
           stream: true,
           host,

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
@@ -1,4 +1,9 @@
-import type { getCopilotHistoriesQuery, RequestOptions } from '@affine/graphql';
+import type {
+  CopilotContextDoc,
+  CopilotContextFile,
+  getCopilotHistoriesQuery,
+  RequestOptions,
+} from '@affine/graphql';
 import type { EditorHost } from '@blocksuite/affine/block-std';
 import type { GfxModel } from '@blocksuite/affine/block-std/gfx';
 import type { BlockModel } from '@blocksuite/affine/store';
@@ -105,10 +110,9 @@ declare global {
       T['stream'] extends true ? TextStream : Promise<string>;
 
     interface ChatOptions extends AITextActionOptions {
-      // related documents
-      docs?: DocContext[];
       sessionId?: string;
       isRootSession?: boolean;
+      docs?: DocContext[];
     }
 
     interface TranslateOptions extends AITextActionOptions {
@@ -232,6 +236,40 @@ declare global {
       ): AIActionTextResponse<T>;
     }
 
+    interface AIContextService {
+      createContext: (
+        workspaceId: string,
+        sessionId: string
+      ) => Promise<string>;
+      getContextId: (
+        workspaceId: string,
+        sessionId: string
+      ) => Promise<string | undefined>;
+      addContextDoc: (options: {
+        contextId: string;
+        docId: string;
+      }) => Promise<Array<{ id: string }>>;
+      removeContextDoc: (options: {
+        contextId: string;
+        docId: string;
+      }) => Promise<boolean>;
+      addContextFile: (options: {
+        contextId: string;
+        fileId: string;
+      }) => Promise<void>;
+      removeContextFile: (options: {
+        contextId: string;
+        fileId: string;
+      }) => Promise<void>;
+      getContextDocsAndFiles: (
+        workspaceId: string,
+        sessionId: string,
+        contextId: string
+      ) => Promise<
+        { docs: CopilotContextDoc[]; files: CopilotContextFile[] } | undefined
+      >;
+    }
+
     // TODO(@Peng): should be refactored to get rid of implement details (like messages, action, role, etc.)
     interface AIHistory {
       sessionId: string;
@@ -255,6 +293,15 @@ declare global {
         'id' | 'createdAt' | 'role'
       >[];
     };
+
+    interface AISessionService {
+      createSession: (
+        workspaceId: string,
+        docId: string,
+        promptName?: string
+      ) => Promise<string>;
+      updateSession: (sessionId: string, promptName: string) => Promise<string>;
+    }
 
     interface AIHistoryService {
       // non chat histories

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-context.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-context.ts
@@ -46,7 +46,6 @@ export type ChatContextValue = {
   // chips of workspace doc or user uploaded file
   chips: ChatChip[];
   abortController: AbortController | null;
-  chatSessionId: string | null;
 };
 
 export type ChatBlockMessage = ChatMessage & {
@@ -55,20 +54,14 @@ export type ChatBlockMessage = ChatMessage & {
   avatarUrl?: string;
 };
 
-export type ChipState =
-  | 'candidate'
-  | 'uploading'
-  | 'embedding'
-  | 'success'
-  | 'failed';
+export type ChipState = 'candidate' | 'processing' | 'success' | 'failed';
 
 export interface BaseChip {
   /**
    * candidate: the chip is a candidate for the chat
-   * uploading: the chip is uploading
-   * embedding: the chip is embedding
-   * success: the chip is successfully embedded
-   * failed: the chip is failed to embed
+   * processing: the chip is processing
+   * success: the chip is successfully processed
+   * failed: the chip is failed to process
    */
   state: ChipState;
   tooltip?: string;

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/chat-panel-messages.ts
@@ -128,6 +128,9 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
   accessor chatContextValue!: ChatContextValue;
 
   @property({ attribute: false })
+  accessor chatSessionId!: string | undefined;
+
+  @property({ attribute: false })
   accessor updateContext!: (context: Partial<ChatContextValue>) => void;
 
   @property({ attribute: false })
@@ -397,8 +400,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
   retry = async () => {
     const { doc } = this.host;
     try {
-      const { chatSessionId } = this.chatContextValue;
-      if (!chatSessionId) return;
+      if (!this.chatSessionId) return;
 
       const abortController = new AbortController();
       const items = [...this.chatContextValue.items];
@@ -410,7 +412,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
       this.updateContext({ items, status: 'loading', error: null });
 
       const stream = AIProvider.actions.chat?.({
-        sessionId: chatSessionId,
+        sessionId: this.chatSessionId,
         retry: true,
         docId: doc.id,
         workspaceId: doc.workspace.id,
@@ -441,7 +443,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
   };
 
   renderEditorActions(item: ChatMessage, isLast: boolean) {
-    const { status, chatSessionId } = this.chatContextValue;
+    const { status } = this.chatContextValue;
 
     if (item.role !== 'assistant') return nothing;
 
@@ -465,7 +467,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
         .actions=${actions}
         .content=${content}
         .isLast=${isLast}
-        .chatSessionId=${chatSessionId ?? undefined}
+        .chatSessionId=${this.chatSessionId}
         .messageId=${messageId}
         .withMargin=${true}
         .retry=${() => this.retry()}
@@ -475,7 +477,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
             .actions=${actions}
             .host=${host}
             .content=${content}
-            .chatSessionId=${chatSessionId ?? undefined}
+            .chatSessionId=${this.chatSessionId}
             .messageId=${messageId ?? undefined}
             .withMargin=${true}
           ></chat-action-list>`

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/components/add-popover.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/components/add-popover.ts
@@ -159,7 +159,7 @@ export class ChatPanelAddPopover extends SignalWatcher(
   private readonly _addDocChip = (meta: DocMeta) => {
     this.addChip({
       docId: meta.id,
-      state: 'embedding',
+      state: 'processing',
     });
     this.abortController.abort();
   };

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/components/file-chip.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/components/file-chip.ts
@@ -15,7 +15,7 @@ export class ChatPanelFileChip extends SignalWatcher(
 
   override render() {
     const { state, fileName, fileType } = this.chip;
-    const isLoading = state === 'embedding' || state === 'uploading';
+    const isLoading = state === 'processing';
     const tooltip = getChipTooltip(state, fileName, this.chip.tooltip);
     const fileIcon = getAttachmentFileIcon(fileType);
     const icon = getChipIcon(state, fileIcon);

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/components/utils.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/components/utils.ts
@@ -1,3 +1,4 @@
+import type { CopilotContextDoc, CopilotContextFile } from '@affine/graphql';
 import { WarningIcon } from '@blocksuite/icons/lit';
 import { type TemplateResult } from 'lit';
 
@@ -15,14 +16,11 @@ export function getChipTooltip(
   if (state === 'candidate') {
     return 'Click to add doc';
   }
-  if (state === 'embedding') {
-    return 'Embedding...';
-  }
-  if (state === 'uploading') {
-    return 'Uploading...';
+  if (state === 'processing') {
+    return 'Processing...';
   }
   if (state === 'failed') {
-    return 'Failed to embed';
+    return 'Failed to process';
   }
   return name;
 }
@@ -31,7 +29,7 @@ export function getChipIcon(
   state: ChipState,
   icon: TemplateResult<1>
 ): TemplateResult<1> {
-  const isLoading = state === 'embedding' || state === 'uploading';
+  const isLoading = state === 'processing';
   const isFailed = state === 'failed';
   if (isFailed) {
     return WarningIcon();
@@ -48,6 +46,18 @@ export function isDocChip(chip: ChatChip): chip is DocChip {
 
 export function isFileChip(chip: ChatChip): chip is FileChip {
   return 'fileId' in chip;
+}
+
+export function isDocContext(
+  context: CopilotContextDoc | CopilotContextFile
+): context is CopilotContextDoc {
+  return !('blobId' in context);
+}
+
+export function isFileContext(
+  context: CopilotContextDoc | CopilotContextFile
+): context is CopilotContextFile {
+  return 'blobId' in context;
 }
 
 export function getChipKey(chip: ChatChip) {

--- a/packages/frontend/core/src/blocksuite/presets/ai/provider.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/provider.ts
@@ -74,6 +74,14 @@ export class AIProvider {
     return AIProvider.instance.histories;
   }
 
+  static get session() {
+    return AIProvider.instance.session;
+  }
+
+  static get context() {
+    return AIProvider.instance.context;
+  }
+
   static get actionHistory() {
     return AIProvider.instance.actionHistory;
   }
@@ -99,6 +107,10 @@ export class AIProvider {
   private photoEngine: BlockSuitePresets.AIPhotoEngineService | null = null;
 
   private histories: BlockSuitePresets.AIHistoryService | null = null;
+
+  private session: BlockSuitePresets.AISessionService | null = null;
+
+  private context: BlockSuitePresets.AIContextService | null = null;
 
   private toggleGeneralAIOnboarding: ((value: boolean) => void) | null = null;
 
@@ -260,6 +272,16 @@ export class AIProvider {
   ): void;
 
   static provide(
+    id: 'session',
+    service: BlockSuitePresets.AISessionService
+  ): void;
+
+  static provide(
+    id: 'context',
+    service: BlockSuitePresets.AIContextService
+  ): void;
+
+  static provide(
     id: 'histories',
     service: BlockSuitePresets.AIHistoryService
   ): void;
@@ -292,6 +314,12 @@ export class AIProvider {
     } else if (id === 'histories') {
       AIProvider.instance.histories =
         action as BlockSuitePresets.AIHistoryService;
+    } else if (id === 'session') {
+      AIProvider.instance.session =
+        action as BlockSuitePresets.AISessionService;
+    } else if (id === 'context') {
+      AIProvider.instance.context =
+        action as BlockSuitePresets.AIContextService;
     } else if (id === 'photoEngine') {
       AIProvider.instance.photoEngine =
         action as BlockSuitePresets.AIPhotoEngineService;

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/copilot-client.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/copilot-client.ts
@@ -1,6 +1,8 @@
 import { showAILoginRequiredAtom } from '@affine/core/components/affine/auth/ai-login-required';
 import {
+  addContextDocMutation,
   cleanupCopilotSessionMutation,
+  createCopilotContextMutation,
   createCopilotMessageMutation,
   createCopilotSessionMutation,
   forkCopilotSessionMutation,
@@ -9,8 +11,11 @@ import {
   getCopilotSessionsQuery,
   GraphQLError,
   type GraphQLQuery,
+  listContextDocsAndFilesQuery,
+  listContextQuery,
   type QueryOptions,
   type QueryResponse,
+  removeContextDocMutation,
   type RequestOptions,
   updateCopilotSessionMutation,
   UserFriendlyError,
@@ -207,6 +212,74 @@ export class CopilotClient {
     } catch (err) {
       throw resolveError(err);
     }
+  }
+
+  async createContext(workspaceId: string, sessionId: string) {
+    const res = await this.gql({
+      query: createCopilotContextMutation,
+      variables: {
+        workspaceId,
+        sessionId,
+      },
+    });
+    return res.createCopilotContext;
+  }
+
+  async getContextId(workspaceId: string, sessionId: string) {
+    const res = await this.gql({
+      query: listContextQuery,
+      variables: {
+        workspaceId,
+        sessionId,
+      },
+    });
+    return res.currentUser?.copilot?.contexts?.[0]?.id;
+  }
+
+  async addContextDoc(options: OptionsField<typeof addContextDocMutation>) {
+    const res = await this.gql({
+      query: addContextDocMutation,
+      variables: {
+        options,
+      },
+    });
+    return res.addContextDoc;
+  }
+
+  async removeContextDoc(
+    options: OptionsField<typeof removeContextDocMutation>
+  ) {
+    const res = await this.gql({
+      query: removeContextDocMutation,
+      variables: {
+        options,
+      },
+    });
+    return res.removeContextDoc;
+  }
+
+  async addContextFile() {
+    return;
+  }
+
+  async removeContextFile() {
+    return;
+  }
+
+  async getContextDocsAndFiles(
+    workspaceId: string,
+    sessionId: string,
+    contextId: string
+  ) {
+    const res = await this.gql({
+      query: listContextDocsAndFilesQuery,
+      variables: {
+        workspaceId,
+        sessionId,
+        contextId,
+      },
+    });
+    return res.currentUser?.copilot?.contexts?.[0];
   }
 
   async chatText({

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/request.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/request.ts
@@ -31,22 +31,29 @@ export type ToImageOptions = TextToTextOptions & {
   seed?: string;
 };
 
-export function createChatSession({
+export async function createChatSession({
   client,
   workspaceId,
   docId,
-  promptName,
+  promptName = 'Chat With AFFiNE AI',
 }: {
   client: CopilotClient;
   workspaceId: string;
   docId: string;
-  promptName: string;
+  promptName?: string;
 }) {
-  return client.createSession({
+  const sessionId = await client.createSession({
     workspaceId,
     docId,
     promptName,
   });
+  // always update the prompt name
+  await updateChatSession({
+    sessionId,
+    client,
+    promptName,
+  });
+  return sessionId;
 }
 
 export function updateChatSession({
@@ -119,7 +126,8 @@ async function createSessionMessage({
   }
   const hasAttachments = attachments && attachments.length > 0;
   const sessionId = await (providedSessionId ??
-    client.createSession({
+    createChatSession({
+      client,
       workspaceId,
       docId,
       promptName: promptName as string,

--- a/packages/frontend/core/src/components/providers/workspace-side-effects.tsx
+++ b/packages/frontend/core/src/components/providers/workspace-side-effects.tsx
@@ -8,7 +8,6 @@ import { SyncAwareness } from '@affine/core/components/affine/awareness';
 import { useRegisterFindInPageCommands } from '@affine/core/components/hooks/affine/use-register-find-in-page-commands';
 import { useRegisterWorkspaceCommands } from '@affine/core/components/hooks/use-register-workspace-commands';
 import { OverCapacityNotification } from '@affine/core/components/over-capacity';
-import { AINetworkSearchService } from '@affine/core/modules/ai-button/services/network-search';
 import {
   EventSourceService,
   FetchService,
@@ -144,7 +143,6 @@ export const WorkspaceSideEffects = () => {
   const graphqlService = useService(GraphQLService);
   const eventSourceService = useService(EventSourceService);
   const fetchService = useService(FetchService);
-  const networkSearchService = useService(AINetworkSearchService);
 
   useEffect(() => {
     const dispose = setupAIProvider(
@@ -153,8 +151,7 @@ export const WorkspaceSideEffects = () => {
         fetchService.fetch,
         eventSourceService.eventSource
       ),
-      globalDialogService,
-      networkSearchService
+      globalDialogService
     );
     return () => {
       dispose();
@@ -164,7 +161,6 @@ export const WorkspaceSideEffects = () => {
     fetchService,
     workspaceDialogService,
     graphqlService,
-    networkSearchService,
     globalDialogService,
   ]);
 

--- a/packages/frontend/graphql/src/graphql/index.ts
+++ b/packages/frontend/graphql/src/graphql/index.ts
@@ -193,8 +193,28 @@ export const removeContextDocMutation = {
   definitionName: 'removeContextDoc',
   containsFile: false,
   query: `
-mutation removeContextDoc($options: RemoveContextFileInput!) {
+mutation removeContextDoc($options: RemoveContextDocInput!) {
   removeContextDoc(options: $options)
+}`,
+};
+
+export const listContextDocsAndFilesQuery = {
+  id: 'listContextDocsAndFilesQuery' as const,
+  operationName: 'listContextDocsAndFiles',
+  definitionName: 'currentUser',
+  containsFile: false,
+  query: `
+query listContextDocsAndFiles($workspaceId: String!, $sessionId: String!, $contextId: String!) {
+  currentUser {
+    copilot(workspaceId: $workspaceId) {
+      contexts(sessionId: $sessionId, contextId: $contextId) {
+        docs {
+          id
+          createdAt
+        }
+      }
+    }
+  }
 }`,
 };
 

--- a/packages/frontend/graphql/src/schema.ts
+++ b/packages/frontend/graphql/src/schema.ts
@@ -42,6 +42,11 @@ export interface AddContextDocInput {
   docId: Scalars['String']['input'];
 }
 
+export interface RemoveContextDocInput {
+  contextId: Scalars['String']['input'];
+  docId: Scalars['String']['input'];
+}
+
 export interface AlreadyInSpaceDataType {
   __typename?: 'AlreadyInSpaceDataType';
   spaceId: Scalars['String']['output'];
@@ -1013,7 +1018,7 @@ export interface MutationReleaseDeletedBlobsArgs {
 }
 
 export interface MutationRemoveContextDocArgs {
-  options: RemoveContextFileInput;
+  options: RemoveContextDocInput;
 }
 
 export interface MutationRemoveWorkspaceFeatureArgs {
@@ -1308,11 +1313,6 @@ export interface QueryTooLongDataType {
 export interface RemoveAvatar {
   __typename?: 'RemoveAvatar';
   success: Scalars['Boolean']['output'];
-}
-
-export interface RemoveContextFileInput {
-  contextId: Scalars['String']['input'];
-  fileId: Scalars['String']['input'];
 }
 
 export interface RevokeDocUserRoleInput {
@@ -1952,26 +1952,54 @@ export type AddContextDocMutationVariables = Exact<{
   options: AddContextDocInput;
 }>;
 
+export type RemoveContextDocMutationVariables = Exact<{
+  options: RemoveContextDocInput;
+}>;
+
 export type AddContextDocMutation = {
   __typename?: 'Mutation';
   addContextDoc: Array<{
     __typename?: 'CopilotContextListItem';
     id: string;
-    createdAt: number;
-    name: string | null;
-    chunkSize: number | null;
-    status: ContextFileStatus | null;
-    blobId: string | null;
   }>;
 };
-
-export type RemoveContextDocMutationVariables = Exact<{
-  options: RemoveContextFileInput;
-}>;
 
 export type RemoveContextDocMutation = {
   __typename?: 'Mutation';
   removeContextDoc: boolean;
+};
+
+export type ListContextDocsAndFilesQueryVariables = Exact<{
+  workspaceId: Scalars['String']['input'];
+  sessionId: Scalars['String']['input'];
+  contextId: Scalars['String']['input'];
+}>;
+
+export type ListContextDocsAndFilesQuery = {
+  __typename?: 'Query';
+  currentUser: {
+    __typename?: 'UserType';
+    copilot: {
+      __typename?: 'Copilot';
+      contexts: Array<{
+        __typename?: 'CopilotContext';
+        docs: Array<{
+          __typename?: 'CopilotContextDoc';
+          id: string;
+          createdAt: number;
+        }>;
+        files: Array<{
+          __typename?: 'CopilotContextFile';
+          id: string;
+          name: string;
+          blobId: string;
+          chunkSize: number;
+          status: ContextFileStatus;
+          createdAt: number;
+        }>;
+      }>;
+    };
+  } | null;
 };
 
 export type ListContextQueryVariables = Exact<{
@@ -3371,6 +3399,11 @@ export type Queries =
       name: 'listBlobsQuery';
       variables: ListBlobsQueryVariables;
       response: ListBlobsQuery;
+    }
+  | {
+      name: 'listContextDocsAndFilesQuery';
+      variables: ListContextDocsAndFilesQueryVariables;
+      response: ListContextDocsAndFilesQuery;
     }
   | {
       name: 'listContextQuery';

--- a/tests/affine-cloud-copilot/e2e/copilot.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/copilot.spec.ts
@@ -10,10 +10,7 @@ import {
   getBlockSuiteEditorTitle,
   waitForEditorLoad,
 } from '@affine-test/kit/utils/page-logic';
-import {
-  clickSideBarAllPageButton,
-  clickSideBarUseAvatar,
-} from '@affine-test/kit/utils/sidebar';
+import { clickSideBarAllPageButton } from '@affine-test/kit/utils/sidebar';
 import { createLocalWorkspace } from '@affine-test/kit/utils/workspace';
 import { expect, type Page } from '@playwright/test';
 
@@ -394,20 +391,12 @@ test.describe('chat panel', () => {
     await page.waitForTimeout(200);
     await createLocalWorkspace({ name: 'test' }, page);
     await clickNewPageButton(page);
-    await clickSideBarUseAvatar(page);
-    await page.getByTestId('workspace-modal-account-settings-option').click();
-    await page.getByTestId('experimental-features-trigger').click();
-    await page
-      .getByTestId('experimental-prompt')
-      .getByTestId('affine-checkbox')
-      .click();
-    await page.getByTestId('experimental-confirm-button').click();
-    await page.getByTestId('enable_ai_network_search').click();
-    await page.getByTestId('modal-close-button').click();
+
     await openChat(page);
     await page.getByTestId('chat-network-search').click();
     await typeChatSequentially(page, 'What is the weather in Shanghai today?');
     await page.keyboard.press('Enter');
+    await page.waitForTimeout(3000);
     let history = await collectChat(page);
     expect(history[0]).toEqual({
       name: 'You',
@@ -423,6 +412,7 @@ test.describe('chat panel', () => {
     await page.getByTestId('chat-network-search').click();
     await typeChatSequentially(page, 'What is the weather in Shanghai today?');
     await page.keyboard.press('Enter');
+    await page.waitForTimeout(3000);
     history = await collectChat(page);
     expect(history[0]).toEqual({
       name: 'You',
@@ -770,11 +760,13 @@ test.describe('chat with doc', () => {
     // oxlint-disable-next-line unicorn/prefer-dom-node-dataset
     expect(await chip.getAttribute('data-state')).toBe('candidate');
     await chip.click();
+    await page.waitForTimeout(1000);
     // oxlint-disable-next-line unicorn/prefer-dom-node-dataset
     expect(await chip.getAttribute('data-state')).toBe('success');
 
     await typeChatSequentially(page, 'What is AFFiNE AI?');
     await page.keyboard.press('Enter');
+    await page.waitForTimeout(3000);
     const history = await collectChat(page);
     expect(history[0]).toEqual({
       name: 'You',
@@ -786,5 +778,13 @@ test.describe('chat with doc', () => {
     ).toBeGreaterThan(0);
     await clearChat(page);
     expect((await collectChat(page)).length).toBe(0);
+
+    await page.reload();
+    await page.waitForTimeout(1000);
+    await openChat(page);
+    expect(await chipTitle.textContent()).toBe('AFFiNE AI');
+    const chip2 = await page.getByTestId('chat-panel-chip');
+    // oxlint-disable-next-line unicorn/prefer-dom-node-dataset
+    expect(await chip2.getAttribute('data-state')).toBe('success');
   });
 });


### PR DESCRIPTION
### What Changed?
- Add graphql APIs.
- Provide context and session service in `AIProvider`.
- Rename the state from `embedding` to `processing`.
- Reafctor front-end session create, update and save logic.



Persist the document selected by the user:
[录屏2025-02-08 11.04.40.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/sJGviKxfE3Ap685cl5bj/195a85f2-43c4-4e49-88d9-6b5fc4f235ca.mov" />](https://app.graphite.dev/media/video/sJGviKxfE3Ap685cl5bj/195a85f2-43c4-4e49-88d9-6b5fc4f235ca.mov)

