### PR TITLE
feat(editor): embed iframe error status card in surface

### DIFF
--- a/blocksuite/affine/blocks/block-embed/src/embed-iframe-block/components/embed-iframe-loading-card.ts
+++ b/blocksuite/affine/blocks/block-embed/src/embed-iframe-block/components/embed-iframe-loading-card.ts
@@ -8,23 +8,9 @@ import { classMap } from 'lit/directives/class-map.js';
 import { styleMap } from 'lit/directives/style-map.js';
 
 import { getEmbedCardIcons } from '../../common/utils';
+import type { EmbedIframeStatusCardOptions } from '../types';
 
-/**
- * The options for the embed iframe loading card
- * layout: the layout of the card, horizontal or vertical
- * width: the width of the card, if not set, the card width will be 100%
- * height: the height of the card, if not set, the card height will be 100%
- * @example
- * {
- *   layout: 'horizontal',
- *   height: 114,
- * }
- */
-export type EmbedIframeLoadingCardOptions = {
-  layout: 'horizontal' | 'vertical';
-  width?: number;
-  height?: number;
-};
+const LOADING_CARD_DEFAULT_HEIGHT = 114;
 
 export class EmbedIframeLoadingCard extends LitElement {
   static override styles = css`
@@ -199,8 +185,8 @@ export class EmbedIframeLoadingCard extends LitElement {
   accessor std!: BlockStdScope;
 
   @property({ attribute: false })
-  accessor options: EmbedIframeLoadingCardOptions = {
+  accessor options: EmbedIframeStatusCardOptions = {
     layout: 'horizontal',
-    height: 114,
+    height: LOADING_CARD_DEFAULT_HEIGHT,
   };
 }

--- a/blocksuite/affine/blocks/block-embed/src/embed-iframe-block/embed-iframe-block.ts
+++ b/blocksuite/affine/blocks/block-embed/src/embed-iframe-block/embed-iframe-block.ts
@@ -16,10 +16,10 @@ import { html, nothing } from 'lit';
 import { type ClassInfo, classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-import type { EmbedIframeLoadingCardOptions } from './components/embed-iframe-loading-card.js';
 import type { IframeOptions } from './extension/embed-iframe-config.js';
 import { EmbedIframeService } from './extension/embed-iframe-service.js';
 import { embedIframeBlockStyles } from './style.js';
+import type { EmbedIframeStatusCardOptions } from './types.js';
 
 export type EmbedIframeStatus = 'idle' | 'loading' | 'success' | 'error';
 const DEFAULT_IFRAME_HEIGHT = 152;
@@ -75,7 +75,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
     return flag ?? false;
   }
 
-  get _loadingCardOptions(): EmbedIframeLoadingCardOptions {
+  get _statusCardOptions(): EmbedIframeStatusCardOptions {
     return this.inSurface
       ? { layout: 'vertical' }
       : { layout: 'horizontal', height: 114 };
@@ -213,7 +213,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
     if (this.isLoading$.value) {
       return html`<embed-iframe-loading-card
         .std=${this.std}
-        .options=${this._loadingCardOptions}
+        .options=${this._statusCardOptions}
       ></embed-iframe-loading-card>`;
     }
 
@@ -223,6 +223,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
         .model=${this.model}
         .onRetry=${this._handleRetry}
         .std=${this.std}
+        .options=${this._statusCardOptions}
       ></embed-iframe-error-card>`;
     }
 

--- a/blocksuite/affine/blocks/block-embed/src/embed-iframe-block/types.ts
+++ b/blocksuite/affine/blocks/block-embed/src/embed-iframe-block/types.ts
@@ -1,0 +1,16 @@
+/**
+ * The options for the embed iframe status card
+ * layout: the layout of the card, horizontal or vertical
+ * width: the width of the card, if not set, the card width will be 100%
+ * height: the height of the card, if not set, the card height will be 100%
+ * @example
+ * {
+ *   layout: 'horizontal',
+ *   height: 114,
+ * }
+ */
+export type EmbedIframeStatusCardOptions = {
+  layout: 'horizontal' | 'vertical';
+  width?: number;
+  height?: number;
+};


### PR DESCRIPTION
To close [BS-2806](https://linear.app/affine-design/issue/BS-2806/iframe-embed-block-edgeless-loading-and-error-status)