### PR TITLE
refactor(core): use the websearch parameters passed in by the front-end

### DIFF
--- a/packages/backend/server/src/plugins/copilot/controller.ts
+++ b/packages/backend/server/src/plugins/copilot/controller.ts
@@ -179,12 +179,16 @@ export class CopilotController implements BeforeApplicationShutdown {
     const reasoning = Array.isArray(params.reasoning)
       ? Boolean(params.reasoning[0])
       : Boolean(params.reasoning);
+    const webSearch = Array.isArray(params.webSearch)
+      ? Boolean(params.webSearch[0])
+      : Boolean(params.webSearch);
 
     delete params.messageId;
     delete params.retry;
     delete params.reasoning;
+    delete params.webSearch;
 
-    return { messageId, retry, reasoning, params };
+    return { messageId, retry, reasoning, webSearch, params };
   }
 
   private getSignal(req: Request) {
@@ -232,7 +236,8 @@ export class CopilotController implements BeforeApplicationShutdown {
     const info: any = { sessionId, params };
 
     try {
-      const { messageId, retry, reasoning } = this.prepareParams(params);
+      const { messageId, retry, reasoning, webSearch } =
+        this.prepareParams(params);
 
       const provider = await this.chooseTextProvider(
         user.id,
@@ -264,6 +269,7 @@ export class CopilotController implements BeforeApplicationShutdown {
         signal: this.getSignal(req),
         user: user.id,
         reasoning,
+        webSearch,
       });
 
       session.push({
@@ -296,7 +302,8 @@ export class CopilotController implements BeforeApplicationShutdown {
     const info: any = { sessionId, params, throwInStream: false };
 
     try {
-      const { messageId, retry, reasoning } = this.prepareParams(params);
+      const { messageId, retry, reasoning, webSearch } =
+        this.prepareParams(params);
 
       const provider = await this.chooseTextProvider(
         user.id,
@@ -330,6 +337,7 @@ export class CopilotController implements BeforeApplicationShutdown {
           signal: this.getSignal(req),
           user: user.id,
           reasoning,
+          webSearch,
         })
       ).pipe(
         connect(shared$ =>

--- a/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
+++ b/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
@@ -1044,9 +1044,9 @@ const chat: Prompt[] = [
         content: `You are AFFiNE AI, a professional and humorous copilot within AFFiNE. You are powered by latest GPT model from OpenAI and AFFiNE. AFFiNE is an open source general purposed productivity tool that contains unified building blocks that users can use on any interfaces, including block-based docs editor, infinite canvas based edgeless graphic mode, or multi-dimensional table with multiple transformable views. Your mission is always to try your very best to assist users to use AFFiNE to write docs, draw diagrams or plan things with these abilities. You always think step-by-step and describe your plan for what to build, using well-structured and clear markdown, written out in great detail. Unless otherwise specified, where list, JSON, or code blocks are required for giving the output. Minimize any other prose so that your responses can be directly used and inserted into the docs. You are able to access to API of AFFiNE to finish your job. You always respect the users' privacy and would not leak their info to anyone else. AFFiNE is made by Toeverything .Pte .Ltd, a company registered in Singapore with a diverse and international team. The company also open sourced blocksuite and octobase for building tools similar to Affine. The name AFFiNE comes from the idea of AFFiNE transform, as blocks in affine can all transform in page, edgeless or database mode. AFFiNE team is now having 25 members, an open source company driven by engineers. Today is: {{affine::date}}, User's preferred language is {{affine::language}}.
 
 # Response Guide
-Use the webSearch tool to gather information from the web. There are two modes for web searching:
-- MUST: Means you always need to use the webSearch tool to gather information from the web, no matter what the user's query is.
-- CAN: Indicates that web searching is optional - you may use the webSearch tool at your discretion when you determine it would provide valuable information for answering the user's query.
+Use the web search tool to gather information from the web. There are two modes for web searching:
+- MUST: Means you always need to use the web search tool to gather information from the web, no matter what the user's query is.
+- CAN: Indicates that web searching is optional - you may use the web search tool at your discretion when you determine it would provide valuable information for answering the user's query.
 Currently, you are in the {{searchMode}} web searching mode.
 
 I will provide you with some content fragments. There are two types of content fragments:
@@ -1115,9 +1115,6 @@ Below is the user's query. Please respond in the user's language without treatin
 `,
       },
     ],
-    config: {
-      webSearch: true,
-    },
   },
   {
     name: 'Search With AFFiNE AI',

--- a/packages/backend/server/src/plugins/copilot/providers/anthropic.ts
+++ b/packages/backend/server/src/plugins/copilot/providers/anthropic.ts
@@ -134,9 +134,7 @@ export class AnthropicProvider
         providerOptions: {
           anthropic: this.getAnthropicOptions(options),
         },
-        tools: {
-          webSearch: createExaTool(this.AFFiNEConfig),
-        },
+        tools: this.getTools(options),
         maxSteps: this.MAX_STEPS,
         experimental_continueSteps: true,
       });
@@ -168,9 +166,7 @@ export class AnthropicProvider
         providerOptions: {
           anthropic: this.getAnthropicOptions(options),
         },
-        tools: {
-          webSearch: createExaTool(this.AFFiNEConfig),
-        },
+        tools: this.getTools(options),
         maxSteps: this.MAX_STEPS,
         experimental_continueSteps: true,
       });
@@ -182,7 +178,7 @@ export class AnthropicProvider
             break;
           }
           case 'tool-result': {
-            if (message.toolName === 'webSearch') {
+            if (message.toolName === 'web_search') {
               this.toolResults.push(this.getWebSearchLinks(message.result));
             }
             break;
@@ -212,6 +208,15 @@ export class AnthropicProvider
       metrics.ai.counter('chat_text_stream_errors').add(1, { model });
       throw this.handleError(e);
     }
+  }
+
+  private getTools(options: CopilotChatOptions) {
+    if (options?.webSearch) {
+      return {
+        web_search: createExaTool(this.AFFiNEConfig),
+      };
+    }
+    return undefined;
   }
 
   private getAnthropicOptions(

--- a/packages/backend/server/src/plugins/copilot/providers/openai.ts
+++ b/packages/backend/server/src/plugins/copilot/providers/openai.ts
@@ -178,8 +178,8 @@ export class OpenAIProvider
     }
   }
 
-  private getToolUse(options: CopilotChatOptions = {}) {
-    if (options.webSearch) {
+  private getTools(options: CopilotChatOptions) {
+    if (options?.webSearch) {
       return {
         web_search_preview: openai.tools.webSearchPreview(),
       };
@@ -224,6 +224,7 @@ export class OpenAIProvider
             providerOptions: {
               openai: options.user ? { user: options.user } : {},
             },
+            tools: this.getTools(options),
           });
 
       return text.trim();
@@ -245,18 +246,16 @@ export class OpenAIProvider
 
       const [system, msgs] = await chatToGPTMessage(messages);
 
-      const modelInstance = options.webSearch
-        ? this.#instance.responses(model)
-        : this.#instance(model, {
-            structuredOutputs: Boolean(options.jsonMode),
-            user: options.user,
-          });
+      const modelInstance = this.#instance(model, {
+        structuredOutputs: Boolean(options.jsonMode),
+        user: options.user,
+      });
 
       const { fullStream } = streamText({
         model: modelInstance,
         system,
         messages: msgs,
-        tools: this.getToolUse(options),
+        tools: this.getTools(options),
         frequencyPenalty: options.frequencyPenalty || 0,
         presencePenalty: options.presencePenalty || 0,
         temperature: options.temperature || 0,

--- a/packages/backend/server/src/plugins/copilot/providers/types.ts
+++ b/packages/backend/server/src/plugins/copilot/providers/types.ts
@@ -22,7 +22,6 @@ export enum CopilotCapability {
 export const PromptConfigStrictSchema = z.object({
   // openai
   jsonMode: z.boolean().nullable().optional(),
-  webSearch: z.boolean().nullable().optional(),
   frequencyPenalty: z.number().nullable().optional(),
   presencePenalty: z.number().nullable().optional(),
   temperature: z.number().nullable().optional(),
@@ -81,6 +80,7 @@ const CopilotChatOptionsSchema = CopilotProviderOptionsSchema.merge(
 )
   .extend({
     reasoning: z.boolean().optional(),
+    webSearch: z.boolean().optional(),
   })
   .optional();
 

--- a/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
@@ -109,7 +109,7 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
         where,
         docId: host.doc.id,
         workspaceId: host.doc.workspace.id,
-        mustSearch: visible?.value && enabled?.value,
+        webSearch: visible?.value && enabled?.value,
       } as Parameters<typeof action>[0];
       // @ts-expect-error TODO(@Peng): maybe fix this
       stream = await action(options);

--- a/packages/frontend/core/src/blocksuite/ai/actions/edgeless-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/edgeless-handler.ts
@@ -199,7 +199,7 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
             host,
             docId: host.doc.id,
             workspaceId: host.doc.workspace.id,
-            mustSearch: visible?.value && enabled?.value,
+            webSearch: visible?.value && enabled?.value,
           } as Parameters<typeof action>[0];
 
           const content = ctx.get().content;

--- a/packages/frontend/core/src/blocksuite/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/types.ts
@@ -133,7 +133,7 @@ declare global {
     interface ChatOptions extends AITextActionOptions {
       sessionId?: string;
       isRootSession?: boolean;
-      mustSearch?: boolean;
+      webSearch?: boolean;
       reasoning?: boolean;
       contexts?: {
         docs: AIDocContextOption[];

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
@@ -560,7 +560,7 @@ export class AIChatInput extends SignalWatcher(WithDisposable(LitElement)) {
         isRootSession: this.isRootSession,
         where: this.trackOptions.where,
         control: this.trackOptions.control,
-        mustSearch: this._isNetworkActive,
+        webSearch: this._isNetworkActive,
         reasoning: this._isReasoningActive,
       });
 

--- a/packages/frontend/core/src/blocksuite/ai/provider/copilot-client.ts
+++ b/packages/frontend/core/src/blocksuite/ai/provider/copilot-client.ts
@@ -351,17 +351,20 @@ export class CopilotClient {
     sessionId,
     messageId,
     reasoning,
+    webSearch,
     signal,
   }: {
     sessionId: string;
     messageId?: string;
     reasoning?: boolean;
+    webSearch?: boolean;
     signal?: AbortSignal;
   }) {
     let url = `/api/copilot/chat/${sessionId}`;
     const queryString = this.paramsToQueryString({
       messageId,
       reasoning,
+      webSearch,
     });
     if (queryString) {
       url += `?${queryString}`;
@@ -376,10 +379,12 @@ export class CopilotClient {
       sessionId,
       messageId,
       reasoning,
+      webSearch,
     }: {
       sessionId: string;
       messageId?: string;
       reasoning?: boolean;
+      webSearch?: boolean;
     },
     endpoint = 'stream'
   ) {
@@ -387,6 +392,7 @@ export class CopilotClient {
     const queryString = this.paramsToQueryString({
       messageId,
       reasoning,
+      webSearch,
     });
     if (queryString) {
       url += `?${queryString}`;

--- a/packages/frontend/core/src/blocksuite/ai/provider/request.ts
+++ b/packages/frontend/core/src/blocksuite/ai/provider/request.ts
@@ -20,6 +20,7 @@ export type TextToTextOptions = {
   isRootSession?: boolean;
   postfix?: (text: string) => string;
   reasoning?: boolean;
+  webSearch?: boolean;
 };
 
 export type ToImageOptions = TextToTextOptions & {
@@ -115,6 +116,7 @@ export function textToText({
   workflow = false,
   postfix,
   reasoning,
+  webSearch,
 }: TextToTextOptions) {
   let messageId: string | undefined;
 
@@ -135,6 +137,7 @@ export function textToText({
             sessionId,
             messageId,
             reasoning,
+            webSearch,
           },
           workflow ? 'workflow' : undefined
         );
@@ -195,6 +198,7 @@ export function textToText({
           sessionId,
           messageId,
           reasoning,
+          webSearch,
         });
       })(),
     ]);

--- a/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
+++ b/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
@@ -82,7 +82,7 @@ export function setupAIProvider(
 
   //#region actions
   AIProvider.provide('chat', async options => {
-    const { input, contexts, mustSearch } = options;
+    const { input, contexts, webSearch } = options;
 
     const sessionId = await createSession({
       promptName: 'Chat With AFFiNE AI',
@@ -96,7 +96,7 @@ export function setupAIProvider(
       params: {
         docs: contexts?.docs,
         files: contexts?.files,
-        searchMode: mustSearch ? 'MUST' : 'CAN',
+        searchMode: webSearch ? 'MUST' : 'CAN',
       },
     });
   });


### PR DESCRIPTION
Support [AI-60](https://linear.app/affine-design/issue/AI-60).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated naming conventions for the web search tool to ensure consistency across AI chat features.
  - Simplified internal handling of web search tool options for a more streamlined experience.
  - Unified parameter naming from "mustSearch" to "webSearch" across AI chat inputs and actions.
- **Chores**
  - Removed unused configuration options related to web search from prompt settings.
  - Added support for enabling or disabling web search via new parameters in chat requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->