### PR TITLE
fix(editor): improve pdf embed viewer UX

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -28,7 +28,7 @@ import { checkAttachmentBlob, downloadAttachmentBlob } from './utils';
 
 @Peekable({
   enableOn: ({ model }: AttachmentBlockComponent) => {
-    return model.props.type.endsWith('pdf');
+    return !model.doc.readonly && model.props.type.endsWith('pdf');
   },
 })
 export class AttachmentBlockComponent extends CaptionedBlockComponent<AttachmentBlockModel> {

--- a/blocksuite/affine/blocks/attachment/src/embed.ts
+++ b/blocksuite/affine/blocks/attachment/src/embed.ts
@@ -146,17 +146,20 @@ const embedConfig: AttachmentEmbedConfig[] = [
       // More options: https://tinytip.co/tips/html-pdf-params/
       // https://chromium.googlesource.com/chromium/src/+/refs/tags/121.0.6153.1/chrome/browser/resources/pdf/open_pdf_params_parser.ts
       const parameters = '#toolbar=0';
-      return html`<iframe
-        style="width: 100%; color-scheme: auto;"
-        height="480"
-        src=${blobUrl + parameters}
-        loading="lazy"
-        scrolling="no"
-        frameborder="no"
-        allowTransparency
-        allowfullscreen
-        type="application/pdf"
-      ></iframe>`;
+      return html`
+        <iframe
+          style="width: 100%; color-scheme: auto;"
+          height="480"
+          src=${blobUrl + parameters}
+          loading="lazy"
+          scrolling="no"
+          frameborder="no"
+          allowTransparency
+          allowfullscreen
+          type="application/pdf"
+        ></iframe>
+        <div class="affine-attachment-embed-event-mask"></div>
+      `;
     },
   },
   {

--- a/blocksuite/affine/blocks/attachment/src/styles.ts
+++ b/blocksuite/affine/blocks/attachment/src/styles.ts
@@ -136,4 +136,9 @@ export const styles = css`
     width: 100%;
     height: 100%;
   }
+
+  .affine-attachment-embed-event-mask {
+    position: absolute;
+    inset: 0;
+  }
 `;

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -155,7 +155,9 @@ const usePatchSpecs = (mode: DocMode) => {
   );
 
   const enablePDFEmbedPreview = useLiveData(
-    featureFlagService.flags.enable_pdf_embed_preview.$
+    featureFlagService.flags.enable_pdf_embed_preview.$.map(
+      flag => !workspaceService.workspace.openOptions.isSharedMode && flag
+    )
   );
 
   const patchedSpecs = useMemo(() => {

--- a/packages/frontend/core/src/modules/peek-view/view/peek-view-controls.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/peek-view-controls.tsx
@@ -40,7 +40,10 @@ type ControlButtonProps = {
   icon: ReactElement<SVGAttributes<SVGElement>>;
   name: string;
   onClick: () => void;
+  enabled: boolean;
 };
+
+const filterByEnabled = (props: ControlButtonProps) => props.enabled;
 
 export const ControlButton = ({
   icon,
@@ -85,12 +88,13 @@ export const DefaultPeekViewControls = ({
   const controls = useMemo(() => {
     return [
       {
-        icon: <CloseIcon />,
         nameKey: 'close',
         name: t['com.affine.peek-view-controls.close'](),
+        icon: <CloseIcon />,
         onClick: () => peekView.close(),
+        enabled: true,
       },
-    ].filter((opt): opt is ControlButtonProps => Boolean(opt));
+    ].filter(filterByEnabled);
   }, [peekView, t]);
   return (
     <div {...rest} className={clsx(styles.root, className)}>
@@ -115,42 +119,46 @@ export const DocPeekViewControls = ({
   const controls = useMemo(() => {
     return [
       {
-        icon: <CloseIcon />,
         nameKey: 'close',
         name: t['com.affine.peek-view-controls.close'](),
+        icon: <CloseIcon />,
         onClick: () => peekView.close(),
+        enabled: true,
       },
       {
-        icon: <ExpandFullIcon />,
-        name: t['com.affine.peek-view-controls.open-doc'](),
         nameKey: 'open',
+        name: t['com.affine.peek-view-controls.open-doc'](),
+        icon: <ExpandFullIcon />,
         onClick: () => {
           workbench.openDoc(docRef);
           peekView.close(false);
         },
+        enabled: true,
       },
       {
-        icon: <OpenInNewIcon />,
         nameKey: 'new-tab',
         name: t['com.affine.peek-view-controls.open-doc-in-new-tab'](),
+        icon: <OpenInNewIcon />,
         onClick: () => {
           workbench.openDoc(docRef, { at: 'new-tab' });
           peekView.close(false);
         },
+        enabled: true,
       },
-      BUILD_CONFIG.isElectron && {
-        icon: <SplitViewIcon />,
+      {
         nameKey: 'split-view',
         name: t['com.affine.peek-view-controls.open-doc-in-split-view'](),
+        icon: <SplitViewIcon />,
         onClick: () => {
           workbench.openDoc(docRef, { at: 'beside' });
           peekView.close(false);
         },
+        enabled: BUILD_CONFIG.isElectron,
       },
       {
-        icon: <LinkIcon />,
         nameKey: 'copy-link',
         name: t['com.affine.peek-view-controls.copy-link'](),
+        icon: <LinkIcon />,
         onClick: async () => {
           const preferredMode = docsService.list.getPrimaryMode(docRef.docId);
           const search = toDocSearchParams({
@@ -167,16 +175,18 @@ export const DocPeekViewControls = ({
           await copyTextToClipboard(url.toString());
           notify.success({ title: t['Copied link to clipboard']() });
         },
+        enabled: true,
       },
       {
-        icon: <InformationIcon />,
         nameKey: 'info',
         name: t['com.affine.peek-view-controls.open-info'](),
+        icon: <InformationIcon />,
         onClick: () => {
           workspaceDialogService.open('doc-info', { docId: docRef.docId });
         },
+        enabled: true,
       },
-    ].filter((opt): opt is ControlButtonProps => Boolean(opt));
+    ].filter(filterByEnabled);
   }, [
     t,
     peekView,
@@ -213,10 +223,11 @@ export const AttachmentPeekViewControls = ({
   const controls = useMemo(() => {
     const controls = [
       {
-        icon: <CloseIcon />,
         nameKey: 'close',
         name: t['com.affine.peek-view-controls.close'](),
+        icon: <CloseIcon />,
         onClick: () => peekView.close(),
+        enabled: true,
       },
     ];
     if (!type) return controls;
@@ -224,42 +235,45 @@ export const AttachmentPeekViewControls = ({
     return [
       ...controls,
       // TODO(@fundon): needs to be implemented on mobile
-      BUILD_CONFIG.isDesktopEdition && {
-        icon: <ExpandFullIcon />,
-        name: t['com.affine.peek-view-controls.open-attachment'](),
+      {
         nameKey: 'open',
+        name: t['com.affine.peek-view-controls.open-attachment'](),
+        icon: <ExpandFullIcon />,
         onClick: () => {
           workbench.openAttachment(docId, blockId);
           peekView.close(false);
 
           track.$.attachment.$.openAttachmentInFullscreen({ type });
         },
+        enabled: BUILD_CONFIG.isDesktopEdition,
       },
       {
-        icon: <OpenInNewIcon />,
         nameKey: 'new-tab',
         name: t['com.affine.peek-view-controls.open-attachment-in-new-tab'](),
+        icon: <OpenInNewIcon />,
         onClick: () => {
           workbench.openAttachment(docId, blockId, { at: 'new-tab' });
           peekView.close(false);
 
           track.$.attachment.$.openAttachmentInNewTab({ type });
         },
+        enabled: true,
       },
-      BUILD_CONFIG.isElectron && {
-        icon: <SplitViewIcon />,
+      {
         nameKey: 'split-view',
         name: t[
           'com.affine.peek-view-controls.open-attachment-in-split-view'
         ](),
+        icon: <SplitViewIcon />,
         onClick: () => {
           workbench.openAttachment(docId, blockId, { at: 'beside' });
           peekView.close(false);
 
           track.$.attachment.$.openAttachmentInSplitView({ type });
         },
+        enabled: BUILD_CONFIG.isElectron,
       },
-    ].filter((opt): opt is ControlButtonProps => Boolean(opt));
+    ].filter(filterByEnabled);
   }, [t, peekView, workbench, docId, blockId, type]);
 
   useEffect(() => {

--- a/tests/kit/src/utils/attachment.ts
+++ b/tests/kit/src/utils/attachment.ts
@@ -1,0 +1,21 @@
+import type { Page } from '@playwright/test';
+
+import { Path } from '../playwright';
+
+const fixturesDir = Path.dir(import.meta.url).join('../../../fixtures');
+
+export async function importAttachment(page: Page, file: string) {
+  await page.evaluate(() => {
+    // Force fallback to input[type=file] in tests
+    // See https://github.com/microsoft/playwright/issues/8850
+    window.showOpenFilePicker = undefined;
+  });
+
+  const fileChooser = page.waitForEvent('filechooser');
+
+  // open slash menu
+  await page.keyboard.type('/attachment', { delay: 50 });
+  await page.keyboard.press('Enter');
+
+  await (await fileChooser).setFiles(fixturesDir.join(file).value);
+}


### PR DESCRIPTION
Closes: [BS-3101](https://linear.app/affine-design/issue/BS-3101/pdf-embed-模式的选中框选-和点开看详情有比较大的问题)

### What's Changed!

* Fixed disable pointer event in native pdf viewer by dragging
* Disable opening peek view with pdf viewer in readonly and sharing modes