### PR TITLE
fix(core):  confirm the tag name before creating a new tag

### DIFF
--- a/packages/frontend/core/src/modules/explorer/views/nodes/tag/index.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/nodes/tag/index.tsx
@@ -28,10 +28,8 @@ export const ExplorerTagNode = ({
   operations: additionalOperations,
   dropEffect,
   canDrop,
-  defaultRenaming,
 }: {
   tagId: string;
-  defaultRenaming?: boolean;
 } & GenericExplorerNode) => {
   const t = useI18n();
   const { tagService, globalContextService } = useServices({
@@ -179,7 +177,6 @@ export const ExplorerTagNode = ({
       setCollapsed={setCollapsed}
       to={`/tag/${tagId}`}
       active={active}
-      defaultRenaming={defaultRenaming}
       reorderable={reorderable}
       onRename={handleRename}
       canDrop={handleCanDrop}

--- a/packages/frontend/core/src/modules/explorer/views/sections/tags/styles.css.ts
+++ b/packages/frontend/core/src/modules/explorer/views/sections/tags/styles.css.ts
@@ -9,3 +9,15 @@ export const draggedOverHighlight = style({
     },
   },
 });
+
+export const iconContainer = style({
+  display: 'flex',
+  position: 'relative',
+});
+
+export const createModalAnchor = style({
+  top: 20,
+  left: 'auto',
+  right: 0,
+  transform: 'translateX(6px)',
+});

--- a/packages/frontend/core/src/modules/explorer/views/tree/node.tsx
+++ b/packages/frontend/core/src/modules/explorer/views/tree/node.tsx
@@ -98,14 +98,16 @@ interface WebExplorerTreeNodeProps extends BaseExplorerTreeNodeProps {
  * specific rename modal for explorer tree node,
  * Separate it into a separate component to prevent re-rendering the entire component when width changes.
  */
-const ExplorerTreeNodeRenameModal = ({
+export const ExplorerTreeNodeRenameModal = ({
   setRenaming,
   handleRename,
   rawName,
+  className,
 }: {
   setRenaming: (renaming: boolean) => void;
   handleRename: (newName: string) => void;
   rawName: string | undefined;
+  className?: string;
 }) => {
   const appSidebarService = useService(AppSidebarService).sidebar;
   const sidebarWidth = useLiveData(appSidebarService.width$);
@@ -117,7 +119,7 @@ const ExplorerTreeNodeRenameModal = ({
       onRename={handleRename}
       currentName={rawName ?? ''}
     >
-      <div className={styles.itemRenameAnchor} />
+      <div className={clsx(styles.itemRenameAnchor, className)} />
     </RenameModal>
   );
 };


### PR DESCRIPTION
close AF-1569

- Show rename modal below the "Add Tag" button instead of at the new tag node
- Tag is created only after the user confirms the name in the modal
- Improves sidebar tag creation flow and user experience
![CleanShot 2025-04-16 at 11 18 28@2x](https://github.com/user-attachments/assets/8b6ccd52-deef-45d7-b523-5f7b1c2cab96)
