### PR TITLE
chore(editor): use at menu to insert linked doc

### DIFF
--- a/packages/frontend/core/src/blocksuite/extensions/quick-search-service.ts
+++ b/packages/frontend/core/src/blocksuite/extensions/quick-search-service.ts
@@ -152,10 +152,7 @@ export function patchQuickSearchService(framework: FrameworkProvider) {
       overrideFn(BookmarkSlashMenuConfigIdentifier);
 
       const modifyFn = (item: SlashMenuItem): SlashMenuItem => {
-        if (
-          'action' in item &&
-          (item.name === 'Linked Doc' || item.name === 'Link')
-        ) {
+        if ('action' in item && item.name === 'Link') {
           item.action = ({ std }) => {
             const [success, { insertedLinkType }] = std.command.exec(
               insertLinkByQuickSearchCommand

--- a/tests/affine-local/e2e/quick-search.spec.ts
+++ b/tests/affine-local/e2e/quick-search.spec.ts
@@ -525,38 +525,6 @@ test('can paste a doc link to create link reference', async ({ page }) => {
   await expect(page.locator(`affine-link:has-text("${url}")`)).toBeVisible();
 });
 
-test('can use slash menu to insert a newly created doc card', async ({
-  page,
-}) => {
-  await openHomePage(page);
-  // title '1' is a workaround to make sure Keyboard enter works correctly
-  await clickNewPageButton(page, '1');
-
-  // flaky: still focus on the title input
-  // goto main content
-  await page.keyboard.press('Enter');
-
-  // open slash menu
-  await page.keyboard.type('/linkedoc', {
-    delay: 50,
-  });
-  await page.keyboard.press('Enter');
-  await expect(page.getByTestId('cmdk-quick-search')).toBeVisible();
-
-  const testTitle = 'test title';
-  await page.locator('[cmdk-input]').fill(testTitle);
-
-  const addNewPage = page.locator(
-    `[cmdk-item] >> text=New "${testTitle}" Page`
-  );
-  await addNewPage.click();
-
-  await expect(page.locator('affine-embed-linked-doc-block')).toBeVisible();
-  await expect(
-    page.locator('.affine-embed-linked-doc-content-title')
-  ).toContainText(testTitle);
-});
-
 test('can use slash menu to insert an external link', async ({ page }) => {
   await openHomePage(page);
   await clickNewPageButton(page);


### PR DESCRIPTION
Close [BS-2799](https://linear.app/affine-design/issue/BS-2799/区分linked-doc入口)

This PR removes the patch for `Linked Doc` action in the slash menu via the `QuickSearch`, reverting it to use the at menu for inserting.