### PR TITLE
refactor(editor): add slash menu config extension entry

### DIFF
--- a/blocksuite/affine/widget-slash-menu/src/consts.ts
+++ b/blocksuite/affine/widget-slash-menu/src/consts.ts
@@ -1,0 +1,5 @@
+export const AFFINE_SLASH_MENU_WIDGET = 'affine-slash-menu-widget';
+export const AFFINE_SLASH_MENU_TRIGGER_KEY = '/';
+export const AFFINE_SLASH_MENU_TOOLTIP_TIMEOUT = 800;
+// TODO(@L-Sun): Move this to styles.ts
+export const AFFINE_SLASH_MENU_MAX_HEIGHT = 334;

--- a/blocksuite/affine/widget-slash-menu/src/effects.ts
+++ b/blocksuite/affine/widget-slash-menu/src/effects.ts
@@ -1,5 +1,6 @@
+import { AFFINE_SLASH_MENU_WIDGET } from './consts';
 import { InnerSlashMenu, SlashMenu } from './slash-menu-popover';
-import { AFFINE_SLASH_MENU_WIDGET, AffineSlashMenuWidget } from './widget';
+import { AffineSlashMenuWidget } from './widget';
 
 export function effects() {
   customElements.define(AFFINE_SLASH_MENU_WIDGET, AffineSlashMenuWidget);

--- a/blocksuite/affine/widget-slash-menu/src/extensions.ts
+++ b/blocksuite/affine/widget-slash-menu/src/extensions.ts
@@ -1,11 +1,20 @@
-import { WidgetViewExtension } from '@blocksuite/block-std';
-import { type Container } from '@blocksuite/global/di';
-import { Extension } from '@blocksuite/store';
+import {
+  type BlockStdScope,
+  StdIdentifier,
+  WidgetViewExtension,
+} from '@blocksuite/block-std';
+import { type Container, createIdentifier } from '@blocksuite/global/di';
+import { Extension, type ExtensionType } from '@blocksuite/store';
 import { literal, unsafeStatic } from 'lit/static-html.js';
 
-import { AFFINE_SLASH_MENU_WIDGET } from './widget';
+import { defaultSlashMenuConfig } from './config';
+import { AFFINE_SLASH_MENU_WIDGET } from './consts';
+import type { SlashMenuConfig } from './types';
+import { mergeSlashMenuConfigs } from './utils';
 
 export class SlashMenuExtension extends Extension {
+  config: SlashMenuConfig;
+
   static override setup(di: Container) {
     WidgetViewExtension(
       'affine:page',
@@ -13,6 +22,37 @@ export class SlashMenuExtension extends Extension {
       literal`${unsafeStatic(AFFINE_SLASH_MENU_WIDGET)}`
     ).setup(di);
 
-    di.add(this);
+    di.add(this, [StdIdentifier]);
+
+    // TODO(@L-Sun): remove this after moving all configs to corresponding extensions
+    SlashMenuConfigExtension({
+      id: 'default',
+      config: defaultSlashMenuConfig,
+    }).setup(di);
   }
+
+  constructor(readonly std: BlockStdScope) {
+    super();
+    this.config = mergeSlashMenuConfigs(
+      this.std.provider.getAll(SlashMenuConfigIdentifier)
+    );
+  }
+}
+
+const SlashMenuConfigIdentifier = createIdentifier<SlashMenuConfig>(
+  `${AFFINE_SLASH_MENU_WIDGET}-config`
+);
+
+export function SlashMenuConfigExtension({
+  id,
+  config,
+}: {
+  id: string;
+  config: SlashMenuConfig;
+}): ExtensionType {
+  return {
+    setup: di => {
+      di.addImpl(SlashMenuConfigIdentifier(id), config);
+    },
+  };
 }

--- a/blocksuite/affine/widget-slash-menu/src/index.ts
+++ b/blocksuite/affine/widget-slash-menu/src/index.ts
@@ -1,3 +1,5 @@
+export { AFFINE_SLASH_MENU_WIDGET } from './consts';
 // TODO(@L-Sun): narrow the scope of the exported symbols
 export * from './extensions';
+export * from './types';
 export * from './widget';

--- a/blocksuite/affine/widget-slash-menu/src/tooltips/index.ts
+++ b/blocksuite/affine/widget-slash-menu/src/tooltips/index.ts
@@ -1,5 +1,4 @@
-import type { TemplateResult } from 'lit';
-
+import type { SlashMenuTooltip } from '../types';
 import { AttachmentTooltip } from './attachment';
 import { BoldTextTooltip } from './bold-text';
 import { BulletedListTooltip } from './bulleted-list';
@@ -39,11 +38,6 @@ import { TweetTooltip } from './tweet';
 import { UnderlineTooltip } from './underline';
 import { YesterdayTooltip } from './yesterday';
 import { YoutubeVideoTooltip } from './youtube-video';
-
-export type SlashMenuTooltip = {
-  figure: TemplateResult;
-  caption: string;
-};
 
 export const slashMenuToolTips: Record<string, SlashMenuTooltip> = {
   Text: {

--- a/blocksuite/affine/widget-slash-menu/src/types.ts
+++ b/blocksuite/affine/widget-slash-menu/src/types.ts
@@ -1,0 +1,60 @@
+import type { BlockStdScope } from '@blocksuite/block-std';
+import type { BlockModel } from '@blocksuite/store';
+import type { TemplateResult } from 'lit';
+
+export type SlashMenuContext = {
+  std: BlockStdScope;
+  model: BlockModel;
+};
+
+export type SlashMenuTooltip = {
+  figure: TemplateResult;
+  caption: string;
+};
+
+export type SlashMenuItemBase = {
+  name: string;
+  description?: string;
+  icon?: TemplateResult;
+  /**
+   * This field defines sorting and grouping of menu items like VSCode.
+   * The first number indicates the group index, the second number indicates the item index in the group.
+   * The group name is the string between `_` and `@`.
+   * You can find an example figure in https://code.visualstudio.com/api/references/contribution-points#menu-example
+   */
+  group?: `${number}_${string}@${number}`;
+
+  // TODO(@L-Sun): move this field to SlashMenuActionItem when refactoring search
+  /**
+   * The alias of the menu item for search.
+   */
+  searchAlias?: string[];
+  /**
+   * The condition to show the menu item.
+   */
+  when?: (ctx: SlashMenuContext) => boolean;
+};
+
+export type SlashMenuActionItem = SlashMenuItemBase & {
+  action: (ctx: SlashMenuContext) => void;
+  tooltip?: SlashMenuTooltip;
+};
+
+export type SlashMenuSubMenu = SlashMenuItemBase & {
+  subMenu: SlashMenuItem[];
+};
+
+export type SlashMenuItem = SlashMenuActionItem | SlashMenuSubMenu;
+
+export type SlashMenuConfig = {
+  // TODO(@L-Sun): change this type to SlashMenuItem[] and (ctx: SlashMenuContext) => SlashMenuItem[]
+  /**
+   * The items in the slash menu. It can be generated dynamically with the context.
+   */
+  items: (SlashMenuItem | ((ctx: SlashMenuContext) => SlashMenuItem[]))[];
+
+  /**
+   * Slash menu will not be triggered when the condition is true.
+   */
+  disableWhen?: (ctx: SlashMenuContext) => boolean;
+};

--- a/packages/frontend/core/src/blocksuite/ai/extensions/ai-edgeless-root.ts
+++ b/packages/frontend/core/src/blocksuite/ai/extensions/ai-edgeless-root.ts
@@ -72,7 +72,7 @@ function getAIEdgelessRootWatcher(framework: FrameworkProvider) {
         }
 
         if (component instanceof AffineSlashMenuWidget) {
-          setupSlashMenuAIEntry(component);
+          setupSlashMenuAIEntry(this.std);
         }
       });
     }

--- a/packages/frontend/core/src/blocksuite/ai/extensions/ai-page-root.ts
+++ b/packages/frontend/core/src/blocksuite/ai/extensions/ai-page-root.ts
@@ -38,7 +38,7 @@ function getAIPageRootWatcher(framework: FrameworkProvider) {
         }
 
         if (component instanceof AffineSlashMenuWidget) {
-          setupSlashMenuAIEntry(component);
+          setupSlashMenuAIEntry(this.std);
         }
       });
     }

--- a/packages/frontend/core/src/blocksuite/extensions/quick-search-service.ts
+++ b/packages/frontend/core/src/blocksuite/extensions/quick-search-service.ts
@@ -132,12 +132,12 @@ export function patchQuickSearchService(framework: FrameworkProvider) {
         }
         const component = payload.view;
         if (component instanceof AffineSlashMenuWidget) {
-          component.config.items.forEach(item => {
+          component.configItemTransform = item => {
             if (
               'action' in item &&
               (item.name === 'Linked Doc' || item.name === 'Link')
             ) {
-              item.action = async ({ std }) => {
+              item.action = ({ std }) => {
                 const [success, { insertedLinkType }] = std.command.exec(
                   insertLinkByQuickSearchCommand
                 );
@@ -164,7 +164,8 @@ export function patchQuickSearchService(framework: FrameworkProvider) {
                   .catch(console.error);
               };
             }
-          });
+            return item;
+          };
         }
       });
     }


### PR DESCRIPTION
Close [BS-2744](https://linear.app/affine-design/issue/BS-2744/slash-menu%E6%8F%92%E4%BB%B6%E5%8C%96%EF%BC%9Aaction%E6%B3%A8%E5%86%8C%E5%85%A5%E5%8F%A3)

This PR mainly focus  on providing an entry point for configuring the SlashMenu feature. Therefore, it strives to retain the original code to ensure that the modifications are simple and easy to review. Subsequent PRs will focus on moving different configurations into separate blocks.

### How to use?
Here is the type definition for the slash menu configuration.  An important change is the new field `group`, which indicates the sorting and grouping of the menu item. See the comments for details.

```ts
// types.ts
export type SlashMenuContext = {
  std: BlockStdScope;
  model: BlockModel;
};

export type SlashMenuItemBase = {
  name: string;
  description?: string;
  icon?: TemplateResult;
  /**
   * This field defines sorting and grouping of menu items like VSCode.
   * The first number indicates the group index, the second number indicates the item index in the group.
   * The group name is the string between `_` and `@`.
   * You can find an example figure in https://code.visualstudio.com/api/references/contribution-points#menu-example
   */
  group?: `${number}_${string}@${number}`;

  /**
   * The condition to show the menu item.
   */
  when?: (ctx: SlashMenuContext) => boolean;
};

export type SlashMenuActionItem = SlashMenuItemBase & {
  action: (ctx: SlashMenuContext) => void;
  tooltip?: SlashMenuTooltip;

  /**
   * The alias of the menu item for search.
   */
  searchAlias?: string[];
};

export type SlashMenuSubMenu = SlashMenuItemBase & {
  subMenu: SlashMenuItem[];
};

export type SlashMenuItem = SlashMenuActionItem | SlashMenuSubMenu;

export type SlashMenuConfig = {
  /**
   * The items in the slash menu. It can be generated dynamically with the context.
   */
  items: SlashMenuItem[] | ((ctx: SlashMenuContext) => SlashMenuItem[]);

  /**
   * Slash menu will not be triggered when the condition is true.
   */
  disableWhen?: (ctx: SlashMenuContext) => boolean;
};

// extensions.ts

/**
 * The extension to add a slash menu items or configure.
 */
export function SlashMenuConfigExtension(ext: {
  id: string;
  config: SlashMenuConfig;
}): ExtensionType {
  return {
    setup: di => {
      di.addImpl(SlashMenuConfigIdentifier(ext.id), ext.config);
    },
  };
}
```

Here is an example, `XXXSlashMenuConfig` adds a `Delete` action to the slash menu, which is assigned to the 8th group named `Actions` at position 0.
```ts
import { SlashMenuConfigExtension, type SlashMenuConfig } from '@blocksuite/affine-widget-slash-menu';

const XXXSlashMenuConfig = SlashMenuConfigExtension({
  id: 'XXX',
  config: {
    items: [
      {
        name: 'Delete',
        description: 'Remove a block.',
        searchAlias: ['remove'],
        icon: DeleteIcon,
        group: '8_Actions@0',
        action: ({ std, model }) => {
          std.host.doc.deleteBlock(model);
        },
      },
    ],
  },
});
```