### PR TITLE
refactor: moving connector label to connector view

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/gfx-tool/default-tool-ext/ext.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/gfx-tool/default-tool-ext/ext.ts
@@ -1,14 +1,10 @@
 export enum DefaultModeDragType {
-  /** Moving connector label */
-  ConnectorLabelMoving = 'connector-label-moving',
   /** Moving selected contents */
   ContentMoving = 'content-moving',
   /** Native range dragging inside active note block */
   NativeEditing = 'native-editing',
   /** Default void state */
   None = 'none',
-  /** Dragging preview */
-  PreviewDragging = 'preview-dragging',
   /** Expanding the dragging area, select the content covered inside */
   Selecting = 'selecting',
 }

--- a/blocksuite/affine/blocks/root/src/edgeless/interact-extensions/dblclick-add-edgeless-text.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/interact-extensions/dblclick-add-edgeless-text.ts
@@ -6,14 +6,17 @@ import {
   FeatureFlagService,
   TelemetryProvider,
 } from '@blocksuite/affine-shared/services';
-import type { PointerEventState } from '@blocksuite/std';
-import { InteractivityExtension } from '@blocksuite/std/gfx';
+import {
+  type GfxInteractivityContext,
+  InteractivityExtension,
+} from '@blocksuite/std/gfx';
 
 export class DblClickAddEdgelessText extends InteractivityExtension {
   static override key = 'dbl-click-add-edgeless-text';
 
   override mounted() {
-    this.event.on('dblclick', (e: PointerEventState) => {
+    this.event.on('dblclick', (ctx: GfxInteractivityContext) => {
+      const { event: e } = ctx;
       const textFlag = this.std.store
         .get(FeatureFlagService)
         .getFlag('enable_edgeless_text');

--- a/blocksuite/affine/gfx/connector/src/view/view.ts
+++ b/blocksuite/affine/gfx/connector/src/view/view.ts
@@ -1,8 +1,14 @@
-import type { ConnectorElementModel } from '@blocksuite/affine-model';
+import {
+  type ConnectorElementModel,
+  LocalShapeElementModel,
+} from '@blocksuite/affine-model';
+import { Bound, serializeXYWH, Vec } from '@blocksuite/global/gfx';
+import type { PointerEventState } from '@blocksuite/std';
 import {
   type DragEndContext,
   type DragMoveContext,
   type DragStartContext,
+  generateKeyBetween,
   GfxElementModelView,
 } from '@blocksuite/std/gfx';
 
@@ -30,11 +36,17 @@ export class ConnectorElementView extends GfxElementModelView<ConnectorElementMo
   override onCreated(): void {
     super.onCreated();
 
-    this._initDblClickToEdit();
+    this._initLabelMoving();
   }
 
-  private _initDblClickToEdit(): void {
-    this.on('dblclick', evt => {
+  private _initLabelMoving(): void {
+    let curLabelElement: LocalShapeElementModel | null = null;
+
+    if (this.model.isLocked()) {
+      return;
+    }
+
+    const enterLabelEditor = (evt: PointerEventState) => {
       const edgeless = this.std.view.getBlock(this.std.store.root!.id);
 
       if (edgeless && !this.model.isLocked()) {
@@ -43,6 +55,121 @@ export class ConnectorElementView extends GfxElementModelView<ConnectorElementMo
           edgeless,
           this.gfx.viewport.toModelCoord(evt.x, evt.y)
         );
+      }
+    };
+    const getCurrentPosition = (evt: PointerEventState) => {
+      const [x, y] = this.gfx.viewport.toModelCoord(evt.x, evt.y);
+      return {
+        x,
+        y,
+        clientX: evt.raw.clientX,
+        clientY: evt.raw.clientY,
+      };
+    };
+    const watchEvent = (labelModel: LocalShapeElementModel) => {
+      const view = this.gfx.view.get(labelModel) as GfxElementModelView;
+      const connectorModel = this.model;
+
+      let labelBound: Bound | null = null;
+      let startPoint = {
+        x: 0,
+        y: 0,
+        clientX: 0,
+        clientY: 0,
+      };
+      let lastPoint = {
+        x: 0,
+        y: 0,
+        clientX: 0,
+        clientY: 0,
+      };
+
+      view.on('dblclick', evt => {
+        enterLabelEditor(evt);
+      });
+      view.on('dragstart', evt => {
+        startPoint = getCurrentPosition(evt);
+        labelBound = Bound.deserialize(labelModel.xywh);
+
+        connectorModel.stash('labelXYWH');
+        connectorModel.stash('labelOffset');
+      });
+
+      view.on('dragmove', evt => {
+        if (!labelBound) {
+          return;
+        }
+
+        lastPoint = getCurrentPosition(evt);
+        const newBound = labelBound.clone();
+        const delta = [lastPoint.x - startPoint.x, lastPoint.y - startPoint.y];
+        const center = connectorModel.getNearestPoint(
+          Vec.add(newBound.center, delta)
+        );
+        const distance = connectorModel.getOffsetDistanceByPoint(center);
+        newBound.center = center;
+
+        connectorModel.labelXYWH = newBound.toXYWH();
+        connectorModel.labelOffset = {
+          distance,
+        };
+      });
+
+      view.on('dragend', () => {
+        if (labelBound) {
+          labelBound = null;
+          connectorModel.pop('labelXYWH');
+          connectorModel.pop('labelOffset');
+        }
+      });
+    };
+    const updateLabelElement = () => {
+      if (!this.model.labelXYWH || !this.model.text) {
+        // Clean up existing label element if conditions are no longer met
+        if (curLabelElement) {
+          this.surface.deleteLocalElement(curLabelElement);
+          curLabelElement = null;
+        }
+        return;
+      }
+
+      const labelElement =
+        curLabelElement || new LocalShapeElementModel(this.surface);
+      labelElement.xywh = serializeXYWH(...this.model.labelXYWH);
+      labelElement.index = generateKeyBetween(this.model.index, null);
+
+      if (!curLabelElement) {
+        curLabelElement = labelElement;
+
+        labelElement.fillColor = 'transparent';
+        labelElement.strokeColor = 'transparent';
+        labelElement.strokeWidth = 0;
+
+        this.surface.addLocalElement(labelElement);
+        this.disposable.add(() => {
+          this.surface.deleteLocalElement(labelElement);
+        });
+        watchEvent(labelElement);
+      }
+    };
+
+    this.disposable.add(
+      this.model.propsUpdated.subscribe(payload => {
+        if (
+          payload.key === 'labelXYWH' ||
+          payload.key === 'text' ||
+          payload.key === 'index'
+        ) {
+          updateLabelElement();
+        }
+      })
+    );
+
+    updateLabelElement();
+
+    this.on('dblclick', evt => {
+      if (!curLabelElement) {
+        enterLabelEditor(evt);
       }
     });
   }

--- a/blocksuite/affine/gfx/shape/src/view.ts
+++ b/blocksuite/affine/gfx/shape/src/view.ts
@@ -1,4 +1,4 @@
-import type { ShapeElementModel } from '@blocksuite/affine-model';
+import { ShapeElementModel } from '@blocksuite/affine-model';
 import { GfxElementModelView } from '@blocksuite/std/gfx';
 
 import { mountShapeTextEditor } from './text/edgeless-shape-text-editor';
@@ -16,7 +16,11 @@ export class ShapeElementView extends GfxElementModelView<ShapeElementModel> {
     this.on('dblclick', () => {
       const edgeless = this.std.view.getBlock(this.std.store.root!.id);
 
-      if (edgeless && !this.model.isLocked()) {
+      if (
+        edgeless &&
+        !this.model.isLocked() &&
+        this.model instanceof ShapeElementModel
+      ) {
         mountShapeTextEditor(this.model, edgeless);
       }
     });

--- a/blocksuite/framework/std/src/gfx/index.ts
+++ b/blocksuite/framework/std/src/gfx/index.ts
@@ -24,6 +24,7 @@ export type {
   ExtensionDragEndContext,
   ExtensionDragMoveContext,
   ExtensionDragStartContext,
+  GfxInteractivityContext,
   SelectedContext,
 } from './interactivity/index.js';
 export {

--- a/blocksuite/framework/std/src/gfx/interactivity/event.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/event.ts
@@ -1,3 +1,5 @@
+import type { PointerEventState, UIEventState } from '../../event';
+
 export type SupportedEvents =
   | 'click'
   | 'dblclick'
@@ -5,4 +7,42 @@ export type SupportedEvents =
   | 'pointerenter'
   | 'pointerleave'
   | 'pointermove'
-  | 'pointerup';
+  | 'pointerup'
+  | 'dragstart'
+  | 'dragmove'
+  | 'dragend';
+
+export type GfxInteractivityContext<
+  EventState extends UIEventState = PointerEventState,
+  RawEvent extends Event = EventState['event'],
+> = {
+  event: EventState;
+
+  /**
+   * The raw dom event.
+   */
+  raw: RawEvent;
+
+  /**
+   * Prevent the default gfx interaction
+   */
+  preventDefault: () => void;
+};
+
+export const createInteractionContext = (event: PointerEventState) => {
+  let preventDefaultState = false;
+
+  return {
+    context: {
+      event,
+      raw: event.raw,
+      preventDefault: () => {
+        preventDefaultState = true;
+        event.raw.preventDefault();
+      },
+    },
+    get preventDefaultState() {
+      return preventDefaultState;
+    },
+  };
+};

--- a/blocksuite/framework/std/src/gfx/interactivity/extension/base.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/extension/base.ts
@@ -2,11 +2,10 @@ import { type Container, createIdentifier } from '@blocksuite/global/di';
 import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import { Extension } from '@blocksuite/store';
 
-import type { PointerEventState } from '../../../event/index.js';
 import type { GfxController } from '../../controller.js';
 import { GfxControllerIdentifier } from '../../identifiers.js';
 import type { GfxModel } from '../../model/model.js';
-import type { SupportedEvents } from '../event.js';
+import type { GfxInteractivityContext, SupportedEvents } from '../event.js';
 import type { ExtensionElementsCloneContext } from '../types/clone.js';
 import type {
   DragExtensionInitializeContext,
@@ -64,10 +63,13 @@ export class InteractivityExtension extends Extension {
 export class InteractivityEventAPI {
   private readonly _handlersMap = new Map<
     SupportedEvents,
-    ((evt: PointerEventState) => void)[]
+    ((evt: GfxInteractivityContext) => void)[]
   >();
 
-  on(eventName: SupportedEvents, handler: (evt: PointerEventState) => void) {
+  on(
+    eventName: SupportedEvents,
+    handler: (evt: GfxInteractivityContext) => void
+  ) {
     const handlers = this._handlersMap.get(eventName) ?? [];
     handlers.push(handler);
     this._handlersMap.set(eventName, handlers);
@@ -81,7 +83,7 @@ export class InteractivityEventAPI {
     };
   }
 
-  emit(eventName: SupportedEvents, evt: PointerEventState) {
+  emit(eventName: SupportedEvents, evt: GfxInteractivityContext) {
     const handlers = this._handlersMap.get(eventName);
     if (!handlers) {
       return;

--- a/blocksuite/framework/std/src/gfx/interactivity/index.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/index.ts
@@ -1,3 +1,4 @@
+export type { GfxInteractivityContext } from './event.js';
 export { InteractivityExtension } from './extension/base.js';
 export { GfxViewEventManager } from './gfx-view-event-handler.js';
 export { InteractivityIdentifier, InteractivityManager } from './manager.js';

--- a/blocksuite/framework/std/src/gfx/view/view.ts
+++ b/blocksuite/framework/std/src/gfx/view/view.ts
@@ -26,6 +26,9 @@ export type EventsHandlerMap = {
   pointerleave: PointerEventState;
   pointermove: PointerEventState;
   pointerup: PointerEventState;
+  dragstart: PointerEventState;
+  dragmove: PointerEventState;
+  dragend: PointerEventState;
 };
 
 export type SupportedEvent = keyof EventsHandlerMap;
@@ -97,11 +100,24 @@ export class GfxElementModelView<
     return this.model.containsBound(bounds);
   }
 
+  /**
+   * Dispatches an event to the view.
+   * @param event
+   * @param evt
+   * @returns Whether the event view has any handlers for the event.
+   */
   dispatch<K extends keyof EventsHandlerMap>(
     event: K,
     evt: EventsHandlerMap[K]
   ) {
-    this._handlers.get(event)?.forEach(callback => callback(evt));
+    const handlers = this._handlers.get(event);
+
+    if (handlers?.length) {
+      handlers.forEach(callback => callback(evt));
+      return true;
+    }
+
+    return false;
   }
 
   getLineIntersections(start: IVec, end: IVec) {


### PR DESCRIPTION
### Changed
Moved connector label moving logic from `default-tool` to connector view. 

#### Other infrastructure changes:​​
- Gfx element view now can handles drag events
- Added `context.preventDefault()` support to bypass built-in interactions in extension
- Handle the pointer events in element view will bypass the built-in interactions automatically

> The built-in interactions include element dragging, click selection, drag-to-scale operations, etc.