### PR TITLE
fix(editor): should update icon status when formatting the entire block text

### DIFF
--- a/blocksuite/affine/widget-toolbar/src/toolbar.ts
+++ b/blocksuite/affine/widget-toolbar/src/toolbar.ts
@@ -257,6 +257,19 @@ export class AffineToolbarWidget extends WidgetComponent {
         })
     );
 
+    disposables.add(
+      std.store.slots.blockUpdated.on(record => {
+        if (
+          flags.isBlock() &&
+          record.type === 'update' &&
+          record.props.key === 'text'
+        ) {
+          flags.refresh(Flag.Block);
+          return;
+        }
+      })
+    );
+
     // Handles `drag and drop`
     const dragStart = () => flags.toggle(Flag.Hiding, true);
     const dragEnd = () => flags.toggle(Flag.Hiding, false);

--- a/blocksuite/tests-legacy/e2e/format-bar.spec.ts
+++ b/blocksuite/tests-legacy/e2e/format-bar.spec.ts
@@ -27,7 +27,6 @@ import {
   selectAllBlocksByKeyboard,
   selectAllByKeyboard,
   setInlineRangeInInlineEditor,
-  setSelection,
   switchReadonly,
   type,
   undoByKeyboard,
@@ -338,7 +337,6 @@ test('should format quick bar be able to link text', async ({
     `${testInfo.title}_init.json`
   );
 
-  await setSelection(page, 3, 0, 3, 3);
   // The link button should be active after click
   await expect(linkBtn).toHaveAttribute('active', '');
   await linkBtn.click();


### PR DESCRIPTION
Closes: [BS-2718](https://linear.app/affine-design/issue/BS-2718/当处于-block-selection-状态且对整段进行-formatting-时，应该更新对应图标状态)