### PR TITLE
feat(ios): add app tracking transparency permission

### DIFF
--- a/packages/frontend/apps/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/frontend/apps/ios/App/App.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		C45499AB2D140B5000E21978 /* NBStore */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
 			path = NBStore;
 			sourceTree = "<group>";
 		};
@@ -326,12 +328,8 @@
 			);
 			inputFileListPaths = (
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/frontend/apps/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/frontend/apps/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "4d0845f9f2901ed657d680c874ffc68d12704cd4",
-        "version" : "1.19.0"
+        "revision" : "51e535dcf5439c01396d668a9598748ea86c7c1a",
+        "version" : "1.20.0"
       }
     },
     {

--- a/packages/frontend/apps/ios/App/App/InfoPlist.xcstrings
+++ b/packages/frontend/apps/ios/App/App/InfoPlist.xcstrings
@@ -48,6 +48,18 @@
           }
         }
       }
+    },
+    "NSUserTrackingUsageDescription" : {
+      "comment" : "Privacy - Tracking Usage Description",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rest assured, enabling this permission won't access your private info on other sites. It's only used to identify your device and improve security and product experience."
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/packages/frontend/apps/ios/App/Podfile
+++ b/packages/frontend/apps/ios/App/Podfile
@@ -15,6 +15,7 @@ def capacitor_pods
   pod 'CapacitorBrowser', :path => '../../../../../node_modules/@capacitor/browser'
   pod 'CapacitorHaptics', :path => '../../../../../node_modules/@capacitor/haptics'
   pod 'CapacitorKeyboard', :path => '../../../../../node_modules/@capacitor/keyboard'
+  pod 'CapacitorPluginAppTrackingTransparency', :path => '../../../../../node_modules/capacitor-plugin-app-tracking-transparency'
 end
 
 target 'AFFiNE' do

--- a/packages/frontend/apps/ios/App/Podfile.lock
+++ b/packages/frontend/apps/ios/App/Podfile.lock
@@ -10,6 +10,8 @@ PODS:
     - Capacitor
   - CapacitorKeyboard (7.0.1):
     - Capacitor
+  - CapacitorPluginAppTrackingTransparency (2.0.5):
+    - Capacitor
   - CryptoSwift (1.8.3)
 
 DEPENDENCIES:
@@ -19,6 +21,7 @@ DEPENDENCIES:
   - "CapacitorCordova (from `../../../../../node_modules/@capacitor/ios`)"
   - "CapacitorHaptics (from `../../../../../node_modules/@capacitor/haptics`)"
   - "CapacitorKeyboard (from `../../../../../node_modules/@capacitor/keyboard`)"
+  - CapacitorPluginAppTrackingTransparency (from `../../../../../node_modules/capacitor-plugin-app-tracking-transparency`)
   - CryptoSwift (~> 1.8.3)
 
 SPEC REPOS:
@@ -38,6 +41,8 @@ EXTERNAL SOURCES:
     :path: "../../../../../node_modules/@capacitor/haptics"
   CapacitorKeyboard:
     :path: "../../../../../node_modules/@capacitor/keyboard"
+  CapacitorPluginAppTrackingTransparency:
+    :path: "../../../../../node_modules/capacitor-plugin-app-tracking-transparency"
 
 SPEC CHECKSUMS:
   Capacitor: 106e7a4205f4618d582b886a975657c61179138d
@@ -46,8 +51,9 @@ SPEC CHECKSUMS:
   CapacitorCordova: 5967b9ba03915ef1d585469d6e31f31dc49be96f
   CapacitorHaptics: 70e47470fa1a6bd6338cd102552e3846b7f9a1b3
   CapacitorKeyboard: 969647d0ca2e5c737d7300088e2517aa832434e2
+  CapacitorPluginAppTrackingTransparency: 2a2792623a5a72795f2e8f9ab3f1147573732fd8
   CryptoSwift: 967f37cea5a3294d9cce358f78861652155be483
 
-PODFILE CHECKSUM: bd61c17ff51f31ae55ec8dc579da83fda7bb51cb
+PODFILE CHECKSUM: 2c1e4be82121f2d9724ecf7e31dd14e165aeb082
 
 COCOAPODS: 1.16.2

--- a/packages/frontend/apps/ios/package.json
+++ b/packages/frontend/apps/ios/package.json
@@ -30,6 +30,7 @@
     "@sentry/react": "^9.2.0",
     "@toeverything/infra": "workspace:^",
     "async-call-rpc": "^6.4.2",
+    "capacitor-plugin-app-tracking-transparency": "^2.0.5",
     "idb": "^8.0.0",
     "next-themes": "^0.4.4",
     "react": "^19.0.0",

--- a/packages/frontend/apps/ios/src/app.tsx
+++ b/packages/frontend/apps/ios/src/app.tsx
@@ -53,6 +53,7 @@ import { Keyboard, KeyboardStyle } from '@capacitor/keyboard';
 import { Framework, FrameworkRoot, getCurrentStore } from '@toeverything/infra';
 import { OpClient } from '@toeverything/infra/op';
 import { AsyncCall } from 'async-call-rpc';
+import { AppTrackingTransparency } from 'capacitor-plugin-app-tracking-transparency';
 import { useTheme } from 'next-themes';
 import { Suspense, useEffect } from 'react';
 import { RouterProvider } from 'react-router-dom';
@@ -375,6 +376,10 @@ CapacitorApp.addListener('appUrlOpen', ({ url }) => {
   }
 }).catch(e => {
   console.error(e);
+});
+
+AppTrackingTransparency.requestPermission().catch(e => {
+  console.error('Failed to request app tracking transparency permission', e);
 });
 
 const KeyboardThemeProvider = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,6 +684,7 @@ __metadata:
     "@types/react": "npm:^19.0.1"
     "@types/react-dom": "npm:^19.0.2"
     async-call-rpc: "npm:^6.4.2"
+    capacitor-plugin-app-tracking-transparency: "npm:^2.0.5"
     cross-env: "npm:^7.0.3"
     idb: "npm:^8.0.0"
     next-themes: "npm:^0.4.4"
@@ -17990,6 +17991,15 @@ __metadata:
   version: 1.0.30001713
   resolution: "caniuse-lite@npm:1.0.30001713"
   checksum: 10/0c1b97320d08cf87c73883fe9a7b9d8037b7c24aa027641e75cce3dee74c9ad538cf17725fdcb46e6ec86be8efedf6edd0848db07c5f8110936ccf0185e2ff68
+  languageName: node
+  linkType: hard
+
+"capacitor-plugin-app-tracking-transparency@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "capacitor-plugin-app-tracking-transparency@npm:2.0.5"
+  peerDependencies:
+    "@capacitor/core": ">= 3.0.0"
+  checksum: 10/dc43c3f7e3241067ef960416a53681b44ecf9ac9c9e22aef3a4fe81afd692bc466fe517cf85a260cf1b0ad4e7f8c961ad2660485ff5fb0bdee74f42ad660e4e2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for App Tracking Transparency, including requesting user permission at runtime and providing a clear privacy usage description.
- **Dependency Updates**
  - Updated the "apollo-ios" package to version 1.20.0.
  - Added the "capacitor-plugin-app-tracking-transparency" package and its related pod dependency.
- **Localization**
  - Added a new localized privacy usage description for tracking permission requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->