### PR TITLE
fix(core): should not invert label when its shape text

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/shape.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/shape.tsx
@@ -72,7 +72,8 @@ export const ShapeSettings = () => {
   const { palettes: textColorPalettes, getCurrentColor: getCurrentTextColor } =
     usePalettes(
       DefaultTheme.ShapeTextColorShortPalettes,
-      DefaultTheme.shapeTextColor
+      DefaultTheme.shapeTextColor,
+      true
     );
 
   const [currentShape, setCurrentShape] = useState<ShapeName>(ShapeType.Rect);

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/utils.ts
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/utils.ts
@@ -17,13 +17,14 @@ export const useResolvedTheme = () => {
 
 export const usePalettes = (
   originalPalettes: Palette[],
-  defaultColor: Color
+  defaultColor: Color,
+  isShapeText = false
 ) => {
   const theme = useResolvedTheme();
   const isDark = theme === ColorScheme.Dark;
   const palettes = originalPalettes.map(({ key, value }) => {
     // Title needs to be inverted.
-    if (isDark) {
+    if (!isShapeText && isDark) {
       if (key === 'Black') {
         key = 'White';
       } else if (key === 'White') {


### PR DESCRIPTION
Closes: [BS-2797](https://linear.app/affine-design/issue/BS-2797/在-settings-preview-中，无需对-shape-text-颜色-label-进行反转)

Releated: https://github.com/toeverything/AFFiNE/pull/10546