### PR TITLE
refactor(web): insert blew action

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/chat-action-list.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/chat-action-list.ts
@@ -115,43 +115,45 @@ export class ChatActionList extends LitElement {
           actions.filter(action => action.showWhen(host)),
           action => action.title,
           action => {
-            return html`<div class="action">
+            return html`<div
+              class="action"
+              @click=${async () => {
+                if (
+                  action.title === 'Insert below' &&
+                  this._selectionValue.length === 1 &&
+                  this._selectionValue[0].type === 'database'
+                ) {
+                  const element = this.host.view.getBlock(
+                    this._selectionValue[0].blockId
+                  );
+                  if (!element) return;
+                  await insertBelow(host, content, element);
+                  return;
+                }
+                const currentSelections = {
+                  text: this._currentTextSelection,
+                  blocks: this._currentBlockSelections,
+                  images: this._currentImageSelections,
+                };
+                const sessionId = await this.getSessionId();
+                const success = await action.handler(
+                  host,
+                  content,
+                  currentSelections,
+                  sessionId,
+                  messageId
+                );
+                if (success) {
+                  this.host.std.getOptional(NotificationProvider)?.notify({
+                    title: action.toast,
+                    accent: 'success',
+                    onClose: function (): void {},
+                  });
+                }
+              }}
+            >
               ${action.icon}
               <div
-                @click=${async () => {
-                  if (
-                    action.title === 'Insert below' &&
-                    this._selectionValue.length === 1 &&
-                    this._selectionValue[0].type === 'database'
-                  ) {
-                    const element = this.host.view.getBlock(
-                      this._selectionValue[0].blockId
-                    );
-                    if (!element) return;
-                    await insertBelow(host, content, element);
-                    return;
-                  }
-                  const currentSelections = {
-                    text: this._currentTextSelection,
-                    blocks: this._currentBlockSelections,
-                    images: this._currentImageSelections,
-                  };
-                  const sessionId = await this.getSessionId();
-                  const success = await action.handler(
-                    host,
-                    content,
-                    currentSelections,
-                    sessionId,
-                    messageId
-                  );
-                  if (success) {
-                    this.host.std.getOptional(NotificationProvider)?.notify({
-                      title: action.toast,
-                      accent: 'success',
-                      onClose: function (): void {},
-                    });
-                  }
-                }}
                 data-testid="action-${action.title
                   .toLowerCase()
                   .replaceAll(' ', '-')}"


### PR DESCRIPTION
### TL;DR
Refactor the insert below functionality to work with page mode and edgeless mode
* Page Mode
  - Insert content below the current selection
  - If nothing selected, insert content below the last block
* EdgeLess Mode
  - If no note block is currently selected, create the content as a new note block.
  - Otherwise, insert content into the selected note


Close BS-2760

### What changed?
- Created separate insert handlers for page and edgeless modes with context-aware behavior
  - Added support for inserting content when nothing is selected by targeting the last content block
  - Added special handling for edgeless mode to support inserting below selected note blocks
- Removed the "Replace selection" action and consolidated insert functionality
- Optimized the clickable area of the action button