### PR TITLE
fix(editor): undo should remove the new frame created by dragging

### DIFF
--- a/blocksuite/affine/blocks/block-frame/src/frame-tool.ts
+++ b/blocksuite/affine/blocks/block-frame/src/frame-tool.ts
@@ -38,9 +38,7 @@ export class FrameTool extends BaseTool {
   override dragEnd(): void {
     if (this._frame) {
       const frame = this._frame;
-      this.doc.transact(() => {
-        frame.pop('xywh');
-      });
+      frame.pop('xywh');
       // @ts-expect-error TODO: refactor gfx tool
       this.gfx.tool.setTool('default');
       this.gfx.selection.set({
@@ -52,8 +50,6 @@ export class FrameTool extends BaseTool {
         frame,
         getTopElements(this.frameManager.getElementsInFrameBound(frame))
       );
-
-      this.doc.captureSync();
     }
 
     this._frame = null;

--- a/tests/blocksuite/e2e/edgeless/frame/frame.spec.ts
+++ b/tests/blocksuite/e2e/edgeless/frame/frame.spec.ts
@@ -25,6 +25,7 @@ import {
   pressBackspace,
   pressEscape,
   SHORT_KEY,
+  undoByKeyboard,
 } from '../../utils/actions/keyboard.js';
 import {
   assertCanvasElementsCount,
@@ -411,4 +412,11 @@ test('outline should keep updated during a new frame created by frame-tool dragg
   expect(
     await pickColorAtPoints(page, [start, [end[0] - 1, end[1] - 1]])
   ).toEqual(['#1e96eb', '#1e96eb']);
+});
+
+test('undo should work when create a frame by dragging', async ({ page }) => {
+  await page.keyboard.press('f');
+  await dragBetweenViewCoords(page, [0, 0], [100, 100], { steps: 50 });
+  await undoByKeyboard(page);
+  await expect(page.locator('affine-frame')).toHaveCount(0);
 });


### PR DESCRIPTION
Close [BS-2848](https://linear.app/affine-design/issue/BS-2848/但我发现frame创建后，要撤销两次才能删掉)