### PR TITLE
fix(core): skip onboarding in e2e tests

### DIFF
--- a/tests/affine-cloud-copilot/e2e/utils/chat-panel-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/chat-panel-utils.ts
@@ -32,9 +32,6 @@ export class ChatPanelUtils {
       });
       await page.waitForTimeout(500); // wait the sidebar stable
     }
-    if (await page.getByTestId('notification-close-button').isVisible()) {
-      await page.getByTestId('notification-close-button').click();
-    }
     await page.getByTestId('sidebar-tab-chat').click();
     await expect(page.getByTestId('sidebar-tab-content-chat')).toBeVisible();
   }

--- a/tests/affine-cloud-copilot/e2e/utils/editor-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/editor-utils.ts
@@ -53,20 +53,6 @@ export class EditorUtils {
     await page.getByTestId('switch-edgeless-mode-button').click();
     await editor.waitForElementState('hidden');
     await page.waitForSelector('edgeless-editor');
-    try {
-      const edgelessNotificationClose = page.getByTestId(
-        'notification-close-button'
-      );
-      await edgelessNotificationClose.waitFor({
-        state: 'visible',
-        timeout: 2000,
-      });
-      await edgelessNotificationClose.click();
-      // Focus to the edgeless editor
-      await page.mouse.click(400, 400);
-    } catch {
-      // do nothing if the notification close button is not found
-    }
   }
 
   public static async switchToPageMode(page: Page) {

--- a/tests/affine-cloud-copilot/e2e/utils/test-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/test-utils.ts
@@ -1,3 +1,4 @@
+import { skipOnboarding } from '@affine-test/kit/playwright';
 import { createRandomAIUser } from '@affine-test/kit/utils/cloud';
 import { openHomePage, setCoreUrl } from '@affine-test/kit/utils/load-page';
 import {
@@ -58,6 +59,7 @@ export class TestUtils {
   }
 
   public async setupTestEnvironment(page: Page) {
+    await skipOnboarding(page.context());
     await openHomePage(page);
     await this.createNewPage(page);
   }

--- a/tests/affine-cloud-copilot/global-setup.ts
+++ b/tests/affine-cloud-copilot/global-setup.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 
+import { skipOnboarding } from '@affine-test/kit/playwright';
 import {
   createRandomAIUser,
   enableCloudWorkspace,
@@ -20,7 +21,9 @@ async function setupTestEnvironment(page: Page) {
 
 export default async function globalSetup() {
   const browser = await chromium.launch();
-  const page = await browser.newPage();
+  const context = await browser.newContext();
+  await skipOnboarding(context);
+  const page = await context.newPage();
   await page.goto('http://localhost:8080/', { timeout: 240 * 1000 });
   const user = await getUser();
   await page.getByTestId('sidebar-user-avatar').click({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated test setup to automatically skip onboarding steps during environment initialization.
	- Simplified test utility methods by removing notification handling logic from chat panel and editor mode switching processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->