### PR TITLE
refactor(core): use workspace role query instead of isOwner query

### DIFF
--- a/packages/common/graphql/src/graphql/get-is-admin.gql
+++ b/packages/common/graphql/src/graphql/get-is-admin.gql
@@ -1,3 +1,0 @@
-query getIsAdmin($workspaceId: String!) {
-  isAdmin(workspaceId: $workspaceId)
-}

--- a/packages/common/graphql/src/graphql/get-is-owner.gql
+++ b/packages/common/graphql/src/graphql/get-is-owner.gql
@@ -1,3 +1,0 @@
-query getIsOwner($workspaceId: String!) {
-  isOwner(workspaceId: $workspaceId)
-}

--- a/packages/common/graphql/src/graphql/get-workspace-info.gql
+++ b/packages/common/graphql/src/graphql/get-workspace-info.gql
@@ -1,7 +1,6 @@
 query getWorkspaceInfo($workspaceId: String!) {
-  isAdmin(workspaceId: $workspaceId)
-  isOwner(workspaceId: $workspaceId)
   workspace(id: $workspaceId) {
+    role
     team
   }
 }

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1036,24 +1036,6 @@ export const getInviteInfoQuery = {
 }`,
 };
 
-export const getIsAdminQuery = {
-  id: 'getIsAdminQuery' as const,
-  op: 'getIsAdmin',
-  query: `query getIsAdmin($workspaceId: String!) {
-  isAdmin(workspaceId: $workspaceId)
-}`,
-  deprecations: ["'isAdmin' is deprecated: use WorkspaceType[role] instead"],
-};
-
-export const getIsOwnerQuery = {
-  id: 'getIsOwnerQuery' as const,
-  op: 'getIsOwner',
-  query: `query getIsOwner($workspaceId: String!) {
-  isOwner(workspaceId: $workspaceId)
-}`,
-  deprecations: ["'isOwner' is deprecated: use WorkspaceType[role] instead"],
-};
-
 export const getMemberCountByWorkspaceIdQuery = {
   id: 'getMemberCountByWorkspaceIdQuery' as const,
   op: 'getMemberCountByWorkspaceId',
@@ -1185,13 +1167,11 @@ export const getWorkspaceInfoQuery = {
   id: 'getWorkspaceInfoQuery' as const,
   op: 'getWorkspaceInfo',
   query: `query getWorkspaceInfo($workspaceId: String!) {
-  isAdmin(workspaceId: $workspaceId)
-  isOwner(workspaceId: $workspaceId)
   workspace(id: $workspaceId) {
+    role
     team
   }
 }`,
-  deprecations: ["'isAdmin' is deprecated: use WorkspaceType[role] instead","'isOwner' is deprecated: use WorkspaceType[role] instead"],
 };
 
 export const getWorkspacePageByIdQuery = {

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -3665,18 +3665,6 @@ export type GetInviteInfoQuery = {
   };
 };
 
-export type GetIsAdminQueryVariables = Exact<{
-  workspaceId: Scalars['String']['input'];
-}>;
-
-export type GetIsAdminQuery = { __typename?: 'Query'; isAdmin: boolean };
-
-export type GetIsOwnerQueryVariables = Exact<{
-  workspaceId: Scalars['String']['input'];
-}>;
-
-export type GetIsOwnerQuery = { __typename?: 'Query'; isOwner: boolean };
-
 export type GetMemberCountByWorkspaceIdQueryVariables = Exact<{
   workspaceId: Scalars['String']['input'];
 }>;
@@ -3829,9 +3817,7 @@ export type GetWorkspaceInfoQueryVariables = Exact<{
 
 export type GetWorkspaceInfoQuery = {
   __typename?: 'Query';
-  isAdmin: boolean;
-  isOwner: boolean;
-  workspace: { __typename?: 'WorkspaceType'; team: boolean };
+  workspace: { __typename?: 'WorkspaceType'; role: Permission; team: boolean };
 };
 
 export type GetWorkspacePageByIdQueryVariables = Exact<{
@@ -4824,16 +4810,6 @@ export type Queries =
       name: 'getInviteInfoQuery';
       variables: GetInviteInfoQueryVariables;
       response: GetInviteInfoQuery;
-    }
-  | {
-      name: 'getIsAdminQuery';
-      variables: GetIsAdminQueryVariables;
-      response: GetIsAdminQuery;
-    }
-  | {
-      name: 'getIsOwnerQuery';
-      variables: GetIsOwnerQueryVariables;
-      response: GetIsOwnerQuery;
     }
   | {
       name: 'getMemberCountByWorkspaceIdQuery';

--- a/packages/frontend/core/src/components/root-app-sidebar/user-info.tsx
+++ b/packages/frontend/core/src/components/root-app-sidebar/user-info.tsx
@@ -83,7 +83,7 @@ const AccountMenu = () => {
   const openSignOutModal = useSignOut();
   const serverService = useService(ServerService);
   const userFeatureService = useService(UserFeatureService);
-  const isAdmin = useLiveData(userFeatureService.userFeature.isAdmin$);
+  const isAFFiNEAdmin = useLiveData(userFeatureService.userFeature.isAdmin$);
 
   const onOpenAccountSetting = useCallback(() => {
     track.$.navigationPanel.profileAndBadge.openSettings({ to: 'account' });
@@ -111,7 +111,7 @@ const AccountMenu = () => {
       >
         {t['com.affine.workspace.cloud.account.settings']()}
       </MenuItem>
-      {isAdmin ? (
+      {isAFFiNEAdmin ? (
         <MenuItem
           prefixIcon={<AdminIcon />}
           data-testid="workspace-modal-account-admin-option"

--- a/packages/frontend/core/src/modules/permissions/entities/permission.ts
+++ b/packages/frontend/core/src/modules/permissions/entities/permission.ts
@@ -1,3 +1,4 @@
+import { Permission } from '@affine/graphql';
 import {
   backoffRetry,
   effect,
@@ -43,8 +44,8 @@ export class WorkspacePermission extends Entity {
           );
 
           return {
-            isOwner: info.isOwner,
-            isAdmin: info.isAdmin,
+            isOwner: info.workspace.role === Permission.Owner,
+            isAdmin: info.workspace.role === Permission.Admin,
             isTeam: info.workspace.team,
           };
         } else {

--- a/packages/frontend/core/src/modules/workspace-engine/impls/cloud.ts
+++ b/packages/frontend/core/src/modules/workspace-engine/impls/cloud.ts
@@ -4,6 +4,7 @@ import {
   deleteWorkspaceMutation,
   getWorkspaceInfoQuery,
   getWorkspacesQuery,
+  Permission,
   ServerDeploymentType,
 } from '@affine/graphql';
 import type {
@@ -339,8 +340,8 @@ class CloudWorkspaceFlavourProvider implements WorkspaceFlavourProvider {
 
     if (!cloudData && !localData) {
       return {
-        isOwner: info.isOwner,
-        isAdmin: info.isAdmin,
+        isOwner: info.workspace.role === Permission.Owner,
+        isAdmin: info.workspace.role === Permission.Admin,
         isTeam: info.workspace.team,
       };
     }
@@ -355,8 +356,8 @@ class CloudWorkspaceFlavourProvider implements WorkspaceFlavourProvider {
     return {
       name: result.name,
       avatar: result.avatar,
-      isOwner: info.isOwner,
-      isAdmin: info.isAdmin,
+      isOwner: info.workspace.role === Permission.Owner,
+      isAdmin: info.workspace.role === Permission.Admin,
       isTeam: info.workspace.team,
     };
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated workspace permission handling to use a unified role field within workspace data instead of separate admin and owner flags.
  - Permission checks now rely on the workspace role for determining admin and owner status.
- **Chores**
  - Removed deprecated queries and types related to admin and owner status.
  - Cleaned up internal logic and variable naming for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->