### PR TITLE
chore(editor): adjust size of synced doc

### DIFF
--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/configs/edgeless-interaction.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/configs/edgeless-interaction.ts
@@ -1,0 +1,85 @@
+import {
+  EmbedSyncedDocBlockSchema,
+  SYNCED_MIN_HEIGHT,
+  SYNCED_MIN_WIDTH,
+} from '@blocksuite/affine-model';
+import { clamp } from '@blocksuite/global/gfx';
+import { GfxViewInteractionExtension } from '@blocksuite/std/gfx';
+
+import type { EmbedEdgelessSyncedDocBlockComponent } from '../embed-edgeless-synced-doc-block';
+import { calcSyncedDocFullHeight } from '../utils';
+
+export const EmbedSyncedDocInteraction =
+  GfxViewInteractionExtension<EmbedEdgelessSyncedDocBlockComponent>(
+    EmbedSyncedDocBlockSchema.model.flavour,
+    {
+      resizeConstraint: {
+        minWidth: SYNCED_MIN_WIDTH,
+        minHeight: SYNCED_MIN_HEIGHT,
+      },
+
+      handleRotate: () => {
+        return {
+          beforeRotate(context) {
+            context.set({
+              rotatable: false,
+            });
+          },
+        };
+      },
+
+      handleResize: ({ view, model }) => {
+        const initialScale = model.props.scale ?? 1;
+        const initHeight = model.elementBound.h;
+        const maxHeight = calcSyncedDocFullHeight(view);
+
+        return {
+          beforeResize: context => {
+            context.set({ maxHeight });
+          },
+          onResizeStart: context => {
+            context.default(context);
+            model.stash('scale');
+            model.stash('preFoldHeight');
+          },
+          onResizeMove: context => {
+            const { lockRatio, originalBound, constraint, newBound } = context;
+
+            let scale = initialScale;
+            const realWidth = originalBound.w / initialScale;
+
+            if (lockRatio) {
+              scale = newBound.w / realWidth;
+            }
+
+            const newWidth = newBound.w / scale;
+
+            newBound.w =
+              clamp(newWidth, constraint.minWidth, constraint.maxWidth) * scale;
+            newBound.h =
+              clamp(newBound.h, constraint.minHeight, constraint.maxHeight) *
+              scale;
+
+            const newHeight = newBound.h / scale;
+
+            // only adjust height check the fold state
+            if (originalBound.w === newBound.w) {
+              let preFoldHeight = 0;
+              if (newHeight === constraint.minHeight) {
+                preFoldHeight = initHeight;
+              }
+              model.props.preFoldHeight = preFoldHeight;
+            }
+
+            model.props.scale = scale;
+            model.xywh = newBound.serialize();
+          },
+          onResizeEnd: context => {
+            context.default(context);
+            model.pop('scale');
+            model.pop('preFoldHeight');
+          },
+        };
+      },
+    }
+  );

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-spec.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-spec.ts
@@ -5,7 +5,6 @@ import { literal } from 'lit/static-html.js';
 
 import { EmbedSyncedDocBlockAdapterExtensions } from './adapters/extension';
 import { createBuiltinToolbarConfigExtension } from './configs/toolbar';
-import { EmbedSyncedDocInteraction } from './embed-edgeless-synced-doc-block';
 import { HeightInitializationExtension } from './init-height-extension';
 
 const flavour = EmbedSyncedDocBlockSchema.model.flavour;
@@ -30,5 +29,4 @@ export const EmbedSyncedDocViewExtensions: ExtensionType[] = [
   }),
   createBuiltinToolbarConfigExtension(flavour),
   HeightInitializationExtension,
-  EmbedSyncedDocInteraction,
 ].flat();

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/utils.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/utils.ts
@@ -5,8 +5,10 @@ import {
   ReloadIcon,
 } from '@blocksuite/affine-components/icons';
 import { ColorScheme } from '@blocksuite/affine-model';
+import type { BlockComponent } from '@blocksuite/std';
 import type { TemplateResult } from 'lit';
 
+import { EmbedEdgelessSyncedDocBlockComponent } from './embed-edgeless-synced-doc-block.js';
 import {
   DarkSyncedDocDeletedBanner,
   DarkSyncedDocEmptyBanner,
@@ -57,4 +59,23 @@ export function getSyncedDocIcons(
       SyncedDocDeletedBanner: DarkSyncedDocDeletedBanner,
     };
   }
+}
+
+/**
+ * This function will return the height of the synced doc block
+ */
+export function calcSyncedDocFullHeight(block: BlockComponent) {
+  if (!(block instanceof EmbedEdgelessSyncedDocBlockComponent)) {
+    return 0;
+  }
+  const headerHeight = block.headerWrapper?.getBoundingClientRect().height ?? 0;
+  // When the content is not found, we use a default height to display empty information
+  const contentHeight =
+    block.contentElement?.getBoundingClientRect().height ?? 200;
+
+  const bottomPadding = 8;
+
+  return (
+    (headerHeight + contentHeight + bottomPadding) / block.gfx.viewport.zoom
+  );
 }

--- a/blocksuite/affine/blocks/embed-doc/src/view.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/view.ts
@@ -11,9 +11,9 @@ import {
 } from './embed-linked-doc-block';
 import {
   EdgelessClipboardEmbedSyncedDocConfig,
-  EmbedSyncedDocInteraction,
   EmbedSyncedDocViewExtensions,
 } from './embed-synced-doc-block';
+import { EmbedSyncedDocInteraction } from './embed-synced-doc-block/configs/edgeless-interaction';
 
 export class EmbedDocViewExtension extends ViewExtensionProvider {
   override name = 'affine-embed-doc-block';

--- a/blocksuite/affine/model/src/blocks/embed/synced-doc/synced-doc-schema.ts
+++ b/blocksuite/affine/model/src/blocks/embed/synced-doc/synced-doc-schema.ts
@@ -8,7 +8,8 @@ import {
 } from './synced-doc-model.js';
 
 export const SYNCED_MIN_WIDTH = 370;
-export const SYNCED_MIN_HEIGHT = 64;
+export const SYNCED_MIN_HEIGHT = 48;
+export const SYNCED_DEFAULT_WIDTH = 800;
 // the default max height of embed doc, user can adjust height by selected rect over this value
 export const SYNCED_DEFAULT_MAX_HEIGHT = 800;
 
@@ -22,7 +23,7 @@ export const defaultEmbedSyncedDocBlockProps: EmbedSyncedDocBlockProps = {
   title: undefined,
   description: undefined,
   index: 'a0',
-  xywh: `[0,0,${SYNCED_MIN_WIDTH},100]`,
+  xywh: `[0,0,${SYNCED_DEFAULT_WIDTH},100]`,
   lockedBySelf: undefined,
 };
 

--- a/blocksuite/affine/shared/src/consts/index.ts
+++ b/blocksuite/affine/shared/src/consts/index.ts
@@ -7,6 +7,7 @@ import {
   EmbedLoomModel,
   EmbedSyncedDocModel,
   EmbedYoutubeModel,
+  SYNCED_DEFAULT_WIDTH,
 } from '@blocksuite/affine-model';
 
 export const BLOCK_CHILDREN_CONTAINER_PADDING_LEFT = 24;
@@ -29,7 +30,7 @@ export const EMBED_CARD_WIDTH: Record<EmbedCardStyle, number> = {
   video: 752,
   figma: 752,
   html: 752,
-  syncedDoc: 800,
+  syncedDoc: SYNCED_DEFAULT_WIDTH,
   pdf: 537 + 24 + 2,
   citation: 752,
 };

--- a/blocksuite/affine/shared/src/services/drag-handle-config.ts
+++ b/blocksuite/affine/shared/src/services/drag-handle-config.ts
@@ -47,6 +47,7 @@ export class DNDAPIExtension extends Extension {
       ...options.props,
       ...(blockId ? { blockId } : {}),
       pageId: docId,
+      style: flavour === 'affine:embed-synced-doc' ? 'syncedDoc' : 'vertical',
     };
     return {
       ...snapshot,

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
@@ -1089,7 +1089,7 @@ export class DragEventWatcher {
           block.flavour === 'affine:bookmark' ||
           block.flavour.startsWith('affine:embed-')
         ) {
-          const style = 'vertical' as EmbedCardStyle;
+          const style = (block.props.style ?? 'vertical') as EmbedCardStyle;
           block.props.style = style;
 
           blockBound.w = EMBED_CARD_WIDTH[style];

--- a/packages/frontend/core/src/blocksuite/view-extensions/edgeless-block-header/edgeless-embed-synced-doc-header.tsx
+++ b/packages/frontend/core/src/blocksuite/view-extensions/edgeless-block-header/edgeless-embed-synced-doc-header.tsx
@@ -5,8 +5,6 @@ import { stopPropagation } from '@affine/core/utils';
 import { useI18n } from '@affine/i18n';
 import { EmbedSyncedDocBlockComponent } from '@blocksuite/affine/blocks/embed-doc';
 import { isPeekable, peek } from '@blocksuite/affine/components/peek';
-import { DisposableGroup } from '@blocksuite/affine/global/disposable';
-import { Bound } from '@blocksuite/affine/global/gfx';
 import type { EmbedSyncedDocModel } from '@blocksuite/affine-model';
 import {
   ArrowDownSmallIcon,
@@ -30,28 +28,10 @@ const ToggleButton = ({ model }: { model: EmbedSyncedDocModel }) => {
   const [isFolded, setIsFolded] = useState(model.isFolded);
   const t = useI18n();
 
-  useEffect(() => {
-    const disposables = new DisposableGroup();
-    disposables.add(
-      model.props.preFoldHeight$.subscribe(value => setIsFolded(!!value))
-    );
-    // the height may be changed by dragging selected rect
-    disposables.add(
-      model.xywh$.subscribe(value => {
-        const bound = Bound.deserialize(value);
-        const preFoldHeight = model.props.preFoldHeight$.peek();
-        if (
-          bound.h !== styles.headerHeight &&
-          preFoldHeight !== undefined &&
-          bound.h !== preFoldHeight
-        ) {
-          model.props.preFoldHeight$.value = 0;
-        }
-      })
-    );
-
-    return () => disposables.dispose();
-  }, [model.props.preFoldHeight$, model.xywh$]);
+  useEffect(
+    () => model.props.preFoldHeight$.subscribe(value => setIsFolded(!!value)),
+    [model.props.preFoldHeight$]
+  );
 
   const toggle = useCallback(() => {
     model.store.captureSync();


### PR DESCRIPTION
Close [BS-3418](https://linear.app/affine-design/issue/BS-3418/折叠的embed-doc调整宽度时，会出现一个最小高度，不需要这个)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved resizing and folding interactions for embedded synced documents in edgeless mode, including dynamic height calculation and enhanced drag-handle styling.
- **Bug Fixes**
  - Adjusted minimum height for synced document embeds to allow more compact display.
  - Ensured consistent width settings across embed cards.
- **Tests**
  - Added end-to-end tests covering folding, unfolding, and resizing behaviors for edgeless synced document embeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->