### PR TITLE
fix(editor): edgeless note duplicated from embed-doc should be above other elements

### DIFF
--- a/blocksuite/affine/blocks/embed/src/embed-synced-doc-block/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-synced-doc-block/configs/toolbar.ts
@@ -375,6 +375,7 @@ const builtinSurfaceToolbarConfig = {
                     DEFAULT_NOTE_WIDTH,
                     DEFAULT_NOTE_HEIGHT
                   ).serialize(),
+                  index: gfx.layer.generateIndex(),
                   displayMode: NoteDisplayMode.EdgelessOnly,
                 } satisfies Partial<NoteProps>,
                 ctx.store.root

--- a/tests/blocksuite/e2e/embed-synced-doc/edgeless.spec.ts
+++ b/tests/blocksuite/e2e/embed-synced-doc/edgeless.spec.ts
@@ -4,6 +4,8 @@ import { expect, type Page } from '@playwright/test';
 import { clickView } from '../utils/actions/click.js';
 import {
   createNote,
+  createShapeElement,
+  getAllSortedIds,
   getIds,
   getSelectedBound,
   getSelectedIds,
@@ -200,6 +202,22 @@ test.describe('Embed synced doc in edgeless mode', () => {
 
       const noteBound = await getSelectedBound(page);
       expect(isIntersected(embedDocBound, noteBound)).toBe(false);
+    });
+
+    test('edgeless note duplicated from embed-synced-doc should be above other elements', async ({
+      page,
+    }) => {
+      await createShapeElement(page, [0, 0], [100, 100]);
+      await page.locator('affine-embed-edgeless-synced-doc-block').click();
+      const toolbar = locateToolbar(page);
+      await toolbar.getByLabel('Duplicate as note').click();
+
+      const edgelessNotes = page.locator('affine-edgeless-note');
+      await expect(edgelessNotes).toHaveCount(2);
+      const duplicatedNoteId = (await getSelectedIds(page))[0];
+      const sortedIds = await getAllSortedIds(page);
+      //
+      expect(sortedIds[sortedIds.length - 1]).toBe(duplicatedNoteId);
     });
   });
 });


### PR DESCRIPTION
Close [BS-3357](https://linear.app/affine-design/issue/BS-3357/duplicate-note-注意设置z轴的数据)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Duplicating an edgeless note now ensures the new note appears above other elements in the stacking order.

- **Tests**
  - Added a test to verify that duplicated edgeless notes are rendered above existing elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->