### PR TITLE
fix(nbstore): should not force throw error

### DIFF
--- a/packages/common/nbstore/src/frontend/blob.ts
+++ b/packages/common/nbstore/src/frontend/blob.ts
@@ -40,7 +40,6 @@ export class BlobFrontend {
       for (const cb of this.onReachedMaxBlobSizeCallbacks) {
         cb(blob.data.byteLength);
       }
-      throw new Error('Blob size exceeds the maximum limit');
     }
     await using lock = await this.lock.lock('blob', blob.key);
     await this.storage.set(blob);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of oversized blobs by allowing operations to continue after notifying about size limits, instead of stopping execution with an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->