### PR TITLE
fix(editor): patch android backspace key binding with beforeInput

### DIFF
--- a/blocksuite/affine/block-code/src/code-block.ts
+++ b/blocksuite/affine/block-code/src/code-block.ts
@@ -182,17 +182,17 @@ export class CodeBlockComponent extends CaptionedBlockComponent<
     // TODO: move to service for better performance
     this.bindHotKey({
       Backspace: ctx => {
-        const state = ctx.get('keyboardState');
+        const event = ctx.get('defaultState').event;
         const textSelection = selectionManager.find(TextSelection);
         if (!textSelection) {
-          state.raw.preventDefault();
+          event.preventDefault();
           return;
         }
 
         const from = textSelection.from;
 
         if (from.index === 0 && from.length === 0) {
-          state.raw.preventDefault();
+          event.preventDefault();
           selectionManager.setGroup('note', [
             selectionManager.create(BlockSelection, { blockId: this.blockId }),
           ]);
@@ -215,7 +215,7 @@ export class CodeBlockComponent extends CaptionedBlockComponent<
             index: index,
             length: 0,
           });
-          state.raw.preventDefault();
+          event.preventDefault();
           return true;
         }
 

--- a/blocksuite/affine/block-list/src/list-keymap.ts
+++ b/blocksuite/affine/block-list/src/list-keymap.ts
@@ -105,7 +105,7 @@ export const ListKeymapExtension = KeymapExtension(
         const isStart = isCollapsed && text.from.index === 0;
         if (!isStart) return false;
 
-        ctx.get('keyboardState').raw.preventDefault();
+        ctx.get('defaultState').event.preventDefault();
         std.command
           .chain()
           .pipe(listToParagraphCommand, {

--- a/blocksuite/affine/block-paragraph/src/paragraph-keymap.ts
+++ b/blocksuite/affine/block-paragraph/src/paragraph-keymap.ts
@@ -42,7 +42,7 @@ export const ParagraphKeymapExtension = KeymapExtension(
         const model = store.getBlock(text.from.blockId)?.model;
         if (!model || !matchModels(model, [ParagraphBlockModel])) return;
 
-        const event = ctx.get('keyboardState').raw;
+        const event = ctx.get('defaultState').event;
         event.preventDefault();
 
         // When deleting at line start of a paragraph block,

--- a/blocksuite/affine/block-root/src/keyboard/keyboard-manager.ts
+++ b/blocksuite/affine/block-root/src/keyboard/keyboard-manager.ts
@@ -21,7 +21,7 @@ import { toDraftModel } from '@blocksuite/store';
 
 export class PageKeyboardManager {
   private readonly _handleDelete: UIEventHandler = ctx => {
-    const event = ctx.get('keyboardState').raw;
+    const event = ctx.get('defaultState').event;
     const blockSelections = this._currentSelection.filter(sel =>
       sel.is(BlockSelection)
     );


### PR DESCRIPTION
Close [BS-1869](https://linear.app/affine-design/issue/BS-1869/[bug]-android-chrome-%E8%BE%93%E5%85%A5%E9%94%99%E8%AF%AF)

## Problem
On Android devices, keyboard events do not properly capture key information, causing the backspace key and other keyboard functionalities to malfunction. This is due to the specific behavior of Android platform, as discussed in:
- https://stackoverflow.com/a/68188679
- https://stackoverflow.com/a/66724830

## Solution
1. Added special handling for Android platform in `KeyboardControl` class by using `beforeInput` event instead of `keyDown` event
2. Implemented `androidBindKeymapPatch` function to handle special key events on Android platform
3. Updated event handling logic in related components, including:
   - CodeBlock
   - ListKeymap
   - ParagraphKeymap
   - PageKeyboardManager

## Changes
- Added `androidBindKeymapPatch` function for handling key events on Android platform
- Modified `KeyboardControl.bindHotkey` method to add `beforeInput` event handling for Android
- Unified event object access using `ctx.get('defaultState').event` instead of `keyboardState.raw`
- Updated key event handling logic in multiple components

## Before

https://github.com/user-attachments/assets/e8602de4-d584-4adf-816f-369f38312022


## After

https://github.com/user-attachments/assets/f9e1680e-28ff-4d52-bdab-7683cdcb6f82

