### PR TITLE
fix(editor): hide collpased content during dragging note

### DIFF
--- a/blocksuite/affine/block-note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/block-note/src/note-edgeless-block.ts
@@ -26,12 +26,13 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
     return (
       this.model.edgeless.collapse &&
       this.gfx.selection.has(this.model.id) &&
+      !this._dragging &&
       (this._isResizing || this._isHover)
     );
   }
 
-  get _zoom() {
-    return this.gfx.viewport.zoom;
+  private get _dragging() {
+    return this._isHover && this.gfx.tool.dragging$.value;
   }
 
   private _collapsedContent() {
@@ -236,6 +237,7 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
         ></edgeless-note-background>
 
         <div
+          data-testid="edgeless-note-clip-container"
           class=${styles.clipContainer}
           style=${styleMap({
             'overflow-y': this._isShowCollapsedContent ? 'initial' : 'clip',

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/edgeless-note-header.css.ts
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/specs/custom/widgets/edgeless-note-header.css.ts
@@ -28,6 +28,7 @@ const buttonPadding = 4;
 export const button = style({
   padding: buttonPadding,
   pointerEvents: 'auto',
+  color: cssVarV2('icon/transparentBlack'),
 });
 
 export const headerHeight = 2 * headerPadding + iconSize + 2 * buttonPadding;


### PR DESCRIPTION
Close [BS-2531](https://linear.app/affine-design/issue/BS-2531/%E6%8B%96%E5%8A%A8%E6%8A%98%E5%8F%A0%E7%9A%84note%E6%97%B6%EF%BC%8C%E4%B8%8D%E6%98%BE%E7%A4%BA%E9%9A%90%E8%97%8F%E5%86%85%E5%AE%B9), [BS-2536](https://linear.app/affine-design/issue/BS-2536/page-block%E9%A1%B6%E9%83%A8toolbar)