### PR TITLE
fix(editor): Fix table selection error and trigger hotkey event

### DIFF
--- a/blocksuite/framework/std/src/gfx/selection.ts
+++ b/blocksuite/framework/std/src/gfx/selection.ts
@@ -232,6 +232,10 @@ export class GfxSelectionManager extends GfxExtension {
         assertType<CursorSelection[]>(cursor);
         assertType<SurfaceSelection[]>(surface);
 
+        if (cursor.length == 0 && surface.length == 0) {
+          return;
+        }
+
         if (cursor[0] && !this.cursorSelection?.equals(cursor[0])) {
           this._cursorSelection = cursor[0];
           this.slots.cursorUpdated.next(cursor[0]);

--- a/blocksuite/framework/std/src/gfx/selection.ts
+++ b/blocksuite/framework/std/src/gfx/selection.ts
@@ -232,7 +232,7 @@ export class GfxSelectionManager extends GfxExtension {
         assertType<CursorSelection[]>(cursor);
         assertType<SurfaceSelection[]>(surface);
 
-        if (cursor.length == 0 && surface.length == 0) {
+        if (cursor.length === 0 && surface.length === 0) {
           return;
         }
 


### PR DESCRIPTION
Closes: #11784 
Closes: #11580 
Closes: #11467 

After table cell selected, host.selection set to new TableSelection, in gfx/selection, subscribe selection changed.
With this TableSelection without Cursor or SurfaceSelection, it lost the editing status of table.
Then if 's', 'm', key pressed, trigger the hotkey event.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved selection handling to prevent unnecessary updates when no cursor or surface selections are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->