### PR TITLE
fix: youtube block style

### DIFF
--- a/blocksuite/affine/blocks/block-embed/src/embed-youtube-block/embed-youtube-block.ts
+++ b/blocksuite/affine/blocks/block-embed/src/embed-youtube-block/embed-youtube-block.ts
@@ -135,7 +135,6 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
             selected: this.selected$.value,
           })}
           style=${styleMap({
-            transform: `scale(${this._scale})`,
             transformOrigin: '0 0',
           })}
           @click=${this._handleClick}


### PR DESCRIPTION
Fixes [BS-2687](https://linear.app/affine-design/issue/BS-2687/[bug]-video-block-缩放选区坏掉)