### PR TITLE
chore(editor): remove unexpected bottom padding of code block

### DIFF
--- a/blocksuite/affine/block-code/src/styles.ts
+++ b/blocksuite/affine/block-code/src/styles.ts
@@ -15,6 +15,10 @@ export const codeBlockStyles = css`
     padding: 12px;
   }
 
+  .affine-code-block-container rich-text {
+    overflow-x: hidden;
+  }
+
   .affine-code-block-container .inline-editor {
     font-family: var(--affine-font-code-family);
     font-variant-ligatures: none;


### PR DESCRIPTION
Close [BS-2765](https://linear.app/affine-design/issue/BS-2765/代码块在字数超出宽度时，下巴变大)

https://github.com/user-attachments/assets/1dc53528-6d36-4b2a-861c-9ca06381c681

