### PR TITLE
fix(editor): android bs keyboard provider error

### DIFF
--- a/blocksuite/affine/blocks/root/src/page/page-root-spec.ts
+++ b/blocksuite/affine/blocks/root/src/page/page-root-spec.ts
@@ -1,4 +1,5 @@
 import { ViewportElementExtension } from '@blocksuite/affine-shared/services';
+import { IS_MOBILE } from '@blocksuite/global/env';
 import { BlockViewExtension, WidgetViewExtension } from '@blocksuite/std';
 import type { ExtensionType } from '@blocksuite/store';
 import { literal, unsafeStatic } from 'lit/static-html.js';
@@ -31,7 +32,7 @@ const PageCommonExtension: ExtensionType[] = [
 export const PageRootBlockSpec: ExtensionType[] = [
   ...PageCommonExtension,
   BlockViewExtension('affine:page', literal`affine-page-root`),
-  keyboardToolbarWidget,
+  IS_MOBILE ? [keyboardToolbarWidget] : [],
   PageClipboard,
 ].flat();
 

--- a/blocksuite/affine/blocks/root/src/widgets/keyboard-toolbar/keyboard-toolbar.ts
+++ b/blocksuite/affine/blocks/root/src/widgets/keyboard-toolbar/keyboard-toolbar.ts
@@ -55,10 +55,8 @@ export class AffineKeyboardToolbar extends SignalWatcher(
   }
 
   private readonly _closeToolPanel = () => {
-    if (!this.panelOpened) return;
-
     this._currentPanelIndex$.value = -1;
-    this.keyboard.show();
+    if (!this.keyboard.visible$.peek()) this.keyboard.show();
   };
 
   private readonly _currentPanelIndex$ = signal(-1);
@@ -252,6 +250,16 @@ export class AffineKeyboardToolbar extends SignalWatcher(
         requestAnimationFrame(() => {
           this._scrollCurrentBlockIntoView();
         });
+      })
+    );
+
+    this.disposables.add(
+      effect(() => {
+        // sometime the keyboard will auto show when user click into different paragraph in Android,
+        // so we need to close the tool panel explicitly when the keyboard is visible
+        if (this.keyboard.visible$.value) {
+          this._closeToolPanel();
+        }
       })
     );
 

--- a/blocksuite/affine/shared/src/services/virtual-keyboard-service.ts
+++ b/blocksuite/affine/shared/src/services/virtual-keyboard-service.ts
@@ -15,3 +15,9 @@ export interface VirtualKeyboardProviderWithAction
 export const VirtualKeyboardProvider = createIdentifier<
   VirtualKeyboardProvider | VirtualKeyboardProviderWithAction
 >('VirtualKeyboardProvider');
+
+export function isVirtualKeyboardProviderWithAction(
+  provider: VirtualKeyboardProvider
+): provider is VirtualKeyboardProviderWithAction {
+  return 'show' in provider && 'hide' in provider;
+}

--- a/packages/frontend/core/src/blocksuite/extensions/entry/enable-mobile.ts
+++ b/packages/frontend/core/src/blocksuite/extensions/entry/enable-mobile.ts
@@ -4,10 +4,7 @@ import {
   codeToolbarWidget,
 } from '@blocksuite/affine/blocks/code';
 import { ParagraphBlockConfigExtension } from '@blocksuite/affine/blocks/paragraph';
-import type {
-  Container,
-  ServiceIdentifier,
-} from '@blocksuite/affine/global/di';
+import type { Container } from '@blocksuite/affine/global/di';
 import { DisposableGroup } from '@blocksuite/affine/global/disposable';
 import {
   FeatureFlagService,
@@ -15,11 +12,7 @@ import {
   type VirtualKeyboardProviderWithAction,
 } from '@blocksuite/affine/shared/services';
 import type { SpecBuilder } from '@blocksuite/affine/shared/utils';
-import {
-  type BlockStdScope,
-  LifeCycleWatcher,
-  LifeCycleWatcherIdentifier,
-} from '@blocksuite/affine/std';
+import { type BlockStdScope, LifeCycleWatcher } from '@blocksuite/affine/std';
 import type { ExtensionType } from '@blocksuite/affine/store';
 import { SlashMenuExtension } from '@blocksuite/affine/widgets/slash-menu';
 import { toolbarWidget } from '@blocksuite/affine/widgets/toolbar';
@@ -78,11 +71,7 @@ function KeyboardToolbarExtension(framework: FrameworkProvider): ExtensionType {
     static override setup(di: Container) {
       super.setup(di);
       di.addImpl(BSVirtualKeyboardProvider, provider => {
-        return provider.get(
-          LifeCycleWatcherIdentifier(
-            this.key
-          ) as ServiceIdentifier<BSVirtualKeyboardService>
-        );
+        return provider.get(this);
       });
     }
 
@@ -103,7 +92,7 @@ function KeyboardToolbarExtension(framework: FrameworkProvider): ExtensionType {
   }
 
   if ('show' in affineVirtualKeyboardProvider) {
-    return class
+    return class BSVirtualKeyboardWithActionService
       extends BSVirtualKeyboardService
       implements VirtualKeyboardProviderWithAction
     {


### PR DESCRIPTION
### What Changes
- fixed keyboard service can not be initialized since a anonymous `BSKeyboardWithActionService` class was provider to di
- fixed tool panel was not closed when focus on other pragraph by clicking
- optimized code structure of fallback `show` and `hide` of keyboard