### PR TITLE
fix(editor): do not display format bar with embed node

### DIFF
--- a/blocksuite/affine/inlines/preset/src/command/utils.ts
+++ b/blocksuite/affine/inlines/preset/src/command/utils.ts
@@ -202,8 +202,25 @@ export function getCombinedTextStyle(chain: Chain<InitCommandCtx>) {
 }
 
 export function isFormatSupported(chain: Chain<InitCommandCtx>) {
-  return handleCurrentSelection(
-    chain,
-    (_type, inlineEditors) => inlineEditors.length > 0
-  );
+  return handleCurrentSelection(chain, (_type, inlineEditors) => {
+    if (inlineEditors.length === 1) {
+      const inlineEditor = inlineEditors[0];
+      const inlineRange = inlineEditor.getInlineRange();
+
+      // support block selection
+      if (!inlineRange) return true;
+
+      if (inlineRange.length !== 1) return true;
+
+      // skip embed node
+      const delta = inlineEditor.getDeltaByRangeIndex(inlineRange.index + 1);
+      if (!delta) return true;
+
+      const isEmbed = inlineEditor.isEmbed(delta);
+      if (isEmbed) return false;
+
+      return true;
+    }
+    return inlineEditors.length > 0;
+  });
 }

--- a/tests/blocksuite/e2e/format-bar.spec.ts
+++ b/tests/blocksuite/e2e/format-bar.spec.ts
@@ -19,6 +19,7 @@ import {
   initThreeParagraphs,
   pasteByKeyboard,
   pressArrowDown,
+  pressArrowLeft,
   pressArrowUp,
   pressEnter,
   pressEscape,
@@ -1050,4 +1051,19 @@ test.describe('more menu button', () => {
 
     await assertRichTexts(page, ['123', '789']);
   });
+});
+
+test('should not display format bar when just select embed node', async ({
+  page,
+}) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page, 0);
+  await type(page, '@\n');
+  await assertRichTextInlineRange(page, 0, 1, 0);
+  await pressArrowLeft(page);
+  await assertRichTextInlineRange(page, 0, 0, 1);
+
+  const { boldBtn } = getFormatBar(page);
+  await expect(boldBtn).toBeHidden();
 });


### PR DESCRIPTION
Close [BS-2895: 点击inline名字区域不需要显示format toolbar](https://linear.app/affine-design/issue/BS-2895/点击inline名字区域不需要显示format-toolbar)