### PR TITLE
chore(y-octo): migrate away depracated JsExternal API

### DIFF
--- a/packages/common/y-octo/node/src/array.rs
+++ b/packages/common/y-octo/node/src/array.rs
@@ -1,4 +1,7 @@
-use napi::{bindgen_prelude::Array as JsArray, Env, JsUnknown, ValueType};
+use napi::{
+  bindgen_prelude::{Array as JsArray, Env, Unknown},
+  ValueType,
+};
 use y_octo::{Any, Array, Value};
 
 use super::*;
@@ -104,7 +107,7 @@ impl YArray {
             Ok((object, length)) => {
               for i in 0..length {
                 if let Ok(any) = object
-                  .get_element::<JsUnknown>(i)
+                  .get_element::<Unknown>(i)
                   .and_then(get_any_from_js_unknown)
                 {
                   self

--- a/packages/common/y-octo/node/src/doc.rs
+++ b/packages/common/y-octo/node/src/doc.rs
@@ -1,5 +1,5 @@
 use napi::{
-  bindgen_prelude::{Buffer, Uint8Array},
+  bindgen_prelude::Uint8Array,
   threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode},
 };
 use y_octo::{CrdtRead, Doc as YDoc, History, RawDecoder, StateVector};
@@ -120,7 +120,7 @@ impl Doc {
   }
 
   #[napi(ts_args_type = "callback: (result: Uint8Array) => void")]
-  pub fn on_update(&mut self, callback: ThreadsafeFunction<Buffer>) -> Result<()> {
+  pub fn on_update(&mut self, callback: ThreadsafeFunction<Uint8Array>) -> Result<()> {
     let callback = move |update: &[u8], _h: &[History]| {
       callback.call(
         Ok(update.to_vec().into()),

--- a/packages/common/y-octo/node/src/map.rs
+++ b/packages/common/y-octo/node/src/map.rs
@@ -1,4 +1,4 @@
-use napi::{Env, JsObject, ValueType};
+use napi::bindgen_prelude::{Env, Object, ValueType};
 use y_octo::{Any, Map, Value};
 
 use super::*;
@@ -10,12 +10,6 @@ pub struct YMap {
 
 #[napi]
 impl YMap {
-  #[allow(clippy::new_without_default)]
-  #[napi(constructor)]
-  pub fn new() -> Self {
-    unimplemented!()
-  }
-
   pub(crate) fn inner_new(map: Map) -> Self {
     Self { map }
   }
@@ -111,7 +105,7 @@ impl YMap {
   }
 
   #[napi]
-  pub fn to_json(&self, env: Env) -> Result<JsObject> {
+  pub fn to_json(&self, env: Env) -> Result<Object> {
     let mut js_object = env.create_object()?;
     for (key, value) in self.map.iter() {
       js_object.set(key, get_js_unknown_from_value(env, value))?;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated JavaScript interop types to newer API versions for improved compatibility and consistency.
  - Changed method and type signatures to use updated types in several areas.
  - Removed an unused constructor from a component.
  - Adjusted a method to use a different JavaScript array buffer type for update callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->