### PR TITLE
feat(server): support query overcapacity member count of workspace

### DIFF
--- a/packages/backend/server/src/core/quota/service.ts
+++ b/packages/backend/server/src/core/quota/service.ts
@@ -142,12 +142,16 @@ export class QuotaService {
     const usedStorageQuota = quota.ownerQuota
       ? await this.getUserStorageUsage(quota.ownerQuota)
       : await this.getWorkspaceStorageUsage(workspaceId);
-    const memberCount = await this.models.workspaceUser.count(workspaceId);
+    const memberCount =
+      await this.models.workspaceUser.chargedCount(workspaceId);
+    const overcapacityMemberCount =
+      await this.models.workspaceUser.insufficientSeatMemberCount(workspaceId);
 
     return {
       ...quota,
       usedStorageQuota,
       memberCount,
+      overcapacityMemberCount,
       usedSize: usedStorageQuota,
     };
   }
@@ -203,6 +207,7 @@ export class QuotaService {
       historyPeriod: formatDate(quota.historyPeriod),
       memberLimit: quota.memberLimit.toString(),
       memberCount: quota.memberCount.toString(),
+      overcapacityMemberCount: quota.overcapacityMemberCount.toString(),
     };
   }
 

--- a/packages/backend/server/src/core/quota/types.ts
+++ b/packages/backend/server/src/core/quota/types.ts
@@ -85,6 +85,9 @@ export class WorkspaceQuotaHumanReadableType {
 
   @Field()
   memberCount!: string;
+
+  @Field()
+  overcapacityMemberCount!: string;
 }
 
 @ObjectType()
@@ -109,6 +112,9 @@ export class WorkspaceQuotaType implements Partial<WorkspaceQuota> {
 
   @Field()
   memberCount!: number;
+
+  @Field()
+  overcapacityMemberCount!: number;
 
   @Field()
   humanReadable!: WorkspaceQuotaHumanReadableType;

--- a/packages/backend/server/src/models/workspace-user.ts
+++ b/packages/backend/server/src/models/workspace-user.ts
@@ -289,6 +289,15 @@ export class WorkspaceUserModel extends BaseModel {
     });
   }
 
+  async insufficientSeatMemberCount(workspaceId: string) {
+    return this.db.workspaceUserRole.count({
+      where: {
+        workspaceId,
+        status: WorkspaceMemberStatus.NeedMoreSeat,
+      },
+    });
+  }
+
   async getUserActiveRoles(
     userId: string,
     filter: { role?: WorkspaceRole } = {}

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1746,6 +1746,7 @@ type WorkspaceQuotaHumanReadableType {
   memberCount: String!
   memberLimit: String!
   name: String!
+  overcapacityMemberCount: String!
   storageQuota: String!
   storageQuotaUsed: String!
 }
@@ -1757,6 +1758,7 @@ type WorkspaceQuotaType {
   memberCount: Int!
   memberLimit: Int!
   name: String!
+  overcapacityMemberCount: Int!
   storageQuota: SafeInt!
   usedSize: SafeInt! @deprecated(reason: "use `usedStorageQuota` instead")
   usedStorageQuota: SafeInt!

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1821,12 +1821,15 @@ export const workspaceQuotaQuery = {
       historyPeriod
       memberLimit
       memberCount
+      overcapacityMemberCount
       humanReadable {
         name
         blobLimit
         storageQuota
         historyPeriod
         memberLimit
+        memberCount
+        overcapacityMemberCount
       }
     }
   }

--- a/packages/common/graphql/src/graphql/workspace-quota.gql
+++ b/packages/common/graphql/src/graphql/workspace-quota.gql
@@ -8,12 +8,15 @@ query workspaceQuota($id: String!) {
       historyPeriod
       memberLimit
       memberCount
+      overcapacityMemberCount
       humanReadable {
         name
         blobLimit
         storageQuota
         historyPeriod
         memberLimit
+        memberCount
+        overcapacityMemberCount
       }
     }
   }

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -2310,6 +2310,7 @@ export interface WorkspaceQuotaHumanReadableType {
   memberCount: Scalars['String']['output'];
   memberLimit: Scalars['String']['output'];
   name: Scalars['String']['output'];
+  overcapacityMemberCount: Scalars['String']['output'];
   storageQuota: Scalars['String']['output'];
   storageQuotaUsed: Scalars['String']['output'];
 }
@@ -2322,6 +2323,7 @@ export interface WorkspaceQuotaType {
   memberCount: Scalars['Int']['output'];
   memberLimit: Scalars['Int']['output'];
   name: Scalars['String']['output'];
+  overcapacityMemberCount: Scalars['Int']['output'];
   storageQuota: Scalars['SafeInt']['output'];
   /** @deprecated use `usedStorageQuota` instead */
   usedSize: Scalars['SafeInt']['output'];
@@ -4498,6 +4500,7 @@ export type WorkspaceQuotaQuery = {
       historyPeriod: number;
       memberLimit: number;
       memberCount: number;
+      overcapacityMemberCount: number;
       humanReadable: {
         __typename?: 'WorkspaceQuotaHumanReadableType';
         name: string;
@@ -4505,6 +4508,8 @@ export type WorkspaceQuotaQuery = {
         storageQuota: string;
         historyPeriod: string;
         memberLimit: string;
+        memberCount: string;
+        overcapacityMemberCount: string;
       };
     };
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new metric displaying the count of workspace members exceeding quota capacity, available in both numeric and human-readable formats.
  - Workspace quota information now includes the overcapacity member count in all relevant views and API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->