### PR TITLE
refactor(core): ai session create

### DIFF
--- a/blocksuite/affine/model/src/elements/mindmap/mindmap.ts
+++ b/blocksuite/affine/model/src/elements/mindmap/mindmap.ts
@@ -743,7 +743,7 @@ export class MindmapElementModel extends GfxGroupLikeElementModel<MindmapElement
     const targetPos =
       typeof targetXYWH === 'string' ? deserializeXYWH(targetXYWH) : targetXYWH;
     const offsetX = targetPos[0] - x;
-    const offsetY = targetPos[1] - y + targetPos[3];
+    const offsetY = targetPos[1] - y;
 
     this.surface.doc.transact(() => {
       this.childElements.forEach(el => {

--- a/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
@@ -108,7 +108,7 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
         workspaceId: host.doc.workspace.id,
       } as Parameters<typeof action>[0];
       // @ts-expect-error TODO(@Peng): maybe fix this
-      stream = action(options);
+      stream = await action(options);
       if (!stream) return;
       yield* stream;
     },

--- a/packages/frontend/core/src/blocksuite/ai/actions/edgeless-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/edgeless-handler.ts
@@ -207,7 +207,7 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
           }
 
           // @ts-expect-error TODO(@Peng): maybe fix this
-          stream = action(options);
+          stream = await action(options);
           if (!stream) return;
           yield* stream;
         },
@@ -237,7 +237,7 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
         } as Parameters<typeof action>[0];
 
         // @ts-expect-error TODO(@Peng): maybe fix this
-        stream = action(options);
+        stream = await action(options);
         if (!stream) return;
         yield* stream;
       },

--- a/packages/frontend/core/src/blocksuite/ai/actions/page-response.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/page-response.ts
@@ -5,7 +5,11 @@ import {
 } from '@blocksuite/affine/blocks/surface';
 import { fitContent } from '@blocksuite/affine/gfx/shape';
 import { createTemplateJob } from '@blocksuite/affine/gfx/template';
-import { Bound, getCommonBound } from '@blocksuite/affine/global/gfx';
+import {
+  Bound,
+  getCommonBound,
+  type XYWH,
+} from '@blocksuite/affine/global/gfx';
 import type {
   MindmapElementModel,
   ShapeElementModel,
@@ -83,7 +87,10 @@ function responseToBrainstormMindmap(
     });
     // wait for mindmap xywh update
     setTimeout(() => {
-      const frameBound = expandBound(mindmap.elementBound, PADDING);
+      const { x, y, w, h } = mindmap.elementBound;
+      const targetBound: XYWH = [x, y + h / 2 + PADDING - 15, w, h];
+      mindmap.moveTo(targetBound);
+      const frameBound = expandBound(new Bound(...targetBound), PADDING);
       addSurfaceRefBlock(host, frameBound, place);
     }, 0);
   });
@@ -107,7 +114,7 @@ function responseToMakeItReal(host: EditorHost, ctx: AIContext, place: Place) {
   const bound = getEdgelessContentBound(host);
   const x = bound ? bound.x + bound.w + PADDING * 2 : 0;
   const y = bound ? bound.y : 0;
-  const htmlBound = new Bound(x, y, width || 800, height || 600);
+  const htmlBound = new Bound(x, y + PADDING, width || 800, height || 600);
   const html = preprocessHtml(aiPanel.answer);
   host.doc.transact(() => {
     host.doc.addBlock(

--- a/packages/frontend/core/src/blocksuite/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/types.ts
@@ -13,6 +13,8 @@ import type { EditorHost } from '@blocksuite/affine/std';
 import type { GfxModel } from '@blocksuite/affine/std/gfx';
 import type { BlockModel } from '@blocksuite/affine/store';
 
+import type { PromptKey } from '../provider/prompt';
+
 export const translateLangs = [
   'English',
   'Spanish',
@@ -131,6 +133,7 @@ declare global {
     interface ChatOptions extends AITextActionOptions {
       sessionId?: string;
       isRootSession?: boolean;
+      networkSearch?: boolean;
       contexts?: {
         docs: AIDocContextOption[];
         files: AIFileContextOption[];
@@ -155,107 +158,107 @@ declare global {
 
     interface AIActions {
       // chat is a bit special because it's has a internally maintained session
-      chat<T extends ChatOptions>(options: T): AIActionTextResponse<T>;
+      chat<T extends ChatOptions>(options: T): Promise<AIActionTextResponse<T>>;
 
       summary<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       improveWriting<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       improveGrammar<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       fixSpelling<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       createHeadings<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       makeLonger<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       makeShorter<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       continueWriting<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       checkCodeErrors<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       explainCode<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       writeArticle<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       writeTwitterPost<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       writePoem<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       writeBlogPost<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       brainstorm<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       writeOutline<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       explainImage<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       findActions<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       // mindmap
       brainstormMindmap<T extends BrainstormMindMap>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       expandMindmap<T extends ExpandMindMap>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       // presentation
       createSlides<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       // explain this
       explain<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       // actions with variants
       translate<T extends TranslateOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       changeTone<T extends ChangeToneOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
 
       // make it real, image to text
       makeItReal<T extends AIImageActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       createImage<T extends AIImageActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       processImage<T extends ProcessImageOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       filterImage<T extends FilterImageOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
       generateCaption<T extends AITextActionOptions>(
         options: T
-      ): AIActionTextResponse<T>;
+      ): Promise<AIActionTextResponse<T>>;
     }
 
     type AIDocsAndFilesContext = {
@@ -357,12 +360,16 @@ declare global {
       >[];
     };
 
+    interface CreateSessionOptions {
+      docId: string;
+      workspaceId: string;
+      promptName: PromptKey;
+      sessionId?: string;
+      retry?: boolean;
+    }
+
     interface AISessionService {
-      createSession: (
-        workspaceId: string,
-        docId: string,
-        promptName?: string
-      ) => Promise<string>;
+      createSession: (options: CreateSessionOptions) => Promise<string>;
       getSessions: (
         workspaceId: string,
         docId?: string,

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/index.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/index.ts
@@ -141,7 +141,6 @@ export class ChatPanel extends SignalWatcher(
     const history = histories?.find(history => history.sessionId === sessionId);
     if (history) {
       messages.push(...history.messages);
-      AIProvider.LAST_ROOT_SESSION_ID = history.sessionId;
     }
 
     this.chatContextValue = {
@@ -182,10 +181,11 @@ export class ChatPanel extends SignalWatcher(
     if (this._sessionId) {
       return this._sessionId;
     }
-    this._sessionId = await AIProvider.session?.createSession(
-      this.doc.workspace.id,
-      this.doc.id
-    );
+    this._sessionId = await AIProvider.session?.createSession({
+      docId: this.doc.id,
+      workspaceId: this.doc.workspace.id,
+      promptName: 'Chat With AFFiNE AI',
+    });
     return this._sessionId;
   };
 

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/const.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/const.ts
@@ -1,2 +1,0 @@
-export const PROMPT_NAME_AFFINE_AI = 'Chat With AFFiNE AI';
-export const PROMPT_NAME_NETWORK_SEARCH = 'Search With AFFiNE AI';

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/index.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/index.ts
@@ -1,3 +1,2 @@
 export * from './ai-chat-input';
-export * from './const';
 export * from './type';

--- a/packages/frontend/core/src/blocksuite/ai/provider/ai-provider.ts
+++ b/packages/frontend/core/src/blocksuite/ai/provider/ai-provider.ts
@@ -100,8 +100,6 @@ export class AIProvider {
 
   static LAST_ACTION_SESSIONID = '';
 
-  static LAST_ROOT_SESSION_ID = '';
-
   static MAX_LOCAL_HISTORY = 10;
 
   private readonly actions: Partial<BlockSuitePresets.AIActions> = {};
@@ -158,10 +156,10 @@ export class AIProvider {
     id: T,
     action: (
       ...options: Parameters<BlockSuitePresets.AIActions[T]>
-    ) => ReturnType<BlockSuitePresets.AIActions[T]>
+    ) => Promise<ReturnType<BlockSuitePresets.AIActions[T]>>
   ): void {
     // @ts-expect-error TODO: maybe fix this
-    this.actions[id] = (
+    this.actions[id] = async (
       ...args: Parameters<BlockSuitePresets.AIActions[T]>
     ) => {
       const options = args[0];
@@ -176,9 +174,8 @@ export class AIProvider {
         this.actionHistory.shift();
       }
       // wrap the action with slot actions
-      const result: BlockSuitePresets.TextStream | Promise<string> = action(
-        ...args
-      );
+      const result: BlockSuitePresets.TextStream | Promise<string> =
+        await action(...args);
       const isTextStream = (
         m: BlockSuitePresets.TextStream | Promise<string>
       ): m is BlockSuitePresets.TextStream =>
@@ -315,7 +312,7 @@ export class AIProvider {
     id: T,
     action: (
       ...options: Parameters<BlockSuitePresets.AIActions[T]>
-    ) => ReturnType<BlockSuitePresets.AIActions[T]>
+    ) => Promise<ReturnType<BlockSuitePresets.AIActions[T]>>
   ): void;
 
   static provide(id: unknown, action: unknown) {


### PR DESCRIPTION
Close [BS-3079](https://linear.app/affine-design/issue/BS-3079).

- Separate the create session logic from the `createMessage function`.
- Ensure the session is created before executing any chat or actions.
- Convert the `AIActions` into asynchronous functions.
- Transfer the update prompt name logic to the chat action.
- Introduce a networkSearch field in `AITextActionOptions`.
- Eliminate the redundant `LAST_ROOT_SESSION_ID`.