### PR TITLE
fix(editor): should not paste in readonly page mode

### DIFF
--- a/blocksuite/affine/blocks/root/src/clipboard/page-clipboard.ts
+++ b/blocksuite/affine/blocks/root/src/clipboard/page-clipboard.ts
@@ -80,6 +80,7 @@ export class PageClipboard extends ReadOnlyClipboard {
     const e = ctx.get('clipboardState').raw;
     e.preventDefault();
 
+    if (this.std.store.readonly) return;
     this.std.store.captureSync();
     this.std.command
       .chain()


### PR DESCRIPTION
### TL;DR

Prevent pasting content when a document is in readonly mode.

### What changed?

Added a check in the `PageClipboard` class to prevent pasting operations when the document is in readonly mode. The function now returns early if `this.std.store.readonly` is true, preventing any clipboard operations from being executed.

### How to test?

1. Open a document and add some content
2. Set the document to readonly mode: `document.querySelector('affine-page-root')!.doc.readonly = true`
3. Try to paste content into the document using:
   - Regular paste operation
   - Keyboard shortcut (Ctrl+V/Cmd+V)
4. Verify that no content is pasted and the document remains unchanged
5. Set the document back to editable mode and confirm pasting works again

### Why make this change?

This change ensures that documents in readonly mode maintain their integrity by preventing unintended modifications through clipboard operations. This is consistent with the expected behavior of readonly documents, where users should not be able to modify content through any means.