### PR TITLE
fix(editor): shadowless element should remove style element correctly

### DIFF
--- a/blocksuite/framework/block-std/src/view/element/shadowless-element.ts
+++ b/blocksuite/framework/block-std/src/view/element/shadowless-element.ts
@@ -12,7 +12,7 @@ export class ShadowlessElement extends LitElement {
 
   static onDisconnectedMap = new WeakMap<
     Constructor, // class
-    (() => void) | null
+    WeakMap<Node, (() => void) | null>
   >();
 
   // styles registered in ShadowlessElement will be available globally
@@ -67,7 +67,10 @@ export class ShadowlessElement extends LitElement {
           injectedStyles.push(style);
         }
       });
-      SE.onDisconnectedMap.set(SE, () => {
+      if (!SE.onDisconnectedMap.has(SE)) {
+        SE.onDisconnectedMap.set(SE, new WeakMap());
+      }
+      SE.onDisconnectedMap.get(SE)?.set(parentRoot, () => {
         injectedStyles.forEach(style => style.remove());
       });
     }
@@ -79,6 +82,7 @@ export class ShadowlessElement extends LitElement {
   }
 
   override disconnectedCallback(): void {
+    const parentRoot = this.getRootNode();
     super.disconnectedCallback();
     const SE = this.constructor as typeof ShadowlessElement;
     let styleInjectedCount = this.getConnectedCount();
@@ -86,7 +90,8 @@ export class ShadowlessElement extends LitElement {
     this.setConnectedCount(styleInjectedCount);
 
     if (styleInjectedCount === 0) {
-      SE.onDisconnectedMap.get(SE)?.();
+      // remove the style element when the last shadowless element is disconnected in the parent root
+      SE.onDisconnectedMap.get(SE)?.get(parentRoot)?.();
     }
   }
 }


### PR DESCRIPTION
[BS-2565](https://linear.app/affine-design/issue/BS-2565/关闭-chat-block-center-peek-后新生成的-chat-block-最后一个-message-样式不正确)