### PR TITLE
fix(edtiro): hide toc drag indicator on edgeless note

### DIFF
--- a/blocksuite/presets/src/fragments/outline/card/outline-card.ts
+++ b/blocksuite/presets/src/fragments/outline/card/outline-card.ts
@@ -119,6 +119,9 @@ export class OutlineNoteCard extends SignalWatcher(
         setDropData: () => ({
           noteId: this.note.id,
         }),
+        canDrop: () => {
+          return this.note.displayMode !== NoteDisplayMode.EdgelessOnly;
+        },
       })
     );
   }


### PR DESCRIPTION
Close [BS-2497](https://linear.app/affine-design/issue/BS-2497/隐藏edgeless-only的toc的dnd-indicator)