### PR TITLE
ci: increase cloud E2E test shards from 3 to 6

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -793,15 +793,24 @@ jobs:
       fail-fast: false
       matrix:
         tests:
-          - name: 'Cloud E2E Test 1/3'
+          - name: 'Cloud E2E Test 1/6'
             shard: 1
-            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=1/3
-          - name: 'Cloud E2E Test 2/3'
+            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=1/6
+          - name: 'Cloud E2E Test 2/6'
             shard: 2
-            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=2/3
-          - name: 'Cloud E2E Test 3/3'
+            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=2/6
+          - name: 'Cloud E2E Test 3/6'
             shard: 3
-            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=3/3
+            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=3/6
+          - name: 'Cloud E2E Test 4/6'
+            shard: 4
+            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=4/6
+          - name: 'Cloud E2E Test 5/6'
+            shard: 5
+            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=5/6
+          - name: 'Cloud E2E Test 6/6'
+            shard: 6
+            script: yarn affine @affine-test/affine-cloud e2e --forbid-only --shard=6/6
           - name: 'Cloud Desktop E2E Test'
             shard: desktop
             script: |


### PR DESCRIPTION
Before 10m

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/hTwOityLamd4hitrae7M/e9698e8f-2220-475e-a6e3-21cca48398e3.png)

After 8m

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/hTwOityLamd4hitrae7M/e6e63736-dd03-4ee8-9ddc-652f71f15067.png)

