### PR TITLE
fix(editor): adjust button background color of inner toolbar in dark mode

### DIFF
--- a/blocksuite/affine/widgets/widget-toolbar/src/toolbar.ts
+++ b/blocksuite/affine/widgets/widget-toolbar/src/toolbar.ts
@@ -92,9 +92,9 @@ export class AffineToolbarWidget extends WidgetComponent {
       .inner-button,
       editor-icon-button,
       editor-menu-button {
-        background: ${unsafeCSSVarV2('button/iconButtonSolid')};
         color: ${unsafeCSSVarV2('text/primary')};
         box-shadow: ${unsafeCSSVar('buttonShadow')};
+        background: ${unsafeCSSVar('white')};
         border-radius: 4px;
       }
       editor-menu-button > div {


### PR DESCRIPTION
Closes: [BS-3018](https://linear.app/affine-design/issue/BS-3018/在-dark-主题下，imagesurface-ref-inner-toolbar-没背景色)