### PR TITLE
fix(nbstore): improve blob size error handling with human-readable limit

### DIFF
--- a/packages/common/nbstore/src/impls/cloud/http.ts
+++ b/packages/common/nbstore/src/impls/cloud/http.ts
@@ -16,7 +16,7 @@ export class HttpConnection extends DummyConnection {
 
     const timeout = 15000;
     const timeoutId = setTimeout(() => {
-      abortController.abort('timeout');
+      abortController.abort(new Error('request timeout'));
     }, timeout);
 
     const res = await globalThis

--- a/packages/common/nbstore/src/storage/errors/over-size.ts
+++ b/packages/common/nbstore/src/storage/errors/over-size.ts
@@ -1,5 +1,6 @@
 export class OverSizeError extends Error {
-  constructor(public originError?: any) {
-    super('Blob size exceeds the limit.');
+  constructor(limit: string | null) {
+    const formattedLimit = limit ? `${limit} ` : '';
+    super(`File size exceeds the ${formattedLimit}limit.`);
   }
 }

--- a/packages/common/nbstore/src/sync/blob/peer.ts
+++ b/packages/common/nbstore/src/sync/blob/peer.ts
@@ -185,8 +185,7 @@ export class BlobSyncPeer {
           this.status.remoteOverCapacity();
           this.status.blobError(blob.key, 'Remote storage over capacity');
         } else if (err instanceof OverSizeError) {
-          this.status.blobOverSize(blob.key);
-          this.status.blobError(blob.key, 'Blob size too large');
+          this.status.blobOverSizeWithError(blob.key, err.message);
         } else {
           this.status.blobError(
             blob.key,
@@ -445,7 +444,6 @@ class BlobSyncPeerStatus {
     if (deleted) {
       this.statusUpdatedSubject$.next(blobId);
     }
-    this.blobErrorFree(blobId);
   }
 
   blobWillUpload(blobId: string) {
@@ -514,6 +512,12 @@ class BlobSyncPeerStatus {
 
   blobOverSize(blobId: string) {
     this.overSize.add(blobId);
+    this.statusUpdatedSubject$.next(blobId);
+  }
+
+  blobOverSizeWithError(blobId: string, errorMessage: string) {
+    this.overSize.add(blobId);
+    this.error.set(blobId, errorMessage);
     this.statusUpdatedSubject$.next(blobId);
   }
 


### PR DESCRIPTION
Closes: [BS-3332](https://linear.app/affine-design/issue/BS-3332/错误信息)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error messages when file uploads exceed the allowed size, now showing the maximum file size limit in a human-readable format.
	- Enhanced status updates for oversized files by displaying clear error messages during blob uploads.
	- Updated request timeout handling to provide clearer error details on aborts.
- **Style**
	- Error messages for file size limits are now more user-friendly and informative.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->