### PR TITLE
fix: note should hide collapse button in presentation mode

### DIFF
--- a/blocksuite/affine/blocks/block-note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/blocks/block-note/src/note-edgeless-block.ts
@@ -216,6 +216,8 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
     const { borderRadius } = edgeless.style;
     const { collapse = false, collapsedHeight, scale = 1 } = edgeless;
 
+    const { tool } = this.gfx;
+
     const bound = Bound.deserialize(xywh);
     const height = bound.h / scale;
 
@@ -280,7 +282,9 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
           .editing=${this._editing}
         ></edgeless-note-mask>
 
-        ${isCollapsable && (!this.model.isPageBlock() || !hasHeader)
+        ${isCollapsable &&
+        tool.currentToolName$.value !== 'frameNavigator' &&
+        (!this.model.isPageBlock() || !hasHeader)
           ? html`<div
               class="${classMap({
                 [styles.collapseButton]: true,

--- a/tests/blocksuite/e2e/edgeless/presentation.spec.ts
+++ b/tests/blocksuite/e2e/edgeless/presentation.spec.ts
@@ -9,8 +9,11 @@ import {
   edgelessCommonSetup,
   enterPresentationMode,
   locatorPresentationToolbarButton,
+  resizeElementByHandle,
+  selectNoteInEdgeless,
   setEdgelessTool,
   Shape,
+  switchEditorMode,
   toggleFramePanel,
 } from '../utils/actions/edgeless.js';
 import {
@@ -19,7 +22,11 @@ import {
   pressEscape,
   selectAllBlocksByKeyboard,
 } from '../utils/actions/keyboard.js';
-import { waitNextFrame } from '../utils/actions/misc.js';
+import {
+  enterPlaygroundRoom,
+  initEmptyEdgelessState,
+  waitNextFrame,
+} from '../utils/actions/misc.js';
 import { test } from '../utils/playwright.js';
 
 test.describe('presentation', () => {
@@ -245,5 +252,23 @@ test.describe('presentation', () => {
     await expect(frameItems.nth(5)).toHaveText('Frame 2');
     await expect(frameItems.nth(6)).toHaveText('Frame 3');
     await expect(frameItems.nth(7)).toHaveText('Frame 4');
+  });
+
+  test('note should hide the collapse button when enter presentation mode', async ({
+    page,
+  }) => {
+    await enterPlaygroundRoom(page);
+    const { noteId } = await initEmptyEdgelessState(page);
+    await switchEditorMode(page);
+
+    await selectNoteInEdgeless(page, noteId);
+    await resizeElementByHandle(page, { x: 0, y: 70 }, 'bottom-right');
+
+    await createFrame(page, [100, 100], [100, 200]);
+
+    await enterPresentationMode(page);
+
+    const collapseButton = page.getByTestId('edgeless-note-collapse-button');
+    await expect(collapseButton).not.toBeVisible();
   });
 });


### PR DESCRIPTION
Fixes [BS-1003](https://linear.app/affine-design/issue/BS-1003/ppt-演示状态下-note-会显示折叠箭头)