### PR TITLE
fix(editor): adjust highlighter color

### DIFF
--- a/blocksuite/affine/gfx/brush/src/toolbar/components/pen/pen-menu.ts
+++ b/blocksuite/affine/gfx/brush/src/toolbar/components/pen/pen-menu.ts
@@ -73,7 +73,7 @@ export class EdgelessPenMenu extends EdgelessToolbarToolMixin(
   private readonly _onPickColor = (e: ColorEvent) => {
     let color = e.detail.value;
     if (this.pen$.peek() === 'highlighter') {
-      color = adjustColorAlpha(color, 0.5);
+      color = adjustColorAlpha(color, 0.3);
     }
     this.onChange({ color });
   };

--- a/blocksuite/affine/gfx/brush/src/toolbar/configs/highlighter.ts
+++ b/blocksuite/affine/gfx/brush/src/toolbar/configs/highlighter.ts
@@ -90,7 +90,7 @@ export const highlighterToolbarConfig = {
         );
         const onPick = (e: PickColorEvent) => {
           if (e.type === 'pick') {
-            const color = adjustColorAlpha(e.detail.value, 0.5);
+            const color = adjustColorAlpha(e.detail.value, 0.3);
             for (const model of models) {
               const props = packColor(field, color);
               ctx.std

--- a/blocksuite/affine/model/src/themes/default.ts
+++ b/blocksuite/affine/model/src/themes/default.ts
@@ -124,8 +124,8 @@ export const DefaultTheme: Theme = {
   shapeFillColor: Medium.Yellow,
   connectorColor: Medium.Grey,
   noteBackgrounColor: NoteBackgroundColorMap.White,
-  // 50% transparent `Default.black`
-  hightlighterColor: { dark: '#ffffff80', light: '#00000080' },
+  // 30% transparent `Medium.Blue`
+  hightlighterColor: '#84cfff4d',
   Palettes,
   ShapeTextColorPalettes,
   NoteBackgroundColorMap,


### PR DESCRIPTION
Closes: [BS-2980](https://linear.app/affine-design/issue/BS-2980/highlighter透明度改为30percent) [BS-2979](https://linear.app/affine-design/issue/BS-2979/highlighter默认选择颜色为蓝色)