### PR TITLE
fix(editor): the switch button style set in the TOC does not effect

### DIFF
--- a/blocksuite/affine/components/src/toggle-switch/index.ts
+++ b/blocksuite/affine/components/src/toggle-switch/index.ts
@@ -38,11 +38,11 @@ const styles = css`
     transition: 0.1s;
   }
 
-  label.subscribe {
+  label.on {
     background: var(--affine-primary-color);
   }
 
-  label.subscribe:after {
+  label.on:after {
     left: calc(100% - 1px);
     transform: translateX(-100%);
   }
@@ -64,7 +64,7 @@ export class ToggleSwitch extends LitElement {
 
   override render() {
     return html`
-      <label class=${this.on ? 'subscribe' : ''}>
+      <label class=${this.on ? 'on' : ''}>
         <input
           type="checkbox"
           class="switch"

--- a/blocksuite/affine/components/src/toggle-switch/index.ts
+++ b/blocksuite/affine/components/src/toggle-switch/index.ts
@@ -64,7 +64,7 @@ export class ToggleSwitch extends LitElement {
 
   override render() {
     return html`
-      <label class=${this.on ? 'on' : ''}>
+      <label class=${this.on ? 'subscribe' : ''}>
         <input
           type="checkbox"
           class="switch"


### PR DESCRIPTION
the switch button style set in the TOC does not effect 

**before:**

https://github.com/user-attachments/assets/ca9318bf-d228-4d71-842f-a9e1679812bb


**after:**

https://github.com/user-attachments/assets/48dbe9c1-c66b-4439-b4b5-010a39c33bc8

