### PR TITLE
chore(editor): adjust min width of edgeless note

### DIFF
--- a/blocksuite/affine/block-note/src/index.ts
+++ b/blocksuite/affine/block-note/src/index.ts
@@ -6,3 +6,4 @@ export * from './note-block';
 export * from './note-edgeless-block';
 export * from './note-service';
 export * from './note-spec';
+export { isPageBlock } from './utils';

--- a/blocksuite/affine/block-paragraph/src/styles.ts
+++ b/blocksuite/affine/block-paragraph/src/styles.ts
@@ -126,6 +126,10 @@ export const paragraphBlockStyles = css`
   .affine-paragraph-placeholder {
     position: absolute;
     display: none;
+    max-width: 100%;
+    overflow-x: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     left: 0;
     bottom: 0;
     pointer-events: none;

--- a/blocksuite/affine/model/src/consts/note.ts
+++ b/blocksuite/affine/model/src/consts/note.ts
@@ -2,10 +2,10 @@ import { z } from 'zod';
 
 import { createEnumMap } from '../utils/enum.js';
 
-export const NOTE_MIN_WIDTH = 450 + 24 * 2;
+export const NOTE_MIN_WIDTH = 170 + 24 * 2;
 export const NOTE_MIN_HEIGHT = 92;
 
-export const DEFAULT_NOTE_WIDTH = NOTE_MIN_WIDTH;
+export const DEFAULT_NOTE_WIDTH = 450 + 24 * 2;
 export const DEFAULT_NOTE_HEIGHT = NOTE_MIN_HEIGHT;
 
 export enum NoteShadow {

--- a/blocksuite/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/blocksuite/blocks/src/root-block/edgeless/components/rects/edgeless-selected-rect.ts
@@ -1145,7 +1145,7 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
     this._isWidthLimit = bound.w === NOTE_MIN_WIDTH * scale;
     this._isHeightLimit = bound.h === NOTE_MIN_HEIGHT * scale;
 
-    if (bound.h >= NOTE_MIN_HEIGHT * scale) {
+    if (bound.h > NOTE_MIN_HEIGHT * scale) {
       this.doc.updateBlock(element, () => {
         element.edgeless.collapse = true;
         element.edgeless.collapsedHeight = bound.h / scale;

--- a/blocksuite/tests-legacy/edgeless/note/resize.spec.ts
+++ b/blocksuite/tests-legacy/edgeless/note/resize.spec.ts
@@ -2,11 +2,11 @@ import { expect } from '@playwright/test';
 
 import {
   activeNoteInEdgeless,
-  dragBetweenCoords,
   enterPlaygroundRoom,
   getNoteRect,
   initEmptyEdgelessState,
   redoByClick,
+  resizeElementByHandle,
   selectNoteInEdgeless,
   setEdgelessTool,
   switchEditorMode,
@@ -44,15 +44,8 @@ test('resize note in edgeless mode', async ({ page }) => {
   await selectNoteInEdgeless(page, noteId);
 
   const initRect = await getNoteRect(page, noteId);
-  const leftHandle = page.locator('.handle[aria-label="left"] .resize');
-  const box = await leftHandle.boundingBox();
-  if (box === null) throw new Error();
+  await resizeElementByHandle(page, { x: -100, y: 0 }, 'bottom-left');
 
-  await dragBetweenCoords(
-    page,
-    { x: box.x + 5, y: box.y + 5 },
-    { x: box.x - 95, y: box.y + 5 }
-  );
   const draggedRect = await getNoteRect(page, noteId);
   assertRectEqual(draggedRect, {
     x: initRect.x - 100,
@@ -84,15 +77,8 @@ test('resize note then collapse note', async ({ page }) => {
   await selectNoteInEdgeless(page, noteId);
 
   const initRect = await getNoteRect(page, noteId);
-  const leftHandle = page.locator('.handle[aria-label="left"] .resize');
-  let box = await leftHandle.boundingBox();
-  if (box === null) throw new Error();
 
-  await dragBetweenCoords(
-    page,
-    { x: box.x + 50, y: box.y + box.height },
-    { x: box.x + 50, y: box.y + box.height + 100 }
-  );
+  await resizeElementByHandle(page, { x: 0, y: 100 }, 'bottom-right');
   let noteRect = await getNoteRect(page, noteId);
   await expect(page.getByTestId('edgeless-note-collapse-button')).toBeVisible();
   assertRectEqual(noteRect, {
@@ -111,17 +97,9 @@ test('resize note then collapse note', async ({ page }) => {
   expect(domRect!.height).toBeCloseTo(initRect.h + 100);
 
   await selectNoteInEdgeless(page, noteId);
-  box = await leftHandle.boundingBox();
-  if (box === null) throw new Error();
-  await dragBetweenCoords(
-    page,
-    { x: box.x + 50, y: box.y + box.height },
-    { x: box.x + 50, y: box.y + box.height - 150 }
-  );
+  await resizeElementByHandle(page, { x: 0, y: -150 }, 'bottom-right');
+
   noteRect = await getNoteRect(page, noteId);
-  await expect(
-    page.getByTestId('edgeless-note-collapse-button')
-  ).not.toBeVisible();
   assertRectEqual(noteRect, {
     x: initRect.x,
     y: initRect.y,
@@ -149,17 +127,8 @@ test('resize note then auto size and custom size', async ({ page }) => {
   await selectNoteInEdgeless(page, noteId);
 
   const initRect = await getNoteRect(page, noteId);
-  const bottomRightResize = page.locator(
-    '.handle[aria-label="bottom-right"] .resize'
-  );
-  const box = await bottomRightResize.boundingBox();
-  if (box === null) throw new Error();
 
-  await dragBetweenCoords(
-    page,
-    { x: box.x + 5, y: box.y + 5 },
-    { x: box.x + 5, y: box.y + 105 }
-  );
+  await resizeElementByHandle(page, { x: 0, y: 100 }, 'bottom-right');
 
   const draggedRect = await getNoteRect(page, noteId);
   assertRectEqual(draggedRect, {


### PR DESCRIPTION
Close [BS-2499](https://linear.app/affine-design/issue/BS-2499/所有notes最小宽度调整为218px)

### What changes
- adjusted min width of edgeless note
  - placeholder show ellipsis in min edgeless note
- refactored somes button of `change-note-button.ts` with `isPageBlock`