### PR TITLE
fix(editor): image size and xywh when converting attachment to image

### DIFF
--- a/blocksuite/affine/block-attachment/src/utils.ts
+++ b/blocksuite/affine/block-attachment/src/utils.ts
@@ -97,7 +97,7 @@ export async function uploadAttachmentBlob(
   }
 }
 
-async function getAttachmentBlob(model: AttachmentBlockModel) {
+export async function getAttachmentBlob(model: AttachmentBlockModel) {
   const sourceId = model.sourceId;
   if (!sourceId) {
     return null;

--- a/blocksuite/affine/block-image/src/utils.ts
+++ b/blocksuite/affine/block-image/src/utils.ts
@@ -12,6 +12,7 @@ import {
 import {
   downloadBlob,
   humanFileSize,
+  readImageSize,
   transformModel,
   withTempBlobData,
 } from '@blocksuite/affine-shared/utils';
@@ -423,27 +424,6 @@ export async function turnImageIntoCardView(
     ...attachmentConvertData,
   };
   transformModel(model, 'affine:attachment', attachmentProp);
-}
-
-export function readImageSize(file: File | Blob) {
-  return new Promise<{ width: number; height: number }>(resolve => {
-    const size = { width: 0, height: 0 };
-    const img = new Image();
-
-    img.onload = () => {
-      size.width = img.width;
-      size.height = img.height;
-      URL.revokeObjectURL(img.src);
-      resolve(size);
-    };
-
-    img.onerror = () => {
-      URL.revokeObjectURL(img.src);
-      resolve(size);
-    };
-
-    img.src = URL.createObjectURL(file);
-  });
 }
 
 export async function addImages(

--- a/blocksuite/affine/shared/package.json
+++ b/blocksuite/affine/shared/package.json
@@ -25,6 +25,7 @@
     "@toeverything/theme": "^1.1.11",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
+    "dompurify": "^3.2.4",
     "fractional-indexing": "^3.2.0",
     "lit": "^3.2.0",
     "lodash.clonedeep": "^4.5.0",

--- a/blocksuite/affine/shared/src/utils/image.ts
+++ b/blocksuite/affine/shared/src/utils/image.ts
@@ -1,0 +1,28 @@
+import DOMPurify from 'dompurify';
+
+export function readImageSize(file: File | Blob) {
+  return new Promise<{ width: number; height: number }>(resolve => {
+    const size = { width: 0, height: 0 };
+    if (!file.type.startsWith('image/')) {
+      resolve(size);
+      return;
+    }
+
+    const img = new Image();
+
+    img.onload = () => {
+      size.width = img.width;
+      size.height = img.height;
+      URL.revokeObjectURL(img.src);
+      resolve(size);
+    };
+
+    img.onerror = () => {
+      URL.revokeObjectURL(img.src);
+      resolve(size);
+    };
+
+    const sanitizedURL = DOMPurify.sanitize(URL.createObjectURL(file));
+    img.src = sanitizedURL;
+  });
+}

--- a/blocksuite/affine/shared/src/utils/index.ts
+++ b/blocksuite/affine/shared/src/utils/index.ts
@@ -8,6 +8,7 @@ export * from './edgeless';
 export * from './event';
 export * from './file';
 export * from './fractional-indexing';
+export * from './image';
 export * from './insert';
 export * from './is-abort-error';
 export * from './math';

--- a/blocksuite/blocks/package.json
+++ b/blocksuite/blocks/package.json
@@ -51,7 +51,7 @@
     "@toeverything/theme": "^1.1.11",
     "@vanilla-extract/css": "^1.17.0",
     "date-fns": "^4.0.0",
-    "dompurify": "^3.1.6",
+    "dompurify": "^3.2.4",
     "fflate": "^0.8.2",
     "file-type": "^20.0.0",
     "fractional-indexing": "^3.2.0",

--- a/blocksuite/framework/block-std/package.json
+++ b/blocksuite/framework/block-std/package.json
@@ -23,7 +23,7 @@
     "@lit/context": "^1.1.2",
     "@preact/signals-core": "^1.8.0",
     "@types/hast": "^3.0.4",
-    "dompurify": "^3.1.6",
+    "dompurify": "^3.2.4",
     "fractional-indexing": "^3.2.0",
     "lib0": "^0.2.97",
     "lit": "^3.2.0",

--- a/blocksuite/tests-legacy/snapshots/attachment.spec.ts/should-turn-attachment-to-image-works-1.json
+++ b/blocksuite/tests-legacy/snapshots/attachment.spec.ts/should-turn-attachment-to-image-works-1.json
@@ -42,10 +42,10 @@
           "version": 1,
           "props": {
             "sourceId": "ejImogf-Tb7AuKY-v94uz1zuOJbClqK-tWBxVr_ksGA=",
-            "width": 0,
-            "height": 0,
+            "width": 460,
+            "height": 345,
             "index": "a0",
-            "xywh": "[0,0,0,0]",
+            "xywh": "[0,0,460,345]",
             "lockedBySelf": false,
             "rotate": 0,
             "size": 45801,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3749,6 +3749,7 @@ __metadata:
     "@types/lodash.clonedeep": "npm:^4.5.9"
     "@types/lodash.mergewith": "npm:^4"
     "@types/mdast": "npm:^4.0.4"
+    dompurify: "npm:^3.2.4"
     fractional-indexing: "npm:^3.2.0"
     lit: "npm:^3.2.0"
     lodash.clonedeep: "npm:^4.5.0"
@@ -3896,7 +3897,7 @@ __metadata:
     "@lit/context": "npm:^1.1.2"
     "@preact/signals-core": "npm:^1.8.0"
     "@types/hast": "npm:^3.0.4"
-    dompurify: "npm:^3.1.6"
+    dompurify: "npm:^3.2.4"
     fractional-indexing: "npm:^3.2.0"
     lib0: "npm:^0.2.97"
     lit: "npm:^3.2.0"
@@ -3954,7 +3955,7 @@ __metadata:
     "@vanilla-extract/css": "npm:^1.17.0"
     "@vanilla-extract/vite-plugin": "npm:^5.0.0"
     date-fns: "npm:^4.0.0"
-    dompurify: "npm:^3.1.6"
+    dompurify: "npm:^3.2.4"
     fflate: "npm:^0.8.2"
     file-type: "npm:^20.0.0"
     fractional-indexing: "npm:^3.2.0"
@@ -20043,7 +20044,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.1.6":
+"dompurify@npm:^3.2.4":
   version: 3.2.4
   resolution: "dompurify@npm:3.2.4"
   dependencies:


### PR DESCRIPTION
In Edgeless, the image size should be read when converting attachment to image:

* fix `size`
* fix `xywh`