### PR TITLE
fix(editor): preserve tag name updates on modifying tag color

### DIFF
--- a/blocksuite/affine/data-view/src/core/component/tags/multi-tag-select.ts
+++ b/blocksuite/affine/data-view/src/core/component/tags/multi-tag-select.ts
@@ -72,7 +72,7 @@ export type TagManagerOptions = {
 };
 
 class TagManager {
-  changeTag = (option: SelectTag) => {
+  changeTag = (option: Partial<SelectTag>) => {
     this.ops.onOptionsChange(
       this.ops.options.value.map(item => {
         if (item.id === option.id) {
@@ -207,7 +207,7 @@ export class MultiTagSelect extends SignalWatcher(
             initialValue: option.value,
             onChange: text => {
               this.tagManager.changeTag({
-                ...option,
+                id: option.id,
                 value: text,
               });
             },
@@ -237,7 +237,7 @@ export class MultiTagSelect extends SignalWatcher(
                 isSelected: option.color === item.color,
                 select: () => {
                   this.tagManager.changeTag({
-                    ...option,
+                    id: option.id,
                     color: item.color,
                   });
                 },


### PR DESCRIPTION
## The problem

For the database view, if you:
- click a select cell,
- choose a tag,
- edit the tag's value,
- and then change the tag's color,

you will find the tag's color changed, but the value is still the original one.

## What's changed

When updating a tag's value and color, ensure that only one property is changed each time.