### PR TITLE
refactor: replace editor container with editor host

### DIFF
--- a/blocksuite/playground/apps/_common/components/custom-outline-panel.ts
+++ b/blocksuite/playground/apps/_common/components/custom-outline-panel.ts
@@ -22,7 +22,7 @@ export class CustomOutlinePanel extends WithDisposable(ShadowlessElement) {
 
   private _renderPanel() {
     return html`<affine-outline-panel
-      .editor=${this.editor}
+      .editor=${this.editor.host}
       .fitPadding=${[50, 360, 50, 50]}
     ></affine-outline-panel>`;
   }

--- a/blocksuite/playground/apps/_common/components/custom-outline-viewer.ts
+++ b/blocksuite/playground/apps/_common/components/custom-outline-viewer.ts
@@ -17,7 +17,7 @@ export class CustomOutlineViewer extends WithDisposable(LitElement) {
 
   private _renderViewer() {
     return html`<affine-outline-viewer
-      .editor=${this.editor}
+      .editor=${this.editor.host}
       .toggleOutlinePanel=${this.toggleOutlinePanel}
     ></affine-outline-viewer>`;
   }

--- a/blocksuite/presets/src/fragments/outline/body/outline-panel-body.ts
+++ b/blocksuite/presets/src/fragments/outline/body/outline-panel-body.ts
@@ -2,6 +2,7 @@ import { effects } from '@blocksuite/affine-block-note/effects';
 import { ShadowlessElement, SurfaceSelection } from '@blocksuite/block-std';
 import {
   changeNoteDisplayMode,
+  DocModeProvider,
   matchModels,
   NoteBlockModel,
   NoteDisplayMode,
@@ -224,7 +225,9 @@ export class OutlinePanelBody extends SignalWatcher(
 
   private _watchSelectedNotes() {
     return effect(() => {
-      const { std, doc, mode } = this.editor;
+      const { std, doc } = this.editor;
+      const docModeService = this.editor.std.get(DocModeProvider);
+      const mode = docModeService.getEditorMode();
       if (mode !== 'edgeless') return;
 
       const currSelectedNotes = std.selection

--- a/blocksuite/presets/src/fragments/outline/config.ts
+++ b/blocksuite/presets/src/fragments/outline/config.ts
@@ -1,3 +1,4 @@
+import type { EditorHost } from '@blocksuite/block-std';
 import type { ParagraphBlockModel, Signal } from '@blocksuite/blocks';
 import {
   AttachmentIcon,
@@ -21,8 +22,6 @@ import {
 } from '@blocksuite/icons/lit';
 import { createContext } from '@lit/context';
 import type { TemplateResult } from 'lit';
-
-import type { AffineEditorContainer } from '../../editors/editor-container.js';
 
 const _16px = { width: '16px', height: '16px' };
 
@@ -85,7 +84,7 @@ export const headingKeys = new Set(
 export const outlineSettingsKey = 'outlinePanelSettings';
 
 export type TocContext = {
-  editor$: Signal<AffineEditorContainer>;
+  editor$: Signal<EditorHost>;
   enableSorting$: Signal<boolean>;
   showIcons$: Signal<boolean>;
   fitPadding$: Signal<number[]>;

--- a/blocksuite/presets/src/fragments/outline/mobile-outline-panel.ts
+++ b/blocksuite/presets/src/fragments/outline/mobile-outline-panel.ts
@@ -1,6 +1,11 @@
 import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
-import { PropTypes, requiredProperties } from '@blocksuite/block-std';
 import {
+  type EditorHost,
+  PropTypes,
+  requiredProperties,
+} from '@blocksuite/block-std';
+import {
+  DocModeProvider,
   matchModels,
   NoteDisplayMode,
   ParagraphBlockModel,
@@ -14,7 +19,6 @@ import { property } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { AffineEditorContainer } from '../../editors/editor-container.js';
 import { getHeadingBlocksFromDoc } from './utils/query.js';
 import {
   observeActiveHeadingDuringScroll,
@@ -162,8 +166,9 @@ export class MobileOutlineMenu extends SignalWatcher(
   };
 
   override render() {
-    if (this.editor.doc.root === null || this.editor.mode === 'edgeless')
-      return nothing;
+    const docModeService = this.editor.std.get(DocModeProvider);
+    const mode = docModeService.getEditorMode();
+    if (this.editor.doc.root === null || mode === 'edgeless') return nothing;
 
     const headingBlocks = getHeadingBlocksFromDoc(
       this.editor.doc,
@@ -182,7 +187,7 @@ export class MobileOutlineMenu extends SignalWatcher(
   }
 
   @property({ attribute: false })
-  accessor editor!: AffineEditorContainer;
+  accessor editor!: EditorHost;
 }
 
 declare global {

--- a/blocksuite/presets/src/fragments/outline/outline-viewer.ts
+++ b/blocksuite/presets/src/fragments/outline/outline-viewer.ts
@@ -1,9 +1,14 @@
 import {
+  type EditorHost,
   PropTypes,
   requiredProperties,
   ShadowlessElement,
 } from '@blocksuite/block-std';
-import { NoteDisplayMode, scrollbarStyle } from '@blocksuite/blocks';
+import {
+  DocModeProvider,
+  NoteDisplayMode,
+  scrollbarStyle,
+} from '@blocksuite/blocks';
 import { SignalWatcher, WithDisposable } from '@blocksuite/global/utils';
 import { TocIcon } from '@blocksuite/icons/lit';
 import { provide } from '@lit/context';
@@ -13,7 +18,6 @@ import { property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { repeat } from 'lit/directives/repeat.js';
 
-import type { AffineEditorContainer } from '../../editors/editor-container.js';
 import { type TocContext, tocContext } from './config.js';
 import { getHeadingBlocksFromDoc } from './utils/query.js';
 import {
@@ -219,8 +223,9 @@ export class OutlineViewer extends SignalWatcher(
   }
 
   override render() {
-    if (this.editor.doc.root === null || this.editor.mode === 'edgeless')
-      return nothing;
+    const docModeService = this.editor.std.get(DocModeProvider);
+    const mode = docModeService.getEditorMode();
+    if (this.editor.doc.root === null || mode === 'edgeless') return nothing;
 
     const headingBlocks = getHeadingBlocksFromDoc(
       this.editor.doc,
@@ -308,7 +313,7 @@ export class OutlineViewer extends SignalWatcher(
   private accessor _showViewer: boolean = false;
 
   @property({ attribute: false })
-  accessor editor!: AffineEditorContainer;
+  accessor editor!: EditorHost;
 
   @property({ attribute: false })
   accessor toggleOutlinePanel: (() => void) | null = null;

--- a/packages/frontend/core/src/components/blocksuite/outline-viewer/index.tsx
+++ b/packages/frontend/core/src/components/blocksuite/outline-viewer/index.tsx
@@ -1,4 +1,4 @@
-import type { AffineEditorContainer } from '@blocksuite/affine/presets';
+import type { EditorHost } from '@blocksuite/affine/block-std';
 import { OutlineViewer } from '@blocksuite/affine/presets';
 import { useCallback, useRef } from 'react';
 
@@ -9,7 +9,7 @@ export const EditorOutlineViewer = ({
   show,
   openOutlinePanel,
 }: {
-  editor: AffineEditorContainer | null;
+  editor: EditorHost | null;
   show: boolean;
   openOutlinePanel?: () => void;
 }) => {

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
@@ -310,7 +310,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
               />
             </Scrollable.Root>
             <EditorOutlineViewer
-              editor={editorContainer}
+              editor={editorContainer?.host ?? null}
               show={mode === 'page' && !isSideBarOpen}
               openOutlinePanel={openOutlinePanel}
             />
@@ -350,7 +350,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
       <ViewSidebarTab tabId="outline" icon={<TocIcon />}>
         <Scrollable.Root className={styles.sidebarScrollArea}>
           <Scrollable.Viewport>
-            <EditorOutlinePanel editor={editorContainer} />
+            <EditorOutlinePanel editor={editorContainer?.host ?? null} />
           </Scrollable.Viewport>
           <Scrollable.Scrollbar />
         </Scrollable.Root>
@@ -359,7 +359,7 @@ const DetailPageImpl = memo(function DetailPageImpl() {
       <ViewSidebarTab tabId="frame" icon={<FrameIcon />}>
         <Scrollable.Root className={styles.sidebarScrollArea}>
           <Scrollable.Viewport>
-            <EditorFramePanel editor={editorContainer} />
+            <EditorFramePanel editor={editorContainer?.host ?? null} />
           </Scrollable.Viewport>
           <Scrollable.Scrollbar />
         </Scrollable.Root>

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/frame.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/frame.tsx
@@ -1,34 +1,30 @@
+import type { EditorHost } from '@blocksuite/affine/block-std';
 import { FramePanel } from '@blocksuite/affine/blocks';
-import type { AffineEditorContainer } from '@blocksuite/affine/presets';
 import { useCallback, useEffect, useRef } from 'react';
 
 import * as styles from './frame.css';
 
 // A wrapper for FramePanel
-export const EditorFramePanel = ({
-  editor,
-}: {
-  editor: AffineEditorContainer | null;
-}) => {
+export const EditorFramePanel = ({ editor }: { editor: EditorHost | null }) => {
   const framePanelRef = useRef<FramePanel | null>(null);
 
   const onRefChange = useCallback(
     (container: HTMLDivElement | null) => {
-      if (editor?.host && container && container.children.length === 0) {
+      if (editor && container && container.children.length === 0) {
         framePanelRef.current = new FramePanel();
-        framePanelRef.current.host = editor.host;
+        framePanelRef.current.host = editor;
         framePanelRef.current.fitPadding = [20, 20, 20, 20];
         container.append(framePanelRef.current);
       }
     },
-    [editor?.host]
+    [editor]
   );
 
   useEffect(() => {
-    if (editor?.host && framePanelRef.current) {
-      framePanelRef.current.host = editor.host;
+    if (editor && framePanelRef.current) {
+      framePanelRef.current.host = editor;
     }
-  }, [editor?.host]);
+  }, [editor]);
 
   return <div className={styles.root} ref={onRefChange} />;
 };

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/outline.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/outline.tsx
@@ -1,4 +1,4 @@
-import type { AffineEditorContainer } from '@blocksuite/affine/presets';
+import type { EditorHost } from '@blocksuite/affine/block-std';
 import { OutlinePanel } from '@blocksuite/affine/presets';
 import { useCallback, useEffect, useRef } from 'react';
 
@@ -8,7 +8,7 @@ import * as styles from './outline.css';
 export const EditorOutlinePanel = ({
   editor,
 }: {
-  editor: AffineEditorContainer | null;
+  editor: EditorHost | null;
 }) => {
   const outlinePanelRef = useRef<OutlinePanel | null>(null);
 

--- a/packages/frontend/core/src/desktop/pages/workspace/share/share-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/share/share-page.tsx
@@ -268,7 +268,7 @@ const SharePageInner = ({
                 <Scrollable.Scrollbar />
               </Scrollable.Root>
               <EditorOutlineViewer
-                editor={editorContainer}
+                editor={editorContainer?.host ?? null}
                 show={publishMode === 'page'}
               />
               {!BUILD_CONFIG.isElectron && <SharePageFooter />}

--- a/packages/frontend/core/src/mobile/components/toc-menu/index.tsx
+++ b/packages/frontend/core/src/mobile/components/toc-menu/index.tsx
@@ -1,14 +1,8 @@
-import {
-  type AffineEditorContainer,
-  MobileOutlineMenu,
-} from '@blocksuite/affine/presets';
+import type { EditorHost } from '@blocksuite/affine/block-std';
+import { MobileOutlineMenu } from '@blocksuite/affine/presets';
 import { useCallback, useRef } from 'react';
 
-export const MobileTocMenu = ({
-  editor,
-}: {
-  editor: AffineEditorContainer | null;
-}) => {
+export const MobileTocMenu = ({ editor }: { editor: EditorHost | null }) => {
   const outlineMenuRef = useRef<MobileOutlineMenu | null>(null);
   const onRefChange = useCallback((container: HTMLDivElement | null) => {
     if (container) {

--- a/packages/frontend/core/src/mobile/pages/workspace/detail/page-header-more-button.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/detail/page-header-more-button.tsx
@@ -127,7 +127,7 @@ export const PageHeaderMenuButton = () => {
         title={t['com.affine.header.menu.toc']()}
         items={
           <div className={styles.outlinePanel}>
-            <MobileTocMenu editor={editorContainer} />
+            <MobileTocMenu editor={editorContainer?.host ?? null} />
           </div>
         }
       >

--- a/packages/frontend/core/src/modules/peek-view/view/doc-preview/doc-peek-view.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/doc-preview/doc-peek-view.tsx
@@ -179,7 +179,7 @@ function DocPeekPreviewEditor({
       </Scrollable.Root>
       {!BUILD_CONFIG.isMobileEdition && !BUILD_CONFIG.isMobileWeb ? (
         <EditorOutlineViewer
-          editor={editorElement}
+          editor={editorElement?.host ?? null}
           show={mode === 'page'}
           openOutlinePanel={openOutlinePanel}
         />


### PR DESCRIPTION
### TL;DR
Refactored editor access to use `EditorHost` instead of `AffineEditorContainer` and updated mode access through `DocModeProvider`.

### What changed?
- Changed editor property types from `AffineEditorContainer` to `EditorHost` across multiple components
- Updated mode access to use `DocModeProvider` service instead of direct editor mode access
- Modified editor references to use `editor.host` where appropriate
- Updated scroll and highlight utilities to work with `EditorHost`

### How to test?
1. Open a document in both page and edgeless modes
2. Verify outline panel functionality works as expected
3. Test outline viewer navigation and highlighting
4. Confirm mobile outline menu operates correctly
5. Check that frame panel and TOC features work in all modes

### Why make this change?
This change improves architectural consistency by using `EditorHost` directly and accessing mode through the proper service provider. This makes the code more maintainable and follows better dependency practices by using the correct abstraction levels.