### PR TITLE
feat(editor): add favicon, title, description support for footnote url reference

### DIFF
--- a/blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts
@@ -2396,6 +2396,9 @@ World!
                           reference: {
                             type: 'url',
                             url: 'https://www.example.com',
+                            favicon: 'https://www.example.com/favicon.ico',
+                            title: 'Example Domain',
+                            description: 'Example Domain',
                           },
                         },
                       },
@@ -2437,7 +2440,7 @@ World!
     };
 
     const markdown =
-      'aaa[^1][^2][^3]\n\n[^1]: {"type":"url","url":"https%3A%2F%2Fwww.example.com"}\n\n[^2]: {"type":"doc","docId":"deadbeef"}\n\n[^3]: {"type":"attachment","blobId":"abcdefg","fileName":"test.txt","fileType":"text/plain"}\n';
+      'aaa[^1][^2][^3]\n\n[^1]: {"type":"url","url":"https%3A%2F%2Fwww.example.com","favicon":"https%3A%2F%2Fwww.example.com%2Ffavicon.ico","title":"Example Domain","description":"Example Domain"}\n\n[^2]: {"type":"doc","docId":"deadbeef"}\n\n[^3]: {"type":"attachment","blobId":"abcdefg","fileName":"test.txt","fileType":"text/plain"}\n';
 
     const mdAdapter = new MarkdownAdapter(createJob(), provider);
     const target = await mdAdapter.fromBlockSnapshot({
@@ -4029,7 +4032,11 @@ hhh
   });
 
   describe('footnote', () => {
-    const createFootnoteBlockSnapshot = (url: string): BlockSnapshot => ({
+    const url = 'https://www.example.com';
+    const favicon = 'https://www.example.com/favicon.ico';
+    const title = 'Example Domain';
+    const description = 'Example Domain';
+    const blockSnapshot = {
       type: 'block',
       id: 'matchesReplaceMap[0]',
       flavour: 'affine:note',
@@ -4061,6 +4068,9 @@ hhh
                       reference: {
                         type: 'url',
                         url,
+                        favicon,
+                        title,
+                        description,
                       },
                     },
                   },
@@ -4097,15 +4107,12 @@ hhh
           children: [],
         },
       ],
-    });
+    };
 
-    test('with encoded url', async () => {
-      const markdown =
-        'aaa[^1][^2][^3]\n\n[^1]: {"type":"url","url":"https%3A%2F%2Fwww.example.com"}\n\n[^2]: {"type":"doc","docId":"deadbeef"}\n\n[^3]: {"type":"attachment","blobId":"abcdefg","fileName":"test.txt","fileType":"text/plain"}\n';
-
-      const blockSnapshot = createFootnoteBlockSnapshot(
-        'https://www.example.com'
-      );
+    test('with encoded url and favicon', async () => {
+      const encodedUrl = encodeURIComponent(url);
+      const encodedFavicon = encodeURIComponent(favicon);
+      const markdown = `aaa[^1][^2][^3]\n\n[^1]: {"type":"url","url":"${encodedUrl}","favicon":"${encodedFavicon}","title":"${title}","description":"${description}"}\n\n[^2]: {"type":"doc","docId":"deadbeef"}\n\n[^3]: {"type":"attachment","blobId":"abcdefg","fileName":"test.txt","fileType":"text/plain"}\n`;
 
       const mdAdapter = new MarkdownAdapter(createJob(), provider);
       const rawBlockSnapshot = await mdAdapter.toBlockSnapshot({
@@ -4114,13 +4121,8 @@ hhh
       expect(nanoidReplacement(rawBlockSnapshot)).toEqual(blockSnapshot);
     });
 
-    test('with unencoded url', async () => {
-      const markdown =
-        'aaa[^1][^2][^3]\n\n[^1]: {"type":"url","url":"https://www.example.com"}\n\n[^2]: {"type":"doc","docId":"deadbeef"}\n\n[^3]: {"type":"attachment","blobId":"abcdefg","fileName":"test.txt","fileType":"text/plain"}\n';
-
-      const blockSnapshot = createFootnoteBlockSnapshot(
-        'https://www.example.com'
-      );
+    test('with unencoded url and favicon', async () => {
+      const markdown = `aaa[^1][^2][^3]\n\n[^1]: {"type":"url","url":"${url}","favicon":"${favicon}","title":"${title}","description":"${description}"}\n\n[^2]: {"type":"doc","docId":"deadbeef"}\n\n[^3]: {"type":"attachment","blobId":"abcdefg","fileName":"test.txt","fileType":"text/plain"}\n`;
 
       const mdAdapter = new MarkdownAdapter(createJob(), provider);
       const rawBlockSnapshot = await mdAdapter.toBlockSnapshot({

--- a/blocksuite/affine/blocks/bookmark/src/__tests__/adapters/preprocessor.unit.spec.ts
+++ b/blocksuite/affine/blocks/bookmark/src/__tests__/adapters/preprocessor.unit.spec.ts
@@ -50,4 +50,28 @@ describe('footnoteUrlPreprocessor', () => {
       '[^ref]: {"type":"url","url":"https%3A%2F%2Fexample.com%2Fpath%20with%20spaces%3Fparam%3Dvalue%26another%3Dparam"}';
     expect(footnoteUrlPreprocessor(input)).toBe(expected);
   });
+
+  it('should encode unencoded favicon URLs', () => {
+    const input =
+      '[^ref]: {"type":"url","url":"https://example.com","favicon":"https://example.com/icon.png"}';
+    const expected =
+      '[^ref]: {"type":"url","url":"https%3A%2F%2Fexample.com","favicon":"https%3A%2F%2Fexample.com%2Ficon.png"}';
+    expect(footnoteUrlPreprocessor(input)).toBe(expected);
+  });
+
+  it('should not encode already encoded favicon URLs', () => {
+    const input =
+      '[^ref]: {"type":"url","url":"https://example.com","favicon":"https%3A%2F%2Fexample.com%2Ficon.png"}';
+    const expected =
+      '[^ref]: {"type":"url","url":"https%3A%2F%2Fexample.com","favicon":"https%3A%2F%2Fexample.com%2Ficon.png"}';
+    expect(footnoteUrlPreprocessor(input)).toBe(expected);
+  });
+
+  it('should handle both URL and icon encoding in the same footnote', () => {
+    const input =
+      '[^ref]: {"type":"url","url":"https://example.com?param=value","favicon":"https://example.com/icon.png?size=large"}';
+    const expected =
+      '[^ref]: {"type":"url","url":"https%3A%2F%2Fexample.com%3Fparam%3Dvalue","favicon":"https%3A%2F%2Fexample.com%2Ficon.png%3Fsize%3Dlarge"}';
+    expect(footnoteUrlPreprocessor(input)).toBe(expected);
+  });
 });

--- a/blocksuite/affine/inlines/footnote/src/adapters/markdown/inline-delta.ts
+++ b/blocksuite/affine/inlines/footnote/src/adapters/markdown/inline-delta.ts
@@ -31,6 +31,11 @@ export const footnoteReferenceDeltaToMarkdownAdapterMatcher =
             clonedFootnoteReference.url
           );
         }
+        if (clonedFootnoteReference.favicon) {
+          clonedFootnoteReference.favicon = encodeURIComponent(
+            clonedFootnoteReference.favicon
+          );
+        }
         configs.set(
           footnoteDefinitionKey,
           JSON.stringify(clonedFootnoteReference)

--- a/blocksuite/affine/inlines/footnote/src/adapters/markdown/markdown-inline.ts
+++ b/blocksuite/affine/inlines/footnote/src/adapters/markdown/markdown-inline.ts
@@ -26,6 +26,11 @@ export const markdownFootnoteReferenceToDeltaMatcher =
             footnoteDefinitionJson.url
           );
         }
+        if (footnoteDefinitionJson.favicon) {
+          footnoteDefinitionJson.favicon = decodeURIComponent(
+            footnoteDefinitionJson.favicon
+          );
+        }
         const footnoteReference = FootNoteReferenceParamsSchema.parse(
           footnoteDefinitionJson
         );

--- a/blocksuite/affine/model/src/consts/doc.ts
+++ b/blocksuite/affine/model/src/consts/doc.ts
@@ -65,6 +65,9 @@ export type ReferenceInfo = z.infer<typeof ReferenceInfoSchema>;
  * 3. url: string - the url of the reference
  * 4. fileName: string - the name of the attachment
  * 5. fileType: string - the type of the attachment
+ * 6. favicon: string - the favicon of the url reference
+ * 7. title: string - the title of the url reference
+ * 8. description: string - the description of the url reference
  */
 export const FootNoteReferenceParamsSchema = z.object({
   type: z.enum(FootNoteReferenceTypes),
@@ -73,6 +76,9 @@ export const FootNoteReferenceParamsSchema = z.object({
   fileName: z.string().optional(),
   fileType: z.string().optional(),
   url: z.string().optional(),
+  favicon: z.string().optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
 });
 
 export type FootNoteReferenceParams = z.infer<


### PR DESCRIPTION
Closes: [BS-3272](https://linear.app/affine-design/issue/BS-3272/footnote-适配-exa-api-返回结果)

## What's Changed

Add link preview data support (favicon, title, description) for URL references in footnotes:
- Store and display URL preview data in footnotes
- Add encoding/decoding support for favicon URLs
- Optimize link preview by using existing preview data when available
