### PR TITLE
feat: responsive chat-panel padding and request

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-config.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-config.ts
@@ -3,6 +3,17 @@ import type { LinkedMenuGroup } from '@blocksuite/affine/blocks';
 import type { Store } from '@blocksuite/affine/store';
 import type { Signal } from '@preact/signals-core';
 
+export interface AppSidebarConfig {
+  getWidth: () => {
+    signal: Signal<number | undefined>;
+    cleanup: () => void;
+  };
+  isOpen: () => {
+    signal: Signal<boolean | undefined>;
+    cleanup: () => void;
+  };
+}
+
 export interface AINetworkSearchConfig {
   visible: Signal<boolean | undefined>;
   enabled: Signal<boolean | undefined>;

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/chat.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/chat.tsx
@@ -4,6 +4,7 @@ import { enableFootnoteConfigExtension } from '@affine/core/blocksuite/extension
 import { AINetworkSearchService } from '@affine/core/modules/ai-button/services/network-search';
 import { DocDisplayMetaService } from '@affine/core/modules/doc-display-meta';
 import { DocSearchMenuService } from '@affine/core/modules/doc-search-menu/services';
+import { WorkbenchService } from '@affine/core/modules/workbench';
 import { WorkspaceService } from '@affine/core/modules/workspace';
 import {
   createSignalFromObservable,
@@ -58,6 +59,17 @@ export const EditorChatPanel = forwardRef(function EditorChatPanel(
       const docDisplayMetaService = framework.get(DocDisplayMetaService);
       const workspaceService = framework.get(WorkspaceService);
       const docSearchMenuService = framework.get(DocSearchMenuService);
+      const workbench = framework.get(WorkbenchService).workbench;
+      chatPanelRef.current.appSidebarConfig = {
+        getWidth: () => {
+          const width$ = workbench.sidebarWidth$;
+          return createSignalFromObservable(width$, 0);
+        },
+        isOpen: () => {
+          const open$ = workbench.sidebarOpen$;
+          return createSignalFromObservable(open$, true);
+        },
+      };
       chatPanelRef.current.networkSearchConfig = {
         visible: searchService.visible,
         enabled: searchService.enabled,


### PR DESCRIPTION
Close [BS-2751](https://linear.app/affine-design/issue/BS-2751).

### What Changed?
- Do not send AI gql request when chat-panel is not open.
- When the chat-panel width is greater than 540px, adjust the padding to 24px.
- Optimize the display and hide logic of scroll-to-end button.