### PR TITLE
fix(nbstore): wrong order of socketio transports

### DIFF
--- a/packages/common/nbstore/src/impls/cloud/socket.ts
+++ b/packages/common/nbstore/src/impls/cloud/socket.ts
@@ -168,7 +168,7 @@ class SocketManager {
   constructor(endpoint: string, isSelfHosted: boolean) {
     this.socketIOManager = new SocketIOManager(endpoint, {
       autoConnect: false,
-      transports: isSelfHosted ? ['websocket', 'polling'] : ['websocket'], // self-hosted server may not support websocket
+      transports: isSelfHosted ? ['polling', 'websocket'] : ['websocket'], // self-hosted server may not support websocket
       secure: new URL(endpoint).protocol === 'https:',
       // we will handle reconnection by ourselves
       reconnection: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the priority order of connection methods for self-hosted servers to improve socket connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->