### PR TITLE
Fix title overflow in edgeless mode

### DIFF
--- a/blocksuite/framework/inline/src/components/v-element.ts
+++ b/blocksuite/framework/inline/src/components/v-element.ts
@@ -76,16 +76,25 @@ export class VElement<
         data-v-embed="true"
         data-v-element="true"
         contenteditable="false"
-        style=${styleMap({ userSelect: 'none' })}
-        >${attributeRenderer(renderProps)}</span
-      >`;
+        style=${styleMap({
+          userSelect: 'none',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap'
+        })}
+      >${attributeRenderer(renderProps)}</span>`;
     }
 
-    // we need to avoid \n appearing before and after the span element, which will
-    // cause the unexpected space
-    return html`<span data-v-element="true"
-      >${attributeRenderer(renderProps)}</span
-    >`;
+    // Regular inline span render with overflow handling added.
+    return html`<span
+      data-v-element="true"
+      style=${styleMap({
+        userSelect: 'none',
+        overflow: 'hidden',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap'
+      })}
+    >${attributeRenderer(renderProps)}</span>`;
   }
 
   @property({ type: Object })


### PR DESCRIPTION
This pull request addresses the issue of title overflow in edgeless mode by adding CSS properties to handle text overflow properly in the `v-element.ts` file.

Issue number: #10171