### PR TITLE
fix(editor): incorrect text position in turbo renderer

### DIFF
--- a/blocksuite/affine/shared/src/viewport-renderer/renderer-utils.ts
+++ b/blocksuite/affine/shared/src/viewport-renderer/renderer-utils.ts
@@ -53,13 +53,13 @@ function getParagraphs(host: EditorHost) {
       const sentences = segmentSentences(paragraphNode.textContent || '');
       paragraph.sentences = sentences.map(sentence => {
         const sentenceRects = getSentenceRects(paragraphNode, sentence);
-        const rects = sentenceRects.map(({ rect }) => {
+        const rects = sentenceRects.map(({ text, rect }) => {
           const [modelX, modelY] = clientToModelCoord(viewportRecord, [
             rect.x,
             rect.y,
           ]);
           return {
-            text: sentence,
+            text,
             ...rect,
             rect: {
               x: modelX,
@@ -105,10 +105,7 @@ export function getViewportLayout(
     });
   });
 
-  const layoutModelCoord = clientToModelCoord(viewport, [
-    layoutMinX,
-    layoutMinY,
-  ]);
+  const layoutModelCoord = [layoutMinX, layoutMinY];
   const w = (layoutMaxX - layoutMinX) / zoom / viewport.viewScale;
   const h = (layoutMaxY - layoutMinY) / zoom / viewport.viewScale;
   const layout: ViewportLayout = {


### PR DESCRIPTION
Fixed incorrect text positioning regression across multiple lines (#10624)

Before:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lEGcysB4lFTEbCwZ8jMv/e1d7ba50-d331-41e3-8d31-dee2324e7439.png)

After:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lEGcysB4lFTEbCwZ8jMv/215ec925-65bf-4014-ba6c-db431cb56261.png)
