### PR TITLE
fix(core): positioning error in fixed floating submenu

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-item/ai-item-list.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-item/ai-item-list.ts
@@ -92,7 +92,6 @@ export class AIItemList extends WithDisposable(LitElement) {
         .onClick=${this.onClick}
         .abortController=${this._abortController}
       ></ai-sub-item-list>`,
-      container: aiItemContainer,
       positionStrategy: 'fixed',
       computePosition: {
         referenceElement: aiItemContainer,


### PR DESCRIPTION
Issue：Close [BS-2150](https://linear.app/affine-design/issue/BS-2150/图片-filterprocessing-二级菜单时而不出现)


In the AI image menu (based on floating-ui):  
- **Floating element**: Submenu items (e.g., "image filter/image processing")  
- **Reference element**: Menu item  
- **Positioning strategy**: `fixed`  
- **Issue**: Specifying the `container` parameter caused the floating element (submenu) to be mounted to the reference element (menu item), leading to incorrect position calculations when floating-ui updated.  
```jsx
<menu-item>
  <submenu-item style={{ position: 'fixed' }}/>
</menu-item>
```
- **Fix**: Remove the `container` configuration and mount the `fixed`-positioned floating element to the `body` instead.  
