### PR TITLE
fix(core): incorrect permissions displayed in member management

### DIFF
--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/index.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/index.tsx
@@ -121,15 +121,21 @@ export const MembersRow = ({ onClick }: { onClick: () => void }) => {
       className={clsx(styles.rowContainerStyle, 'clickable')}
       onClick={onClick}
     >
-      <div className={styles.memberContainerStyle}>
-        <Avatar
-          url={docOwner?.user.avatarUrl || ''}
-          name={docOwner?.user.name}
-          size={24}
-        />
-        <span>{docOwner?.user.name}</span>
-      </div>
-      <div className={styles.OwnerStyle}>{t['Owner']()}</div>
+      {docOwner ? (
+        <>
+          <div className={styles.memberContainerStyle}>
+            <Avatar
+              url={docOwner.user.avatarUrl || ''}
+              name={docOwner.user.name}
+              size={24}
+            />
+            <span>{docOwner.user.name}</span>
+          </div>
+          <div className={styles.OwnerStyle}>{t['Owner']()}</div>
+        </>
+      ) : (
+        <div>{t['com.affine.share-menu.invite-editor.manage-members']()}</div>
+      )}
       <div className={styles.IconButtonStyle}>
         <ArrowRightSmallIcon />
       </div>

--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-item.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-item.tsx
@@ -9,7 +9,6 @@ import {
   useConfirmModal,
 } from '@affine/component';
 import { useAsyncCallback } from '@affine/core/components/hooks/affine-async-hooks';
-import { AuthService } from '@affine/core/modules/cloud';
 import { DocService } from '@affine/core/modules/doc';
 import {
   DocGrantedUsersService,
@@ -31,16 +30,15 @@ export const MemberItem = ({
   openPaywallModal,
   hittingPaywall,
   grantedUser,
+  canManageUsers,
 }: {
   grantedUser: GrantedUser;
   hittingPaywall: boolean;
+  canManageUsers: boolean;
   openPaywallModal: () => void;
 }) => {
   const user = grantedUser.user;
-  const session = useService(AuthService).session;
-  const account = useLiveData(session.account$);
-  const disableManage =
-    account?.id === user.id || grantedUser.role === DocRole.Owner;
+  const disableManage = grantedUser.role === DocRole.Owner || !canManageUsers;
 
   const role = useMemo(() => {
     switch (grantedUser.role) {

--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-management.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-management.tsx
@@ -66,6 +66,7 @@ export const MemberManagement = ({
           grantedUserList={grantedUserList}
           grantedUserCount={grantedUserCount}
           loadMore={loadMore}
+          canManageUsers={canManageUsers}
         />
       ) : (
         <Skeleton className={styles.scrollableRootStyle} />
@@ -90,8 +91,10 @@ const MemberList = ({
   grantedUserList,
   grantedUserCount,
   loadMore,
+  canManageUsers,
 }: {
   hittingPaywall: boolean;
+  canManageUsers: boolean;
   grantedUserList: GrantedUser[];
   grantedUserCount?: number;
   openPaywallModal: () => void;
@@ -105,10 +108,11 @@ const MemberList = ({
           grantedUser={data}
           openPaywallModal={openPaywallModal}
           hittingPaywall={hittingPaywall}
+          canManageUsers={canManageUsers}
         />
       );
     },
-    [hittingPaywall, openPaywallModal]
+    [canManageUsers, hittingPaywall, openPaywallModal]
   );
   return (
     <div className={styles.memberListStyle}>
@@ -119,6 +123,7 @@ const MemberList = ({
             grantedUser={item}
             openPaywallModal={openPaywallModal}
             hittingPaywall={hittingPaywall}
+            canManageUsers={canManageUsers}
           />
         ))
       ) : (


### PR DESCRIPTION
When a user who cannot manage members clicks to enter member management, no operation options should be displayed.