### PR TITLE
feat(core): move context docs to user prompt

### DIFF
--- a/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
+++ b/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
@@ -949,7 +949,7 @@ const chat: Prompt[] = [
         role: 'system',
         content: `You are AFFiNE AI, a professional and humorous copilot within AFFiNE. You are powered by latest GPT model from OpenAI and AFFiNE. AFFiNE is an open source general purposed productivity tool that contains unified building blocks that users can use on any interfaces, including block-based docs editor, infinite canvas based edgeless graphic mode, or multi-dimensional table with multiple transformable views. Your mission is always to try your very best to assist users to use AFFiNE to write docs, draw diagrams or plan things with these abilities. You always think step-by-step and describe your plan for what to build, using well-structured and clear markdown, written out in great detail. Unless otherwise specified, where list, JSON, or code blocks are required for giving the output. Minimize any other prose so that your responses can be directly used and inserted into the docs. You are able to access to API of AFFiNE to finish your job. You always respect the users' privacy and would not leak their info to anyone else. AFFiNE is made by Toeverything .Pte .Ltd, a company registered in Singapore with a diverse and international team. The company also open sourced blocksuite and octobase for building tools similar to Affine. The name AFFiNE comes from the idea of AFFiNE transform, as blocks in affine can all transform in page, edgeless or database mode. AFFiNE team is now having 25 members, an open source company driven by engineers.
 # Context Documents
-The following documents provide relevant context and background information for your reference. 
+The following user messages provide relevant context and background information for your reference. 
 If the provided documents are relevant to the user's query:
 - Use them to enrich and support your response
 - Cite sources using the citation rules below
@@ -957,14 +957,6 @@ If the provided documents are relevant to the user's query:
 If the documents are not relevant:
 - Answer the question directly based on your knowledge
 - Do not reference or mention the provided documents
-
-{{#docs}}
-## Document {{index}}
-- document_index: {{index}}
-- document_id: {{docId}} 
-- document_content:
-{{markdown}}
-{{/docs}}
 
 # Citations Rules:
 When referencing information from the provided documents in your response:
@@ -974,6 +966,17 @@ When referencing information from the provided documents in your response:
 4. At the end of your response, include the full citation in the format:
    [^document_index]:{"type":"doc","docId":"document_id"}
 5. Ensure citations adhere strictly to the required format to avoid response errors. Do not add extra spaces in citations like [^ document_index] or [ ^document_index].`,
+      },
+      {
+        role: 'user',
+        content: `# Context Documents
+{{#docs}}
+## Document {{index}}
+- document_index: {{index}}
+- document_id: {{docId}} 
+- document_content:
+{{markdown}}
+{{/docs}}`,
       },
     ],
   },

--- a/packages/backend/server/src/plugins/copilot/resolver.ts
+++ b/packages/backend/server/src/plugins/copilot/resolver.ts
@@ -151,6 +151,9 @@ class QueryChatHistoriesInput implements Partial<ListHistoriesOptions> {
 
   @Field(() => String, { nullable: true })
   sessionId: string | undefined;
+
+  @Field(() => Boolean, { nullable: true })
+  withPrompt: boolean | undefined;
 }
 
 // ================== Return Types ==================
@@ -346,8 +349,7 @@ export class CopilotResolver {
       user.id,
       workspaceId,
       docId,
-      options,
-      true
+      options
     );
 
     return histories.map(h => ({

--- a/packages/backend/server/src/plugins/copilot/types.ts
+++ b/packages/backend/server/src/plugins/copilot/types.ts
@@ -149,6 +149,7 @@ export type ListHistoriesOptions = {
   sessionOrder: 'asc' | 'desc' | undefined;
   messageOrder: 'asc' | 'desc' | undefined;
   sessionId: string | undefined;
+  withPrompt: boolean | undefined;
 };
 
 // ======== Provider Interface ========

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -881,6 +881,7 @@ input QueryChatHistoriesInput {
   sessionId: String
   sessionOrder: ChatHistoryOrder
   skip: Int
+  withPrompt: Boolean
 }
 
 type QueryTooLongDataType {

--- a/packages/frontend/apps/android/App/service/src/main/graphql/affine/schema.graphqls
+++ b/packages/frontend/apps/android/App/service/src/main/graphql/affine/schema.graphqls
@@ -1123,6 +1123,8 @@ input QueryChatHistoriesInput {
   sessionOrder: ChatHistoryOrder
 
   skip: Int
+
+  withPrompt: Boolean
 }
 
 type QuotaQueryType {

--- a/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/actions/types.ts
@@ -1,4 +1,5 @@
 import type {
+  ChatHistoryOrder,
   CopilotContextDoc,
   CopilotContextFile,
   getCopilotHistoriesQuery,
@@ -312,9 +313,10 @@ declare global {
       chats: (
         workspaceId: string,
         docId?: string,
-        options?: RequestOptions<
-          typeof getCopilotHistoriesQuery
-        >['variables']['options']
+        options?: {
+          sessionId?: string;
+          messageOrder?: ChatHistoryOrder;
+        }
       ) => Promise<AIHistory[] | undefined>;
       cleanup: (
         workspaceId: string,

--- a/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
+++ b/packages/frontend/core/src/blocksuite/presets/ai/chat-panel/index.ts
@@ -125,7 +125,7 @@ export class ChatPanel extends WithDisposable(ShadowlessElement) {
     const currentRequest = ++this._updateHistoryCounter;
 
     const [histories, actions] = await Promise.all([
-      AIProvider.histories?.chats(doc.workspace.id, doc.id, { fork: false }),
+      AIProvider.histories?.chats(doc.workspace.id, doc.id),
       AIProvider.histories?.actions(doc.workspace.id, doc.id),
     ]);
 

--- a/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/setup-provider.tsx
+++ b/packages/frontend/core/src/components/blocksuite/block-suite-editor/ai/setup-provider.tsx
@@ -2,6 +2,7 @@ import { AIProvider } from '@affine/core/blocksuite/presets/ai';
 import { toggleGeneralAIOnboarding } from '@affine/core/components/affine/ai-onboarding/apis';
 import type { GlobalDialogService } from '@affine/core/modules/dialogs';
 import {
+  type ChatHistoryOrder,
   type getCopilotHistoriesQuery,
   type RequestOptions,
 } from '@affine/graphql';
@@ -469,15 +470,17 @@ Could you make a new website based on these notes and send back just the html fi
       return (
         (await client.getHistories(workspaceId, docId, {
           action: true,
+          withPrompt: true,
         })) ?? []
       );
     },
     chats: async (
       workspaceId: string,
       docId?: string,
-      options?: RequestOptions<
-        typeof getCopilotHistoriesQuery
-      >['variables']['options']
+      options?: {
+        sessionId?: string;
+        messageOrder?: ChatHistoryOrder;
+      }
     ): Promise<BlockSuitePresets.AIHistory[]> => {
       // @ts-expect-error - 'action' is missing in server impl
       return (await client.getHistories(workspaceId, docId, options)) ?? [];

--- a/packages/frontend/graphql/src/schema.ts
+++ b/packages/frontend/graphql/src/schema.ts
@@ -1298,6 +1298,7 @@ export interface QueryChatHistoriesInput {
   sessionId?: InputMaybe<Scalars['String']['input']>;
   sessionOrder?: InputMaybe<ChatHistoryOrder>;
   skip?: InputMaybe<Scalars['Int']['input']>;
+  withPrompt?: InputMaybe<Scalars['Boolean']['input']>;
 }
 
 export interface QueryTooLongDataType {


### PR DESCRIPTION
Fix issue [BS-2522](https://linear.app/affine-design/issue/BS-2522).

### Why make this change?
If the user data contains illegal content, carrying the user data in the system prompt will run the risk of having the account banned.

### What Changed?
- Move the `Context Documents` to the user prompt.
- Add `withPrompt` in `QueryChatHistoriesInput` options.
- Get chat histories without prompt messages.
- Omit document context when saving messages to the `aiSessionMessage` db.