### PR TITLE
fix(core): do not need to inline fonts

### DIFF
--- a/tools/cli/src/webpack/index.ts
+++ b/tools/cli/src/webpack/index.ts
@@ -202,7 +202,7 @@ export function createHTMLTargetConfig(
             },
             {
               test: /\.(ttf|eot|woff|woff2)$/,
-              type: IN_CI ? 'asset/inline' : 'asset/resource',
+              type: 'asset/resource',
             },
             {
               test: /\.txt$/,


### PR DESCRIPTION
The fonts are always loaded via url thus it is not needed to have fonts inlined.  Inlining fonts will increase the size of bundled files.