### PR TITLE
refactor(editor): use doc title and id as snapshot file name

### DIFF
--- a/blocksuite/affine/block-root/src/transformers/zip.ts
+++ b/blocksuite/affine/block-root/src/transformers/zip.ts
@@ -29,7 +29,10 @@ async function exportDocs(collection: Workspace, docs: Store[]) {
     snapshots
       .filter((snapshot): snapshot is DocSnapshot => !!snapshot)
       .map(async snapshot => {
-        const snapshotName = `${snapshot.meta.title || 'untitled'}.snapshot.json`;
+        // Use the title and id as the snapshot file name
+        const title = snapshot.meta.title || 'untitled';
+        const id = snapshot.meta.id;
+        const snapshotName = `${title}-${id}.snapshot.json`;
         await zip.file(snapshotName, JSON.stringify(snapshot, null, 2));
       })
   );
@@ -63,6 +66,7 @@ async function exportDocs(collection: Workspace, docs: Store[]) {
   }
 
   const downloadBlob = await zip.generate();
+  // Use the collection id as the zip file name
   return download(downloadBlob, `${collection.id}.bs.zip`);
 }
 


### PR DESCRIPTION
[BS-2549](https://linear.app/affine-design/issue/BS-2549/snap-shot-导出建议使用文档名称作为文件名，而不是一个-id)