### PR TITLE
feat(editor): support zooming placeholder in turbo renderer

### DIFF
--- a/blocksuite/affine/block-root/src/edgeless/edgeless-root-block.ts
+++ b/blocksuite/affine/block-root/src/edgeless/edgeless-root-block.ts
@@ -447,7 +447,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
           );
 
           const zoom = normalizeWheelDeltaY(e.deltaY, viewport.zoom);
-          viewport.setZoom(zoom, new Point(baseX, baseY));
+          viewport.setZoom(zoom, new Point(baseX, baseY), true);
           e.stopPropagation();
         }
         // pan

--- a/blocksuite/affine/shared/src/viewport-renderer/renderer-utils.ts
+++ b/blocksuite/affine/shared/src/viewport-renderer/renderer-utils.ts
@@ -115,3 +115,50 @@ export function debugLog(message: string, state: RenderingState) {
     'color: inherit;'
   );
 }
+
+export function paintPlaceholder(
+  canvas: HTMLCanvasElement,
+  layout: ViewportLayout | null,
+  viewport: Viewport
+) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  if (!layout) return;
+  const dpr = window.devicePixelRatio;
+  const layoutViewCoord = viewport.toViewCoord(layout.rect.x, layout.rect.y);
+
+  const offsetX = layoutViewCoord[0];
+  const offsetY = layoutViewCoord[1];
+  const colors = [
+    'rgba(200, 200, 200, 0.7)',
+    'rgba(180, 180, 180, 0.7)',
+    'rgba(160, 160, 160, 0.7)',
+  ];
+
+  layout.paragraphs.forEach((paragraph, paragraphIndex) => {
+    ctx.fillStyle = colors[paragraphIndex % colors.length];
+    const renderedPositions = new Set<string>();
+
+    paragraph.sentences.forEach(sentence => {
+      sentence.rects.forEach(textRect => {
+        const x =
+          ((textRect.rect.x - layout.rect.x) * viewport.zoom + offsetX) * dpr;
+        const y =
+          ((textRect.rect.y - layout.rect.y) * viewport.zoom + offsetY) * dpr;
+        dpr;
+        const width = textRect.rect.w * viewport.zoom * dpr;
+        const height = textRect.rect.h * viewport.zoom * dpr;
+
+        const posKey = `${x},${y}`;
+        if (renderedPositions.has(posKey)) return;
+        ctx.fillRect(x, y, width, height);
+        if (width > 10 && height > 5) {
+          ctx.strokeStyle = 'rgba(150, 150, 150, 0.3)';
+          ctx.strokeRect(x, y, width, height);
+        }
+
+        renderedPositions.add(posKey);
+      });
+    });
+  });
+}

--- a/blocksuite/affine/shared/src/viewport-renderer/types.ts
+++ b/blocksuite/affine/shared/src/viewport-renderer/types.ts
@@ -37,7 +37,13 @@ export interface TextRect {
  * Represents the rendering state of the ViewportTurboRenderer
  * - inactive: Renderer is not active
  * - pending: Bitmap is invalid or not yet available, falling back to DOM rendering
+ * - zooming: Zooming in or out, will use fast canvas placeholder rendering
  * - rendering: Currently rendering to a bitmap (async operation in progress)
  * - ready: Bitmap is valid and rendered, DOM elements can be safely removed
  */
-export type RenderingState = 'inactive' | 'pending' | 'rendering' | 'ready';
+export type RenderingState =
+  | 'inactive'
+  | 'pending'
+  | 'zooming'
+  | 'rendering'
+  | 'ready';

--- a/blocksuite/framework/block-std/src/gfx/viewport.ts
+++ b/blocksuite/framework/block-std/src/gfx/viewport.ts
@@ -78,7 +78,7 @@ export class Viewport {
     () => {
       this.zooming$.value = false;
     },
-    100,
+    200,
     { leading: false, trailing: true }
   );
 
@@ -86,7 +86,7 @@ export class Viewport {
     () => {
       this.panning$.value = false;
     },
-    100,
+    200,
     { leading: false, trailing: true }
   );
 
@@ -390,7 +390,7 @@ export class Viewport {
     this._resizeObserver.observe(el);
   }
 
-  setZoom(zoom: number, focusPoint?: IPoint) {
+  setZoom(zoom: number, focusPoint?: IPoint, wheel = false) {
     const prevZoom = this.zoom;
     focusPoint = (focusPoint ?? this._center) as IPoint;
     this._zoom = clamp(zoom, this.ZOOM_MIN, this.ZOOM_MAX);
@@ -401,7 +401,9 @@ export class Viewport {
       Vec.toVec(focusPoint),
       Vec.mul(offset, prevZoom / newZoom)
     );
-    this.zooming$.value = true;
+    if (wheel) {
+      this.zooming$.value = true;
+    }
     this.setCenter(newCenter[0], newCenter[1]);
     this.viewportUpdated.emit({
       zoom: this.zoom,


### PR DESCRIPTION
[Screen Recording 2025-02-28 at 4.32.20 PM.mov <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/lEGcysB4lFTEbCwZ8jMv/6c08b827-8428-42f3-aa7a-a2366756bd16.mov" />](https://app.graphite.dev/media/video/lEGcysB4lFTEbCwZ8jMv/6c08b827-8428-42f3-aa7a-a2366756bd16.mov)

This prevents painting task backlog during zooming by adding a fast placeholder painter, with a `zooming` state in renderer state machine.