### PR TITLE
refactor(editor): invalidate support in turbo renderer

### DIFF
--- a/blocksuite/affine/shared/src/viewport-renderer/dom-utils.ts
+++ b/blocksuite/affine/shared/src/viewport-renderer/dom-utils.ts
@@ -1,7 +1,4 @@
-import {
-  GfxControllerIdentifier,
-  type Viewport,
-} from '@blocksuite/block-std/gfx';
+import { type Viewport } from '@blocksuite/block-std/gfx';
 import { Pane } from 'tweakpane';
 
 import { getSentenceRects, segmentSentences } from './text-utils.js';
@@ -109,22 +106,7 @@ export function initTweakpane(
     .on('change', ({ value }) => {
       renderer.state = value ? 'paused' : 'monitoring';
     });
-
-  debugPane
-    .addBinding({ keepDOM: true }, 'keepDOM', {
-      label: 'Keep DOM',
-    })
-    .on('change', ({ value }) => {
-      const container = viewportElement.querySelector('gfx-viewport')!;
-      (container as HTMLElement).style.display = value ? 'block' : 'none';
-    });
-
-  debugPane.addButton({ title: 'Fit Viewport' }).on('click', () => {
-    const gfx = renderer.std.get(GfxControllerIdentifier);
-    gfx.fitToScreen();
-  });
-
-  debugPane.addButton({ title: 'Force Refresh' }).on('click', () => {
-    renderer.refresh(true).catch(console.error);
+  debugPane.addButton({ title: 'Invalidate' }).on('click', () => {
+    renderer.invalidate();
   });
 }

--- a/blocksuite/integration-test/src/__tests__/utils/renderer-entry.ts
+++ b/blocksuite/integration-test/src/__tests__/utils/renderer-entry.ts
@@ -1,4 +1,7 @@
-import { ViewportTurboRendererExtension } from '@blocksuite/affine-shared/viewport-renderer';
+import {
+  ViewportTurboRendererExtension,
+  ViewportTurboRendererIdentifier,
+} from '@blocksuite/affine-shared/viewport-renderer';
 
 import { addSampleNotes } from './doc-generator.js';
 import { setupEditor } from './setup.js';
@@ -7,6 +10,9 @@ async function init() {
   setupEditor('edgeless', [ViewportTurboRendererExtension]);
   addSampleNotes(doc, 100);
   doc.load();
+
+  const renderer = editor.std.get(ViewportTurboRendererIdentifier);
+  window.renderer = renderer;
 }
 
 init();

--- a/blocksuite/integration-test/src/__tests__/utils/setup.ts
+++ b/blocksuite/integration-test/src/__tests__/utils/setup.ts
@@ -9,6 +9,7 @@ import { effects } from '../../effects.js';
 blocksEffects();
 effects();
 
+import type { ViewportTurboRendererExtension } from '@blocksuite/affine-shared/viewport-renderer';
 import {
   CommunityCanvasTextFonts,
   type DocMode,
@@ -136,5 +137,6 @@ declare global {
     doc: Store;
     job: Transformer;
     collection: TestWorkspace;
+    renderer: ViewportTurboRendererExtension;
   }
 }


### PR DESCRIPTION
refactor(editor): invalidate support in turbo renderer

- Added `invalidate()` method to clear cache and canvas
- Simplified debug pane controls to single invalidate button
- Replaced layout update with refresh debounce on block updates
- Improved cache handling and bitmap drawing flow

refactor: refresh after invalidate