### PR TITLE
perf(editor): avoid redundant dom query when editing single block

### DIFF
--- a/blocksuite/framework/std/src/inline/range/inline-range-provider.ts
+++ b/blocksuite/framework/std/src/inline/range/inline-range-provider.ts
@@ -40,6 +40,13 @@ export const getInlineRangeProvider: (
       return null;
     }
 
+    if (
+      textSelection.isInSameBlock() &&
+      textSelection.from.blockId !== element.blockId
+    ) {
+      return null;
+    }
+
     const elementRange = rangeManager.textSelectionToRange(
       selectionManager.create(TextSelection, {
         from: {
@@ -96,14 +103,6 @@ export const getInlineRangeProvider: (
       const range = rangeManager.value;
       if (!range || !textSelection) {
         inlineRange$.value = null;
-        return;
-      }
-
-      // Avoid DOM query when not operating on this block component
-      if (
-        textSelection.isInSameBlock() &&
-        textSelection.from.blockId !== element.blockId
-      ) {
         return;
       }
 

--- a/blocksuite/framework/std/src/inline/range/inline-range-provider.ts
+++ b/blocksuite/framework/std/src/inline/range/inline-range-provider.ts
@@ -98,6 +98,19 @@ export const getInlineRangeProvider: (
         inlineRange$.value = null;
         return;
       }
+
+      const isCollaspsedTextSelection =
+        selections.length === 1 &&
+        selections[0].type === 'text' &&
+        !(selections[0] as TextSelection).to;
+      // Avoid DOM query when not operating on the element
+      if (isCollaspsedTextSelection) {
+        const textSelection = selections[0] as TextSelection;
+        if (textSelection.from.blockId !== element.blockId) {
+          return;
+        }
+      }
+
       const inlineRange = calculateInlineRange(range, textSelection);
       inlineRange$.value = inlineRange;
     })

--- a/blocksuite/framework/std/src/inline/range/inline-range-provider.ts
+++ b/blocksuite/framework/std/src/inline/range/inline-range-provider.ts
@@ -99,16 +99,12 @@ export const getInlineRangeProvider: (
         return;
       }
 
-      const isCollaspsedTextSelection =
-        selections.length === 1 &&
-        selections[0].type === 'text' &&
-        !(selections[0] as TextSelection).to;
-      // Avoid DOM query when not operating on the element
-      if (isCollaspsedTextSelection) {
-        const textSelection = selections[0] as TextSelection;
-        if (textSelection.from.blockId !== element.blockId) {
-          return;
-        }
+      // Avoid DOM query when not operating on this block component
+      if (
+        textSelection.isInSameBlock() &&
+        textSelection.from.blockId !== element.blockId
+      ) {
+        return;
       }
 
       const inlineRange = calculateInlineRange(range, textSelection);


### PR DESCRIPTION
Currently, all blocks would subscribe selection event and run `calculateInlineRange` on every text input, leading to heavy DOM redundant queries. This PR statically returns `null` for the range queries if the text selection is surely NOT happening in current block.

Tested with a snapshot with ~1500 paragraphs.

[9bf222c2-3574-46b4-8c9c-0dd807cd4d48.bs.zip](https://github.com/user-attachments/files/19774480/9bf222c2-3574-46b4-8c9c-0dd807cd4d48.bs.zip)

Before (>20ms per `transformInput`) when typing in a single block:

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lEGcysB4lFTEbCwZ8jMv/4c94210c-6252-418b-8381-ec1e2aa6add4.png)

After (~2ms per `transformInput`):

<img width="849" alt="image" src="https://github.com/user-attachments/assets/31ff0636-4840-4702-b071-fcbfdf493a4f" />
