### PR TITLE
feat(server): add doc meta for ignored docs

### DIFF
--- a/packages/backend/server/src/models/common/copilot.ts
+++ b/packages/backend/server/src/models/common/copilot.ts
@@ -120,3 +120,15 @@ export type CopilotWorkspaceFile = CopilotWorkspaceFileMetadata & {
   fileId: string;
   createdAt: Date;
 };
+
+export type IgnoredDoc = {
+  docId: string;
+  createdAt: Date;
+  // metadata
+  docCreatedAt: Date | undefined;
+  docUpdatedAt: Date | undefined;
+  title: string | undefined;
+  createdBy: string | undefined;
+  createdByAvatar: string | undefined;
+  updatedBy: string | undefined;
+};

--- a/packages/backend/server/src/models/doc.ts
+++ b/packages/backend/server/src/models/doc.ts
@@ -373,6 +373,29 @@ export class DocModel extends BaseModel {
     });
   }
 
+  async findAuthors(ids: { workspaceId: string; docId: string }[]) {
+    const rows = await this.db.snapshot.findMany({
+      where: {
+        workspaceId: { in: ids.map(id => id.workspaceId) },
+        id: { in: ids.map(id => id.docId) },
+      },
+      select: {
+        workspaceId: true,
+        id: true,
+        createdAt: true,
+        updatedAt: true,
+        createdByUser: { select: publicUserSelect },
+        updatedByUser: { select: publicUserSelect },
+      },
+    });
+    const resultMap = new Map(
+      rows.map(row => [`${row.workspaceId}-${row.id}`, row])
+    );
+    return ids.map(
+      id => resultMap.get(`${id.workspaceId}-${id.docId}`) ?? null
+    );
+  }
+
   async findMetas(ids: { workspaceId: string; docId: string }[]) {
     const rows = await this.db.workspaceDoc.findMany({
       where: {

--- a/packages/backend/server/src/plugins/copilot/workspace/types.ts
+++ b/packages/backend/server/src/plugins/copilot/workspace/types.ts
@@ -2,7 +2,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { SafeIntResolver } from 'graphql-scalars';
 
 import { Paginated } from '../../../base';
-import { CopilotWorkspaceFile } from '../../../models';
+import { CopilotWorkspaceFile, IgnoredDoc } from '../../../models';
 
 declare global {
   interface Events {
@@ -16,12 +16,30 @@ declare global {
 }
 
 @ObjectType('CopilotWorkspaceIgnoredDoc')
-export class CopilotWorkspaceIgnoredDocType {
+export class CopilotWorkspaceIgnoredDocType implements IgnoredDoc {
   @Field(() => String)
   docId!: string;
 
   @Field(() => Date)
   createdAt!: Date;
+
+  @Field(() => Date, { nullable: true })
+  docCreatedAt!: Date | undefined;
+
+  @Field(() => Date, { nullable: true })
+  docUpdatedAt!: Date | undefined;
+
+  @Field(() => String, { nullable: true })
+  title!: string | undefined;
+
+  @Field(() => String, { nullable: true })
+  createdBy!: string | undefined;
+
+  @Field(() => String, { nullable: true })
+  createdByAvatar!: string | undefined;
+
+  @Field(() => String, { nullable: true })
+  updatedBy!: string | undefined;
 }
 
 @ObjectType()

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -295,7 +295,13 @@ type CopilotWorkspaceFileTypeEdge {
 
 type CopilotWorkspaceIgnoredDoc {
   createdAt: DateTime!
+  createdBy: String
+  createdByAvatar: String
+  docCreatedAt: DateTime
   docId: String!
+  docUpdatedAt: DateTime
+  title: String
+  updatedBy: String
 }
 
 type CopilotWorkspaceIgnoredDocTypeEdge {

--- a/packages/common/graphql/src/graphql/copilot-workspace-ignored-docs-get.gql
+++ b/packages/common/graphql/src/graphql/copilot-workspace-ignored-docs-get.gql
@@ -11,6 +11,12 @@ query getWorkspaceEmbeddingIgnoredDocs($workspaceId: String!, $pagination: Pagin
           node {
             docId
             createdAt
+            docCreatedAt
+            docUpdatedAt
+            title
+            createdBy
+            createdByAvatar
+            updatedBy
           }
         }
       }

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -830,6 +830,12 @@ export const getWorkspaceEmbeddingIgnoredDocsQuery = {
           node {
             docId
             createdAt
+            docCreatedAt
+            docUpdatedAt
+            title
+            createdBy
+            createdByAvatar
+            updatedBy
           }
         }
       }

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -399,7 +399,13 @@ export interface CopilotWorkspaceFileTypeEdge {
 export interface CopilotWorkspaceIgnoredDoc {
   __typename?: 'CopilotWorkspaceIgnoredDoc';
   createdAt: Scalars['DateTime']['output'];
+  createdBy: Maybe<Scalars['String']['output']>;
+  createdByAvatar: Maybe<Scalars['String']['output']>;
+  docCreatedAt: Maybe<Scalars['DateTime']['output']>;
   docId: Scalars['String']['output'];
+  docUpdatedAt: Maybe<Scalars['DateTime']['output']>;
+  title: Maybe<Scalars['String']['output']>;
+  updatedBy: Maybe<Scalars['String']['output']>;
 }
 
 export interface CopilotWorkspaceIgnoredDocTypeEdge {
@@ -3374,6 +3380,12 @@ export type GetWorkspaceEmbeddingIgnoredDocsQuery = {
             __typename?: 'CopilotWorkspaceIgnoredDoc';
             docId: string;
             createdAt: string;
+            docCreatedAt: string | null;
+            docUpdatedAt: string | null;
+            title: string | null;
+            createdBy: string | null;
+            createdByAvatar: string | null;
+            updatedBy: string | null;
           };
         }>;
       };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ignored documents in workspace embedding now display additional metadata, including document title, creation and update timestamps, and the names and avatars of users who created or updated the document.
- **Enhancements**
  - The list of ignored documents provides richer information for easier identification and management within the workspace.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->