### PR TITLE
fix: drag handler hover rect state is not cleaned

### DIFF
--- a/blocksuite/affine/widgets/drag-handle/src/drag-handle.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/drag-handle.ts
@@ -46,8 +46,6 @@ export class AffineDragHandleWidget extends WidgetComponent<RootBlockModel> {
   private readonly _reset = () => {
     this.dragging = false;
 
-    this.dragHoverRect = null;
-    this.anchorBlockId.value = null;
     this.isDragHandleHovered = false;
 
     this.pointerEventWatcher.reset();
@@ -105,6 +103,9 @@ export class AffineDragHandleWidget extends WidgetComponent<RootBlockModel> {
     );
   };
 
+  /**
+   * @param force Reset the dragging state
+   */
   hide = (force = false) => {
     if (this.dragging && !force) return;
     updateDragHandleClassName();
@@ -112,6 +113,7 @@ export class AffineDragHandleWidget extends WidgetComponent<RootBlockModel> {
     this.isDragHandleHovered = false;
 
     this.anchorBlockId.value = null;
+    this.dragHoverRect = null;
     this.activeDragHandle = null;
 
     if (this.dragHandleContainer) {
@@ -179,7 +181,6 @@ export class AffineDragHandleWidget extends WidgetComponent<RootBlockModel> {
     this._disposables.addFromEvent(this.host, 'pointerleave', () => {
       this.hide();
     });
-
     this._handleEventWatcher.watch();
 
     if (isInsidePageEditor(this.host)) {


### PR DESCRIPTION
Fixes [BS-3261](https://linear.app/affine-design/issue/BS-3261/部分情况下-edgeless-dnd-响应区域有问题)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Improved documentation for the drag handle by adding a description for the `force` parameter in the hide method.

- **Style**
  - Minor code formatting adjustments with no impact on functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->