### PR TITLE
fix(editor): repeat trigger keys of at-menu was added

### DIFF
--- a/blocksuite/affine/blocks/embed/src/embed-linked-doc-block/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-linked-doc-block/configs/slash-menu.ts
@@ -1,8 +1,5 @@
 import { EmbedLinkedDocBlockSchema } from '@blocksuite/affine-model';
-import {
-  getInlineEditorByModel,
-  insertContent,
-} from '@blocksuite/affine-rich-text';
+import { insertContent } from '@blocksuite/affine-rich-text';
 import { REFERENCE_NODE } from '@blocksuite/affine-shared/consts';
 import { createDefaultDoc } from '@blocksuite/affine-shared/utils';
 import {
@@ -68,22 +65,7 @@ const linkedDocSlashMenuConfig: SlashMenuConfig = {
         if (!linkedDocWidget) return;
         // TODO(@L-Sun): make linked-doc-widget as extension
         // @ts-expect-error same as above
-        const triggerKey = linkedDocWidget.config.triggerKeys[0];
-
-        insertContent(std, model, triggerKey);
-
-        const inlineEditor = getInlineEditorByModel(std, model);
-        if (inlineEditor) {
-          // Wait for range to be updated
-          const subscription = inlineEditor.slots.inlineRangeSync.subscribe(
-            () => {
-              // TODO(@L-Sun): make linked-doc-widget as extension
-              subscription.unsubscribe();
-              // @ts-expect-error same as above
-              linkedDocWidget.show({ addTriggerKey: true });
-            }
-          );
-        }
+        linkedDocWidget.show({ addTriggerKey: true });
       },
     },
   ],

--- a/blocksuite/affine/blocks/root/src/widgets/keyboard-toolbar/config.ts
+++ b/blocksuite/affine/blocks/root/src/widgets/keyboard-toolbar/config.ts
@@ -34,10 +34,7 @@ import {
   toggleUnderline,
 } from '@blocksuite/affine-inline-preset';
 import type { FrameBlockModel } from '@blocksuite/affine-model';
-import {
-  getInlineEditorByModel,
-  insertContent,
-} from '@blocksuite/affine-rich-text';
+import { insertContent } from '@blocksuite/affine-rich-text';
 import {
   copySelectedModelsCommand,
   deleteSelectedModelsCommand,
@@ -348,35 +345,11 @@ const pageToolGroup: KeyboardToolPanelGroup = {
         );
         if (!linkedDocWidget) return;
         assertType<AffineLinkedDocWidget>(linkedDocWidget);
-
-        const triggerKey = linkedDocWidget.config.triggerKeys[0];
-
-        std.command
-          .chain()
-          .pipe(getSelectedModelsCommand)
-          .pipe(ctx => {
-            const { selectedModels } = ctx;
-            if (!selectedModels?.length) return;
-
-            const currentModel = selectedModels[0];
-            insertContent(std, currentModel, triggerKey);
-
-            const inlineEditor = getInlineEditorByModel(std, currentModel);
-            // Wait for range to be updated
-            if (inlineEditor) {
-              const subscription = inlineEditor.slots.inlineRangeSync.subscribe(
-                () => {
-                  subscription.unsubscribe();
-                  linkedDocWidget.show({
-                    mode: 'mobile',
-                    addTriggerKey: true,
-                  });
-                  closeToolPanel();
-                }
-              );
-            }
-          })
-          .run();
+        linkedDocWidget.show({
+          mode: 'mobile',
+          addTriggerKey: true,
+        });
+        closeToolPanel();
       },
     },
   ],

--- a/blocksuite/affine/widgets/linked-doc/src/config.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/config.ts
@@ -112,6 +112,7 @@ export type LinkedDocContext = {
   std: BlockStdScope;
   inlineEditor: AffineInlineEditor;
   startRange: InlineRange;
+  startNativeRange: Range;
   triggerKey: string;
   config: LinkedWidgetConfig;
   close: () => void;

--- a/blocksuite/affine/widgets/linked-doc/src/linked-doc-popover.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/linked-doc-popover.ts
@@ -7,7 +7,6 @@ import {
 import { unsafeCSSVar } from '@blocksuite/affine-shared/theme';
 import {
   createKeydownObserver,
-  getCurrentNativeRange,
   getPopperPosition,
   getViewportElement,
 } from '@blocksuite/affine-shared/utils';
@@ -160,11 +159,15 @@ export class LinkedDocPopover extends SignalWatcher(
 
     // init
     this._updateLinkedDocGroup().catch(console.error);
-    this._disposables.addFromEvent(this, 'mousedown', e => {
+    this._disposables.addFromEvent(this, 'pointerdown', e => {
       // Prevent input from losing focus
       e.preventDefault();
     });
-    this._disposables.addFromEvent(window, 'mousedown', e => {
+    this._disposables.addFromEvent(this, 'mousedown', e => {
+      // Prevent input from losing focus in electron
+      e.preventDefault();
+    });
+    this._disposables.addFromEvent(window, 'pointerdown', e => {
       if (e.target === this) return;
       // We don't clear the query when clicking outside the popover
       this.context.close();
@@ -338,11 +341,8 @@ export class LinkedDocPopover extends SignalWatcher(
 
   override willUpdate() {
     if (!this.hasUpdated) {
-      const curRange = getCurrentNativeRange();
-      if (!curRange) return;
-
       const updatePosition = throttle(() => {
-        this._position = getPopperPosition(this, curRange);
+        this._position = getPopperPosition(this, this.context.startNativeRange);
       }, 10);
 
       this.disposables.addFromEvent(window, 'resize', updatePosition);

--- a/tests/blocksuite/e2e/slash-menu.spec.ts
+++ b/tests/blocksuite/e2e/slash-menu.spec.ts
@@ -841,3 +841,21 @@ test('delete block by slash menu should remove children', async ({
   await redoByKeyboard(page);
   await assertRichTexts(page, ['123']);
 });
+
+test('should slash menu can trigger linked doc popover', async ({ page }) => {
+  await enterPlaygroundRoom(page);
+  await initEmptyParagraphState(page);
+  await focusRichText(page);
+
+  await type(page, '/linked');
+  await pressEnter(page);
+  await expect(page.locator('.linked-doc-popover')).toBeVisible();
+  await assertRichTexts(page, ['@']);
+
+  await type(page, 'doc');
+  await pressEnter(page);
+  await expect(page.locator('affine-reference')).toBeVisible();
+  await expect(
+    page.locator('affine-reference .affine-reference-title')
+  ).toHaveText('doc');
+});


### PR DESCRIPTION
Close [BS-2716](https://linear.app/affine-design/issue/BS-2716/移动端通过toolpanel唤起的at-menu，出现两个)