### PR TITLE
chore(editor): improve highlight of toc card

### DIFF
--- a/blocksuite/affine/fragments/outline/src/card/outline-card.css.ts
+++ b/blocksuite/affine/fragments/outline/src/card/outline-card.css.ts
@@ -26,10 +26,10 @@ export const cardPreview = style({
   borderRadius: '4px',
   cursor: 'default',
   userSelect: 'none',
-  ':hover': {
-    background: cssVarV2('layer/background/hoverOverlay'),
-  },
   selectors: {
+    [`${outlineCard}[data-sortable="true"] &:hover`]: {
+      background: cssVarV2('layer/background/hoverOverlay'),
+    },
     [`${outlineCard}[data-status="selected"] &`]: {
       background: cssVarV2('layer/background/hoverOverlay'),
     },


### PR DESCRIPTION
Close [BS-3166](https://linear.app/affine-design/issue/BS-3166/toc-hover有时会出现两个阴影)

https://github.com/user-attachments/assets/842a69bc-e299-4b84-8780-ff2b54c30bab

