### PR TITLE
feat(editor): support user provided role and role schema

### DIFF
--- a/blocksuite/affine/blocks/block-surface/src/surface-model.ts
+++ b/blocksuite/affine/blocks/block-surface/src/surface-model.ts
@@ -21,7 +21,7 @@ export const SurfaceBlockSchema = defineBlockSchema({
   metadata: {
     version: 5,
     role: 'hub',
-    parent: ['affine:page'],
+    parent: ['@root'],
     children: [
       'affine:frame',
       'affine:image',

--- a/blocksuite/affine/model/src/blocks/note/note-model.ts
+++ b/blocksuite/affine/model/src/blocks/note/note-model.ts
@@ -25,7 +25,6 @@ import {
   StrokeStyleSchema,
 } from '../../consts/note';
 import { type Color, ColorSchema, DefaultTheme } from '../../themes';
-import { TableModelFlavour } from '../table';
 
 export const NoteZodSchema = z
   .object({
@@ -74,22 +73,12 @@ export const NoteBlockSchema = defineBlockSchema({
   metadata: {
     version: 1,
     role: 'hub',
-    parent: ['affine:page'],
+    parent: ['@root'],
     children: [
-      'affine:paragraph',
-      'affine:list',
-      'affine:code',
-      'affine:divider',
+      '@content',
       'affine:database',
       'affine:data-view',
-      'affine:image',
-      'affine:bookmark',
-      'affine:attachment',
-      'affine:surface-ref',
-      'affine:embed-*',
-      'affine:latex',
       'affine:callout',
-      TableModelFlavour,
     ],
   },
   toModel: () => {

--- a/blocksuite/framework/store/src/model/block/zod.ts
+++ b/blocksuite/framework/store/src/model/block/zod.ts
@@ -8,10 +8,9 @@ import type { BlockModel } from './block-model.js';
 const FlavourSchema = z.string();
 const ParentSchema = z.array(z.string()).optional();
 const ContentSchema = z.array(z.string()).optional();
-const role = ['root', 'hub', 'content'] as const;
-const RoleSchema = z.enum(role);
+const RoleSchema = z.string();
 
-export type RoleType = (typeof role)[number];
+export type RoleType = 'root' | 'content' | string;
 
 export interface InternalPrimitives {
   Text: (input?: Y.Text | string) => Text;


### PR DESCRIPTION
Let me analyze the key changes in this diff:

1. **Role System Changes**:
- Changed from a fixed enum of roles (`root`, `hub`, `content`) to a more flexible string-based system
- Removed strict role hierarchy validation rules (hub/content/root relationships)
- Added support for role-based matching using `@` prefix (e.g., `@root`, `@content`)

2. **Schema Validation Updates**:
- Added new `_matchFlavourOrRole` method to handle both flavour and role-based matching
- Updated `_validateParent` to consider both roles and flavours when validating parent-child relationships
- Simplified `_validateRole` by removing specific role hierarchy constraints

3. **Block Schema Changes**:
- Updated parent/children references in various block schemas to use the new `@` prefix notation
- Changed parent definitions from `['affine:page']` to `['@root']` in several blocks
- Updated children definitions to use role-based references (e.g., `['@content']`)

4. **Test Updates**:
- Added new test cases for role-based schema validation
- Introduced new test block schemas (`TestRoleBlockSchema`, `TestParagraphBlockSchema`) to verify role-based functionality

This appears to be a significant architectural change that makes the block schema system more flexible by:
1. Moving away from hardcoded role hierarchies
2. Introducing a more dynamic role-based relationship system
3. Supporting both flavour-based and role-based parent-child relationships
4. Using the `@` prefix convention to distinguish role references from flavour references

The changes make the system more extensible while maintaining backward compatibility with existing flavour-based relationships.
