### PR TITLE
fix(server): query workspace embed files

### DIFF
--- a/packages/backend/server/src/__tests__/copilot-provider.spec.ts
+++ b/packages/backend/server/src/__tests__/copilot-provider.spec.ts
@@ -284,7 +284,15 @@ const actions = [
     verifier: (t: ExecutionContext<Tester>, result: string) => {
       assertNotWrappedInCodeBlock(t, result);
       assertCitation(t, result, (t, c) => {
-        t.assert(c.length === 0, 'should not have citation');
+        t.assert(
+          c.length === 0 ||
+            // ignore web search result
+            c
+              .map(c => JSON.parse(c.citationJson).type)
+              .filter(type => ['attachment', 'doc'].includes(type)).length ===
+              0,
+          'should not have citation'
+        );
       });
     },
     type: 'text' as const,
@@ -404,8 +412,9 @@ const actions = [
     messages: [{ role: 'user' as const, content: TestAssets.SSOT }],
     verifier: (t: ExecutionContext<Tester>, result: string) => {
       assertNotWrappedInCodeBlock(t, result);
+      const cleared = result.toLowerCase();
       t.assert(
-        result.toLowerCase().includes('single source of truth'),
+        cleared.includes('single source of truth') || cleared.includes('ssot'),
         'should include original keyword'
       );
     },

--- a/packages/backend/server/src/__tests__/copilot.e2e.ts
+++ b/packages/backend/server/src/__tests__/copilot.e2e.ts
@@ -120,7 +120,7 @@ test.before(async t => {
   t.context.jobs = jobs;
 });
 
-const promptName = 'prompt';
+const textPromptName = 'prompt';
 test.beforeEach(async t => {
   Sinon.restore();
   const { app, prompt } = t.context;
@@ -128,7 +128,7 @@ test.beforeEach(async t => {
   await prompt.onApplicationBootstrap();
   t.context.u1 = await app.signupV1('u1@affine.pro');
 
-  await prompt.set(promptName, 'test', [
+  await prompt.set(textPromptName, 'test', [
     { role: 'system', content: 'hello {{word}}' },
   ]);
 });
@@ -150,7 +150,7 @@ test('should create session correctly', async t => {
     }
   ) => {
     await asserter(
-      createCopilotSession(app, workspaceId, randomUUID(), promptName)
+      createCopilotSession(app, workspaceId, randomUUID(), textPromptName)
     );
   };
 
@@ -202,7 +202,7 @@ test('should update session correctly', async t => {
       t.truthy(await x, error);
     }
   ) => {
-    await asserter(updateCopilotSession(app, sessionId, promptName));
+    await asserter(updateCopilotSession(app, sessionId, textPromptName));
   };
 
   {
@@ -212,7 +212,7 @@ test('should update session correctly', async t => {
       app,
       workspaceId,
       docId,
-      promptName
+      textPromptName
     );
     await assertUpdateSession(
       sessionId,
@@ -225,7 +225,7 @@ test('should update session correctly', async t => {
       app,
       randomUUID(),
       randomUUID(),
-      promptName
+      textPromptName
     );
     await assertUpdateSession(
       sessionId,
@@ -244,7 +244,7 @@ test('should update session correctly', async t => {
       app,
       workspaceId,
       randomUUID(),
-      promptName
+      textPromptName
     );
     await assertUpdateSession(
       sessionId,
@@ -294,7 +294,7 @@ test('should fork session correctly', async t => {
     app,
     id,
     randomUUID(),
-    promptName
+    textPromptName
   );
 
   let forkedSessionId: string;
@@ -363,7 +363,7 @@ test('should be able to use test provider', async t => {
 
   const { id } = await createWorkspace(app);
   t.truthy(
-    await createCopilotSession(app, id, randomUUID(), promptName),
+    await createCopilotSession(app, id, randomUUID(), textPromptName),
     'failed to create session'
   );
 });
@@ -379,7 +379,7 @@ test('should create message correctly', async t => {
       app,
       id,
       randomUUID(),
-      promptName
+      textPromptName
     );
     const messageId = await createCopilotMessage(app, sessionId);
     t.truthy(messageId, 'should be able to create message with valid session');
@@ -393,7 +393,7 @@ test('should create message correctly', async t => {
         app,
         id,
         randomUUID(),
-        promptName
+        textPromptName
       );
       const messageId = await createCopilotMessage(app, sessionId, undefined, [
         'http://example.com/cat.jpg',
@@ -408,7 +408,7 @@ test('should create message correctly', async t => {
         app,
         id,
         randomUUID(),
-        promptName
+        textPromptName
       );
       const smallestPng =
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII';
@@ -445,7 +445,7 @@ test('should be able to chat with api', async t => {
     app,
     id,
     randomUUID(),
-    promptName
+    textPromptName
   );
   const messageId = await createCopilotMessage(app, sessionId);
   const ret = await chatWithText(app, sessionId, messageId);
@@ -543,7 +543,7 @@ test('should be able to retry with api', async t => {
       app,
       id,
       randomUUID(),
-      promptName
+      textPromptName
     );
     const messageId = await createCopilotMessage(app, sessionId);
     // chat 2 times
@@ -565,7 +565,7 @@ test('should be able to retry with api', async t => {
       app,
       id,
       randomUUID(),
-      promptName
+      textPromptName
     );
     const messageId = await createCopilotMessage(app, sessionId);
     await chatWithText(app, sessionId, messageId);
@@ -587,7 +587,7 @@ test('should be able to retry with api', async t => {
       app,
       id,
       randomUUID(),
-      promptName
+      textPromptName
     );
     const messageId = await createCopilotMessage(app, sessionId);
     await chatWithText(app, sessionId, messageId);
@@ -614,13 +614,13 @@ test('should reject message from different session', async t => {
     app,
     id,
     randomUUID(),
-    promptName
+    textPromptName
   );
   const anotherSessionId = await createCopilotSession(
     app,
     id,
     randomUUID(),
-    promptName
+    textPromptName
   );
   const anotherMessageId = await createCopilotMessage(app, anotherSessionId);
   await t.throwsAsync(
@@ -639,7 +639,7 @@ test('should reject request from different user', async t => {
     app,
     id,
     randomUUID(),
-    promptName
+    textPromptName
   );
 
   // should reject message from different user
@@ -677,7 +677,7 @@ test('should be able to list history', async t => {
     app,
     workspaceId,
     randomUUID(),
-    promptName
+    textPromptName
   );
 
   const messageId = await createCopilotMessage(app, sessionId, 'hello');
@@ -740,7 +740,7 @@ test('should reject request that user have not permission', async t => {
       app,
       workspaceId,
       randomUUID(),
-      promptName
+      textPromptName
     );
 
     const messageId = await createCopilotMessage(app, sessionId);
@@ -777,7 +777,7 @@ test('should be able to manage context', async t => {
     app,
     workspaceId,
     randomUUID(),
-    promptName
+    textPromptName
   );
 
   // use mocked embedding client
@@ -859,7 +859,7 @@ test('should be able to manage context', async t => {
       app,
       workspaceId,
       randomUUID(),
-      promptName
+      textPromptName
     );
     const contextId = await createCopilotContext(app, workspaceId, sessionId);
 

--- a/packages/backend/server/src/__tests__/models/copilot-context.spec.ts
+++ b/packages/backend/server/src/__tests__/models/copilot-context.spec.ts
@@ -96,20 +96,16 @@ test('should insert embedding by doc id', async t => {
   const { id: contextId } = await t.context.copilotContext.create(session.id);
 
   {
-    await t.context.copilotContext.insertContentEmbedding(
-      contextId,
-      'file-id',
-      [
-        {
-          index: 0,
-          content: 'content',
-          embedding: Array.from({ length: 1024 }, () => 1),
-        },
-      ]
-    );
+    await t.context.copilotContext.insertFileEmbedding(contextId, 'file-id', [
+      {
+        index: 0,
+        content: 'content',
+        embedding: Array.from({ length: 1024 }, () => 1),
+      },
+    ]);
 
     {
-      const ret = await t.context.copilotContext.matchContentEmbedding(
+      const ret = await t.context.copilotContext.matchFileEmbedding(
         Array.from({ length: 1024 }, () => 0.9),
         contextId,
         1,
@@ -121,7 +117,7 @@ test('should insert embedding by doc id', async t => {
 
     {
       await t.context.copilotContext.deleteEmbedding(contextId, 'file-id');
-      const ret = await t.context.copilotContext.matchContentEmbedding(
+      const ret = await t.context.copilotContext.matchFileEmbedding(
         Array.from({ length: 1024 }, () => 0.9),
         contextId,
         1,

--- a/packages/backend/server/src/__tests__/models/copilot-workspace.spec.ts
+++ b/packages/backend/server/src/__tests__/models/copilot-workspace.spec.ts
@@ -110,16 +110,20 @@ test('should insert and search embedding', async t => {
       mimeType: 'text/plain',
       size: 1,
     });
-    await t.context.copilotWorkspace.addFileEmbeddings(workspace.id, fileId, [
-      {
-        index: 0,
-        content: 'content',
-        embedding: Array.from({ length: 1024 }, () => 1),
-      },
-    ]);
+    await t.context.copilotWorkspace.insertFileEmbeddings(
+      workspace.id,
+      fileId,
+      [
+        {
+          index: 0,
+          content: 'content',
+          embedding: Array.from({ length: 1024 }, () => 1),
+        },
+      ]
+    );
 
     {
-      const ret = await t.context.copilotWorkspace.matchWorkspaceFileEmbedding(
+      const ret = await t.context.copilotWorkspace.matchFileEmbedding(
         workspace.id,
         Array.from({ length: 1024 }, () => 0.9),
         1,

--- a/packages/backend/server/src/models/copilot-context.ts
+++ b/packages/backend/server/src/models/copilot-context.ts
@@ -153,7 +153,7 @@ export class CopilotContextModel extends BaseModel {
     return Prisma.join(groups.map(row => Prisma.sql`(${Prisma.join(row)})`));
   }
 
-  async insertContentEmbedding(
+  async insertFileEmbedding(
     contextId: string,
     fileId: string,
     embeddings: Embedding[]
@@ -168,7 +168,7 @@ export class CopilotContextModel extends BaseModel {
   `;
   }
 
-  async matchContentEmbedding(
+  async matchFileEmbedding(
     embedding: number[],
     contextId: string,
     topK: number,

--- a/packages/backend/server/src/plugins/copilot/context/types.ts
+++ b/packages/backend/server/src/plugins/copilot/context/types.ts
@@ -1,7 +1,7 @@
 import { File } from 'node:buffer';
 
 import { CopilotContextFileNotSupported } from '../../../base';
-import { Embedding } from '../../../models';
+import { ChunkSimilarity, Embedding } from '../../../models';
 import { parseDoc } from '../../../native';
 
 declare global {
@@ -36,7 +36,7 @@ declare global {
     };
 
     'copilot.embedding.files': {
-      contextId: string;
+      contextId?: string;
       userId: string;
       workspaceId: string;
       blobId: string;
@@ -112,6 +112,15 @@ export abstract class EmbeddingClient {
 
     // fix the index of the embeddings
     return embeddings.map(e => ({ ...e, index: chunks[e.index].index }));
+  }
+
+  async reRank<Chunk extends ChunkSimilarity = ChunkSimilarity>(
+    embeddings: Chunk[]
+  ): Promise<Chunk[]> {
+    // sort by distance with ascending order
+    return embeddings.sort(
+      (a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity)
+    );
   }
 
   abstract getEmbeddings(

--- a/packages/backend/server/src/plugins/copilot/workspace/resolver.ts
+++ b/packages/backend/server/src/plugins/copilot/workspace/resolver.ts
@@ -135,7 +135,7 @@ export class CopilotWorkspaceEmbeddingConfigResolver {
     @Parent() config: CopilotWorkspaceConfigType,
     @Args('pagination', PaginationInput.decode) pagination: PaginationInput
   ): Promise<PaginatedCopilotWorkspaceFileType> {
-    const [files, totalCount] = await this.copilotWorkspace.listWorkspaceFiles(
+    const [files, totalCount] = await this.copilotWorkspace.listFiles(
       config.workspaceId,
       pagination
     );
@@ -177,12 +177,12 @@ export class CopilotWorkspaceEmbeddingConfigResolver {
     }
 
     try {
-      const { blobId, file } = await this.copilotWorkspace.addWorkspaceFile(
+      const { blobId, file } = await this.copilotWorkspace.addFile(
         user.id,
         workspaceId,
         content
       );
-      await this.copilotWorkspace.addWorkspaceFileEmbeddingQueue({
+      await this.copilotWorkspace.queueFileEmbedding({
         userId: user.id,
         workspaceId,
         blobId,
@@ -219,6 +219,6 @@ export class CopilotWorkspaceEmbeddingConfigResolver {
       .workspace(workspaceId)
       .assert('Workspace.Settings.Update');
 
-    return await this.copilotWorkspace.removeWorkspaceFile(workspaceId, fileId);
+    return await this.copilotWorkspace.removeFile(workspaceId, fileId);
   }
 }

--- a/packages/backend/server/src/plugins/copilot/workspace/service.ts
+++ b/packages/backend/server/src/plugins/copilot/workspace/service.ts
@@ -53,11 +53,7 @@ export class CopilotWorkspaceService implements OnApplicationBootstrap {
     ]);
   }
 
-  async addWorkspaceFile(
-    userId: string,
-    workspaceId: string,
-    content: FileUpload
-  ) {
+  async addFile(userId: string, workspaceId: string, content: FileUpload) {
     const fileName = content.filename;
     const buffer = await readStream(content.createReadStream());
     const blobId = createHash('sha256').update(buffer).digest('base64url');
@@ -70,29 +66,25 @@ export class CopilotWorkspaceService implements OnApplicationBootstrap {
     return { blobId, file };
   }
 
-  async getWorkspaceFile(workspaceId: string, fileId: string) {
+  async getFile(workspaceId: string, fileId: string) {
     return await this.models.copilotWorkspace.getFile(workspaceId, fileId);
   }
 
-  async listWorkspaceFiles(
+  async listFiles(
     workspaceId: string,
     pagination?: {
       includeRead?: boolean;
     } & PaginationInput
   ) {
     return await Promise.all([
-      this.models.copilotWorkspace.listWorkspaceFiles(workspaceId, pagination),
-      this.models.copilotWorkspace.countIgnoredDocs(workspaceId),
+      this.models.copilotWorkspace.listFiles(workspaceId, pagination),
+      this.models.copilotWorkspace.countFiles(workspaceId),
     ]);
   }
 
-  async addWorkspaceFileEmbeddingQueue(
-    file: Jobs['copilot.workspace.embedding.files']
-  ) {
-    if (!this.supportEmbedding) return;
-
+  async queueFileEmbedding(file: Jobs['copilot.embedding.files']) {
     const { userId, workspaceId, blobId, fileId, fileName } = file;
-    await this.queue.add('copilot.workspace.embedding.files', {
+    await this.queue.add('copilot.embedding.files', {
       userId,
       workspaceId,
       blobId,
@@ -101,10 +93,7 @@ export class CopilotWorkspaceService implements OnApplicationBootstrap {
     });
   }
 
-  async removeWorkspaceFile(workspaceId: string, fileId: string) {
-    return await this.models.copilotWorkspace.removeWorkspaceFile(
-      workspaceId,
-      fileId
-    );
+  async removeFile(workspaceId: string, fileId: string) {
+    return await this.models.copilotWorkspace.removeFile(workspaceId, fileId);
   }
 }

--- a/packages/backend/server/src/plugins/copilot/workspace/types.ts
+++ b/packages/backend/server/src/plugins/copilot/workspace/types.ts
@@ -13,15 +13,6 @@ declare global {
       jobId: string;
     };
   }
-  interface Jobs {
-    'copilot.workspace.embedding.files': {
-      userId: string;
-      workspaceId: string;
-      blobId: string;
-      fileId: string;
-      fileName: string;
-    };
-  }
 }
 
 @ObjectType('CopilotWorkspaceIgnoredDoc')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded file chunk matching to include both context and workspace file embeddings, providing broader and more relevant search results.
- **Improvements**
	- Enhanced result ranking by introducing a re-ranking step for combined embedding matches, improving the relevance of returned file chunks.
	- Adjusted file count reporting to reflect the total number of workspace files instead of ignored documents for more accurate workspace file statistics.
	- Renamed and streamlined workspace file management methods for clearer and more consistent API usage.
- **Bug Fixes**
	- Prevented embedding similarity queries when embedding is disabled for a workspace, improving system behavior consistency.
- **Tests**
	- Added comprehensive tests to verify workspace embedding management, including enabling, matching, and disabling embedding functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->