### PR TITLE
refactor(editor): use default fallback placeholder for turbo renderer

### DIFF
--- a/blocksuite/affine/gfx/turbo-renderer/src/turbo-renderer.ts
+++ b/blocksuite/affine/gfx/turbo-renderer/src/turbo-renderer.ts
@@ -422,12 +422,7 @@ export class ViewportTurboRendererExtension extends GfxExtension {
   }
 
   private paintPlaceholder() {
-    paintPlaceholder(
-      this.std.host,
-      this.canvas,
-      this.layoutCache,
-      this.viewport
-    );
+    paintPlaceholder(this.canvas, this.layoutCache, this.viewport);
   }
 }
 


### PR DESCRIPTION
Based on this PR, all block types support zooming placeholder now.

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/lEGcysB4lFTEbCwZ8jMv/33a32735-d31e-4055-9dbf-faaed444a6d2.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced layout rendering accuracy for non-root nodes, leading to more precise placement and sizing.
  - Simplified placeholder painting logic for improved consistency, with all nodes now displayed using a color based on their depth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->