### PR TITLE
feat: use tags when creating a new doc using template

### DIFF
--- a/packages/frontend/core/src/modules/doc/entities/doc.ts
+++ b/packages/frontend/core/src/modules/doc/entities/doc.ts
@@ -34,6 +34,7 @@ export class Doc extends Entity {
   readonly primaryMode$ = this.record.primaryMode$;
   readonly title$ = this.record.title$;
   readonly trash$ = this.record.trash$;
+  readonly tags$ = this.record.tags$;
 
   customProperty$(propertyId: string) {
     return this.record.customProperty$(propertyId);
@@ -53,6 +54,10 @@ export class Doc extends Entity {
 
   setCustomProperty(propertyId: string, value: string) {
     return this.record.setCustomProperty(propertyId, value);
+  }
+
+  setTags(tags: string[]) {
+    return this.record.setTags(tags);
   }
 
   setPrimaryMode(mode: DocMode) {

--- a/packages/frontend/core/src/modules/doc/entities/record.ts
+++ b/packages/frontend/core/src/modules/doc/entities/record.ts
@@ -84,6 +84,12 @@ export class DocRecord extends Entity<{ id: string }> {
     return this.setMeta({ trash: false, trashDate: undefined });
   }
 
+  setTags(tags: string[]) {
+    return this.setMeta({ tags: tags });
+  }
+
+  tags$ = this.meta$.map(meta => meta.tags ?? []);
+
   title$ = this.meta$.map(meta => meta.title ?? '');
 
   trash$ = this.meta$.map(meta => meta.trash ?? false);

--- a/packages/frontend/core/src/modules/doc/services/docs.ts
+++ b/packages/frontend/core/src/modules/doc/services/docs.ts
@@ -242,9 +242,9 @@ export class DocsService extends Service {
     removedProperties.forEach(key => {
       delete properties[key];
     });
+    targetDoc.updateProperties(properties);
     // ensure tags are copied over too
     targetDoc.setTags(sourceDoc.tags$.value);
-    targetDoc.updateProperties(properties);
 
     return targetDocId;
   }

--- a/packages/frontend/core/src/modules/doc/services/docs.ts
+++ b/packages/frontend/core/src/modules/doc/services/docs.ts
@@ -242,6 +242,8 @@ export class DocsService extends Service {
     removedProperties.forEach(key => {
       delete properties[key];
     });
+    // ensure tags are copied over too
+    targetDoc.setTags(sourceDoc.tags$.value);
     targetDoc.updateProperties(properties);
 
     return targetDocId;


### PR DESCRIPTION
Loving the new template functionality!

However, I noticed the tags assigned to a template are not copied to a new document. This is unexpected. Ideally, the template's tags are copied over to the newly created document.

This PR also copies over tags from the template to the newly created doc.