### PR TITLE
test(editor): revert timeout condition in turbo renderer

### DIFF
--- a/blocksuite/integration-test/src/__tests__/edgeless/turbo-renderer.spec.ts
+++ b/blocksuite/integration-test/src/__tests__/edgeless/turbo-renderer.spec.ts
@@ -8,7 +8,6 @@ import {
   ViewportTurboRendererExtension,
 } from '@blocksuite/affine-gfx-turbo-renderer';
 import { firstValueFrom } from 'rxjs';
-import { filter } from 'rxjs/operators';
 import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import { wait } from '../utils/common.js';
@@ -39,10 +38,7 @@ describe('viewport turbo renderer', () => {
 
   test('should render 6 notes in viewport', async () => {
     addSampleNotes(doc, 6);
-    const renderer = getRenderer();
-    await renderer.refresh();
     await wait(FRAME);
-    await firstValueFrom(renderer.state$.pipe(filter(s => s === 'ready')));
 
     const notes = document.querySelectorAll('affine-edgeless-note');
     expect(notes.length).toBe(6);
@@ -63,13 +59,12 @@ describe('viewport turbo renderer', () => {
   test('zooming should change internal state and populate optimized block ids', async () => {
     const renderer = getRenderer();
     addSampleNotes(doc, 1);
-    await renderer.refresh();
     await wait(FRAME);
-    await firstValueFrom(renderer.state$.pipe(filter(s => s === 'ready')));
     expect(renderer.optimizedBlockIds.length).toBe(0);
 
     renderer.viewport.zooming$.next(true);
-    await firstValueFrom(renderer.state$.pipe(filter(s => s === 'zooming')));
+    const nextState = await firstValueFrom(renderer.state$);
+    expect(nextState).toBe('zooming');
 
     const canUseCache = renderer.canUseBitmapCache();
     expect(canUseCache).toBe(false);
@@ -79,9 +74,9 @@ describe('viewport turbo renderer', () => {
     expect(renderer.optimizedBlockIds.length).toBe(1);
 
     renderer.viewport.zooming$.next(false);
-    await firstValueFrom(renderer.state$.pipe(filter(s => s === 'ready')));
+    await wait(renderer.options.debounceTime + 100);
 
-    expect(renderer.state$.value).toBe('ready');
+    expect(renderer.state$.value).not.toBe('zooming');
     expect(renderer.optimizedBlockIds.length).toBe(0);
   });
 
@@ -89,16 +84,12 @@ describe('viewport turbo renderer', () => {
     const renderer = getRenderer();
 
     addSampleNotes(doc, 1);
-    await renderer.refresh();
     await wait(FRAME);
-    await firstValueFrom(renderer.state$.pipe(filter(s => s === 'pending')));
     expect(renderer.state$.value).toBe('pending');
 
+    // Ensure zooming is off and wait for debounce + buffer
     renderer.viewport.zooming$.next(false);
-    await renderer.refresh();
-    await wait(FRAME);
-    await firstValueFrom(renderer.state$.pipe(filter(s => s === 'ready')));
-
+    await wait(renderer.options.debounceTime + 500);
     expect(renderer.state$.value).toBe('ready');
   });
 
@@ -112,14 +103,14 @@ describe('viewport turbo renderer', () => {
     addSampleNotes(doc, 1);
     await wait(100);
 
+    // Access getter to populate cache
     const _cache = renderer.layoutCache;
     noop(_cache);
     expect(renderer.layoutCacheData).not.toBeNull();
 
+    // Invalidate
     addSampleNotes(doc, 1);
     await wait(100);
-    await renderer.refresh();
-    await wait(FRAME);
 
     expect(renderer.layoutCacheData).toBeNull();
   });
@@ -127,7 +118,6 @@ describe('viewport turbo renderer', () => {
   test('accessing layoutCache getter should populate cache data', async () => {
     const renderer = getRenderer();
     addSampleNotes(doc, 1);
-    await renderer.refresh();
     await wait(FRAME);
     expect(renderer.layoutCacheData).toBeNull();
 


### PR DESCRIPTION
This reverts #12082 due to timeouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Simplified test synchronization by replacing reactive state filtering and explicit refresh calls with timed waits and direct state checks.
  - Improved comments for clarity on debounce periods and cache population in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->