### PR TITLE
refactor(core): use overcapacityMemberCount for quota checking instead of calculating the difference

### DIFF
--- a/packages/frontend/core/src/modules/quota/views/quota-check.tsx
+++ b/packages/frontend/core/src/modules/quota/views/quota-check.tsx
@@ -57,8 +57,7 @@ export const QuotaCheck = ({
     if (workspaceMeta.flavour === 'local' || !quota || isTeam) {
       return;
     }
-    const memberOverflow = quota.memberCount > quota.memberLimit;
-    // remember to use real percent
+    const memberOverflow = quota.overcapacityMemberCount > 0;
     const storageOverflow = usedPercent && usedPercent >= 100;
     const message = getSyncPausedMessage(
       !!isOwner,

--- a/tests/affine-cloud/e2e/workspace.spec.ts
+++ b/tests/affine-cloud/e2e/workspace.spec.ts
@@ -62,8 +62,6 @@ test('should have pagination in member list', async ({ page }) => {
 
   await page.waitForTimeout(1000);
 
-  await page.getByTestId('confirm-modal-cancel').click();
-
   const firstPageMemberItemCount = await page
     .locator('[data-testid="member-item"]')
     .count();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of member quota warnings by updating the logic that detects when the member limit has been exceeded.
  - Enhanced test reliability by adjusting member list pagination test to better handle confirmation modals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->