### PR TITLE
fix(editor): code block toolbar float offset

### DIFF
--- a/blocksuite/affine/block-code/src/code-toolbar/index.ts
+++ b/blocksuite/affine/block-code/src/code-toolbar/index.ts
@@ -8,7 +8,6 @@ import {
   getMoreMenuConfig,
 } from '@blocksuite/affine-components/toolbar';
 import type { CodeBlockModel } from '@blocksuite/affine-model';
-import { PAGE_HEADER_HEIGHT } from '@blocksuite/affine-shared/consts';
 import {
   BlockSelection,
   TextSelection,
@@ -92,7 +91,6 @@ export class AffineCodeToolbarWidget extends WidgetComponent<
               shift({
                 crossAxis: true,
                 padding: {
-                  top: PAGE_HEADER_HEIGHT + 12,
                   bottom: 12,
                   right: 12,
                 },

--- a/blocksuite/affine/block-code/src/styles.ts
+++ b/blocksuite/affine/block-code/src/styles.ts
@@ -1,10 +1,6 @@
 import { css } from 'lit';
 
 export const codeBlockStyles = css`
-  affine-code {
-    position: relative;
-  }
-
   .affine-code-block-container {
     font-size: var(--affine-font-xs);
     line-height: var(--affine-line-height);


### PR DESCRIPTION
Close [BS-2736](https://linear.app/affine-design/issue/BS-2736/代码块工具栏偏移太大), [BS-1974](https://linear.app/affine-design/issue/BS-1974/code-block-浮标歪)

## Before

https://github.com/user-attachments/assets/f4ec4d7d-8c18-43ea-9464-c18e8b8dce60


https://github.com/user-attachments/assets/76f89ce6-bd89-49d6-a987-e9e5d5f9842a


### After


https://github.com/user-attachments/assets/dac919b9-d19c-4fb3-99bf-be02a460ad8c


https://github.com/user-attachments/assets/e5329f84-f1cf-4776-a789-8d12bea17ece

