### PR TITLE
fixes(core): confusing default Shape Text Color in default settings UI

### DIFF
--- a/blocksuite/affine/model/src/themes/default.ts
+++ b/blocksuite/affine/model/src/themes/default.ts
@@ -49,6 +49,7 @@ const NoteBackgroundColorMap = {
   Black: getColorByKey('edgeless/note/black'),
   Grey: getColorByKey('edgeless/note/grey'),
   White: getColorByKey('edgeless/note/white'),
+  Transparent: Transparent,
 } as const;
 
 const Palettes: Palette[] = [
@@ -78,7 +79,7 @@ const StrokeColorShortPalettes: Palette[] = [
   ...buildPalettes(StrokeColorShortMap),
 ] as const;
 
-const FillColorShortMap = { ...Medium, Black, White } as const;
+const FillColorShortMap = { ...Medium, Black, White, Transparent } as const;
 
 const FillColorShortPalettes: Palette[] = [
   ...buildPalettes(FillColorShortMap),

--- a/packages/frontend/core/package.json
+++ b/packages/frontend/core/package.json
@@ -18,6 +18,7 @@
     "@affine/templates": "workspace:*",
     "@affine/track": "workspace:*",
     "@blocksuite/affine": "workspace:*",
+    "@blocksuite/affine-model": "workspace:*",
     "@blocksuite/icons": "2.2.4",
     "@dotlottie/player-component": "^2.7.12",
     "@emotion/cache": "^11.14.0",

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/utils.ts
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/utils.ts
@@ -5,6 +5,7 @@ import {
   type Palette,
   resolveColor,
 } from '@blocksuite/affine/blocks';
+import { DefaultTheme } from '@blocksuite/affine-model';
 import { isEqual } from 'lodash-es';
 import { useTheme } from 'next-themes';
 
@@ -26,8 +27,10 @@ export const usePalettes = (
     if (isDark) {
       if (key === 'Black') {
         key = 'White';
+        value = DefaultTheme.pureWhite;
       } else if (key === 'White') {
         key = 'Black';
+        value = DefaultTheme.pureBlack;
       }
     }
 


### PR DESCRIPTION
This PR does two things:

## 1. Fixes default Shape Text Color in default settings UI

The settings for default shape text color had a weird bug that caused the color and label to be mismatched (screenshot below). This PR ensures labels and colors will always be matched. 

![image](https://github.com/user-attachments/assets/3331a8f2-c2ab-4f88-8c8f-d1c771ad543d)


## 2. Adds "transparent" as a default option for shapes and notes

Also, noticed that there was no "transparent" option for shapes and notes in the default colors. Will be a nice quality of life update for users.



