### PR TITLE
fix(core): can not clear chat-panel history

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/types.ts
@@ -2,6 +2,7 @@ import type {
   ChatHistoryOrder,
   CopilotContextDoc,
   CopilotContextFile,
+  CopilotSessionType,
   getCopilotHistoriesQuery,
   RequestOptions,
 } from '@affine/graphql';
@@ -305,7 +306,7 @@ declare global {
         workspaceId: string,
         docId?: string,
         options?: { action?: boolean }
-      ) => Promise<{ id: string; promptName: string }[] | undefined>;
+      ) => Promise<CopilotSessionType[] | undefined>;
       updateSession: (sessionId: string, promptName: string) => Promise<string>;
     }
 


### PR DESCRIPTION
Close [BS-2754](https://linear.app/affine-design/issue/BS-2754).

### What Changed?
Use the latest session id and display the corresponding historical messages.