### PR TITLE
fix(core): always update session prompt before chat

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-panel-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-panel-input.ts
@@ -203,8 +203,6 @@ export class ChatPanelInput extends SignalWatcher(WithDisposable(LitElement)) {
   @property({ attribute: false })
   accessor networkSearchConfig!: AINetworkSearchConfig;
 
-  private _lastPromptName: string | null = null;
-
   private get _isNetworkActive() {
     return (
       !!this.networkSearchConfig.visible.value &&
@@ -230,12 +228,9 @@ export class ChatPanelInput extends SignalWatcher(WithDisposable(LitElement)) {
   }
 
   private async _updatePromptName(promptName: string) {
-    if (this._lastPromptName !== promptName) {
-      const sessionId = await this.getSessionId();
-      if (sessionId && AIProvider.session) {
-        await AIProvider.session.updateSession(sessionId, promptName);
-        this._lastPromptName = promptName;
-      }
+    const sessionId = await this.getSessionId();
+    if (sessionId && AIProvider.session) {
+      await AIProvider.session.updateSession(sessionId, promptName);
     }
   }
 

--- a/packages/frontend/core/src/blocksuite/ai/peek-view/chat-block-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/peek-view/chat-block-input.ts
@@ -239,8 +239,6 @@ export class ChatBlockInput extends SignalWatcher(LitElement) {
   @state()
   accessor _focused = false;
 
-  private _lastPromptName: string | null = null;
-
   private get _isNetworkActive() {
     return (
       !!this.networkSearchConfig.visible.value &&
@@ -262,12 +260,9 @@ export class ChatBlockInput extends SignalWatcher(LitElement) {
   }
 
   private async _updatePromptName(promptName: string) {
-    if (this._lastPromptName !== promptName) {
-      const { currentSessionId } = this.chatContext;
-      if (currentSessionId && AIProvider.session) {
-        await AIProvider.session.updateSession(currentSessionId, promptName);
-        this._lastPromptName = promptName;
-      }
+    const { currentSessionId } = this.chatContext;
+    if (currentSessionId && AIProvider.session) {
+      await AIProvider.session.updateSession(currentSessionId, promptName);
     }
   }
 


### PR DESCRIPTION
Why make this fix?
The network search flag is saved locally. If the user opens multiple clients, the local status and server status may be inconsistent.
