### PR TITLE
refactor(editor): simplify renderer state

### DIFF
--- a/blocksuite/affine/block-root/src/widgets/linked-doc/index.ts
+++ b/blocksuite/affine/block-root/src/widgets/linked-doc/index.ts
@@ -20,10 +20,8 @@ import { choose } from 'lit/directives/choose.js';
 import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
-import {
-  type PageRootBlockComponent,
-  RootBlockConfigExtension,
-} from '../../index.js';
+import type { PageRootBlockComponent } from '../../page/page-root-block.js';
+import { RootBlockConfigExtension } from '../../root-config.js';
 import {
   type AFFINE_LINKED_DOC_WIDGET,
   getMenus,

--- a/blocksuite/affine/shared/src/viewport-renderer/dom-utils.ts
+++ b/blocksuite/affine/shared/src/viewport-renderer/dom-utils.ts
@@ -2,7 +2,11 @@ import { type Viewport } from '@blocksuite/block-std/gfx';
 import { Pane } from 'tweakpane';
 
 import { getSentenceRects, segmentSentences } from './text-utils.js';
-import type { ParagraphLayout, ViewportLayout } from './types.js';
+import type {
+  ParagraphLayout,
+  RenderingState,
+  ViewportLayout,
+} from './types.js';
 import type { ViewportTurboRendererExtension } from './viewport-renderer.js';
 
 export function syncCanvasSize(canvas: HTMLCanvasElement, host: HTMLElement) {
@@ -98,15 +102,15 @@ export function initTweakpane(
   paneElement.style.right = '10px';
   paneElement.style.width = '250px';
   debugPane.title = 'Viewport Turbo Renderer';
-
-  debugPane
-    .addBinding({ paused: false }, 'paused', {
-      label: 'Paused',
-    })
-    .on('change', ({ value }) => {
-      renderer.state = value ? 'paused' : 'monitoring';
-    });
   debugPane.addButton({ title: 'Invalidate' }).on('click', () => {
     renderer.invalidate();
   });
+}
+
+export function debugLog(message: string, state: RenderingState) {
+  console.log(
+    `%c[ViewportTurboRenderer]%c ${message} | state=${state}`,
+    'color: #4285f4; font-weight: bold;',
+    'color: inherit;'
+  );
 }

--- a/blocksuite/affine/shared/src/viewport-renderer/types.ts
+++ b/blocksuite/affine/shared/src/viewport-renderer/types.ts
@@ -32,3 +32,12 @@ export interface TextRect {
   rect: Rect;
   text: string;
 }
+
+/**
+ * Represents the rendering state of the ViewportTurboRenderer
+ * - inactive: Renderer is not active
+ * - pending: Bitmap is invalid or not yet available, falling back to DOM rendering
+ * - rendering: Currently rendering to a bitmap (async operation in progress)
+ * - ready: Bitmap is valid and rendered, DOM elements can be safely removed
+ */
+export type RenderingState = 'inactive' | 'pending' | 'rendering' | 'ready';


### PR DESCRIPTION
The redundant `monitoring` state has been removed. The new `ready` state is used for querying if DOM elements can be safely optimized away.