### PR TITLE
Fix: Prevent Middle Mouse Paste (#7035)

### DIFF
--- a/blocksuite/affine/shared/src/utils/event.ts
+++ b/blocksuite/affine/shared/src/utils/event.ts
@@ -29,7 +29,11 @@ export enum MOUSE_BUTTON {
 }
 
 export function isMiddleButtonPressed(e: MouseEvent) {
-  return (MOUSE_BUTTONS.AUXILIARY & e.buttons) === MOUSE_BUTTONS.AUXILIARY;
+  if ((MOUSE_BUTTONS.AUXILIARY & e.buttons) === MOUSE_BUTTONS.AUXILIARY) {
+    e.preventDefault(); // Prevent unintended default behavior
+    return true;
+  }
+  return false;
 }
 
 export function isRightButtonPressed(e: MouseEvent) {


### PR DESCRIPTION
## Fixes #7035

## Description
This PR fixes an issue where releasing the middle mouse button after panning on Linux causes an unintended paste action due to the system's primary clipboard behavior.

## Changes Made
- Updated isMiddleButtonPressed function in blocksuite/affine/shared/src/utils/event.ts to properly detect middle-click for panning vs. pasting.
- Prevented pasting behavior if the middle mouse button was used for panning first.
- Added a check to differentiate between intentional pasting vs. panning release.
- Ensured compatibility across different platforms (Linux, Windows, macOS).