### PR TITLE
feat(core): poll context docs and files embedding status

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/types.ts
@@ -242,6 +242,11 @@ declare global {
       ): AIActionTextResponse<T>;
     }
 
+    type AIDocsAndFilesContext = {
+      docs: CopilotContextDoc[];
+      files: CopilotContextFile[];
+    };
+
     interface AIContextService {
       createContext: (
         workspaceId: string,
@@ -274,13 +279,14 @@ declare global {
         workspaceId: string,
         sessionId: string,
         contextId: string
-      ) => Promise<
-        | {
-            docs: Array<CopilotContextDoc>;
-            files: Array<CopilotContextFile>;
-          }
-        | undefined
-      >;
+      ) => Promise<AIDocsAndFilesContext | undefined>;
+      pollContextDocsAndFiles: (
+        workspaceId: string,
+        sessionId: string,
+        contextId: string,
+        onPoll: (result: AIDocsAndFilesContext | undefined) => void,
+        abortSignal: AbortSignal
+      ) => Promise<void>;
       matchContext: (
         contextId: string,
         content: string,

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-context.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-context.ts
@@ -70,13 +70,13 @@ export type ChatBlockMessage = ChatMessage & {
   avatarUrl?: string;
 };
 
-export type ChipState = 'candidate' | 'processing' | 'success' | 'failed';
+export type ChipState = 'candidate' | 'processing' | 'finished' | 'failed';
 
 export interface BaseChip {
   /**
    * candidate: the chip is a candidate for the chat
    * processing: the chip is processing
-   * success: the chip is successfully processed
+   * finished: the chip is successfully processed
    * failed: the chip is failed to process
    */
   state: ChipState;

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-panel-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-panel-input.ts
@@ -226,7 +226,7 @@ export class ChatPanelInput extends SignalWatcher(WithDisposable(LitElement)) {
   private get _isNetworkDisabled() {
     return (
       !!this.chatContextValue.images.length ||
-      !!this.chatContextValue.chips.filter(chip => chip.state === 'success')
+      !!this.chatContextValue.chips.filter(chip => chip.state === 'finished')
         .length
     );
   }
@@ -561,7 +561,7 @@ export class ChatPanelInput extends SignalWatcher(WithDisposable(LitElement)) {
       : [];
     const contexts = this.chatContextValue.chips.reduce(
       (acc, chip, index) => {
-        if (chip.state !== 'success') {
+        if (chip.state !== 'finished') {
           return acc;
         }
         if (isDocChip(chip) && !!chip.markdown?.value) {

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/components/doc-chip.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/components/doc-chip.ts
@@ -112,7 +112,7 @@ export class ChatPanelDocChip extends SignalWatcher(
         const markdown = this.chip.markdown ?? new Signal<string>('');
         markdown.value = value;
         this.updateChip(this.chip, {
-          state: 'success',
+          state: 'finished',
           markdown,
           tokenCount,
         });

--- a/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
+++ b/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
@@ -451,6 +451,38 @@ Could you make a new website based on these notes and send back just the html fi
     ) => {
       return client.getContextDocsAndFiles(workspaceId, sessionId, contextId);
     },
+    pollContextDocsAndFiles: async (
+      workspaceId: string,
+      sessionId: string,
+      contextId: string,
+      onPoll: (
+        result: BlockSuitePresets.AIDocsAndFilesContext | undefined
+      ) => void,
+      abortSignal: AbortSignal
+    ) => {
+      const poll = async () => {
+        const result = await client.getContextDocsAndFiles(
+          workspaceId,
+          sessionId,
+          contextId
+        );
+        onPoll(result);
+      };
+
+      let attempts = 0;
+      const MIN_INTERVAL = 1000;
+      const MAX_INTERVAL = 30 * 1000;
+
+      while (!abortSignal.aborted) {
+        await poll();
+        const interval = Math.min(
+          MIN_INTERVAL * Math.pow(1.5, attempts),
+          MAX_INTERVAL
+        );
+        attempts++;
+        await new Promise(resolve => setTimeout(resolve, interval));
+      }
+    },
     matchContext: async (
       contextId: string,
       content: string,

--- a/tests/affine-cloud-copilot/e2e/copilot.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/copilot.spec.ts
@@ -1026,7 +1026,7 @@ test.describe('chat with doc', () => {
     expect(await chipTitle.textContent()).toBe('Untitled');
     let chip = await page.getByTestId('chat-panel-chip');
     // oxlint-disable-next-line unicorn/prefer-dom-node-dataset
-    expect(await chip.getAttribute('data-state')).toBe('success');
+    expect(await chip.getAttribute('data-state')).toBe('finished');
 
     const editorTitle = await page.locator('doc-title .inline-editor').nth(0);
     await editorTitle.pressSequentially('AFFiNE AI', {
@@ -1048,7 +1048,7 @@ test.describe('chat with doc', () => {
 
     expect(await chipTitle.textContent()).toBe('AFFiNE AI');
     // oxlint-disable-next-line unicorn/prefer-dom-node-dataset
-    expect(await chip.getAttribute('data-state')).toBe('success');
+    expect(await chip.getAttribute('data-state')).toBe('finished');
 
     await typeChatSequentially(page, 'What is AFiAI?');
     await page.keyboard.press('Enter');
@@ -1071,6 +1071,6 @@ test.describe('chat with doc', () => {
     expect(await chipTitle.textContent()).toBe('AFFiNE AI');
     const chip2 = await page.getByTestId('chat-panel-chip');
     // oxlint-disable-next-line unicorn/prefer-dom-node-dataset
-    expect(await chip2.getAttribute('data-state')).toBe('success');
+    expect(await chip2.getAttribute('data-state')).toBe('finished');
   });
 });


### PR DESCRIPTION
Close [BS-2791](https://linear.app/affine-design/issue/BS-2791).

### What Changed?
- Add status filed to `CopilotContextDoc` to querying document embedding processing progress. 
- Change `ChipState` from `success` to `finished` to better align with backend server status.
- Add `pollContextDocsAndFiles` API for embedding status polling.

### About Polling
- Set the minimum interval to 1 second and the maximum interval to 30 seconds
- Use exponential backoff and increase the interval by 50% after each poll
- Make sure the interval does not exceed the maximum