### PR TITLE
fix(editor): descendant elements are missing in edgelessToCanvas

### DIFF
--- a/blocksuite/affine/blocks/block-surface/src/extensions/export-manager/export-manager.ts
+++ b/blocksuite/affine/blocks/block-surface/src/extensions/export-manager/export-manager.ts
@@ -1,6 +1,5 @@
 import {
   FrameBlockModel,
-  GroupElementModel,
   ImageBlockModel,
   type NoteBlockModel,
   type RootBlockModel,
@@ -26,6 +25,7 @@ import {
   type GfxController,
   GfxControllerIdentifier,
   type GfxPrimitiveElementModel,
+  isGfxGroupCompatibleModel,
 } from '@blocksuite/block-std/gfx';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import type { IBound } from '@blocksuite/global/gfx';
@@ -525,8 +525,8 @@ export class ExportManager {
 
     if (surfaces?.length) {
       const surfaceElements = surfaces.flatMap(element =>
-        element instanceof GroupElementModel
-          ? (element.childElements.filter(
+        isGfxGroupCompatibleModel(element)
+          ? (element.descendantElements.filter(
               el => el instanceof SurfaceElementModel
             ) as SurfaceElementModel[])
           : element


### PR DESCRIPTION
### Before

![CleanShot 2025-03-17 at 20.24.39@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/c097d8b2-69df-4965-8e49-3798e930e779.png)

### After

![CleanShot 2025-03-17 at 20.24.17@2x.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyRfgiN4RuBxJfrza3SG/6af03a7d-1e64-4ced-ac4d-e7cbc5648da6.png)

