### PR TITLE
refactor(editor): enable forceUpdate by default in viewport apis

### DIFF
--- a/blocksuite/framework/std/src/gfx/viewport.ts
+++ b/blocksuite/framework/std/src/gfx/viewport.ts
@@ -144,7 +144,7 @@ export class Viewport {
     const newCenterX = initialTopLeftX + width / (2 * this.zoom);
     const newCenterY = initialTopLeftY + height / (2 * this.zoom);
 
-    this.setCenter(newCenterX, newCenterY);
+    this.setCenter(newCenterX, newCenterY, false);
     this._width = width;
     this._height = height;
     this._left = left;
@@ -362,7 +362,7 @@ export class Viewport {
    * @param centerY The new y coordinate of the center of the viewport.
    * @param forceUpdate Whether to force complete any pending resize operations before setting the viewport.
    */
-  setCenter(centerX: number, centerY: number, forceUpdate = false) {
+  setCenter(centerX: number, centerY: number, forceUpdate = true) {
     if (forceUpdate && this._isResizing) {
       this._forceCompleteResize();
     }
@@ -405,7 +405,7 @@ export class Viewport {
     newZoom: number,
     newCenter = Vec.toVec(this.center),
     smooth = false,
-    forceUpdate = smooth
+    forceUpdate = true
   ) {
     // Force complete any pending resize operations if forceUpdate is true
     if (forceUpdate && this._isResizing) {
@@ -445,7 +445,7 @@ export class Viewport {
     bound: Bound,
     padding: [number, number, number, number] = [0, 0, 0, 0],
     smooth = false,
-    forceUpdate = smooth
+    forceUpdate = true
   ) {
     let [pt, pr, pb, pl] = padding;
 
@@ -511,7 +511,7 @@ export class Viewport {
     zoom: number,
     focusPoint?: IPoint,
     wheel = false,
-    forceUpdate = false
+    forceUpdate = true
   ) {
     if (forceUpdate && this._isResizing) {
       this._forceCompleteResize();

--- a/packages/frontend/core/src/blocksuite/extensions/note-config/index.tsx
+++ b/packages/frontend/core/src/blocksuite/extensions/note-config/index.tsx
@@ -90,7 +90,7 @@ export function patchForEdgelessNoteConfig(
           ]);
 
           const center = Vec.sub(edgelessTitleAnchor, pageTitleAnchor);
-          gfx.viewport.setCenter(center[0], center[1], true);
+          gfx.viewport.setCenter(center[0], center[1]);
           gfx.viewport.smoothZoom(0.65, undefined, 15);
 
           return true;

--- a/packages/frontend/core/src/modules/peek-view/view/doc-preview/doc-peek-view.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/doc-preview/doc-peek-view.tsx
@@ -58,8 +58,7 @@ function fitViewport(
       viewport.setViewportByBound(
         Bound.deserialize(newViewport.xywh),
         newViewport.padding,
-        false,
-        true
+        false
       );
     } else {
       gfx.fitToScreen({


### PR DESCRIPTION
In this way, all downstream callers can be guaranteed by correct viewport fit result, instead of requiring them to set `forceUpdate: true` param explicitly to them. The resizing optimization is an internal exception.
