### PR TITLE
fix(editor): should not show toolbar when elements have been deleted

### DIFF
--- a/blocksuite/affine/widgets/widget-toolbar/src/toolbar.ts
+++ b/blocksuite/affine/widgets/widget-toolbar/src/toolbar.ts
@@ -157,6 +157,9 @@ export class AffineToolbarWidget extends WidgetComponent {
         .map(id => gfx.getElementById(id))
         .filter(model => model !== null) as GfxModel[];
 
+      // Should double check
+      activated &&= Boolean(elements.length);
+
       hasLocked = elements.some(e => e.isLocked());
 
       const grouped = groupBy(

--- a/tests/affine-local/e2e/blocksuite/toolbar.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/toolbar.spec.ts
@@ -1,5 +1,10 @@
 import { test } from '@affine-test/kit/playwright';
-import { locateToolbar } from '@affine-test/kit/utils/editor';
+import {
+  clickEdgelessModeButton,
+  dragView,
+  locateToolbar,
+  setEdgelessTool,
+} from '@affine-test/kit/utils/editor';
 import { selectAllByKeyboard } from '@affine-test/kit/utils/keyboard';
 import { openHomePage } from '@affine-test/kit/utils/load-page';
 import {
@@ -157,4 +162,37 @@ test.describe('Formatting', () => {
     await expect(textSpan1).toHaveCSS('background-color', hexToRGB(bgColor));
     await expect(textSpan2).toHaveCSS('background-color', hexToRGB(bgColor));
   });
+});
+
+test('should not show toolbar when releasing spacebar and elements have been deleted', async ({
+  page,
+}) => {
+  await clickEdgelessModeButton(page);
+
+  await setEdgelessTool(page, 'shape');
+  await dragView(page, [100, 300], [200, 400]);
+
+  const toolbar = locateToolbar(page);
+
+  await expect(toolbar).toBeVisible();
+
+  await page.keyboard.down('Space');
+
+  await expect(toolbar).toBeHidden();
+
+  await page.keyboard.up('Space');
+
+  await expect(toolbar).toBeVisible();
+
+  await page.keyboard.press('Delete');
+
+  await expect(toolbar).toBeHidden();
+
+  await page.keyboard.down('Space');
+
+  await expect(toolbar).toBeHidden();
+
+  await page.keyboard.up('Space');
+
+  await expect(toolbar).toBeHidden();
 });


### PR DESCRIPTION
Closes: [BS-2691](https://linear.app/affine-design/issue/BS-2691/[bug]-当-edgeless-为空的时候，点击-space-会在左上角出现一个莫名的-toolbar)