### PR TITLE
fix(editor): improve string conversion logic for checkbox property

### DIFF
--- a/blocksuite/affine/data-view/src/property-presets/checkbox/define.ts
+++ b/blocksuite/affine/data-view/src/property-presets/checkbox/define.ts
@@ -3,17 +3,30 @@ import { propertyType } from '../../core/property/property-config.js';
 
 export const checkboxPropertyType = propertyType('checkbox');
 
+const FALSE_VALUES = new Set([
+  'false',
+  'no',
+  '0',
+  '',
+  'undefined',
+  'null',
+  '否',
+  '不',
+  '错',
+  '错误',
+  '取消',
+  '关闭',
+]);
+
 export const checkboxPropertyModelConfig =
   checkboxPropertyType.modelConfig<boolean>({
     name: 'Checkbox',
     type: () => t.boolean.instance(),
     defaultData: () => ({}),
     cellToString: ({ value }) => (value ? 'True' : 'False'),
-    cellFromString: ({ value }) => {
-      return {
-        value: value !== 'False',
-      };
-    },
+    cellFromString: ({ value }) => ({
+      value: !FALSE_VALUES.has((value?.trim() ?? '').toLowerCase()),
+    }),
     cellToJson: ({ value }) => value ?? null,
     cellFromJson: ({ value }) =>
       typeof value !== 'boolean' ? undefined : value,


### PR DESCRIPTION
fix: BS-2465

- Add a FALSE_VALUES set containing various falsy string representations

- Support Chinese negation terms like "否", "不", "错", etc.

- Optimize the implementation of cellFromString method