### PR TITLE
fix(electron): adjust switch tab shortcuts on Mac

### DIFF
--- a/packages/frontend/apps/electron/src/main/application-menu/create.ts
+++ b/packages/frontend/apps/electron/src/main/application-menu/create.ts
@@ -216,14 +216,14 @@ export function createApplicationMenu() {
         }),
         {
           label: 'Switch to next tab',
-          accelerator: 'CommandOrControl+Tab',
+          accelerator: 'Control+Tab',
           click: () => {
             switchToNextTab();
           },
         },
         {
           label: 'Switch to previous tab',
-          accelerator: 'CommandOrControl+Shift+Tab',
+          accelerator: 'Control+Shift+Tab',
           click: () => {
             switchToPreviousTab();
           },


### PR DESCRIPTION
fix #10541

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated keyboard shortcuts for switching tabs to use 'Control+Tab' and 'Control+Shift+Tab'.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->