### PR TITLE
fix(core): ExplorerDocNode no longer displays links multiple times

### DIFF
--- a/packages/frontend/core/src/modules/explorer/views/nodes/doc/index.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/nodes/doc/index.tsx
@@ -94,6 +94,16 @@ export const ExplorerDocNode = ({
       [docsSearchService, docId, collapsed]
     )
   );
+
+  const uniqueChildren = useMemo(() => {
+    if (!children) return children;
+    const unique = children.filter(
+      (child, index, self) =>
+        index === self.findIndex(c => c.docId === child.docId)
+    );
+    return unique;
+  }, [children]);
+
   const searching = children === null;
 
   const indexerLoading = useLiveData(
@@ -267,7 +277,7 @@ export const ExplorerDocNode = ({
       dropEffect={handleDropEffectOnDoc}
       data-testid={`explorer-doc-${docId}`}
     >
-      {children?.map(child => (
+      {uniqueChildren?.map(child => (
         <ExplorerDocNode
           key={child.docId}
           docId={child.docId}


### PR DESCRIPTION
Fixes https://github.com/toeverything/AFFiNE/issues/8522 by creating a new memoized and filtered array of unique linked docs and iterating over the uniqueChildren when creating the Linked ExplorerDocNodes.

Potential issue with Speed: Using a Set might be faster. Especially with large lists of links. 

It might be more "elegant" to directly edit the children coming instead of hooking into the changes to children. But I am not very comfortable with the LiveData class so I'm hesitant to use it here. The solution below does work, though. 

##### Version within the children assignment
```ts

  const children = useLiveData(
    useMemo(
      () => {
        const data = LiveData.from(
          !collapsed ? docsSearchService.watchRefsFrom(docId) : NEVER,
          null
        )
        return data.map(v => v?.filter(
          (child, index, self) =>
            index === self.findIndex(c => c.docId === child.docId)
          
        )) 
       }, [docsSearchService, docId, collapsed]
    )
  );
```


