### PR TITLE
fix(editor): disable pointer event in surface-ref content

### DIFF
--- a/blocksuite/affine/blocks/block-surface-ref/src/surface-ref-block.ts
+++ b/blocksuite/affine/blocks/block-surface-ref/src/surface-ref-block.ts
@@ -106,6 +106,15 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
       pointer-events: none;
       user-select: none;
     }
+
+    .ref-viewport-event-mask {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: auto;
+    }
   `;
 
   private _previewDoc: Store | null = null;
@@ -390,6 +399,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
               }).render()
             : nothing;
         })}
+        <div class="ref-viewport-event-mask"></div>
       </div>
     </div>`;
   }


### PR DESCRIPTION
Close [BS-3016](https://linear.app/affine-design/issue/BS-3016/当在-page-下框选时，如果遇到-affine-surface-ref-block-则会阻断框选)
Close [BS-3020](https://linear.app/affine-design/issue/BS-3020/inserted-frame-%E7%82%B9%E5%87%BB%E9%87%8C%E9%9D%A2%E7%9A%84%E5%9B%BE%E7%89%87%E4%BC%9A%E7%9B%B4%E6%8E%A5%E6%89%93%E5%BC%80)