### PR TITLE
refactor: migrate elements clone from default-tool to extension

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-builtin-spec.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-builtin-spec.ts
@@ -29,6 +29,7 @@ import { EdgelessRootBlockSpec } from './edgeless-root-spec.js';
 import { DefaultTool } from './gfx-tool/default-tool.js';
 import { EmptyTool } from './gfx-tool/empty-tool.js';
 import { PanTool } from './gfx-tool/pan-tool.js';
+import { AltCloneExtension } from './interact-extensions/clone-ext.js';
 import { DblClickAddEdgelessText } from './interact-extensions/dblclick-add-edgeless-text.js';
 import { SnapExtension } from './interact-extensions/snap-manager.js';
 import { EditPropsMiddlewareBuilder } from './middlewares/base.js';
@@ -63,6 +64,7 @@ export const EdgelessBuiltInManager: ExtensionType[] = [
   ConnectionOverlay,
   MindMapIndicatorOverlay,
   SnapOverlay,
+  AltCloneExtension,
   EditPropsMiddlewareBuilder,
   EdgelessElementToolbarExtension,
 ].flat();

--- a/blocksuite/affine/blocks/root/src/edgeless/interact-extensions/clone-ext.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/interact-extensions/clone-ext.ts
@@ -1,0 +1,32 @@
+import { getCommonBoundWithRotation } from '@blocksuite/global/gfx';
+import { type GfxModel, InteractivityExtension } from '@blocksuite/std/gfx';
+
+import { createElementsFromClipboardDataCommand } from '../clipboard/command.js';
+import { prepareCloneData } from '../utils/clone-utils.js';
+
+export class AltCloneExtension extends InteractivityExtension {
+  static override key = 'alt-clone';
+
+  override mounted(): void {
+    this.action.onRequestElementsClone(async context => {
+      const { elements: elementsToClone } = context;
+      const snapshot = prepareCloneData(elementsToClone, this.std);
+
+      const bound = getCommonBoundWithRotation(elementsToClone);
+      const [_, { createdElementsPromise }] = this.std.command.exec(
+        createElementsFromClipboardDataCommand,
+        {
+          elementsRawData: snapshot,
+          pasteCenter: bound.center,
+        }
+      );
+
+      if (!createdElementsPromise) return;
+      const { canvasElements, blockModels } = await createdElementsPromise;
+
+      return {
+        elements: [...canvasElements, ...blockModels] as GfxModel[],
+      };
+    });
+  }
+}

--- a/blocksuite/framework/std/src/gfx/interactivity/extension/base.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/extension/base.ts
@@ -5,7 +5,9 @@ import { Extension } from '@blocksuite/store';
 import type { PointerEventState } from '../../../event/index.js';
 import type { GfxController } from '../../controller.js';
 import { GfxControllerIdentifier } from '../../identifiers.js';
+import type { GfxModel } from '../../model/model.js';
 import type { SupportedEvents } from '../event.js';
+import type { ExtensionElementsCloneContext } from '../types/clone.js';
 import type {
   DragExtensionInitializeContext,
   ExtensionDragEndContext,
@@ -105,11 +107,22 @@ type ActionContextMap = {
       clear?: () => void;
     };
   };
+  elementsClone: {
+    context: ExtensionElementsCloneContext;
+    returnType: Promise<
+      | {
+          elements: GfxModel[];
+        }
+      | undefined
+    >;
+  };
 };
 
 export class InteractivityActionAPI {
   private readonly _handlers: Partial<{
-    dragInitialize: Parameters<InteractivityActionAPI['onDragInitialize']>[0];
+    [K in keyof ActionContextMap]: (
+      ctx: ActionContextMap[K]['context']
+    ) => ActionContextMap[K]['returnType'];
   }> = {};
 
   onDragInitialize(
@@ -121,6 +134,18 @@ export class InteractivityActionAPI {
 
     return () => {
       delete this._handlers['dragInitialize'];
+    };
+  }
+
+  onRequestElementsClone(
+    handler: (
+      ctx: ActionContextMap['elementsClone']['context']
+    ) => ActionContextMap['elementsClone']['returnType']
+  ) {
+    this._handlers['elementsClone'] = handler;
+
+    return () => {
+      return delete this._handlers['elementsClone'];
     };
   }
 

--- a/blocksuite/framework/std/src/gfx/interactivity/manager.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/manager.ts
@@ -12,6 +12,7 @@ import {
   InteractivityExtensionIdentifier,
 } from './extension/base.js';
 import { GfxViewEventManager } from './gfx-view-event-handler.js';
+import type { RequestElementsCloneContext } from './types/clone.js';
 import type {
   DragExtensionInitializeContext,
   DragInitializationOption,
@@ -287,5 +288,22 @@ export class InteractivityManager extends GfxExtension {
 
     listenEvent();
     dragStart();
+  }
+
+  requestElementsClone(options: RequestElementsCloneContext) {
+    const extensions = this.interactExtensions;
+
+    for (let ext of extensions.values()) {
+      const cloneData = (ext.action as InteractivityActionAPI).emit(
+        'elementsClone',
+        options
+      );
+
+      if (cloneData) {
+        return cloneData;
+      }
+    }
+
+    return Promise.resolve(undefined);
   }
 }

--- a/blocksuite/framework/std/src/gfx/interactivity/types/clone.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/types/clone.ts
@@ -1,0 +1,7 @@
+import type { GfxModel } from '../../model/model';
+
+export type ExtensionElementsCloneContext = {
+  elements: GfxModel[];
+};
+
+export type RequestElementsCloneContext = ExtensionElementsCloneContext;


### PR DESCRIPTION
### Changed
- Add `onRequestElementsClone` action to allow extension to define how to clone gfx elements