### PR TITLE
feat(infra): livedata react hook add deps

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -238,7 +238,7 @@ export default tseslint.config(
         'warn',
         {
           additionalHooks:
-            '(useAsyncCallback|useCatchEventCallback|useDraggable|useDropTarget|useRefEffect)',
+            '(useAsyncCallback|useCatchEventCallback|useDraggable|useDropTarget|useRefEffect|useLiveData)',
         },
       ],
       'rxjs/finnish': [

--- a/packages/common/infra/src/livedata/__tests__/react.spec.tsx
+++ b/packages/common/infra/src/livedata/__tests__/react.spec.tsx
@@ -3,7 +3,6 @@
  */
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
-import { useMemo } from 'react';
 import type { Subscriber } from 'rxjs';
 import { Observable } from 'rxjs';
 import { afterEach, describe, expect, test, vi } from 'vitest';
@@ -20,6 +19,22 @@ describe('livedata', () => {
     const Component = () => {
       renderCount++;
       const value = useLiveData(livedata$);
+      return <main>{value}</main>;
+    };
+    render(<Component />);
+    expect(screen.getByRole('main').innerText).toBe('0');
+    livedata$.next(1);
+    // wait for rerender
+    await waitFor(() => expect(screen.getByRole('main').innerText).toBe('1'));
+    expect(renderCount).toBe(2);
+  });
+
+  test('react with deps', async () => {
+    const livedata$ = new LiveData(0);
+    let renderCount = 0;
+    const Component = () => {
+      renderCount++;
+      const value = useLiveData(() => livedata$, []);
       return <main>{value}</main>;
     };
     render(<Component />);
@@ -83,14 +98,12 @@ describe('livedata', () => {
     const Component = () => {
       renderCount++;
       const value = useLiveData(
-        useMemo(
-          () =>
-            livedata$.map(v => {
-              objectCopyCount++;
-              return { ...v };
-            }),
-          []
-        )
+        () =>
+          livedata$.map(v => {
+            objectCopyCount++;
+            return { ...v };
+          }),
+        []
       );
       return <main>{value.hello}</main>;
     };

--- a/packages/common/infra/src/livedata/react.ts
+++ b/packages/common/infra/src/livedata/react.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from 'react';
+import { type DependencyList, useMemo, useSyncExternalStore } from 'react';
 
 import type { LiveData } from './livedata';
 
@@ -18,7 +18,8 @@ function undefinedGetSnapshot() {
  * subscribe LiveData and return the value.
  */
 export function useLiveData<Input extends LiveData<any> | null | undefined>(
-  liveData: Input
+  liveDataOrFn: Input | (() => Input),
+  deps?: any[]
 ): NonNullable<Input> extends LiveData<infer T>
   ? Input extends undefined
     ? T | undefined
@@ -26,6 +27,11 @@ export function useLiveData<Input extends LiveData<any> | null | undefined>(
       ? T | null
       : T
   : never {
+  const liveData = useMemo(() => {
+    return typeof liveDataOrFn === 'function' ? liveDataOrFn() : liveDataOrFn;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps as DependencyList);
+
   return useSyncExternalStore(
     liveData ? liveData.reactSubscribe : noopSubscribe,
     liveData

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/audio/transcription-block.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/audio/transcription-block.tsx
@@ -2,7 +2,7 @@ import { createReactComponentFromLit } from '@affine/component';
 import { LitTranscriptionBlock } from '@affine/core/blocksuite/ai/blocks/ai-chat-block/ai-transcription-block';
 import type { TranscriptionBlockModel } from '@blocksuite/affine/model';
 import { LiveData, useLiveData } from '@toeverything/infra';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback } from 'react';
 
 import * as styles from './transcription-block.css';
 
@@ -16,11 +16,10 @@ export const TranscriptionBlock = ({
 }: {
   block: TranscriptionBlockModel;
 }) => {
-  const childMap$ = useMemo(
+  const childMap = useLiveData(
     () => LiveData.fromSignal(block.childMap),
     [block.childMap]
   );
-  const childMap = useLiveData(childMap$);
   const onDragStart = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
   }, []);

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/pdf/pdf-viewer-embedded.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/pdf/pdf-viewer-embedded.tsx
@@ -54,16 +54,17 @@ export function PDFViewerEmbedded({ model }: AttachmentViewerProps) {
   const [pageSize, setPageSize] = useState<PageSize | null>(null);
 
   const meta = useLiveData(
-    useMemo(() => {
-      return pdfEntity
+    () =>
+      pdfEntity
         ? pdfEntity.pdf.state$.map(s => {
             return s.status === PDFStatus.Opened ? s.meta : defaultMeta();
           })
-        : new LiveData<PDFMeta>(defaultMeta());
-    }, [pdfEntity])
+        : new LiveData<PDFMeta>(defaultMeta()),
+    [pdfEntity]
   );
   const img = useLiveData(
-    useMemo(() => (pageEntity ? pageEntity.page.bitmap$ : null), [pageEntity])
+    () => (pageEntity ? pageEntity.page.bitmap$ : null),
+    [pageEntity]
   );
 
   const [name, setName] = useState(model.props.name);

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/bi-directional-link-panel.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/bi-directional-link-panel.tsx
@@ -178,24 +178,26 @@ const useBacklinkGroups: () => BacklinkGroups[] = () => {
   });
 
   const backlinkGroups = useLiveData(
-    LiveData.computed(get => {
-      const links = get(docLinksService.backlinks.backlinks$);
+    () =>
+      LiveData.computed(get => {
+        const links = get(docLinksService.backlinks.backlinks$);
 
-      // group by docId
-      const groupedLinks = links.reduce(
-        (acc, link) => {
-          acc[link.docId] = [...(acc[link.docId] || []), link];
-          return acc;
-        },
-        {} as Record<string, Backlink[]>
-      );
+        // group by docId
+        const groupedLinks = links.reduce(
+          (acc, link) => {
+            acc[link.docId] = [...(acc[link.docId] || []), link];
+            return acc;
+          },
+          {} as Record<string, Backlink[]>
+        );
 
-      return Object.entries(groupedLinks).map(([docId, links]) => ({
-        docId,
-        title: links[0].title, // title should be the same for all blocks
-        links,
-      }));
-    })
+        return Object.entries(groupedLinks).map(([docId, links]) => ({
+          docId,
+          title: links[0].title, // title should be the same for all blocks
+          links,
+        }));
+      }),
+    [docLinksService.backlinks.backlinks$]
   );
 
   return backlinkGroups;
@@ -266,7 +268,10 @@ export const LinkPreview = ({
   textRendererOptions: TextRendererOptions;
 }) => {
   const guardService = useService(GuardService);
-  const canAccess = useLiveData(guardService.can$('Doc_Read', linkGroup.docId));
+  const canAccess = useLiveData(
+    () => guardService.can$('Doc_Read', linkGroup.docId),
+    [linkGroup.docId, guardService]
+  );
   const t = useI18n();
 
   if (!canAccess) {

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/starter-bar.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/starter-bar.tsx
@@ -27,7 +27,6 @@ import {
   type HTMLAttributes,
   useCallback,
   useEffect,
-  useMemo,
   useState,
 } from 'react';
 
@@ -66,10 +65,8 @@ const StarterBarNotEmpty = ({ doc }: { doc: Store }) => {
   const [templateMenuOpen, setTemplateMenuOpen] = useState(false);
 
   const isTemplate = useLiveData(
-    useMemo(
-      () => templateDocService.list.isTemplate$(doc.id),
-      [doc.id, templateDocService.list]
-    )
+    () => templateDocService.list.isTemplate$(doc.id),
+    [doc.id, templateDocService.list]
   );
   const enableAI = useLiveData(featureFlagService.flags.enable_ai.$);
 
@@ -172,10 +169,8 @@ export const StarterBar = ({ doc }: { doc: Store }) => {
   const templateDocService = useService(TemplateDocService);
 
   const isTemplate = useLiveData(
-    useMemo(
-      () => templateDocService.list.isTemplate$(doc.id),
-      [doc.id, templateDocService.list]
-    )
+    () => templateDocService.list.isTemplate$(doc.id),
+    [doc.id, templateDocService.list]
   );
 
   useEffect(() => {

--- a/packages/frontend/core/src/blocksuite/block-suite-header/menu/index.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-header/menu/index.tsx
@@ -333,8 +333,14 @@ const PageHeaderMenuItem = ({
     openInAppService?.showOpenInAppPage();
   }, [openInAppService]);
 
-  const canEdit = useLiveData(guardService.can$('Doc_Update', pageId));
-  const canMoveToTrash = useLiveData(guardService.can$('Doc_Trash', pageId));
+  const canEdit = useLiveData(
+    () => guardService.can$('Doc_Update', pageId),
+    [pageId, guardService]
+  );
+  const canMoveToTrash = useLiveData(
+    () => guardService.can$('Doc_Trash', pageId),
+    [pageId, guardService]
+  );
 
   return (
     <>

--- a/packages/frontend/core/src/blocksuite/block-suite-header/title/index.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-header/title/index.tsx
@@ -38,7 +38,8 @@ export const BlocksuiteHeaderTitle = (props: BlockSuiteHeaderTitleProps) => {
   );
 
   const canEdit = useLiveData(
-    guardService.can$('Doc_Update', docService.doc.id)
+    () => guardService.can$('Doc_Update', docService.doc.id),
+    [docService.doc.id, guardService]
   );
 
   return (

--- a/packages/frontend/core/src/components/affine/page-history-modal/history-modal.tsx
+++ b/packages/frontend/core/src/components/affine/page-history-modal/history-modal.tsx
@@ -441,7 +441,10 @@ const PageHistoryManager = ({
   const i18n = useI18n();
 
   const title = useLiveData(docDisplayMetaService.title$(pageId));
-  const canEdit = useLiveData(guardService.can$('Doc_Update', pageDocId));
+  const canEdit = useLiveData(
+    () => guardService.can$('Doc_Update', pageDocId),
+    [pageDocId, guardService]
+  );
 
   const onConfirmRestore = useCallback(() => {
     openConfirmModal({

--- a/packages/frontend/core/src/components/doc-properties/manager/index.tsx
+++ b/packages/frontend/core/src/components/doc-properties/manager/index.tsx
@@ -43,7 +43,8 @@ const PropertyItem = ({
   const docsService = useService(DocsService);
   const [moreMenuOpen, setMoreMenuOpen] = useState(defaultOpenEditMenu);
   const canEditPropertyInfo = useLiveData(
-    guardService.can$('Workspace_Properties_Update')
+    () => guardService.can$('Workspace_Properties_Update'),
+    [guardService]
   );
 
   const typeInfo = isSupportedDocPropertyType(propertyInfo.type)

--- a/packages/frontend/core/src/components/doc-properties/sidebar/index.tsx
+++ b/packages/frontend/core/src/components/doc-properties/sidebar/index.tsx
@@ -33,7 +33,8 @@ export const DocPropertySidebar = () => {
   const propertyList = docsService.propertyList;
   const properties = useLiveData(propertyList.properties$);
   const canEditPropertyInfo = useLiveData(
-    guardService.can$('Workspace_Properties_Update')
+    () => guardService.can$('Workspace_Properties_Update'),
+    [guardService]
   );
   const onAddProperty = useCallback(
     (option: { type: string; name: string }) => {

--- a/packages/frontend/core/src/components/doc-properties/table.tsx
+++ b/packages/frontend/core/src/components/doc-properties/table.tsx
@@ -297,10 +297,12 @@ const DocWorkspacePropertiesTableBody = forwardRef<
     const [newPropertyId, setNewPropertyId] = useState<string | null>(null);
 
     const canEditProperty = useLiveData(
-      guardService.can$('Doc_Update', docService.doc.id)
+      () => guardService.can$('Doc_Update', docService.doc.id),
+      [docService.doc.id, guardService]
     );
     const canEditPropertyInfo = useLiveData(
-      guardService.can$('Workspace_Properties_Update')
+      () => guardService.can$('Workspace_Properties_Update'),
+      [guardService]
     );
 
     const handlePropertyAdded = useCallback(

--- a/packages/frontend/core/src/components/guard/doc-guard.tsx
+++ b/packages/frontend/core/src/components/guard/doc-guard.tsx
@@ -15,7 +15,10 @@ export const DocPermissionGuard = ({
   children: (can: boolean | undefined) => React.ReactNode;
 }) => {
   const guardService = useService(GuardService);
-  const can = useLiveData(guardService.can$(permission, docId));
+  const can = useLiveData(
+    () => guardService.can$(permission, docId),
+    [permission, docId, guardService]
+  );
 
   if (typeof children === 'function') {
     return children(can);

--- a/packages/frontend/core/src/components/page-list/operation-cell.tsx
+++ b/packages/frontend/core/src/components/page-list/operation-cell.tsx
@@ -76,7 +76,10 @@ const PageOperationCellMenuItem = ({
     GuardService,
   });
 
-  const canMoveToTrash = useLiveData(guardService.can$('Doc_Trash', page.id));
+  const canMoveToTrash = useLiveData(
+    () => guardService.can$('Doc_Trash', page.id),
+    [page.id, guardService]
+  );
   const currentWorkspace = workspaceService.workspace;
   const favourite = useLiveData(favAdapter.isFavorite$(page.id, 'doc'));
   const workbench = workbenchService.workbench;

--- a/packages/frontend/core/src/desktop/dialogs/doc-info/info-modal.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/doc-info/info-modal.tsx
@@ -40,16 +40,18 @@ export const InfoTable = ({
     GuardService,
   });
   const canEditPropertyInfo = useLiveData(
-    guardService.can$('Workspace_Properties_Update')
+    () => guardService.can$('Workspace_Properties_Update'),
+    [guardService]
   );
-  const canEditProperty = useLiveData(guardService.can$('Doc_Update', docId));
+  const canEditProperty = useLiveData(
+    () => guardService.can$('Doc_Update', docId),
+    [docId, guardService]
+  );
   const [newPropertyId, setNewPropertyId] = useState<string | null>(null);
   const properties = useLiveData(docsService.propertyList.sortedProperties$);
   const links = useLiveData(
-    useMemo(
-      () => LiveData.from(docsSearchService.watchRefsFrom(docId), null),
-      [docId, docsSearchService]
-    )
+    () => LiveData.from(docsSearchService.watchRefsFrom(docId), null),
+    [docId, docsSearchService]
   );
 
   const backlinks = useLiveData(

--- a/packages/frontend/core/src/desktop/dialogs/selectors/collection.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/selectors/collection.tsx
@@ -23,7 +23,8 @@ const FavoriteOperation = ({ collection }: { collection: ListItem }) => {
   const t = useI18n();
   const favAdapter = useService(CompatibleFavoriteItemsAdapter);
   const isFavorite = useLiveData(
-    favAdapter.isFavorite$(collection.id, 'collection')
+    () => favAdapter.isFavorite$(collection.id, 'collection'),
+    [collection, favAdapter]
   );
 
   const onToggleFavoriteCollection = useCallback(() => {

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
@@ -381,7 +381,8 @@ export const Component = () => {
 
   const pageId = params.pageId;
   const canAccess = useLiveData(
-    pageId ? guardService.can$('Doc_Read', pageId) : undefined
+    () => (pageId ? guardService.can$('Doc_Read', pageId) : undefined),
+    [pageId, guardService]
   );
 
   return pageId ? (

--- a/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
@@ -192,7 +192,10 @@ const DetailPageImpl = () => {
     [docCollection.id, editor, jumpToPageBlock, openPage, server]
   );
 
-  const canEdit = useLiveData(guardService.can$('Doc_Update', doc.id));
+  const canEdit = useLiveData(
+    () => guardService.can$('Doc_Update', doc.id),
+    [doc.id, guardService]
+  );
 
   const readonly =
     !canEdit ||
@@ -255,7 +258,10 @@ const MobileDetailPage = ({
   const title = useLiveData(docDisplayMetaService.title$(pageId));
 
   const guardService = useService(GuardService);
-  const canAccess = useLiveData(guardService.can$('Doc_Read', pageId));
+  const canAccess = useLiveData(
+    () => guardService.can$('Doc_Read', pageId),
+    [pageId, guardService]
+  );
 
   const allJournalDates = useLiveData(journalService.allJournalDates$);
 

--- a/packages/frontend/core/src/mobile/pages/workspace/detail/page-header-more-button.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/detail/page-header-more-button.tsx
@@ -36,7 +36,10 @@ export const PageHeaderMenuButton = () => {
 
   const docId = useService(DocService).doc.id;
   const guardService = useService(GuardService);
-  const canEdit = useLiveData(guardService.can$('Doc_Update', docId));
+  const canEdit = useLiveData(
+    () => guardService.can$('Doc_Update', docId),
+    [docId, guardService]
+  );
 
   const editorService = useService(EditorService);
   const editorContainer = useLiveData(editorService.editor.editorContainer$);

--- a/packages/frontend/core/src/modules/peek-view/view/doc-preview/doc-peek-view.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/doc-preview/doc-peek-view.tsx
@@ -151,7 +151,10 @@ function DocPeekPreviewEditor({
     peekView.close();
   }, [doc, peekView, workbench]);
 
-  const canEdit = useLiveData(guardService.can$('Doc_Update', doc.id));
+  const canEdit = useLiveData(
+    () => guardService.can$('Doc_Update', doc.id),
+    [doc.id, guardService]
+  );
 
   const readonly = !canEdit || isInTrash;
 
@@ -221,7 +224,10 @@ export function DocPeekPreview({
   );
 
   const guardService = useService(GuardService);
-  const canAccess = useLiveData(guardService.can$('Doc_Read', docId));
+  const canAccess = useLiveData(
+    () => guardService.can$('Doc_Read', docId),
+    [docId, guardService]
+  );
 
   // if sync engine has been synced and the page is null, show 404 page.
   if (!doc || !editor || !canAccess) {

--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-item.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-item.tsx
@@ -143,7 +143,8 @@ const Options = ({
     useLiveData(guardService.can$('Doc_TransferOwner', docService.doc.id)) &&
     !!isWorkspaceOwner;
   const canManageUsers = useLiveData(
-    guardService.can$('Doc_Users_Manage', docService.doc.id)
+    () => guardService.can$('Doc_Users_Manage', docService.doc.id),
+    [docService.doc.id, guardService]
   );
 
   const updateUserRole = useCallback(

--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-management.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/member-management/member-management.tsx
@@ -36,7 +36,8 @@ export const MemberManagement = ({
   const guardService = useService(GuardService);
 
   const canManageUsers = useLiveData(
-    guardService.can$('Doc_Users_Manage', docService.doc.id)
+    () => guardService.can$('Doc_Users_Manage', docService.doc.id),
+    [docService.doc.id, guardService]
   );
 
   const t = useI18n();

--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/share-page.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/share-page.tsx
@@ -67,11 +67,13 @@ export const AFFiNESharePage = (
   const guardService = useService(GuardService);
 
   const canManageUsers = useLiveData(
-    guardService.can$('Doc_Users_Manage', docService.doc.id)
+    () => guardService.can$('Doc_Users_Manage', docService.doc.id),
+    [docService.doc.id, guardService]
   );
 
   const canPublish = useLiveData(
-    guardService.can$('Doc_Publish', docService.doc.id)
+    () => guardService.can$('Doc_Publish', docService.doc.id),
+    [docService.doc.id, guardService]
   );
 
   useEffect(() => {


### PR DESCRIPTION
a new mode to `useLiveData` hook

```ts
useLiveData(
  () => xxx$,
  [deps1, deps2]
)
```

This is equal to

```ts
useLiveData(
  useMemo(
    () => xxx$,
    [deps1, deps2]
  )
)
```

This is because some subscribe have side effects, such as `guardService.can$()` will revalidate permissions on each call.

Now we use

```ts
useLiveData(
  () => guardService.can$("Doc.Read", docId),
  [guardService, docId]
)
```

this guaranteed `can$` is only called once
