### PR TITLE
fix(editor): turbo renderer placeholder for built in template

### DIFF
--- a/blocksuite/affine/blocks/code/src/turbo/code-layout-handler.ts
+++ b/blocksuite/affine/blocks/code/src/turbo/code-layout-handler.ts
@@ -25,7 +25,9 @@ export class CodeLayoutHandlerExtension extends BlockLayoutHandlerExtension<Code
     host: EditorHost,
     viewportRecord: ViewportRecord
   ): CodeLayout | null {
-    const component = host.std.view.getBlock(model.id) as GfxBlockComponent;
+    const component = host.std.view.getBlock(
+      model.id
+    ) as GfxBlockComponent | null;
     if (!component) return null;
 
     const codeBlockElement = component.querySelector(

--- a/blocksuite/affine/blocks/image/src/turbo/image-layout-handler.ts
+++ b/blocksuite/affine/blocks/image/src/turbo/image-layout-handler.ts
@@ -25,7 +25,9 @@ export class ImageLayoutHandlerExtension extends BlockLayoutHandlerExtension<Ima
     host: EditorHost,
     viewportRecord: ViewportRecord
   ): ImageLayout | null {
-    const component = host.std.view.getBlock(model.id) as GfxBlockComponent;
+    const component = host.std.view.getBlock(
+      model.id
+    ) as GfxBlockComponent | null;
     if (!component) return null;
 
     const imageContainer = component.querySelector('.affine-image-container');

--- a/blocksuite/affine/blocks/list/src/turbo/list-layout-handler.ts
+++ b/blocksuite/affine/blocks/list/src/turbo/list-layout-handler.ts
@@ -27,7 +27,9 @@ export class ListLayoutHandlerExtension extends BlockLayoutHandlerExtension<List
     host: EditorHost,
     viewportRecord: ViewportRecord
   ): ListLayout | null {
-    const component = host.std.view.getBlock(model.id) as GfxBlockComponent;
+    const component = host.std.view.getBlock(
+      model.id
+    ) as GfxBlockComponent | null;
     if (!component) return null;
 
     // Find the list items within this specific list component

--- a/blocksuite/affine/blocks/note/src/turbo/note-layout-handler.ts
+++ b/blocksuite/affine/blocks/note/src/turbo/note-layout-handler.ts
@@ -30,7 +30,9 @@ export class NoteLayoutHandlerExtension extends BlockLayoutHandlerExtension<Note
     host: EditorHost,
     viewportRecord: ViewportRecord
   ): NoteLayout | null {
-    const component = host.std.view.getBlock(model.id) as GfxBlockComponent;
+    const component = host.std.view.getBlock(
+      model.id
+    ) as GfxBlockComponent | null;
     if (!component) return null;
 
     // Get the note container element

--- a/blocksuite/affine/blocks/paragraph/src/turbo/paragraph-layout-handler.ts
+++ b/blocksuite/affine/blocks/paragraph/src/turbo/paragraph-layout-handler.ts
@@ -27,7 +27,10 @@ export class ParagraphLayoutHandlerExtension extends BlockLayoutHandlerExtension
     host: EditorHost,
     viewportRecord: ViewportRecord
   ): ParagraphLayout | null {
-    const component = host.std.view.getBlock(model.id) as GfxBlockComponent;
+    const component = host.std.view.getBlock(
+      model.id
+    ) as GfxBlockComponent | null;
+    if (!component) return null;
     const paragraphSelector =
       '.affine-paragraph-rich-text-wrapper [data-v-text="true"]';
     const paragraphNode = component.querySelector(paragraphSelector);

--- a/blocksuite/affine/gfx/turbo-renderer/src/types.ts
+++ b/blocksuite/affine/gfx/turbo-renderer/src/types.ts
@@ -82,6 +82,7 @@ export interface BlockLayoutPainter {
 export interface RendererOptions {
   zoomThreshold: number;
   debounceTime: number;
+  enableBitmapRendering?: boolean;
 }
 
 export interface TurboRendererConfig {


### PR DESCRIPTION
Fixed compat error for new built-in template with test updated.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lEGcysB4lFTEbCwZ8jMv/f8c69d3f-9602-4509-994b-7243b26b4656.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to enable or disable bitmap rendering in the renderer settings.
  - Introduced a cooldown period after zooming before block optimization resumes, improving rendering performance and stability.

- **Bug Fixes**
  - Improved handling of cases where block components may be missing, preventing potential runtime errors.

- **Tests**
  - Expanded and refined tests to verify zooming behavior, bitmap caching, and internal state transitions for enhanced reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->