### PR TITLE
fix(editor): add credentialless attribute to iframe for COEP compliance

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/embed.ts
+++ b/blocksuite/affine/blocks/attachment/src/embed.ts
@@ -157,6 +157,7 @@ const embedConfig: AttachmentEmbedConfig[] = [
           allowTransparency
           allowfullscreen
           type="application/pdf"
+          credentialless
         ></iframe>
         <div class="affine-attachment-embed-event-mask"></div>
       `;

--- a/blocksuite/affine/blocks/embed/src/embed-figma-block/embed-figma-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-figma-block/embed-figma-block.ts
@@ -89,6 +89,7 @@ export class EmbedFigmaBlockComponent extends EmbedBlockComponent<EmbedFigmaMode
                 src=${`https://www.figma.com/embed?embed_host=blocksuite&url=${url}`}
                 allowfullscreen
                 loading="lazy"
+                credentialless
               ></iframe>
 
               <!-- overlay to prevent the iframe from capturing pointer events -->

--- a/blocksuite/affine/blocks/embed/src/embed-iframe-block/embed-iframe-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-iframe-block/embed-iframe-block.ts
@@ -311,6 +311,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
         ?allowfullscreen=${allowFullscreen}
         loading="lazy"
         frameborder="0"
+        credentialless
         src=${ifDefined(iframeUrl)}
         allow=${ifDefined(allow)}
         referrerpolicy=${ifDefined(referrerpolicy)}

--- a/blocksuite/affine/blocks/embed/src/embed-loom-block/embed-loom-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-loom-block/embed-loom-block.ts
@@ -127,6 +127,7 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
                       frameborder="0"
                       allow="fullscreen; accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                       loading="lazy"
+                      credentialless
                     ></iframe>
 
                     <!-- overlay to prevent the iframe from capturing pointer events -->

--- a/blocksuite/affine/blocks/embed/src/embed-youtube-block/embed-youtube-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-youtube-block/embed-youtube-block.ts
@@ -151,6 +151,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
                       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                       allowfullscreen
                       loading="lazy"
+                      credentialless
                     ></iframe>
 
                     <!-- overlay to prevent the iframe from capturing pointer events -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced privacy for embedded content by adding the `credentialless` attribute to iframes for PDF, Figma, Loom, YouTube, and generic embeds, improving security when viewing embedded media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->