### PR TITLE
chore(editor): add feature flag entry for testing turbo renderer

### DIFF
--- a/blocksuite/blocks/src/index.ts
+++ b/blocksuite/blocks/src/index.ts
@@ -100,6 +100,10 @@ export {
   SpecProvider,
   stopPropagation,
 } from '@blocksuite/affine-shared/utils';
+export {
+  ViewportTurboRendererExtension,
+  ViewportTurboRendererIdentifier,
+} from '@blocksuite/affine-shared/viewport-renderer';
 export type { DragBlockPayload } from '@blocksuite/affine-widget-drag-handle';
 
 const env: Record<string, unknown> =

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -21,7 +21,11 @@ import { toURLSearchParams } from '@affine/core/modules/navigation';
 import { PeekViewService } from '@affine/core/modules/peek-view/services/peek-view';
 import { WorkspaceService } from '@affine/core/modules/workspace';
 import track from '@affine/track';
-import type { DocMode, DocTitle } from '@blocksuite/affine/blocks';
+import {
+  type DocMode,
+  type DocTitle,
+  ViewportTurboRendererExtension,
+} from '@blocksuite/affine/blocks';
 import type { Store } from '@blocksuite/affine/store';
 import {
   useFramework,
@@ -132,6 +136,10 @@ const usePatchSpecs = (mode: DocMode) => {
 
   const enableAI = useEnableAI();
 
+  const enableTurboRenderer = useLiveData(
+    featureFlagService.flags.enable_turbo_renderer.$
+  );
+
   const patchedSpecs = useMemo(() => {
     const builder = enableEditorExtension(framework, mode, enableAI);
 
@@ -147,6 +155,9 @@ const usePatchSpecs = (mode: DocMode) => {
         patchQuickSearchService(framework),
         patchSideBarService(framework),
         patchDocModeService(docService, docsService, editorService),
+        mode === 'edgeless' && enableTurboRenderer
+          ? [ViewportTurboRendererExtension]
+          : [],
       ].flat()
     );
 
@@ -173,6 +184,7 @@ const usePatchSpecs = (mode: DocMode) => {
     referenceRenderer,
     featureFlagService,
     enableAI,
+    enableTurboRenderer,
   ]);
 
   return [

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -238,6 +238,13 @@ export const AFFINE_FLAGS = {
     configurable: BUILD_CONFIG.isMobileEdition,
     defaultState: false,
   },
+  enable_turbo_renderer: {
+    category: 'affine',
+    displayName: 'Enable Turbo Renderer',
+    description: 'Enable experimental edgeless turbo renderer',
+    configurable: isCanaryBuild,
+    defaultState: false,
+  },
 } satisfies { [key in string]: FlagInfo };
 
 // oxlint-disable-next-line no-redeclare


### PR DESCRIPTION
The debug pane will be displayed once the `enable_turbo_renderer` feature flag is enabled.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lEGcysB4lFTEbCwZ8jMv/c1ba558a-2d84-403c-aa81-864b0338c861.png)
