### PR TITLE
feat(editor): replace flat layout cache with tree in turbo renderer

### DIFF
--- a/blocksuite/affine/blocks/list/src/turbo/list-painter.worker.ts
+++ b/blocksuite/affine/blocks/list/src/turbo/list-painter.worker.ts
@@ -77,10 +77,15 @@ class ListLayoutPainter implements BlockLayoutPainter {
       return;
     }
 
-    if (!isListLayout(layout)) return;
+    if (!isListLayout(layout)) {
+      console.warn(
+        'Expected list layout but received different format:',
+        layout
+      );
+      return;
+    }
 
     const renderedPositions = new Set<string>();
-
     layout.items.forEach(item => {
       const fontSize = item.fontSize;
       const baselineY = getBaseline(fontSize);

--- a/blocksuite/affine/blocks/paragraph/src/turbo/paragraph-painter.worker.ts
+++ b/blocksuite/affine/blocks/paragraph/src/turbo/paragraph-painter.worker.ts
@@ -73,10 +73,15 @@ class ParagraphLayoutPainter implements BlockLayoutPainter {
       return;
     }
 
-    if (!isParagraphLayout(layout)) return; // cast to ParagraphLayout
+    if (!isParagraphLayout(layout)) {
+      console.warn(
+        'Expected paragraph layout but received different format:',
+        layout
+      );
+      return;
+    }
 
     const renderedPositions = new Set<string>();
-
     layout.sentences.forEach(sentence => {
       const fontSize = sentence.fontSize;
       const baselineY = getBaseline(fontSize);

--- a/blocksuite/affine/gfx/turbo-renderer/src/layout/block-layout-provider.ts
+++ b/blocksuite/affine/gfx/turbo-renderer/src/layout/block-layout-provider.ts
@@ -1,5 +1,7 @@
 import { createIdentifier } from '@blocksuite/global/di';
-import type { GfxBlockComponent } from '@blocksuite/std';
+import type { EditorHost } from '@blocksuite/std';
+import type { ViewportRecord } from '@blocksuite/std/gfx';
+import type { BlockModel } from '@blocksuite/store';
 import { Extension } from '@blocksuite/store';
 
 import type { BlockLayout, Rect } from '../types';
@@ -8,7 +10,13 @@ export abstract class BlockLayoutHandlerExtension<
   T extends BlockLayout = BlockLayout,
 > extends Extension {
   abstract readonly blockType: string;
-  abstract queryLayout(component: GfxBlockComponent): T | null;
+
+  abstract queryLayout(
+    model: BlockModel,
+    host: EditorHost,
+    viewportRecord: ViewportRecord
+  ): T | null;
+
   abstract calculateBound(layout: T): {
     rect: Rect;
     subRects: Rect[];

--- a/blocksuite/affine/gfx/turbo-renderer/src/types.ts
+++ b/blocksuite/affine/gfx/turbo-renderer/src/types.ts
@@ -14,13 +14,14 @@ export interface ViewportState {
 }
 
 export interface BlockLayout extends Record<string, unknown> {
+  blockId: string;
   type: string;
-  rect?: Rect;
-}
-
-export interface ViewportLayout {
-  blocks: BlockLayout[];
-  rect: Rect;
+  rect: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  };
 }
 
 export interface TextRect {
@@ -60,7 +61,7 @@ export type WorkerToHostMessage = MessageBitmapPainted | MessagePaintError;
 export type MessagePaint = {
   type: 'paintLayout';
   data: {
-    layout: ViewportLayout;
+    layout: ViewportLayoutTree;
     width: number;
     height: number;
     dpr: number;
@@ -89,3 +90,15 @@ export interface TurboRendererConfig {
 }
 
 export type HostToWorkerMessage = MessagePaint;
+
+export interface BlockLayoutTreeNode {
+  blockId: string;
+  type: string;
+  layout: BlockLayout;
+  children: BlockLayoutTreeNode[];
+}
+
+export interface ViewportLayoutTree {
+  roots: BlockLayoutTreeNode[];
+  overallRect: BlockLayout['rect'];
+}

--- a/packages/frontend/core/src/blocksuite/extensions/turbo-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/extensions/turbo-renderer.ts
@@ -7,7 +7,7 @@ import {
 } from '@blocksuite/affine/gfx/turbo-renderer';
 
 function createPainterWorker() {
-  const worker = new Worker(getWorkerUrl('turbo-painter-entry.worker.js'));
+  const worker = new Worker(getWorkerUrl('turbo-painter.worker.js'));
   return worker;
 }
 


### PR DESCRIPTION
### TL;DR

Refactored the BlockSuite turbo renderer to use a hierarchical tree structure for layouts instead of a flat list, improving rendering accuracy and performance.

### What changed?

- Redesigned the layout system to use a tree structure (`ViewportLayoutTree`) that better represents the document hierarchy
- Added `blockId` to all layout objects for better tracking and debugging
- Updated the layout query mechanism to work with models directly instead of components
- Enhanced error handling with more descriptive warnings and error messages
- Improved the painting process to traverse the layout tree recursively
- Fixed viewport coordinate calculations for more accurate rendering
- Updated the worker communication to support the new tree-based layout structure

### Why make this change?

The previous flat layout structure didn't properly represent the hierarchical nature of documents, leading to rendering issues with nested blocks. This tree-based approach:

1. Better represents the actual document structure
2. Improves rendering accuracy for nested elements
3. Makes debugging easier with more consistent block identification
4. Provides a more robust foundation for future rendering optimizations
5. Reduces the likelihood of rendering artifacts when scrolling or zooming