### PR TITLE
feat(core): add transparent as default shape fill

### DIFF
--- a/blocksuite/affine/model/src/themes/default.ts
+++ b/blocksuite/affine/model/src/themes/default.ts
@@ -49,6 +49,7 @@ const NoteBackgroundColorMap = {
   Black: getColorByKey('edgeless/note/black'),
   Grey: getColorByKey('edgeless/note/grey'),
   White: getColorByKey('edgeless/note/white'),
+  Transparent: Transparent,
 } as const;
 
 const Palettes: Palette[] = [
@@ -78,7 +79,7 @@ const StrokeColorShortPalettes: Palette[] = [
   ...buildPalettes(StrokeColorShortMap),
 ] as const;
 
-const FillColorShortMap = { ...Medium, Black, White } as const;
+const FillColorShortMap = { ...Medium, Black, White, Transparent } as const;
 
 const FillColorShortPalettes: Palette[] = [
   ...buildPalettes(FillColorShortMap),


### PR DESCRIPTION
This PR adds transparent as a default option for shape and note fill color on edgeless mode:

<img width="855" alt="image" src="https://github.com/user-attachments/assets/fa237699-94ec-4757-836f-62720d3272c0" />
