### PR TITLE
fix(electron): electron fallback container should not contain tabs header

### DIFF
--- a/packages/frontend/core/src/desktop/components/app-container/index.tsx
+++ b/packages/frontend/core/src/desktop/components/app-container/index.tsx
@@ -64,16 +64,18 @@ const DesktopLayout = ({
   const isInWorkspace = !!workspaceService;
   return (
     <div className={styles.desktopAppViewContainer}>
-      <div className={styles.desktopTabsHeader}>
-        <AppTabsHeader
-          left={
-            <>
-              {isInWorkspace && <SidebarSwitch show />}
-              {isInWorkspace && <NavigationButtons />}
-            </>
-          }
-        />
-      </div>
+      {!fallback ? (
+        <div className={styles.desktopTabsHeader}>
+          <AppTabsHeader
+            left={
+              <>
+                {isInWorkspace && <SidebarSwitch show />}
+                {isInWorkspace && <NavigationButtons />}
+              </>
+            }
+          />
+        </div>
+      ) : null}
       <div className={styles.desktopAppViewMain}>
         {fallback ? (
           <AppSidebarFallback />


### PR DESCRIPTION
![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/T2klNLEk0wxLh4NRDzhk/3e8e4838-7f28-453d-bd7f-32bfa96f09ae.png)

fix double tabs header issue when loading from external url