### PR TITLE
fix(editor): description of linked doc should be displayed on multiple lines

### DIFF
--- a/blocksuite/affine/blocks/block-embed/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/blocksuite/affine/blocks/block-embed/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -33,6 +33,7 @@ import { computed } from '@preact/signals-core';
 import { html, nothing } from 'lit';
 import { property, queryAsync, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { repeat } from 'lit/directives/repeat.js';
 import { styleMap } from 'lit/directives/style-map.js';
 import { when } from 'lit/directives/when.js';
 import throttle from 'lodash-es/throttle';
@@ -452,7 +453,10 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
               hasDescriptionAlias,
               () =>
                 html`<div class="affine-embed-linked-doc-content-note alias">
-                  ${description}
+                  ${repeat(
+                    (description.value ?? '').split('\n'),
+                    text => html`<p>${text}</p>`
+                  )}
                 </div>`,
               () =>
                 when(

--- a/blocksuite/affine/blocks/block-embed/src/embed-linked-doc-block/styles.ts
+++ b/blocksuite/affine/blocks/block-embed/src/embed-linked-doc-block/styles.ts
@@ -97,6 +97,10 @@ export const styles = css`
     font-style: normal;
     font-weight: 400;
     line-height: 20px;
+
+    p {
+      padding: 0 2px;
+    }
   }
 
   .affine-embed-linked-doc-content-note.alias {


### PR DESCRIPTION
Closes: [BS-2902](https://linear.app/affine-design/issue/BS-2902/有个bug，这个编辑之后换行会没有-fundon)