### PR TITLE
fix(core): ai flaky tests

### DIFF
--- a/tests/affine-cloud-copilot/e2e/utils/editor-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/editor-utils.ts
@@ -14,6 +14,9 @@ import type {
 } from '@blocksuite/affine-model';
 import type { GfxModel } from '@blocksuite/std/gfx';
 import { type Page } from '@playwright/test';
+
+import { ChatPanelUtils } from './chat-panel-utils';
+
 export class EditorUtils {
   public static async focusToEditor(page: Page) {
     const title = getBlockSuiteEditorTitle(page);
@@ -53,20 +56,9 @@ export class EditorUtils {
     await page.getByTestId('switch-edgeless-mode-button').click();
     await editor.waitForElementState('hidden');
     await page.waitForSelector('edgeless-editor');
-    try {
-      const edgelessNotificationClose = page.getByTestId(
-        'notification-close-button'
-      );
-      await edgelessNotificationClose.waitFor({
-        state: 'visible',
-        timeout: 2000,
-      });
-      await edgelessNotificationClose.click();
-      // Focus to the edgeless editor
-      await page.mouse.click(400, 400);
-    } catch {
-      // do nothing if the notification close button is not found
-    }
+    await ChatPanelUtils.closeNotification(page);
+    // Focus to the edgeless editor after closing notification
+    await page.mouse.click(400, 400);
   }
 
   public static async switchToPageMode(page: Page) {


### PR DESCRIPTION
- The notification in the lower right corner is weird. It is visible but not clickable. 
- Let's change it to MutationObserver to see if it works better.


![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/7cebe935-7398-4ed7-a535-456beedb2f1b.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/sJGviKxfE3Ap685cl5bj/27a8ea6a-7d6b-4318-8040-c02023f00b1e.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the handling of notification pop-ups in end-to-end tests, making notification closure more robust and reliable during automated interactions.
  - Streamlined notification closing logic across different test utilities for better consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->