### PR TITLE
fix(electron): sometimes pops up failed to save dialog

### DIFF
--- a/packages/frontend/apps/electron/src/main/recording/feature.ts
+++ b/packages/frontend/apps/electron/src/main/recording/feature.ts
@@ -531,6 +531,7 @@ export function startRecording(
 
   // set a timeout to stop the recording after MAX_DURATION_FOR_TRANSCRIPTION
   setTimeout(() => {
+    const state = recordingStateMachine.status$.value;
     if (
       state?.status === 'recording' &&
       state.id === recordingStatus$.value?.id


### PR DESCRIPTION
fix AF-2557 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of recording state checks to ensure recordings stop correctly when conditions are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->