### PR TITLE
refactor(editor): move block-specific extensions to their respective modules

### DIFF
--- a/blocksuite/affine/all/src/extensions/store.ts
+++ b/blocksuite/affine/all/src/extensions/store.ts
@@ -1,8 +1,4 @@
-import { CodeMarkdownPreprocessorExtension } from '@blocksuite/affine-block-code';
 import { DatabaseSelectionExtension } from '@blocksuite/affine-block-database';
-import { EmbedIframeConfigExtensions } from '@blocksuite/affine-block-embed';
-import { ImageStoreSpec } from '@blocksuite/affine-block-image';
-import { LatexMarkdownPreprocessorExtension } from '@blocksuite/affine-block-latex';
 import {
   RootBlockHtmlAdapterExtension,
   RootBlockMarkdownAdapterExtension,
@@ -36,7 +32,6 @@ import {
 import { HighlightSelectionExtension } from '@blocksuite/affine-shared/selection';
 import {
   BlockMetaService,
-  EmbedIframeService,
   FeatureFlagService,
   FileSizeLimitService,
   LinkPreviewerService,
@@ -64,16 +59,9 @@ const defaultBlockHtmlAdapterMatchers = [RootBlockHtmlAdapterExtension];
 
 const defaultBlockMarkdownAdapterMatchers = [RootBlockMarkdownAdapterExtension];
 
-const defaultMarkdownPreprocessors = [
-  LatexMarkdownPreprocessorExtension,
-  CodeMarkdownPreprocessorExtension,
-];
-
 const defaultBlockNotionHtmlAdapterMatchers: ExtensionType[] = [
   RootBlockNotionHtmlAdapterExtension,
 ];
-
-const defaultBlockPlainTextAdapterMatchers: ExtensionType[] = [];
 
 function getHtmlAdapterExtensions(): ExtensionType[] {
   return [
@@ -88,7 +76,6 @@ function getMarkdownAdapterExtensions(): ExtensionType[] {
     ...MarkdownInlineToDeltaAdapterExtensions,
     ...defaultBlockMarkdownAdapterMatchers,
     ...InlineDeltaToMarkdownAdapterExtensions,
-    ...defaultMarkdownPreprocessors,
   ];
 }
 
@@ -100,10 +87,7 @@ function getNotionHtmlAdapterExtensions(): ExtensionType[] {
 }
 
 function getPlainTextAdapterExtensions(): ExtensionType[] {
-  return [
-    ...defaultBlockPlainTextAdapterMatchers,
-    ...InlineDeltaToPlainTextAdapterExtensions,
-  ];
+  return [...InlineDeltaToPlainTextAdapterExtensions];
 }
 
 const MigratingStoreExtensions: ExtensionType[] = [
@@ -127,10 +111,7 @@ const MigratingStoreExtensions: ExtensionType[] = [
   FeatureFlagService,
   LinkPreviewerService,
   FileSizeLimitService,
-  ImageStoreSpec,
   BlockMetaService,
-  EmbedIframeConfigExtensions,
-  EmbedIframeService,
 ].flat();
 
 export class MigratingStoreExtension extends StoreExtensionProvider {

--- a/blocksuite/affine/blocks/code/src/store.ts
+++ b/blocksuite/affine/blocks/code/src/store.ts
@@ -5,6 +5,7 @@ import {
 import { CodeBlockSchemaExtension } from '@blocksuite/affine-model';
 
 import { CodeBlockAdapterExtensions } from './adapters/extension';
+import { CodeMarkdownPreprocessorExtension } from './adapters/markdown/preprocessor';
 
 export class CodeStoreExtension extends StoreExtensionProvider {
   override name = 'affine-code-block';
@@ -13,5 +14,6 @@ export class CodeStoreExtension extends StoreExtensionProvider {
     super.setup(context);
     context.register(CodeBlockSchemaExtension);
     context.register(CodeBlockAdapterExtensions);
+    context.register(CodeMarkdownPreprocessorExtension);
   }
 }

--- a/blocksuite/affine/blocks/embed/src/store.ts
+++ b/blocksuite/affine/blocks/embed/src/store.ts
@@ -12,9 +12,11 @@ import {
   EmbedSyncedDocBlockSchemaExtension,
   EmbedYoutubeBlockSchemaExtension,
 } from '@blocksuite/affine-model';
+import { EmbedIframeService } from '@blocksuite/affine-shared/services';
 
 import { EmbedFigmaBlockAdapterExtensions } from './embed-figma-block/adapters/extension';
 import { EmbedGithubBlockAdapterExtensions } from './embed-github-block/adapters/extension';
+import { EmbedIframeConfigExtensions } from './embed-iframe-block';
 import { EmbedIframeBlockAdapterExtensions } from './embed-iframe-block/adapters';
 import { EmbedLinkedDocBlockAdapterExtensions } from './embed-linked-doc-block/adapters/extension';
 import { EmbedLoomBlockAdapterExtensions } from './embed-loom-block/adapters/extension';
@@ -43,5 +45,8 @@ export class EmbedStoreExtension extends StoreExtensionProvider {
     context.register(EmbedIframeBlockAdapterExtensions);
     context.register(EmbedLinkedDocBlockAdapterExtensions);
     context.register(EmbedSyncedDocBlockAdapterExtensions);
+
+    context.register(EmbedIframeConfigExtensions);
+    context.register(EmbedIframeService);
   }
 }

--- a/blocksuite/affine/blocks/latex/src/store.ts
+++ b/blocksuite/affine/blocks/latex/src/store.ts
@@ -5,6 +5,7 @@ import {
 import { LatexBlockSchemaExtension } from '@blocksuite/affine-model';
 
 import { LatexBlockAdapterExtensions } from './adapters/extension';
+import { LatexMarkdownPreprocessorExtension } from './adapters/markdown/preprocessor';
 
 export class LatexStoreExtension extends StoreExtensionProvider {
   override name = 'affine-latex-block';
@@ -13,5 +14,6 @@ export class LatexStoreExtension extends StoreExtensionProvider {
     super.setup(context);
     context.register([LatexBlockSchemaExtension]);
     context.register(LatexBlockAdapterExtensions);
+    context.register(LatexMarkdownPreprocessorExtension);
   }
 }


### PR DESCRIPTION
### TL;DR

Refactored extension registration to follow a more modular approach by moving extensions to their respective block packages.

### What changed?

- Removed centralized registration of several extensions from `store.ts` in the main package
- Moved the following extensions to their respective block packages:
  - `CodeMarkdownPreprocessorExtension` to the code block package
  - `LatexMarkdownPreprocessorExtension` to the latex block package
  - `EmbedIframeConfigExtensions` and `EmbedIframeService` to the embed block package
  - `ImageStoreSpec` removed from central registration
- Cleaned up unused arrays and imports in the main store file
- Removed empty `defaultBlockPlainTextAdapterMatchers` array

### How to test?

1. Verify that markdown preprocessing for code and latex blocks still works correctly
2. Check that iframe embeds function properly
3. Ensure image handling continues to work as expected
4. Test import/export functionality for all affected block types

### Why make this change?

This change improves code organization by following a more modular architecture where each block package is responsible for registering its own extensions. This approach reduces coupling between packages, makes the codebase more maintainable, and follows the principle that extensions should be registered where they are defined.