### PR TITLE
fix(editor): for single-select, picking the original option should make the TagManager disappear

### DIFF
--- a/blocksuite/affine/data-view/src/core/component/tags/multi-tag-select.ts
+++ b/blocksuite/affine/data-view/src/core/component/tags/multi-tag-select.ts
@@ -177,7 +177,7 @@ class TagManager {
   }
 
   selectTag(id: string) {
-    if (this.isSelected(id)) {
+    if (!this.isSingleMode && this.isSelected(id)) {
       return;
     }
     const newValue = this.isSingleMode ? [id] : [...this.value$.value, id];


### PR DESCRIPTION
Clicking a selected tag in multi-select mode should have no effect, as indicated by the `return` statement in line 181.

However, for single-select mode, clicking a selected tag can safely lead to the TagManager disappearing. That's why I added another condition for the shortcut `return` branch.