### PR TITLE
fix(editor): no need to sync local selection from awareness

### DIFF
--- a/blocksuite/affine/blocks/block-data-view/src/data-view-block.ts
+++ b/blocksuite/affine/blocks/block-data-view/src/data-view-block.ts
@@ -174,17 +174,11 @@ export class DataViewBlockComponent extends CaptionedBlockComponent<DataViewBloc
     }
   );
 
-  selection$ = computed(() => {
-    const databaseSelection = this.selection.value.find(
-      (selection): selection is DatabaseSelection => {
-        if (selection.blockId !== this.blockId) {
-          return false;
-        }
-        return selection instanceof DatabaseSelection;
-      }
-    );
-    return databaseSelection?.viewSelection;
-  });
+  selection$ = computed(
+    () =>
+      this.selection.find$(DatabaseSelection, s => s.blockId === this.blockId)
+        .value?.viewSelection
+  );
 
   setSelection = (selection: DataViewSelection | undefined) => {
     this.selection.setGroup(

--- a/blocksuite/affine/blocks/block-database/src/database-block.ts
+++ b/blocksuite/affine/blocks/block-database/src/database-block.ts
@@ -319,17 +319,11 @@ export class DatabaseBlockComponent extends CaptionedBlockComponent<DatabaseBloc
     ],
   });
 
-  viewSelection$ = computed(() => {
-    const databaseSelection = this.selection.value.find(
-      (selection): selection is DatabaseSelection => {
-        if (selection.blockId !== this.blockId) {
-          return false;
-        }
-        return selection instanceof DatabaseSelection;
-      }
-    );
-    return databaseSelection?.viewSelection;
-  });
+  viewSelection$ = computed(
+    () =>
+      this.selection.find$(DatabaseSelection, s => s.blockId === this.blockId)
+        .value?.viewSelection
+  );
 
   virtualPadding$ = signal(0);
 

--- a/blocksuite/affine/blocks/block-paragraph/src/paragraph-block.ts
+++ b/blocksuite/affine/blocks/block-paragraph/src/paragraph-block.ts
@@ -32,13 +32,12 @@ import { paragraphBlockStyles } from './styles.js';
 export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBlockModel> {
   static override styles = paragraphBlockStyles;
 
-  focused$ = computed(() => {
-    const selection = this.std.selection.value.find(
-      selection => selection.blockId === this.model?.id
-    );
-    if (!selection) return false;
-    return selection.is(TextSelection);
-  });
+  focused$ = computed(() =>
+    Boolean(
+      this.selection.find$(TextSelection, s => s.blockId === this.model.id)
+        .value
+    )
+  );
 
   private readonly _composing = signal(false);
 
@@ -129,7 +128,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
           this._displayPlaceholder.value = false;
           return;
         }
-        const textSelection = this.host.selection.find(TextSelection);
+        const textSelection = this.host.selection.find$(TextSelection).value;
         const isCollapsed = textSelection?.isCollapsed() ?? false;
         if (!this.focused$.value || !isCollapsed) {
           this._displayPlaceholder.value = false;
@@ -169,7 +168,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
         // reset text selection when selected block is collapsed
         if (this.model.props.type$.value.startsWith('h') && collapsed) {
           const collapsedSiblings = this.collapsedSiblings;
-          const textSelection = this.host.selection.find(TextSelection);
+          const textSelection = this.host.selection.find$(TextSelection).value;
 
           if (
             textSelection &&

--- a/blocksuite/affine/blocks/block-root/src/edgeless/edgeless-root-preview-block.ts
+++ b/blocksuite/affine/blocks/block-root/src/edgeless/edgeless-root-preview-block.ts
@@ -184,9 +184,7 @@ export class EdgelessRootPreviewBlockComponent extends BlockComponent<
     super.connectedCallback();
 
     this.handleEvent('selectionChange', () => {
-      const surface = this.host.selection.value.find(
-        (sel): sel is SurfaceSelection => sel.is(SurfaceSelection)
-      );
+      const surface = this.host.selection.find(SurfaceSelection);
       if (!surface) return;
 
       const el = this._crud.getElementById(surface.elements[0]);

--- a/blocksuite/affine/blocks/block-root/src/page/page-root-block.ts
+++ b/blocksuite/affine/blocks/block-root/src/page/page-root-block.ts
@@ -231,9 +231,8 @@ export class PageRootBlockComponent extends BlockComponent<
       },
       ArrowUp: () => {
         const selection = this.host.selection;
-        const sel = selection.value.find(
-          sel => sel.is(TextSelection) || sel.is(BlockSelection)
-        );
+        const sel =
+          selection.find(TextSelection) ?? selection.find(BlockSelection);
         if (!sel) return;
         let model: BlockModel | null = null;
         let current = this.doc.getModelById(sel.blockId);

--- a/blocksuite/affine/blocks/block-table/src/selection-controller.ts
+++ b/blocksuite/affine/blocks/block-table/src/selection-controller.ts
@@ -519,9 +519,10 @@ export class SelectionController implements ReactiveController {
   }
   selected$ = computed(() => this.getSelected());
   getSelected(): TableSelectionData | undefined {
-    const selection = this.host.selection.value.find(
-      selection => selection.blockId === this.host.model.id
+    const selection = this.host.selection.find(
+      TableSelection,
+      s => s.blockId === this.host.model.id
     );
-    return selection?.is(TableSelection) ? selection.data : undefined;
+    return selection?.data;
   }
 }

--- a/blocksuite/affine/fragments/fragment-outline/src/body/outline-panel-body.ts
+++ b/blocksuite/affine/fragments/fragment-outline/src/body/outline-panel-body.ts
@@ -268,8 +268,8 @@ export class OutlinePanelBody extends SignalWatcher(
       if (mode !== 'edgeless') return;
 
       const currSelectedNotes = std.selection
-        .filter(SurfaceSelection)
-        .map(({ blockId }) => doc.getBlock(blockId)?.model)
+        .filter$(SurfaceSelection)
+        .value.map(({ blockId }) => doc.getBlock(blockId)?.model)
         .filter(model => {
           return !!model && matchModels(model, [NoteBlockModel]);
         });

--- a/blocksuite/affine/widgets/widget-scroll-anchoring/src/scroll-anchoring.ts
+++ b/blocksuite/affine/widgets/widget-scroll-anchoring/src/scroll-anchoring.ts
@@ -60,7 +60,9 @@ export class AffineScrollAnchoringWidget extends WidgetComponent {
 
   anchorBounds$ = signal<Bound | null>(null);
 
-  highlighted$ = computed(() => this.std.selection.find(HighlightSelection));
+  highlighted$ = computed(
+    () => this.std.selection.find$(HighlightSelection).value
+  );
 
   #getBoundsInEdgeless() {
     const controller = this.std.get(GfxControllerIdentifier);

--- a/blocksuite/framework/std/src/view/element/block-component.ts
+++ b/blocksuite/framework/std/src/view/element/block-component.ts
@@ -37,13 +37,12 @@ export class BlockComponent<
   @consume({ context: stdContext })
   accessor std!: BlockStdScope;
 
-  selected$ = computed(() => {
-    const selection = this.std.selection.value.find(
-      selection => selection.blockId === this.model?.id
-    );
-    if (!selection) return false;
-    return selection.is(BlockSelection);
-  });
+  selected$ = computed(() =>
+    Boolean(
+      this.std.selection.find$(BlockSelection, s => s.blockId === this.model.id)
+        .value
+    )
+  );
 
   [blockComponentSymbol] = true;
 

--- a/blocksuite/framework/std/src/view/element/gfx-block-component.ts
+++ b/blocksuite/framework/std/src/view/element/gfx-block-component.ts
@@ -198,13 +198,14 @@ export function toGfxBlockComponent<
 
     readonly transformState$ = signal<'idle' | 'active'>('active');
 
-    override selected$ = computed(() => {
-      const selection = this.std.selection.value.find(
-        selection => selection.blockId === this.model?.id
-      );
-      if (!selection) return false;
-      return selection.is(SurfaceSelection);
-    });
+    override selected$ = computed(() =>
+      Boolean(
+        this.std.selection.find$(
+          SurfaceSelection,
+          s => s.blockId === this.model.id
+        ).value
+      )
+    );
 
     onDragMove({ dx, dy, currentBound }: DragMoveContext) {
       this.model.xywh = currentBound.moveDelta(dx, dy).serialize();

--- a/blocksuite/framework/store/src/extension/selection/selection-extension.ts
+++ b/blocksuite/framework/store/src/extension/selection/selection-extension.ts
@@ -14,13 +14,13 @@ export class StoreSelectionExtension extends StoreExtension {
 
   private readonly _id = `${this.store.id}:${nanoid()}`;
   private _selectionConstructors: Record<string, SelectionConstructor> = {};
-  private readonly _selections = signal<BaseSelection[]>([]);
-  private readonly _remoteSelections = signal<Map<number, BaseSelection[]>>(
+  private readonly _selections$ = signal<BaseSelection[]>([]);
+  private readonly _remoteSelections$ = signal<Map<number, BaseSelection[]>>(
     new Map()
   );
 
   private readonly _itemAdded = (event: { stackItem: StackItem }) => {
-    event.stackItem.meta.set('selection-state', this._selections.value);
+    event.stackItem.meta.set('selection-state', this.value);
   };
 
   private readonly _itemPopped = (event: { stackItem: StackItem }) => {
@@ -59,21 +59,14 @@ export class StoreSelectionExtension extends StoreExtension {
         const all = change.updated.concat(change.added).concat(change.removed);
         const localClientID = this.store.awarenessStore.awareness.clientID;
         const exceptLocal = all.filter(id => id !== localClientID);
-        const hasLocal = all.includes(localClientID);
-        if (hasLocal) {
-          const localSelectionJson =
-            this.store.awarenessStore.getLocalSelection(this._id);
-          const localSelection = localSelectionJson.map(json => {
-            return this._jsonToSelection(json);
-          });
-          this._selections.value = localSelection;
-        }
 
         // Only consider remote selections from other clients
-        if (exceptLocal.length > 0) {
-          const map = new Map<number, BaseSelection[]>();
-          this.store.awarenessStore.getStates().forEach((state, id) => {
-            if (id === this.store.awarenessStore.awareness.clientID) return;
+        if (exceptLocal.length === 0) return;
+
+        const map = new Map<number, BaseSelection[]>();
+        Array.from(this.store.awarenessStore.getStates().entries())
+          .filter(([id]) => id !== localClientID)
+          .forEach(([id, state]) => {
             // selection id starts with the same block collection id from others clients would be considered as remote selections
             const selection = Object.entries(state.selectionV2)
               .filter(([key]) => key.startsWith(this.store.id))
@@ -97,9 +90,8 @@ export class StoreSelectionExtension extends StoreExtension {
 
             map.set(id, selections);
           });
-          this._remoteSelections.value = map;
-          this.slots.remoteChanged.next(map);
-        }
+        this._remoteSelections$.value = map;
+        this.slots.remoteChanged.next(map);
       }
     );
 
@@ -108,18 +100,16 @@ export class StoreSelectionExtension extends StoreExtension {
   }
 
   get value() {
-    return this._selections.value;
+    return this._selections$.peek();
   }
 
   get remoteSelections() {
-    return this._remoteSelections.value;
+    return this._remoteSelections$.peek();
   }
 
   clear(types?: string[]) {
     if (types) {
-      const values = this.value.filter(
-        selection => !types.includes(selection.type)
-      );
+      const values = this.value.filter(s => !types.includes(s.type));
       this.set(values);
     } else {
       this.set([]);
@@ -138,22 +128,28 @@ export class StoreSelectionExtension extends StoreExtension {
   }
 
   filter<T extends SelectionConstructor>(type: T) {
-    return this.filter$(type).value;
+    return this.filter$(type).peek();
   }
 
   filter$<T extends SelectionConstructor>(type: T) {
     return computed(() =>
-      this.value.filter((sel): sel is InstanceType<T> => sel.is(type))
+      this._selections$.value.filter((s): s is InstanceType<T> => s.is(type))
     );
   }
 
-  find<T extends SelectionConstructor>(type: T) {
-    return this.find$(type).value;
+  find<T extends SelectionConstructor>(
+    type: T,
+    predicate?: (s: InstanceType<T>) => boolean
+  ) {
+    return this.find$(type, predicate).peek();
   }
 
-  find$<T extends SelectionConstructor>(type: T) {
+  find$<T extends SelectionConstructor>(
+    type: T,
+    predicate?: (s: InstanceType<T>) => boolean
+  ) {
     return computed(() =>
-      this.value.find((sel): sel is InstanceType<T> => sel.is(type))
+      this.filter$(type).value.find(s => predicate?.(s) ?? true)
     );
   }
 
@@ -162,6 +158,7 @@ export class StoreSelectionExtension extends StoreExtension {
       this._id,
       selections.map(s => s.toJSON())
     );
+    this._selections$.value = selections;
     this.slots.changed.next(selections);
   }
 
@@ -176,9 +173,7 @@ export class StoreSelectionExtension extends StoreExtension {
   }
 
   fromJSON(json: Record<string, unknown>[]) {
-    const selections = json.map(json => {
-      return this._jsonToSelection(json);
-    });
+    const selections = json.map(json => this._jsonToSelection(json));
     return this.set(selections);
   }
 }


### PR DESCRIPTION
1. Local selection should be set directly without syncing from awareness.
2. Fixed an error in the selection signal: `Cycle detected`.