### PR TITLE
refactor(web): save as doc & save as block action

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/_common/chat-actions-handle.ts
+++ b/packages/frontend/core/src/blocksuite/ai/_common/chat-actions-handle.ts
@@ -334,9 +334,9 @@ const EDGELESS_INSERT = {
   },
 };
 
-const SAVE_CHAT_TO_BLOCK_ACTION: ChatAction = {
+const SAVE_AS_BLOCK: ChatAction = {
   icon: BlockIcon({ width: '20px', height: '20px' }),
-  title: 'Save chat to block',
+  title: 'Save as block',
   toast: 'Successfully saved chat to a block',
   showWhen: (host: EditorHost) => {
     if (host.std.store.readonly$.value) {
@@ -470,9 +470,9 @@ const ADD_TO_EDGELESS_AS_NOTE = {
   },
 };
 
-const CREATE_AS_DOC = {
+const SAVE_AS_DOC = {
   icon: PageIcon({ width: '20px', height: '20px' }),
-  title: 'Create as a doc',
+  title: 'Save as doc',
   showWhen: () => true,
   toast: 'New doc created',
   handler: (host: EditorHost, content: string) => {
@@ -577,16 +577,13 @@ const CREATE_AS_LINKED_DOC = {
   },
 };
 
-export const PageEditorActions = [
-  PAGE_INSERT,
-  CREATE_AS_DOC,
-  SAVE_CHAT_TO_BLOCK_ACTION,
-];
+export const PageEditorActions = [PAGE_INSERT, SAVE_AS_DOC, SAVE_AS_BLOCK];
 
 export const EdgelessEditorActions = [
   EDGELESS_INSERT,
   ADD_TO_EDGELESS_AS_NOTE,
-  SAVE_CHAT_TO_BLOCK_ACTION,
+  SAVE_AS_DOC,
+  SAVE_AS_BLOCK,
 ];
 
 export const ChatBlockPeekViewActions = [

--- a/tests/affine-cloud-copilot/e2e/copilot.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/copilot.spec.ts
@@ -387,7 +387,7 @@ test.describe('chat panel', () => {
     await makeChat(page, 'hello');
     const content = (await collectChat(page))[1].content;
     const editor = await page.waitForSelector('page-editor');
-    await page.getByTestId('action-create-as-a-doc').click();
+    await page.getByTestId('action-save-as-doc').click();
     // wait for new editor
     editor.waitForElementState('hidden');
     await page.waitForSelector('page-editor');
@@ -435,7 +435,7 @@ test.describe('chat panel', () => {
     test('can be save chat to block when page mode', async ({ page }) => {
       const contents = (await collectChat(page)).map(m => m.content);
       expect(await getPageMode(page)).toBe('page');
-      await page.getByTestId('action-save-chat-to-block').click();
+      await page.getByTestId('action-save-as-block').click();
       const chatBlock = await page.waitForSelector('affine-edgeless-ai-chat');
       // should switch to edgeless mode
       expect(await getPageMode(page)).toBe('edgeless');
@@ -452,7 +452,7 @@ test.describe('chat panel', () => {
       const contents = (await collectChat(page)).map(m => m.content);
       await switchToEdgelessMode(page);
       expect(await getPageMode(page)).toBe('edgeless');
-      await page.getByTestId('action-save-chat-to-block').click();
+      await page.getByTestId('action-save-as-block').click();
       const chatBlock = await page.waitForSelector('affine-edgeless-ai-chat');
       expect(
         await Promise.all(
@@ -466,7 +466,7 @@ test.describe('chat panel', () => {
     test('can save chat to block and clear history', async ({ page }) => {
       await collectChat(page);
       expect(await getPageMode(page)).toBe('page');
-      await page.getByTestId('action-save-chat-to-block').click();
+      await page.getByTestId('action-save-as-block').click();
       await page.waitForSelector('affine-edgeless-ai-chat');
 
       await page.reload();
@@ -477,7 +477,7 @@ test.describe('chat panel', () => {
 
     test('chat in center peek', async ({ page }) => {
       const contents = (await collectChat(page)).map(m => m.content);
-      await page.getByTestId('action-save-chat-to-block').click();
+      await page.getByTestId('action-save-as-block').click();
       const chatBlock = await page.waitForSelector('affine-edgeless-ai-chat');
       // open chat in center peek
       await chatBlock.dblclick();


### PR DESCRIPTION
### TL;DR

Added "Save as doc" option to Edgeless editor actions.

### What changed?

- Renamed `SAVE_CHAT_TO_BLOCK_ACTION` to `SAVE_AS_BLOCK` and updated its title from "Save chat to block" to "Save as block"
- Renamed `CREATE_AS_DOC` to `SAVE_AS_DOC` and updated its title from "Create as a doc" to "Save as doc"
- Added `SAVE_AS_DOC` to the `EdgelessEditorActions` array, making this option available in the Edgeless editor