### PR TITLE
fix(server): read the .env file on time

### DIFF
--- a/packages/backend/server/src/dotenv.ts
+++ b/packages/backend/server/src/dotenv.ts
@@ -1,0 +1,2 @@
+import * as dotenv from 'dotenv';
+dotenv.config();

--- a/packages/backend/server/src/dotenv.ts
+++ b/packages/backend/server/src/dotenv.ts
@@ -1,2 +1,0 @@
-import * as dotenv from 'dotenv';
-dotenv.config();

--- a/packages/backend/server/src/env.ts
+++ b/packages/backend/server/src/env.ts
@@ -132,4 +132,8 @@ export class Env implements AppEnv {
   }
 }
 
-globalThis.env = new Env();
+export const createGlobalEnv = () => {
+  if (!globalThis.env) {
+    globalThis.env = new Env();
+  }
+};

--- a/packages/backend/server/src/prelude.ts
+++ b/packages/backend/server/src/prelude.ts
@@ -1,12 +1,12 @@
 import 'reflect-metadata';
-import './dotenv';
-import './env';
 
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import { config } from 'dotenv';
+
+import { createGlobalEnv } from './env';
 
 const CUSTOM_CONFIG_PATH = `${homedir()}/.affine/config`;
 
@@ -38,3 +38,4 @@ function load() {
 }
 
 load();
+createGlobalEnv();

--- a/packages/backend/server/src/prelude.ts
+++ b/packages/backend/server/src/prelude.ts
@@ -1,4 +1,5 @@
 import 'reflect-metadata';
+import './dotenv';
 import './env';
 
 import { existsSync, readFileSync } from 'node:fs';


### PR DESCRIPTION
Problem in @affine/server:
At the time of the globalThis.env's creation in packages\backend\server\src\env.ts, the .env file has not yet been read into process.env, which causes some configurations in the .env file to be invalid. For example, the server always print "AFFiNE Server is running in [affine] mode" even when the DEPLOYMENT_TYPE="selfhosted" configuration is set.

Solution:
Read the .env file into process.env before the first import of packages\backend\server\src\env.ts in packages/backend/server/src/prelude.ts using dotenv, which is already available via @nestjs/config in NestJS framework.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the initialization process for environment configuration to ensure more controlled and reliable setup. No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->