### PR TITLE
feat(core): upgrade react-router from v6 to v7

### DIFF
--- a/packages/frontend/admin/package.json
+++ b/packages/frontend/admin/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^3.0.0",
-    "react-router-dom": "^7.5.1",
+    "react-router": "^7.6.0",
     "sonner": "^2.0.0",
     "swr": "^2.2.5",
     "vaul": "^1.1.1",

--- a/packages/frontend/admin/src/app.tsx
+++ b/packages/frontend/admin/src/app.tsx
@@ -1,5 +1,5 @@
 import { Toaster } from '@affine/admin/components/ui/sonner';
-import { lazy, ROUTES } from '@affine/routes';
+import { FACTORIES, lazy, RELATIVE_ROUTES } from '@affine/routes';
 import { withSentryReactRouterV7Routing } from '@sentry/react';
 import { useEffect } from 'react';
 import {
@@ -9,7 +9,7 @@ import {
   Route,
   Routes as ReactRouterRoutes,
   useLocation,
-} from 'react-router-dom';
+} from 'react-router';
 import { toast } from 'sonner';
 import { SWRConfig } from 'swr';
 
@@ -18,22 +18,24 @@ import { isAdmin, useCurrentUser, useServerConfig } from './modules/common';
 import { Layout } from './modules/layout';
 
 export const Setup = lazy(
-  () => import(/* webpackChunkName: "setup" */ './modules/setup')
+  async () => await import(/* webpackChunkName: "setup" */ './modules/setup')
 );
 export const Accounts = lazy(
-  () => import(/* webpackChunkName: "accounts" */ './modules/accounts')
+  async () =>
+    await import(/* webpackChunkName: "accounts" */ './modules/accounts')
 );
 export const AI = lazy(
-  () => import(/* webpackChunkName: "ai" */ './modules/ai')
+  async () => await import(/* webpackChunkName: "ai" */ './modules/ai')
 );
 export const About = lazy(
-  () => import(/* webpackChunkName: "about" */ './modules/about')
+  async () => await import(/* webpackChunkName: "about" */ './modules/about')
 );
 export const Settings = lazy(
-  () => import(/* webpackChunkName: "settings" */ './modules/settings')
+  async () =>
+    await import(/* webpackChunkName: "settings" */ './modules/settings')
 );
 export const Auth = lazy(
-  () => import(/* webpackChunkName: "auth" */ './modules/auth')
+  async () => await import(/* webpackChunkName: "auth" */ './modules/auth')
 );
 
 const Routes = window.SENTRY_RELEASE
@@ -50,7 +52,7 @@ function AuthenticatedRoutes() {
   }, [user]);
 
   if (!user || !isAdmin(user)) {
-    return <Navigate to="/admin/auth" />;
+    return <Navigate to={FACTORIES.admin.auth()} />;
   }
 
   return (
@@ -86,19 +88,21 @@ export const App = () => {
       >
         <BrowserRouter basename={environment.subPath}>
           <Routes>
-            <Route path={ROUTES.admin.index} element={<RootRoutes />}>
-              <Route path={ROUTES.admin.auth} element={<Auth />} />
-              <Route path={ROUTES.admin.setup} element={<Setup />} />
+            <Route path={RELATIVE_ROUTES.admin.index}>
+              <Route index element={<RootRoutes />} />
+              <Route path={RELATIVE_ROUTES.admin.auth} element={<Auth />} />
+              <Route path={RELATIVE_ROUTES.admin.setup} element={<Setup />} />
               <Route element={<AuthenticatedRoutes />}>
-                <Route path={ROUTES.admin.accounts} element={<Accounts />} />
-                <Route path={ROUTES.admin.ai} element={<AI />} />
-                <Route path={ROUTES.admin.about} element={<About />} />
                 <Route
-                  path={ROUTES.admin.settings.index}
-                  element={<Settings />}
-                >
+                  path={RELATIVE_ROUTES.admin.accounts}
+                  element={<Accounts />}
+                />
+                <Route path={RELATIVE_ROUTES.admin.ai} element={<AI />} />
+                <Route path={RELATIVE_ROUTES.admin.about} element={<About />} />
+                <Route path={RELATIVE_ROUTES.admin.settings.index}>
+                  <Route index element={<Settings />} />
                   <Route
-                    path={ROUTES.admin.settings.module}
+                    path={RELATIVE_ROUTES.admin.settings.module}
                     element={<Settings />}
                   />
                 </Route>

--- a/packages/frontend/admin/src/modules/auth/index.tsx
+++ b/packages/frontend/admin/src/modules/auth/index.tsx
@@ -4,7 +4,7 @@ import { Label } from '@affine/admin/components/ui/label';
 import { FeatureType, getUserFeaturesQuery } from '@affine/graphql';
 import type { FormEvent } from 'react';
 import { useCallback, useRef } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 import { toast } from 'sonner';
 
 import { affineFetch } from '../../fetch-utils';

--- a/packages/frontend/admin/src/modules/nav/collapsible-item.tsx
+++ b/packages/frontend/admin/src/modules/nav/collapsible-item.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { buttonVariants } from '../../components/ui/button';
 import { cn } from '../../utils';

--- a/packages/frontend/admin/src/modules/nav/nav-item.tsx
+++ b/packages/frontend/admin/src/modules/nav/nav-item.tsx
@@ -1,7 +1,7 @@
 import { buttonVariants } from '@affine/admin/components/ui/button';
 import { cn } from '@affine/admin/utils';
 import { cssVarV2 } from '@toeverything/theme/v2';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 interface NavItemProps {
   icon: React.ReactNode;

--- a/packages/frontend/admin/src/modules/nav/nav.tsx
+++ b/packages/frontend/admin/src/modules/nav/nav.tsx
@@ -2,7 +2,7 @@ import { buttonVariants } from '@affine/admin/components/ui/button';
 import { cn } from '@affine/admin/utils';
 import { AccountIcon, AiOutlineIcon, SelfhostIcon } from '@blocksuite/icons/rc';
 import { cssVarV2 } from '@toeverything/theme/v2';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { ServerVersion } from './server-version';
 import { SettingsItem } from './settings-item';

--- a/packages/frontend/admin/src/modules/nav/settings-item.tsx
+++ b/packages/frontend/admin/src/modules/nav/settings-item.tsx
@@ -10,7 +10,7 @@ import { SettingsIcon } from '@blocksuite/icons/rc';
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
 import * as ScrollAreaPrimitive from '@radix-ui/react-scroll-area';
 import { cssVarV2 } from '@toeverything/theme/v2';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 
 import { KNOWN_CONFIG_GROUPS, UNKNOWN_CONFIG_GROUPS } from '../settings/config';
 import { NormalSubItem } from './collapsible-item';

--- a/packages/frontend/admin/src/modules/setup/form.tsx
+++ b/packages/frontend/admin/src/modules/setup/form.tsx
@@ -8,7 +8,7 @@ import {
 import { validateEmailAndPassword } from '@affine/admin/utils';
 import { useAsyncCallback } from '@affine/core/components/hooks/affine-async-hooks';
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
 import { affineFetch } from '../../fetch-utils';
@@ -149,7 +149,7 @@ export const Form = () => {
     }
 
     if (current === count) {
-      return navigate('/', { replace: true });
+      return await navigate('/', { replace: true });
     }
 
     api?.scrollNext();
@@ -168,7 +168,7 @@ export const Form = () => {
   const onPrevious = useAsyncCallback(async () => {
     if (current === count) {
       if (serverConfig.initialized === true) {
-        return navigate('/admin', { replace: true });
+        return await navigate('/admin', { replace: true });
       }
       toast.error('Goto Admin Panel failed, please try again.');
       return;

--- a/packages/frontend/admin/src/modules/setup/index.tsx
+++ b/packages/frontend/admin/src/modules/setup/index.tsx
@@ -1,4 +1,4 @@
-import { Navigate } from 'react-router-dom';
+import { Navigate } from 'react-router';
 
 import { useServerConfig } from '../common';
 import { Form } from './form';

--- a/packages/frontend/apps/android/package.json
+++ b/packages/frontend/apps/android/package.json
@@ -31,7 +31,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.28.0"
+    "react-router": "^7.6.0"
   },
   "devDependencies": {
     "@capacitor/cli": "^7.0.0",

--- a/packages/frontend/apps/android/src/app.tsx
+++ b/packages/frontend/apps/android/src/app.tsx
@@ -1,6 +1,5 @@
 import { getStoreManager } from '@affine/core/blocksuite/manager/store';
 import { AffineContext } from '@affine/core/components/context';
-import { AppFallback } from '@affine/core/mobile/components/app-fallback';
 import { configureMobileModules } from '@affine/core/mobile/modules';
 import { VirtualKeyboardProvider } from '@affine/core/mobile/modules/virtual-keyboard';
 import { router } from '@affine/core/mobile/router';
@@ -46,7 +45,7 @@ import { OpClient } from '@toeverything/infra/op';
 import { AsyncCall } from 'async-call-rpc';
 import { useTheme } from 'next-themes';
 import { Suspense, useEffect } from 'react';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router/dom';
 
 import { AffineTheme } from './plugins/affine-theme';
 import { AIButton } from './plugins/ai-button';
@@ -59,10 +58,6 @@ const storeManagerClient = createStoreManagerClient();
 window.addEventListener('beforeunload', () => {
   storeManagerClient.dispose();
 });
-
-const future = {
-  v7_startTransition: true,
-} as const;
 
 const framework = new Framework();
 configureCommonModules(framework);
@@ -342,11 +337,7 @@ export function App() {
         <I18nProvider>
           <AffineContext store={getCurrentStore()}>
             <ThemeProvider />
-            <RouterProvider
-              fallbackElement={<AppFallback />}
-              router={router}
-              future={future}
-            />
+            <RouterProvider router={router} />
           </AffineContext>
         </I18nProvider>
       </FrameworkRoot>

--- a/packages/frontend/apps/electron-renderer/package.json
+++ b/packages/frontend/apps/electron-renderer/package.json
@@ -25,7 +25,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.28.0",
+    "react-router": "^7.6.0",
     "uuid": "^11.0.3",
     "webm-muxer": "^5.0.3"
   },

--- a/packages/frontend/apps/electron-renderer/src/app/app.tsx
+++ b/packages/frontend/apps/electron-renderer/src/app/app.tsx
@@ -1,13 +1,12 @@
 import { AffineContext } from '@affine/core/components/context';
 import { WindowsAppControls } from '@affine/core/components/pure/header/windows-app-controls';
-import { AppContainer } from '@affine/core/desktop/components/app-container';
 import { router } from '@affine/core/desktop/router';
 import { I18nProvider } from '@affine/core/modules/i18n';
 import createEmotionCache from '@affine/core/utils/create-emotion-cache';
 import { CacheProvider } from '@emotion/react';
 import { FrameworkRoot, getCurrentStore } from '@toeverything/infra';
 import { Suspense } from 'react';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router/dom';
 
 import { setupEffects } from './effects';
 import { DesktopThemeSync } from './theme-sync';
@@ -34,10 +33,6 @@ if (
 
 const cache = createEmotionCache();
 
-const future = {
-  v7_startTransition: true,
-} as const;
-
 export function App() {
   return (
     <Suspense>
@@ -46,11 +41,7 @@ export function App() {
           <I18nProvider>
             <AffineContext store={getCurrentStore()}>
               <DesktopThemeSync />
-              <RouterProvider
-                fallbackElement={<AppContainer fallback />}
-                router={router}
-                future={future}
-              />
+              <RouterProvider router={router} />
               {environment.isWindows && (
                 <div style={{ position: 'fixed', right: 0, top: 0, zIndex: 5 }}>
                   <WindowsAppControls />

--- a/packages/frontend/apps/ios/package.json
+++ b/packages/frontend/apps/ios/package.json
@@ -35,7 +35,7 @@
     "next-themes": "^0.4.4",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.28.0",
+    "react-router": "^7.6.0",
     "yjs": "^13.6.21"
   },
   "devDependencies": {

--- a/packages/frontend/apps/ios/src/app.tsx
+++ b/packages/frontend/apps/ios/src/app.tsx
@@ -1,6 +1,5 @@
 import { getStoreManager } from '@affine/core/blocksuite/manager/store';
 import { AffineContext } from '@affine/core/components/context';
-import { AppFallback } from '@affine/core/mobile/components/app-fallback';
 import { configureMobileModules } from '@affine/core/mobile/modules';
 import { HapticProvider } from '@affine/core/mobile/modules/haptics';
 import { NavigationGestureProvider } from '@affine/core/mobile/modules/navigation-gesture';
@@ -56,7 +55,7 @@ import { AsyncCall } from 'async-call-rpc';
 import { AppTrackingTransparency } from 'capacitor-plugin-app-tracking-transparency';
 import { useTheme } from 'next-themes';
 import { Suspense, useEffect } from 'react';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router/dom';
 
 import { BlocksuiteMenuConfigProvider } from './bs-menu-config';
 import { ModalConfigProvider } from './modal-config';
@@ -71,10 +70,6 @@ const storeManagerClient = createStoreManagerClient();
 window.addEventListener('beforeunload', () => {
   storeManagerClient.dispose();
 });
-
-const future = {
-  v7_startTransition: true,
-} as const;
 
 const framework = new Framework();
 configureCommonModules(framework);
@@ -411,11 +406,7 @@ export function App() {
             <KeyboardThemeProvider />
             <ModalConfigProvider>
               <BlocksuiteMenuConfigProvider>
-                <RouterProvider
-                  fallbackElement={<AppFallback />}
-                  router={router}
-                  future={future}
-                />
+                <RouterProvider router={router} />
               </BlocksuiteMenuConfigProvider>
             </ModalConfigProvider>
           </AffineContext>

--- a/packages/frontend/apps/mobile/package.json
+++ b/packages/frontend/apps/mobile/package.json
@@ -20,7 +20,7 @@
     "@toeverything/infra": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.28.0"
+    "react-router": "^7.6.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.1",

--- a/packages/frontend/apps/mobile/src/app.tsx
+++ b/packages/frontend/apps/mobile/src/app.tsx
@@ -1,5 +1,4 @@
 import { AffineContext } from '@affine/core/components/context';
-import { AppFallback } from '@affine/core/mobile/components/app-fallback';
 import { configureMobileModules } from '@affine/core/mobile/modules';
 import { HapticProvider } from '@affine/core/mobile/modules/haptics';
 import { VirtualKeyboardProvider } from '@affine/core/mobile/modules/virtual-keyboard';
@@ -19,7 +18,7 @@ import { StoreManagerClient } from '@affine/nbstore/worker/client';
 import { Framework, FrameworkRoot, getCurrentStore } from '@toeverything/infra';
 import { OpClient } from '@toeverything/infra/op';
 import { Suspense } from 'react';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router/dom';
 
 let storeManagerClient: StoreManagerClient;
 
@@ -34,10 +33,6 @@ if (window.SharedWorker) {
 window.addEventListener('beforeunload', () => {
   storeManagerClient.dispose();
 });
-
-const future = {
-  v7_startTransition: true,
-} as const;
 
 const framework = new Framework();
 configureCommonModules(framework);
@@ -149,11 +144,7 @@ export function App() {
       <FrameworkRoot framework={frameworkProvider}>
         <I18nProvider>
           <AffineContext store={getCurrentStore()}>
-            <RouterProvider
-              fallbackElement={<AppFallback />}
-              router={router}
-              future={future}
-            />
+            <RouterProvider router={router} />
           </AffineContext>
         </I18nProvider>
       </FrameworkRoot>

--- a/packages/frontend/apps/web/package.json
+++ b/packages/frontend/apps/web/package.json
@@ -20,7 +20,7 @@
     "@toeverything/infra": "workspace:*",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.28.0"
+    "react-router": "^7.6.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.1",

--- a/packages/frontend/apps/web/src/app.tsx
+++ b/packages/frontend/apps/web/src/app.tsx
@@ -1,5 +1,4 @@
 import { AffineContext } from '@affine/core/components/context';
-import { AppContainer } from '@affine/core/desktop/components/app-container';
 import { router } from '@affine/core/desktop/router';
 import { configureCommonModules } from '@affine/core/modules';
 import { I18nProvider } from '@affine/core/modules/i18n';
@@ -18,7 +17,7 @@ import { CacheProvider } from '@emotion/react';
 import { Framework, FrameworkRoot, getCurrentStore } from '@toeverything/infra';
 import { OpClient } from '@toeverything/infra/op';
 import { Suspense } from 'react';
-import { RouterProvider } from 'react-router-dom';
+import { RouterProvider } from 'react-router/dom';
 
 const cache = createEmotionCache();
 
@@ -41,10 +40,6 @@ if (
 window.addEventListener('beforeunload', () => {
   storeManagerClient.dispose();
 });
-
-const future = {
-  v7_startTransition: true,
-} as const;
 
 const framework = new Framework();
 configureCommonModules(framework);
@@ -90,11 +85,7 @@ export function App() {
         <CacheProvider value={cache}>
           <I18nProvider>
             <AffineContext store={getCurrentStore()}>
-              <RouterProvider
-                fallbackElement={<AppContainer fallback />}
-                router={router}
-                future={future}
-              />
+              <RouterProvider router={router} />
             </AffineContext>
           </I18nProvider>
         </CacheProvider>

--- a/packages/frontend/component/package.json
+++ b/packages/frontend/component/package.json
@@ -61,7 +61,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-paginate": "^8.2.0",
-    "react-router-dom": "^6.28.0",
+    "react-router": "^7.6.0",
     "react-transition-state": "^2.2.0",
     "sonner": "^2.0.0",
     "swr": "^2.2.5",

--- a/packages/frontend/component/src/components/auth-components/onboarding-page.tsx
+++ b/packages/frontend/component/src/components/auth-components/onboarding-page.tsx
@@ -1,14 +1,16 @@
+import { UserFriendlyError } from '@affine/error';
 import { ArrowRightSmallIcon } from '@blocksuite/icons/rc';
 import clsx from 'clsx';
-import { useMemo, useState } from 'react';
-import type { Location } from 'react-router-dom';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useCallback, useMemo, useState } from 'react';
+import type { Location } from 'react-router';
+import { useLocation, useNavigate } from 'react-router';
 import useSWR from 'swr';
 
 import { Button } from '../../ui/button';
 import { Checkbox } from '../../ui/checkbox';
 import { Divider } from '../../ui/divider';
 import Input from '../../ui/input';
+import { notify } from '../../ui/notification';
 import { ScrollableContainer } from '../../ui/scrollbar';
 import * as styles from './onboarding-page.css';
 import type { User } from './type';
@@ -118,6 +120,21 @@ export const OnboardingPage = ({
     () => questions?.[questionIdx],
     [questionIdx, questions]
   );
+
+  const onClick = useCallback(() => {
+    if (callbackUrl) {
+      const result = navigate(callbackUrl);
+      if (result instanceof Promise) {
+        result.catch((err: Error) => {
+          const error = UserFriendlyError.fromAny(err);
+          console.error(error);
+          notify.error(error);
+        });
+      }
+    } else {
+      onOpenAffine();
+    }
+  }, [callbackUrl, navigate, onOpenAffine]);
   const isMacosDesktop = BUILD_CONFIG.isElectron && environment.isMacOs;
   const isWindowsDesktop = BUILD_CONFIG.isElectron && environment.isWindows;
 
@@ -263,13 +280,7 @@ export const OnboardingPage = ({
           className={clsx(styles.button, styles.openAFFiNEButton)}
           variant="primary"
           size="extraLarge"
-          onClick={() => {
-            if (callbackUrl) {
-              navigate(callbackUrl);
-            } else {
-              onOpenAffine();
-            }
-          }}
+          onClick={onClick}
           suffix={<ArrowRightSmallIcon />}
         >
           Get Started

--- a/packages/frontend/component/src/ui/modal/overlay-modal.tsx
+++ b/packages/frontend/component/src/ui/modal/overlay-modal.tsx
@@ -1,7 +1,7 @@
 import { DialogTrigger } from '@radix-ui/react-dialog';
 import { cssVar } from '@toeverything/theme';
 import { memo, useCallback } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import type { ButtonProps } from '../button';
 import { Button } from '../button';

--- a/packages/frontend/core/package.json
+++ b/packages/frontend/core/package.json
@@ -74,7 +74,7 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-error-boundary": "^6.0.0",
-    "react-router-dom": "^6.28.0",
+    "react-router": "^7.6.0",
     "react-transition-state": "^2.2.0",
     "react-virtuoso": "^4.12.3",
     "rxjs": "^7.8.1",

--- a/packages/frontend/core/src/components/affine/affine-error-boundary/affine-error-fallback.tsx
+++ b/packages/frontend/core/src/components/affine/affine-error-boundary/affine-error-fallback.tsx
@@ -4,7 +4,7 @@ import clsx from 'clsx';
 import { Provider } from 'jotai/react';
 import type { FC } from 'react';
 import { useCallback, useMemo } from 'react';
-import { useRouteError } from 'react-router-dom';
+import { useRouteError } from 'react-router';
 
 import * as styles from './affine-error-fallback.css';
 import { ErrorDetail } from './error-basic/error-detail';

--- a/packages/frontend/core/src/components/affine/affine-error-boundary/error-basic/info-logger.tsx
+++ b/packages/frontend/core/src/components/affine/affine-error-boundary/error-basic/info-logger.tsx
@@ -1,7 +1,7 @@
 import { GlobalContextService } from '@affine/core/modules/global-context';
 import { useLiveData, useServices } from '@toeverything/infra';
 import { useEffect } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams } from 'react-router';
 
 export interface DumpInfoProps {
   error: any;

--- a/packages/frontend/core/src/components/affine/reference-link/index.tsx
+++ b/packages/frontend/core/src/components/affine/reference-link/index.tsx
@@ -18,7 +18,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import * as styles from './styles.css';
 

--- a/packages/frontend/core/src/components/hooks/affine/use-block-suite-meta-helper.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-block-suite-meta-helper.ts
@@ -8,7 +8,7 @@ import { useNavigateHelper } from '../use-navigate-helper';
 
 export function useBlockSuiteMetaHelper() {
   const workspace = useService(WorkspaceService).workspace;
-  const { openPage } = useNavigateHelper();
+  const { jumpToPage } = useNavigateHelper();
   const docsService = useService(DocsService);
   const docRecordList = useService(DocsService).list;
 
@@ -45,9 +45,9 @@ export function useBlockSuiteMetaHelper() {
     async (pageId: string, openPageAfterDuplication: boolean = true) => {
       const newPageId = await docsService.duplicate(pageId);
       openPageAfterDuplication &&
-        openPage(workspace.docCollection.id, newPageId);
+        jumpToPage(workspace.docCollection.id, newPageId);
     },
-    [docsService, openPage, workspace.docCollection.id]
+    [docsService, jumpToPage, workspace.docCollection.id]
   );
 
   return {

--- a/packages/frontend/core/src/components/hooks/affine/use-sign-out.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-sign-out.ts
@@ -26,7 +26,7 @@ export const useSignOut = ({
 }: ConfirmModalProps = {}) => {
   const t = useI18n();
   const { openConfirmModal } = useConfirmModal();
-  const { openPage } = useNavigateHelper();
+  const { jumpToAll } = useNavigateHelper();
 
   const serverService = useService(ServerService);
   const authService = useService(AuthService);
@@ -56,14 +56,14 @@ export const useSignOut = ({
         w => w.flavour !== serverService.server.id
       );
       if (localWorkspace) {
-        openPage(localWorkspace.id, 'all');
+        jumpToAll(localWorkspace.id);
       }
     }
   }, [
     authService,
     currentWorkspaceFlavour,
+    jumpToAll,
     onConfirm,
-    openPage,
     serverService.server.id,
     workspaces,
   ]);

--- a/packages/frontend/core/src/components/page-list/docs/page-list-header.tsx
+++ b/packages/frontend/core/src/components/page-list/docs/page-list-header.tsx
@@ -25,7 +25,7 @@ import {
 import { useLiveData, useService, useServices } from '@toeverything/infra';
 import clsx from 'clsx';
 import { useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 
 import { usePageHelper } from '../../../blocksuite/block-suite-page-list/utils';
 import {

--- a/packages/frontend/core/src/components/page-list/types.ts
+++ b/packages/frontend/core/src/components/page-list/types.ts
@@ -1,7 +1,7 @@
 import type { CollectionMeta } from '@affine/core/modules/collection';
 import type { DocMeta, Workspace } from '@blocksuite/affine/store';
 import type { JSX, PropsWithChildren, ReactNode } from 'react';
-import type { To } from 'react-router-dom';
+import type { To } from 'react-router';
 
 export type ListItem =
   | DocMeta

--- a/packages/frontend/core/src/components/workspace-selector/user-with-workspace-list/workspace-list/index.tsx
+++ b/packages/frontend/core/src/components/workspace-selector/user-with-workspace-list/workspace-list/index.tsx
@@ -160,7 +160,7 @@ const CloudWorkSpaceList = ({
     if (currentWorkspaceFlavour === server.id) {
       const otherWorkspace = workspaces.find(w => w.flavour !== server.id);
       if (otherWorkspace) {
-        navigateHelper.openPage(otherWorkspace.id, 'all');
+        navigateHelper.jumpToAll(otherWorkspace.id);
       }
     }
   }, [

--- a/packages/frontend/core/src/desktop/dialogs/enable-cloud/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/enable-cloud/index.tsx
@@ -49,7 +49,7 @@ const Dialog = ({
     ? workspacesService.open({ metadata: workspaceMeta })
     : { workspace: undefined };
 
-  const { jumpToPage } = useNavigateHelper();
+  const { jumpToPage, jumpToAll } = useNavigateHelper();
 
   const enableCloud = useCallback(async () => {
     try {
@@ -61,7 +61,11 @@ const Dialog = ({
         account.id,
         selectedServer.id
       );
-      jumpToPage(newId, openPageId || 'all');
+      if (openPageId) {
+        jumpToPage(newId, openPageId);
+      } else {
+        jumpToAll(newId);
+      }
       close?.();
     } catch (e) {
       console.error(e);
@@ -74,9 +78,10 @@ const Dialog = ({
     account,
     workspacesService,
     selectedServer.id,
-    jumpToPage,
     openPageId,
     close,
+    jumpToPage,
+    jumpToAll,
     t,
   ]);
 

--- a/packages/frontend/core/src/desktop/dialogs/import-template/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/import-template/index.tsx
@@ -57,7 +57,7 @@ const Dialog = ({
     workspaces.find(w => w.flavour !== 'local') ??
     workspaces.at(0);
   const selectedWorkspaceName = useWorkspaceName(selectedWorkspace);
-  const { openPage, jumpToSignIn } = useNavigateHelper();
+  const { jumpToPage, jumpToSignIn } = useNavigateHelper();
 
   const noWorkspace = workspaces.length === 0;
 
@@ -119,7 +119,7 @@ const Dialog = ({
           templateDownloader.data$.value,
           templateMode
         );
-        openPage(selectedWorkspace.id, docId);
+        jumpToPage(selectedWorkspace.id, docId);
         onClose?.();
       } catch (err) {
         setImportingError(err);
@@ -129,8 +129,8 @@ const Dialog = ({
     }
   }, [
     importTemplateService,
+    jumpToPage,
     onClose,
-    openPage,
     selectedWorkspace,
     templateDownloader.data$.value,
     templateMode,
@@ -149,7 +149,7 @@ const Dialog = ({
           'Workspace',
           templateDownloader.data$.value
         );
-      openPage(workspaceId, docId);
+      jumpToPage(workspaceId, docId);
       onClose?.();
     } catch (err) {
       setImportingError(err);
@@ -158,8 +158,8 @@ const Dialog = ({
     }
   }, [
     importTemplateService,
+    jumpToPage,
     onClose,
-    openPage,
     templateDownloader.data$.value,
   ]);
 

--- a/packages/frontend/core/src/desktop/pages/ai-upgrade-success/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/ai-upgrade-success/index.tsx
@@ -3,7 +3,7 @@ import { AuthPageContainer } from '@affine/component/auth-components';
 import { useNavigateHelper } from '@affine/core/components/hooks/use-navigate-helper';
 import { Trans, useI18n } from '@affine/i18n';
 import { useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import * as styles from './styles.css';
 

--- a/packages/frontend/core/src/desktop/pages/auth/auth.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/auth.tsx
@@ -14,8 +14,8 @@ import {
 import { useI18n } from '@affine/i18n';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback } from 'react';
-import type { LoaderFunction } from 'react-router-dom';
-import { redirect, useParams, useSearchParams } from 'react-router-dom';
+import type { LoaderFunction } from 'react-router';
+import { redirect, useParams, useSearchParams } from 'react-router';
 import { z } from 'zod';
 
 import { useMutation } from '../../../components/hooks/use-mutation';

--- a/packages/frontend/core/src/desktop/pages/auth/confirm-change-email.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/confirm-change-email.tsx
@@ -7,7 +7,7 @@ import { changeEmailMutation } from '@affine/graphql';
 import { useI18n } from '@affine/i18n';
 import { useService } from '@toeverything/infra';
 import { type FC, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { AppContainer } from '../../components/app-container';
 

--- a/packages/frontend/core/src/desktop/pages/auth/email-verified-email.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/email-verified-email.tsx
@@ -7,7 +7,7 @@ import { verifyEmailMutation } from '@affine/graphql';
 import { useI18n } from '@affine/i18n';
 import { useService } from '@toeverything/infra';
 import { type FC, useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { AppContainer } from '../../components/app-container';
 

--- a/packages/frontend/core/src/desktop/pages/auth/magic-link.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/magic-link.tsx
@@ -1,12 +1,7 @@
+import { useAsyncNavigate } from '@affine/core/utils/use-async-navigate';
 import { useService } from '@toeverything/infra';
 import { useEffect, useRef } from 'react';
-import {
-  type LoaderFunction,
-  redirect,
-  useLoaderData,
-  // eslint-disable-next-line @typescript-eslint/no-restricted-imports
-  useNavigate,
-} from 'react-router-dom';
+import { type LoaderFunction, redirect, useLoaderData } from 'react-router';
 
 import { AuthService } from '../../../modules/cloud';
 import { supportedClient } from './common';
@@ -58,7 +53,8 @@ export const Component = () => {
   const auth = useService(AuthService);
   const data = useLoaderData() as LoaderData;
 
-  const nav = useNavigate();
+  const nav = useAsyncNavigate();
+
   // loader data from useLoaderData is not reactive, so that we can safely
   // assume the effect below is only triggered once
   const triggeredRef = useRef(false);

--- a/packages/frontend/core/src/desktop/pages/auth/oauth-callback.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/oauth-callback.tsx
@@ -1,11 +1,7 @@
+import { useAsyncNavigate } from '@affine/core/utils/use-async-navigate';
 import { useService } from '@toeverything/infra';
 import { useEffect, useRef } from 'react';
-import {
-  type LoaderFunction,
-  redirect,
-  useLoaderData,
-  useNavigate,
-} from 'react-router-dom';
+import { type LoaderFunction, redirect, useLoaderData } from 'react-router';
 
 import { AuthService } from '../../../modules/cloud';
 import { supportedClient } from './common';
@@ -66,7 +62,7 @@ export const Component = () => {
   // assume the effect below is only triggered once
   const triggeredRef = useRef(false);
 
-  const nav = useNavigate();
+  const nav = useAsyncNavigate();
 
   useEffect(() => {
     if (triggeredRef.current) {

--- a/packages/frontend/core/src/desktop/pages/auth/oauth-login.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/oauth-login.tsx
@@ -1,14 +1,9 @@
 import { AuthService } from '@affine/core/modules/cloud';
+import { useAsyncNavigate } from '@affine/core/utils';
 import { OAuthProviderType } from '@affine/graphql';
 import { useService } from '@toeverything/infra';
 import { useEffect } from 'react';
-import {
-  type LoaderFunction,
-  redirect,
-  useLoaderData,
-  // oxlint-disable-next-line @typescript-eslint/no-restricted-imports
-  useNavigate,
-} from 'react-router-dom';
+import { type LoaderFunction, redirect, useLoaderData } from 'react-router';
 import { z } from 'zod';
 
 import { supportedClient } from './common';
@@ -62,7 +57,7 @@ export const Component = () => {
   const auth = useService(AuthService);
   const data = useLoaderData() as LoaderData;
 
-  const nav = useNavigate();
+  const nav = useAsyncNavigate();
 
   useEffect(() => {
     auth

--- a/packages/frontend/core/src/desktop/pages/auth/sign-in.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/sign-in.tsx
@@ -4,9 +4,10 @@ import { SignInPageContainer } from '@affine/component/auth-components';
 import { SignInPanel } from '@affine/core/components/sign-in';
 import { SignInBackgroundArts } from '@affine/core/components/sign-in/background-arts';
 import type { AuthSessionStatus } from '@affine/core/modules/cloud/entities/session';
+import { useAsyncNavigate } from '@affine/core/utils';
 import { useI18n } from '@affine/i18n';
 import { useCallback, useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import {
   RouteLogic,
@@ -19,7 +20,7 @@ export const SignIn = ({
   redirectUrl?: string;
 }) => {
   const t = useI18n();
-  const navigate = useNavigate();
+  const navigate = useAsyncNavigate();
   const { jumpToIndex } = useNavigateHelper();
   const [searchParams] = useSearchParams();
   const redirectUrl = redirectUrlFromProps ?? searchParams.get('redirect_uri');

--- a/packages/frontend/core/src/desktop/pages/import-template/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/import-template/index.tsx
@@ -2,7 +2,7 @@ import { GlobalDialogService } from '@affine/core/modules/dialogs';
 import type { DocMode } from '@blocksuite/affine/model';
 import { useService } from '@toeverything/infra';
 import { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { useNavigateHelper } from '../../../components/hooks/use-navigate-helper';
 

--- a/packages/frontend/core/src/desktop/pages/invite/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/invite/index.tsx
@@ -12,7 +12,7 @@ import { UserFriendlyError } from '@affine/error';
 import { WorkspaceMemberStatus } from '@affine/graphql';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback, useEffect, useState } from 'react';
-import { Navigate, useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router';
 
 import {
   RouteLogic,

--- a/packages/frontend/core/src/desktop/pages/onboarding/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/onboarding/index.tsx
@@ -1,7 +1,7 @@
 import { DesktopApiService } from '@affine/core/modules/desktop-api';
 import { useServiceOptional } from '@toeverything/infra';
 import { useCallback } from 'react';
-import { redirect } from 'react-router-dom';
+import { redirect } from 'react-router';
 
 import { Onboarding } from '../../../components/affine/onboarding/onboarding';
 import { appConfigStorage } from '../../../components/hooks/use-app-config-storage';

--- a/packages/frontend/core/src/desktop/pages/open-app/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/open-app/index.tsx
@@ -10,7 +10,7 @@ import type { GetCurrentUserQuery } from '@affine/graphql';
 import { getCurrentUserQuery } from '@affine/graphql';
 import { useService } from '@toeverything/infra';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router';
 
 import { AppContainer } from '../../components/app-container';
 

--- a/packages/frontend/core/src/desktop/pages/redirect/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/redirect/index.tsx
@@ -1,5 +1,5 @@
 import { DebugLogger } from '@affine/debug';
-import { type LoaderFunction, Navigate, useLoaderData } from 'react-router-dom';
+import { type LoaderFunction, Navigate, useLoaderData } from 'react-router';
 
 const trustedDomain = [
   'google.com',

--- a/packages/frontend/core/src/desktop/pages/root/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/root/index.tsx
@@ -2,7 +2,7 @@ import { NotificationCenter } from '@affine/component';
 import { DefaultServerService } from '@affine/core/modules/cloud';
 import { FrameworkScope, useService } from '@toeverything/infra';
 import { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { GlobalDialogs } from '../../dialogs';
 import { CustomThemeModifier } from './custom-theme';

--- a/packages/frontend/core/src/desktop/pages/subscribe/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/subscribe/index.tsx
@@ -10,7 +10,7 @@ import { track } from '@affine/track';
 import { effect, fromPromise, useServices } from '@toeverything/infra';
 import { nanoid } from 'nanoid';
 import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { switchMap } from 'rxjs';
 
 import { generateSubscriptionCallbackLink } from '../../../components/hooks/affine/use-subscription-notify';

--- a/packages/frontend/core/src/desktop/pages/upgrade-success/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/upgrade-success/index.tsx
@@ -3,7 +3,7 @@ import { AuthPageContainer } from '@affine/component/auth-components';
 import { useNavigateHelper } from '@affine/core/components/hooks/use-navigate-helper';
 import { Trans, useI18n } from '@affine/i18n';
 import { useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import * as styles from './styles.css';
 

--- a/packages/frontend/core/src/desktop/pages/upgrade-success/self-host-team/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/upgrade-success/self-host-team/index.tsx
@@ -7,7 +7,7 @@ import { Trans, useI18n } from '@affine/i18n';
 import { CopyIcon } from '@blocksuite/icons/rc';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback, useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { PageNotFound } from '../../404';
 import * as styles from './styles.css';

--- a/packages/frontend/core/src/desktop/pages/upgrade-to-team/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/upgrade-to-team/index.tsx
@@ -29,7 +29,7 @@ import { type I18nString, Trans, useI18n } from '@affine/i18n';
 import { DoneIcon, NewPageIcon, SignOutIcon } from '@blocksuite/icons/rc';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 import { Upgrade } from '../../dialogs/setting/general-setting/plans/plan-card';
 import { PageNotFound } from '../404';

--- a/packages/frontend/core/src/desktop/pages/workspace/attachment/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/attachment/index.tsx
@@ -4,7 +4,7 @@ import { type Doc, DocsService } from '@affine/core/modules/doc';
 import { type AttachmentBlockModel } from '@blocksuite/affine/model';
 import { FrameworkScope, useLiveData, useService } from '@toeverything/infra';
 import { type ReactElement, useLayoutEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { ViewIcon, ViewTitle } from '../../../../modules/workbench';
 import { PageNotFound } from '../../404';

--- a/packages/frontend/core/src/desktop/pages/workspace/collection/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/collection/index.tsx
@@ -18,7 +18,7 @@ import { useI18n } from '@affine/i18n';
 import { ViewLayersIcon } from '@blocksuite/icons/rc';
 import { useLiveData, useService, useServices } from '@toeverything/infra';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { useNavigateHelper } from '../../../../components/hooks/use-navigate-helper';
 import {

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page.tsx
@@ -50,7 +50,7 @@ import {
 import clsx from 'clsx';
 import { nanoid } from 'nanoid';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 import type { Subscription } from 'rxjs';
 
 import { PageNotFound } from '../../404';

--- a/packages/frontend/core/src/desktop/pages/workspace/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/index.tsx
@@ -30,7 +30,7 @@ import {
   useLocation,
   useParams,
   useSearchParams,
-} from 'react-router-dom';
+} from 'react-router';
 import { map } from 'rxjs';
 import * as _Y from 'yjs';
 

--- a/packages/frontend/core/src/desktop/pages/workspace/settings/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/settings/index.tsx
@@ -3,7 +3,7 @@ import type { SettingTab } from '@affine/core/modules/dialogs/constant';
 import { WorkbenchService } from '@affine/core/modules/workbench';
 import { useService } from '@toeverything/infra';
 import { useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 
 export const Component = () => {
   const workbenchService = useService(WorkbenchService);

--- a/packages/frontend/core/src/desktop/pages/workspace/share/share-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/share/share-page.tsx
@@ -27,7 +27,7 @@ import { Logo1Icon } from '@blocksuite/icons/rc';
 import { FrameworkScope, useLiveData, useService } from '@toeverything/infra';
 import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import { PageNotFound } from '../../404';
 import { ShareFooter } from './share-footer';
@@ -186,7 +186,7 @@ const SharePageInner = ({
 
   const t = useI18n();
   const pageTitle = useLiveData(page?.title$);
-  const { jumpToPageBlock, openPage } = useNavigateHelper();
+  const { jumpToPageBlock, jumpToPage } = useNavigateHelper();
 
   const onEditorLoad = useCallback(
     (editorContainer: AffineEditorContainer) => {
@@ -212,7 +212,7 @@ const SharePageInner = ({
               return;
             }
 
-            return openPage(workspaceId, pageId);
+            return jumpToPage(workspaceId, pageId);
           })
         );
       }
@@ -221,7 +221,13 @@ const SharePageInner = ({
         unbind();
       };
     },
-    [editor, setActiveBlocksuiteEditor, jumpToPageBlock, openPage, workspaceId]
+    [
+      setActiveBlocksuiteEditor,
+      editor,
+      jumpToPage,
+      workspaceId,
+      jumpToPageBlock,
+    ]
   );
 
   if (noPermission) {

--- a/packages/frontend/core/src/desktop/pages/workspace/tag/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/tag/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '@affine/core/modules/workbench';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback, useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { PageNotFound } from '../../404';
 import { AllDocSidebarTabs } from '../layouts/all-doc-sidebar-tabs';

--- a/packages/frontend/core/src/desktop/router.tsx
+++ b/packages/frontend/core/src/desktop/router.tsx
@@ -1,11 +1,11 @@
-import { wrapCreateBrowserRouterV6 } from '@sentry/react';
+import { wrapCreateBrowserRouterV7 } from '@sentry/react';
 import { useEffect, useState } from 'react';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import {
   createBrowserRouter as reactRouterCreateBrowserRouter,
   redirect,
   useNavigate,
-} from 'react-router-dom';
+} from 'react-router';
 
 import { AffineErrorComponent } from '../components/affine/affine-error-boundary/affine-error-fallback';
 import { NavigateContext } from '../components/hooks/use-navigate-helper';
@@ -35,11 +35,11 @@ export const topLevelRoutes = [
     children: [
       {
         path: '/',
-        lazy: () => import('./pages/index'),
+        lazy: async () => await import('./pages/index'),
       },
       {
         path: '/workspace/:workspaceId/*',
-        lazy: () => import('./pages/workspace/index'),
+        lazy: async () => await import('./pages/workspace/index'),
       },
       {
         path: '/share/:workspaceId/:pageId',
@@ -49,47 +49,48 @@ export const topLevelRoutes = [
       },
       {
         path: '/404',
-        lazy: () => import('./pages/404'),
+        lazy: async () => await import('./pages/404'),
       },
       {
         path: '/expired',
-        lazy: () => import('./pages/expired'),
+        lazy: async () => await import('./pages/expired'),
       },
       {
         path: '/invite/:inviteId',
-        lazy: () => import('./pages/invite'),
+        lazy: async () => await import('./pages/invite'),
       },
       {
         path: '/upgrade-success',
-        lazy: () => import('./pages/upgrade-success'),
+        lazy: async () => await import('./pages/upgrade-success'),
       },
       {
         path: '/upgrade-success/team',
-        lazy: () => import('./pages/upgrade-success/team'),
+        lazy: async () => await import('./pages/upgrade-success/team'),
       },
       {
         path: '/upgrade-success/self-hosted-team',
-        lazy: () => import('./pages/upgrade-success/self-host-team'),
+        lazy: async () =>
+          await import('./pages/upgrade-success/self-host-team'),
       },
       {
         path: '/ai-upgrade-success',
-        lazy: () => import('./pages/ai-upgrade-success'),
+        lazy: async () => await import('./pages/ai-upgrade-success'),
       },
       {
         path: '/onboarding',
-        lazy: () => import('./pages/onboarding'),
+        lazy: async () => await import('./pages/onboarding'),
       },
       {
         path: '/redirect-proxy',
-        lazy: () => import('./pages/redirect'),
+        lazy: async () => await import('./pages/redirect'),
       },
       {
         path: '/subscribe',
-        lazy: () => import('./pages/subscribe'),
+        lazy: async () => await import('./pages/subscribe'),
       },
       {
         path: '/upgrade-to-team',
-        lazy: () => import('./pages/upgrade-to-team'),
+        lazy: async () => await import('./pages/upgrade-to-team'),
       },
       {
         path: '/try-cloud',
@@ -101,15 +102,15 @@ export const topLevelRoutes = [
       },
       {
         path: '/theme-editor',
-        lazy: () => import('./pages/theme-editor'),
+        lazy: async () => await import('./pages/theme-editor'),
       },
       {
         path: '/clipper/import',
-        lazy: () => import('./pages/import-clipper'),
+        lazy: async () => await import('./pages/import-clipper'),
       },
       {
         path: '/template/import',
-        lazy: () => import('./pages/import-template'),
+        lazy: async () => await import('./pages/import-template'),
       },
       {
         path: '/template/preview',
@@ -133,63 +134,69 @@ export const topLevelRoutes = [
       },
       {
         path: '/auth/:authType',
-        lazy: () => import(/* webpackChunkName: "auth" */ './pages/auth/auth'),
+        lazy: async () =>
+          await import(/* webpackChunkName: "auth" */ './pages/auth/auth'),
       },
       {
         path: '/sign-In',
-        lazy: () =>
-          import(/* webpackChunkName: "auth" */ './pages/auth/sign-in'),
+        lazy: async () =>
+          await import(/* webpackChunkName: "auth" */ './pages/auth/sign-in'),
       },
       {
         path: '/magic-link',
-        lazy: () =>
-          import(/* webpackChunkName: "auth" */ './pages/auth/magic-link'),
+        lazy: async () =>
+          await import(
+            /* webpackChunkName: "auth" */ './pages/auth/magic-link'
+          ),
       },
       {
         path: '/oauth/login',
-        lazy: () =>
-          import(/* webpackChunkName: "auth" */ './pages/auth/oauth-login'),
+        lazy: async () =>
+          await import(
+            /* webpackChunkName: "auth" */ './pages/auth/oauth-login'
+          ),
       },
       {
         path: '/oauth/callback',
-        lazy: () =>
-          import(/* webpackChunkName: "auth" */ './pages/auth/oauth-callback'),
+        lazy: async () =>
+          await import(
+            /* webpackChunkName: "auth" */ './pages/auth/oauth-callback'
+          ),
       },
       // deprecated, keep for old client compatibility
       // TODO(@forehalo): remove
       {
         path: '/desktop-signin',
-        lazy: () =>
-          import(/* webpackChunkName: "auth" */ './pages/auth/oauth-login'),
+        lazy: async () =>
+          await import(
+            /* webpackChunkName: "auth" */ './pages/auth/oauth-login'
+          ),
       },
       // deprecated, keep for old client compatibility
       // use '/sign-in'
       // TODO(@forehalo): remove
       {
         path: '/signIn',
-        lazy: () =>
-          import(/* webpackChunkName: "auth" */ './pages/auth/sign-in'),
+        lazy: async () =>
+          await import(/* webpackChunkName: "auth" */ './pages/auth/sign-in'),
       },
       {
         path: '/open-app/:action',
-        lazy: () => import('./pages/open-app'),
+        lazy: async () => await import('./pages/open-app'),
       },
       {
         path: '*',
-        lazy: () => import('./pages/404'),
+        lazy: async () => await import('./pages/404'),
       },
     ],
   },
 ] satisfies [RouteObject, ...RouteObject[]];
 
-const createBrowserRouter = wrapCreateBrowserRouterV6(
+const createBrowserRouter = wrapCreateBrowserRouterV7(
   reactRouterCreateBrowserRouter
 );
 export const router = (
   window.SENTRY_RELEASE ? createBrowserRouter : reactRouterCreateBrowserRouter
 )(topLevelRoutes, {
   basename: environment.subPath,
-  future: {
-    v7_normalizeFormMethod: true,
-  },
 });

--- a/packages/frontend/core/src/desktop/workbench-router.ts
+++ b/packages/frontend/core/src/desktop/workbench-router.ts
@@ -1,52 +1,52 @@
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 export const workbenchRoutes = [
   {
     path: '/all',
-    lazy: () => import('./pages/workspace/all-page/all-page'),
+    lazy: async () => await import('./pages/workspace/all-page/all-page'),
   },
   {
     path: '/all-old',
-    lazy: () => import('./pages/workspace/all-page-old/all-page'),
+    lazy: async () => await import('./pages/workspace/all-page-old/all-page'),
   },
   {
     path: '/collection',
-    lazy: () => import('./pages/workspace/all-collection'),
+    lazy: async () => await import('./pages/workspace/all-collection'),
   },
   {
     path: '/collection/:collectionId',
-    lazy: () => import('./pages/workspace/collection/index'),
+    lazy: async () => await import('./pages/workspace/collection/index'),
   },
   {
     path: '/tag',
-    lazy: () => import('./pages/workspace/all-tag'),
+    lazy: async () => await import('./pages/workspace/all-tag'),
   },
   {
     path: '/tag/:tagId',
-    lazy: () => import('./pages/workspace/tag'),
+    lazy: async () => await import('./pages/workspace/tag'),
   },
   {
     path: '/trash',
-    lazy: () => import('./pages/workspace/trash-page'),
+    lazy: async () => await import('./pages/workspace/trash-page'),
   },
   {
     path: '/:pageId',
-    lazy: () => import('./pages/workspace/detail-page/detail-page'),
+    lazy: async () => await import('./pages/workspace/detail-page/detail-page'),
   },
   {
     path: '/:pageId/attachments/:attachmentId',
-    lazy: () => import('./pages/workspace/attachment/index'),
+    lazy: async () => await import('./pages/workspace/attachment/index'),
   },
   {
     path: '/journals',
-    lazy: () => import('./pages/journals'),
+    lazy: async () => await import('./pages/journals'),
   },
   {
     path: '/settings',
-    lazy: () => import('./pages/workspace/settings'),
+    lazy: async () => await import('./pages/workspace/settings'),
   },
   {
     path: '*',
-    lazy: () => import('./pages/404'),
+    lazy: async () => await import('./pages/404'),
   },
 ] satisfies RouteObject[];

--- a/packages/frontend/core/src/mobile/components/workspace-selector/menu.tsx
+++ b/packages/frontend/core/src/mobile/components/workspace-selector/menu.tsx
@@ -216,7 +216,7 @@ const CloudWorkSpaceList = ({
     if (currentWorkspaceFlavour === server.id) {
       const otherWorkspace = workspaces.find(w => w.flavour !== server.id);
       if (otherWorkspace) {
-        navigateHelper.openPage(otherWorkspace.id, 'all');
+        navigateHelper.jumpToAll(otherWorkspace.id);
       }
     }
   }, [

--- a/packages/frontend/core/src/mobile/pages/root/index.tsx
+++ b/packages/frontend/core/src/mobile/pages/root/index.tsx
@@ -2,7 +2,7 @@ import { NotificationCenter } from '@affine/component';
 import { DefaultServerService } from '@affine/core/modules/cloud';
 import { FrameworkScope, useService } from '@toeverything/infra';
 import { useEffect, useState } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { GlobalDialogs } from '../../dialogs';
 

--- a/packages/frontend/core/src/mobile/pages/sign-in.tsx
+++ b/packages/frontend/core/src/mobile/pages/sign-in.tsx
@@ -1,10 +1,13 @@
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { useNavigate } from 'react-router-dom';
+import { useAsyncNavigate } from '@affine/core/utils';
+import { useCallback } from 'react';
 
 import { MobileSignInPanel } from '../components/sign-in';
 
 export const Component = () => {
-  const navigate = useNavigate();
+  const navigate = useAsyncNavigate();
+  const onClose = useCallback(() => {
+    navigate('/');
+  }, [navigate]);
 
-  return <MobileSignInPanel onClose={() => navigate('/')} />;
+  return <MobileSignInPanel onClose={onClose} />;
 };

--- a/packages/frontend/core/src/mobile/pages/workspace/collection/detail.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/collection/detail.tsx
@@ -3,7 +3,7 @@ import { CollectionService } from '@affine/core/modules/collection';
 import { GlobalContextService } from '@affine/core/modules/global-context';
 import { useLiveData, useServices } from '@toeverything/infra';
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { CollectionDetail } from '../../../views';
 

--- a/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
@@ -37,7 +37,7 @@ import { cssVarV2 } from '@toeverything/theme/v2';
 import clsx from 'clsx';
 import dayjs from 'dayjs';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { AppTabs } from '../../../components';
 import { JournalConflictBlock } from './journal-conflict-block';
@@ -73,7 +73,7 @@ const DetailPageImpl = () => {
   const mode = useLiveData(editor.mode$);
 
   const isInTrash = useLiveData(doc.meta$.map(meta => meta.trash));
-  const { openPage, jumpToPageBlock } = useNavigateHelper();
+  const { jumpToPage, jumpToPageBlock } = useNavigateHelper();
   const scrollViewportRef = useRef<HTMLDivElement | null>(null);
 
   const editorContainer = useLiveData(editor.editorContainer$);
@@ -163,7 +163,7 @@ const DetailPageImpl = () => {
               );
             }
 
-            return openPage(docCollection.id, pageId);
+            return jumpToPage(docCollection.id, pageId);
           })
         );
       }
@@ -178,7 +178,7 @@ const DetailPageImpl = () => {
         disposable.dispose();
       };
     },
-    [docCollection.id, editor, jumpToPageBlock, openPage, server]
+    [docCollection.id, editor, jumpToPage, jumpToPageBlock, server.baseUrl]
   );
 
   const canEdit = useGuard('Doc_Update', doc.id);

--- a/packages/frontend/core/src/mobile/pages/workspace/index.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/index.tsx
@@ -17,7 +17,7 @@ import {
   type RouteObject,
   useLocation,
   useParams,
-} from 'react-router-dom';
+} from 'react-router';
 
 import { WorkspaceLayout } from './layout';
 import { MobileWorkbenchRoot } from './workbench-root';
@@ -37,7 +37,11 @@ const MobileRouteContainer = ({ route }: { route: Route }) => {
 };
 
 const warpedRoutes = workbenchRoutes.map((originalRoute: RouteObject) => {
-  if (originalRoute.Component || !originalRoute.lazy) {
+  if (
+    originalRoute.Component ||
+    !originalRoute.lazy ||
+    typeof originalRoute.lazy !== 'function'
+  ) {
     return originalRoute;
   }
 

--- a/packages/frontend/core/src/mobile/pages/workspace/tag/detail.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/tag/detail.tsx
@@ -4,7 +4,7 @@ import { GlobalContextService } from '@affine/core/modules/global-context';
 import { TagService } from '@affine/core/modules/tag';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router';
 
 import { TagDetail } from '../../../views';
 

--- a/packages/frontend/core/src/mobile/pages/workspace/workbench-root.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/workbench-root.tsx
@@ -5,7 +5,7 @@ import {
 import { ViewRoot } from '@affine/core/modules/workbench/view/view-root';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useEffect } from 'react';
-import { type RouteObject, useLocation } from 'react-router-dom';
+import { type RouteObject, useLocation } from 'react-router';
 
 export const MobileWorkbenchRoot = ({ routes }: { routes: RouteObject[] }) => {
   const workbench = useService(WorkbenchService).workbench;

--- a/packages/frontend/core/src/mobile/router.tsx
+++ b/packages/frontend/core/src/mobile/router.tsx
@@ -1,13 +1,14 @@
 import { NavigateContext } from '@affine/core/components/hooks/use-navigate-helper';
-import { wrapCreateBrowserRouterV6 } from '@sentry/react';
+import { wrapCreateBrowserRouterV7 } from '@sentry/react';
 import { useEffect, useState } from 'react';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import {
   createBrowserRouter as reactRouterCreateBrowserRouter,
   redirect,
   useNavigate,
-} from 'react-router-dom';
+} from 'react-router';
 
+import { AppFallback } from './components/app-fallback';
 import { RootWrapper } from './pages/root';
 
 function RootRouter() {
@@ -30,77 +31,74 @@ function RootRouter() {
 export const topLevelRoutes = [
   {
     element: <RootRouter />,
+    hydrateFallbackElement: <AppFallback />,
     children: [
       {
         path: '/',
-        lazy: () => import('./pages/index'),
+        lazy: async () => await import('./pages/index'),
       },
       {
         path: '/workspace/:workspaceId/*',
-        lazy: () => import('./pages/workspace/index'),
+        lazy: async () => await import('./pages/workspace/index'),
       },
       {
         path: '/share/:workspaceId/:pageId',
-        loader: ({ params }) => {
+        loader: async ({ params }) => {
           return redirect(`/workspace/${params.workspaceId}/${params.pageId}`);
         },
       },
       {
         path: '/404',
-        lazy: () => import('./pages/404'),
+        lazy: async () => await import('./pages/404'),
       },
       {
         path: '/auth/:authType',
-        lazy: () => import('./pages/auth'),
+        lazy: async () => await import('./pages/auth'),
       },
       {
         path: '/sign-in',
-        lazy: () => import('./pages/sign-in'),
+        lazy: async () => await import('./pages/sign-in'),
       },
       {
         path: '/magic-link',
-        lazy: () =>
-          import(
+        lazy: async () =>
+          await import(
             /* webpackChunkName: "auth" */ '@affine/core/desktop/pages/auth/magic-link'
           ),
       },
       {
         path: '/oauth/login',
-        lazy: () =>
-          import(
+        lazy: async () =>
+          await import(
             /* webpackChunkName: "auth" */ '@affine/core/desktop/pages/auth/oauth-login'
           ),
       },
       {
         path: '/oauth/callback',
-        lazy: () =>
-          import(
+        lazy: async () =>
+          await import(
             /* webpackChunkName: "auth" */ '@affine/core/desktop/pages/auth/oauth-callback'
           ),
       },
       {
         path: '/redirect-proxy',
-        lazy: () => import('@affine/core/desktop/pages/redirect'),
+        lazy: async () => await import('@affine/core/desktop/pages/redirect'),
       },
       {
         path: '/open-app/:action',
-        lazy: () => import('@affine/core/desktop/pages/open-app'),
+        lazy: async () => await import('@affine/core/desktop/pages/open-app'),
       },
       {
         path: '*',
-        lazy: () => import('./pages/404'),
+        lazy: async () => await import('./pages/404'),
       },
     ],
   },
 ] satisfies [RouteObject, ...RouteObject[]];
 
-const createBrowserRouter = wrapCreateBrowserRouterV6(
+const createBrowserRouter = wrapCreateBrowserRouterV7(
   reactRouterCreateBrowserRouter
 );
 export const router = (
   window.SENTRY_RELEASE ? createBrowserRouter : reactRouterCreateBrowserRouter
-)(topLevelRoutes, {
-  future: {
-    v7_normalizeFormMethod: true,
-  },
-});
+)(topLevelRoutes);

--- a/packages/frontend/core/src/mobile/workbench-router.ts
+++ b/packages/frontend/core/src/mobile/workbench-router.ts
@@ -1,4 +1,4 @@
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 
 import { Component as All } from './pages/workspace/all';
 import { Component as Collection } from './pages/workspace/collection';
@@ -43,14 +43,15 @@ export const workbenchRoutes = [
   },
   {
     path: '/trash',
-    lazy: () => import('./pages/workspace/trash'),
+    lazy: async () => await import('./pages/workspace/trash'),
   },
   {
     path: '/:pageId',
-    lazy: () => import('./pages/workspace/detail/mobile-detail-page'),
+    lazy: async () =>
+      await import('./pages/workspace/detail/mobile-detail-page'),
   },
   {
     path: '*',
-    lazy: () => import('./pages/404'),
+    lazy: async () => await import('./pages/404'),
   },
 ] satisfies [RouteObject, ...RouteObject[]];

--- a/packages/frontend/core/src/modules/app-sidebar/views/menu-item/external-menu-link-item.tsx
+++ b/packages/frontend/core/src/modules/app-sidebar/views/menu-item/external-menu-link-item.tsx
@@ -1,7 +1,7 @@
 import { DualLinkIcon } from '@blocksuite/icons/rc';
 import { cssVarV2 } from '@toeverything/theme/v2';
 import type { ReactElement, SVGAttributes } from 'react';
-import type { To } from 'react-router-dom';
+import type { To } from 'react-router';
 
 import { MenuLinkItem } from './index';
 

--- a/packages/frontend/core/src/modules/app-sidebar/views/menu-item/index.tsx
+++ b/packages/frontend/core/src/modules/app-sidebar/views/menu-item/index.tsx
@@ -2,7 +2,7 @@ import { WorkbenchLink } from '@affine/core/modules/workbench';
 import { ArrowDownSmallIcon } from '@blocksuite/icons/rc';
 import clsx from 'clsx';
 import React, { type SVGAttributes } from 'react';
-import type { To } from 'react-router-dom';
+import type { To } from 'react-router';
 
 import * as styles from './index.css';
 

--- a/packages/frontend/core/src/modules/workbench/view/browser-adapter.ts
+++ b/packages/frontend/core/src/modules/workbench/view/browser-adapter.ts
@@ -1,8 +1,8 @@
+import { useAsyncNavigate } from '@affine/core/utils';
 import { useLiveData } from '@toeverything/infra';
 import type { Location } from 'history';
 import { useEffect } from 'react';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { Workbench } from '../entities/workbench';
 
@@ -26,7 +26,7 @@ export function useBindWorkbenchToBrowserRouter(
   workbench: Workbench,
   basename: string
 ) {
-  const navigate = useNavigate();
+  const navigate = useAsyncNavigate();
   const browserLocation = useLocation();
 
   const view = useLiveData(workbench.activeView$);

--- a/packages/frontend/core/src/modules/workbench/view/desktop-adapter.ts
+++ b/packages/frontend/core/src/modules/workbench/view/desktop-adapter.ts
@@ -1,7 +1,6 @@
 import type { Location } from 'history';
 import { useEffect } from 'react';
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 import type { Workbench } from '../entities/workbench';
 

--- a/packages/frontend/core/src/modules/workbench/view/route-container.tsx
+++ b/packages/frontend/core/src/modules/workbench/view/route-container.tsx
@@ -3,7 +3,7 @@ import { AffineErrorBoundary } from '@affine/core/components/affine/affine-error
 import { RightSidebarIcon } from '@blocksuite/icons/rc';
 import { useLiveData, useService } from '@toeverything/infra';
 import { Suspense, useCallback } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 
 import { AppSidebarService } from '../../app-sidebar';
 import { SidebarSwitch } from '../../app-sidebar/views/sidebar-header';

--- a/packages/frontend/core/src/modules/workbench/view/view-root.tsx
+++ b/packages/frontend/core/src/modules/workbench/view/view-root.tsx
@@ -1,12 +1,12 @@
 import { FrameworkScope, useLiveData } from '@toeverything/infra';
 import { useLayoutEffect, useMemo } from 'react';
-import type { RouteObject } from 'react-router-dom';
+import type { RouteObject } from 'react-router';
 import {
   createMemoryRouter,
   RouterProvider,
   UNSAFE_LocationContext,
   UNSAFE_RouteContext,
-} from 'react-router-dom';
+} from 'react-router';
 
 import type { View } from '../entities/view';
 

--- a/packages/frontend/core/src/modules/workbench/view/workbench-root.tsx
+++ b/packages/frontend/core/src/modules/workbench/view/workbench-root.tsx
@@ -9,7 +9,7 @@ import {
 } from '@toeverything/infra';
 import { useAtomValue } from 'jotai';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
-import { type RouteObject, useLocation } from 'react-router-dom';
+import { type RouteObject, useLocation } from 'react-router';
 
 import type { View } from '../entities/view';
 import { WorkbenchService } from '../services/workbench';

--- a/packages/frontend/core/src/utils/index.ts
+++ b/packages/frontend/core/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './extract-emoji-icon';
 export * from './string2color';
 export * from './toast';
 export * from './unflatten-object';
+export * from './use-async-navigate';

--- a/packages/frontend/core/src/utils/use-async-navigate.ts
+++ b/packages/frontend/core/src/utils/use-async-navigate.ts
@@ -1,0 +1,25 @@
+import { notify } from '@affine/component';
+import { UserFriendlyError } from '@affine/error';
+import { useCallback } from 'react';
+import { type NavigateOptions, type To, useNavigate } from 'react-router';
+
+export const useAsyncNavigate = () => {
+  const navigate = useNavigate();
+
+  const nav = useCallback(
+    (to: To, options?: NavigateOptions) => {
+      const result = navigate(to, options);
+      if (result instanceof Promise) {
+        result.catch((err: Error) => {
+          const error = UserFriendlyError.fromAny(err);
+          console.error(error);
+          notify.error(error);
+        });
+      }
+      return;
+    },
+    [navigate]
+  );
+
+  return nav;
+};

--- a/packages/frontend/routes/package.json
+++ b/packages/frontend/routes/package.json
@@ -18,6 +18,6 @@
   },
   "peerDependencies": {
     "react": "^19.1.0",
-    "react-router-dom": "^7.5.1"
+    "react-router": "^7.5.2"
   }
 }

--- a/packages/frontend/track/package.json
+++ b/packages/frontend/track/package.json
@@ -10,7 +10,7 @@
     "@affine/debug": "workspace:*",
     "@sentry/react": "^9.2.0",
     "mixpanel-browser": "^2.56.0",
-    "react-router-dom": "6.30.0"
+    "react-router": "^7.6.0"
   },
   "devDependencies": {
     "@types/mixpanel-browser": "^2.50.2",

--- a/packages/frontend/track/src/sentry.ts
+++ b/packages/frontend/track/src/sentry.ts
@@ -5,7 +5,7 @@ import {
   matchRoutes,
   useLocation,
   useNavigationType,
-} from 'react-router-dom';
+} from 'react-router';
 
 function createSentry() {
   let client: Sentry.BrowserClient | undefined;
@@ -18,7 +18,7 @@ function createSentry() {
           debug: BUILD_CONFIG.debug ?? false,
           environment: BUILD_CONFIG.appBuildType,
           integrations: [
-            Sentry.reactRouterV6BrowserTracingIntegration({
+            Sentry.reactRouterV7BrowserTracingIntegration({
               useEffect,
               useLocation,
               useNavigationType,

--- a/tests/affine-local/e2e/blocksuite/embed/synced.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/embed/synced.spec.ts
@@ -46,6 +46,7 @@ test('should not show hidden note in embed view page mode', async ({
   await createLinkedPage(page, 'Test Page');
   const inlineLink = page.locator('affine-reference');
   await inlineLink.dblclick();
+  await waitForEditorLoad(page);
 
   // reference the previous page
   await page.keyboard.press('Enter');

--- a/tests/affine-local/e2e/template.spec.ts
+++ b/tests/affine-local/e2e/template.spec.ts
@@ -255,6 +255,7 @@ test('create template doc from sidebar template entrance', async ({ page }) => {
 test('should show starter-bar when doc is empty', async ({ page }) => {
   await openHomePage(page);
   await page.getByTestId('sidebar-new-page-button').click();
+  await waitForEditorLoad(page);
   await page.keyboard.press('ArrowDown');
   const starterBar = page.getByTestId('starter-bar');
   await expect(starterBar).toBeVisible();

--- a/tests/affine-mobile/e2e/home.spec.ts
+++ b/tests/affine-mobile/e2e/home.spec.ts
@@ -46,6 +46,7 @@ test('all tab', async ({ page }) => {
   await expect(docsTab).toBeVisible();
 
   await docsTab.click();
+  await page.waitForTimeout(300);
 
   const todayDocs = page.getByTestId('doc-list-item');
   expect(await todayDocs.count()).toBeGreaterThan(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13,9 +13,9 @@ __metadata:
   linkType: hard
 
 "@adobe/css-tools@npm:^4.4.0":
-  version: 4.4.2
-  resolution: "@adobe/css-tools@npm:4.4.2"
-  checksum: 10/893d97ba524d92d5fdcee517a47fa7a144ca89dfcc559f5e1c3a9894599bf64c4ee5fc811fb11de0ab84da6778f4b69ea6aede73813534aeb5dfbc412d0788db
+  version: 4.4.3
+  resolution: "@adobe/css-tools@npm:4.4.3"
+  checksum: 10/701379c514b7a43ca6681705a93cd57ad79565cfef9591122e9499897550cf324a5e5bb1bc51df0e7433cf0e91b962c90f18ac459dcc98b2431daa04aa63cb20
   languageName: node
   linkType: hard
 
@@ -231,7 +231,7 @@ __metadata:
     react-dom: "npm:^19.0.0"
     react-hook-form: "npm:^7.54.1"
     react-resizable-panels: "npm:^3.0.0"
-    react-router-dom: "npm:^7.5.1"
+    react-router: "npm:^7.6.0"
     shadcn-ui: "npm:^0.9.4"
     sonner: "npm:^2.0.0"
     swr: "npm:^2.2.5"
@@ -271,7 +271,7 @@ __metadata:
     next-themes: "npm:^0.4.4"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
@@ -359,7 +359,7 @@ __metadata:
     react: "npm:19.1.0"
     react-dom: "npm:19.1.0"
     react-paginate: "npm:^8.2.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     react-transition-state: "npm:^2.2.0"
     sonner: "npm:^2.0.0"
     storybook: "npm:^8.4.7"
@@ -466,7 +466,7 @@ __metadata:
     react: "npm:19.1.0"
     react-dom: "npm:19.1.0"
     react-error-boundary: "npm:^6.0.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     react-transition-state: "npm:^2.2.0"
     react-virtuoso: "npm:^4.12.3"
     rxjs: "npm:^7.8.1"
@@ -535,7 +535,7 @@ __metadata:
     next-themes: "npm:^0.4.4"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     typescript: "npm:^5.7.2"
     uuid: "npm:^11.0.3"
     webm-muxer: "npm:^5.0.3"
@@ -692,7 +692,7 @@ __metadata:
     next-themes: "npm:^0.4.4"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     typescript: "npm:^5.7.2"
     yjs: "npm:^13.6.21"
   languageName: unknown
@@ -748,7 +748,7 @@ __metadata:
     cross-env: "npm:^7.0.3"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
@@ -882,7 +882,7 @@ __metadata:
     vitest: "npm:^3.0.6"
   peerDependencies:
     react: ^19.1.0
-    react-router-dom: ^7.5.1
+    react-router: ^7.5.2
   languageName: unknown
   linkType: soft
 
@@ -1045,7 +1045,7 @@ __metadata:
     "@types/mixpanel-browser": "npm:^2.50.2"
     "@types/react": "npm:^19.0.1"
     mixpanel-browser: "npm:^2.56.0"
-    react-router-dom: "npm:6.30.0"
+    react-router: "npm:^7.6.0"
     vitest: "npm:3.1.3"
   languageName: unknown
   linkType: soft
@@ -1068,20 +1068,20 @@ __metadata:
     cross-env: "npm:^7.0.3"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
-    react-router-dom: "npm:^6.28.0"
+    react-router: "npm:^7.6.0"
     typescript: "npm:^5.7.2"
   languageName: unknown
   linkType: soft
 
 "@ai-sdk/anthropic@npm:^1.2.10":
-  version: 1.2.11
-  resolution: "@ai-sdk/anthropic@npm:1.2.11"
+  version: 1.2.12
+  resolution: "@ai-sdk/anthropic@npm:1.2.12"
   dependencies:
     "@ai-sdk/provider": "npm:1.1.3"
     "@ai-sdk/provider-utils": "npm:2.2.8"
   peerDependencies:
     zod: ^3.0.0
-  checksum: 10/89f48e23f406bef946d2b9153e67eb8417ba01693e291566693f4d49ca4eb9e41e7e49ec83cbb738c7ac2eaf8c3aa572327a0ab6ae7f8f8bf50f08d3be0c2471
+  checksum: 10/ee09f00328c88954fba8d00795f6c379091f95b7717bb90292acf32f41b072b2c89b178c1c18dfc23fcec7532e04fcd13233b9a813ce4881e0a16cae20a878c8
   languageName: node
   linkType: hard
 
@@ -1558,30 +1558,30 @@ __metadata:
   linkType: hard
 
 "@aws-sdk/client-s3@npm:^3.709.0, @aws-sdk/client-s3@npm:^3.779.0":
-  version: 3.815.0
-  resolution: "@aws-sdk/client-s3@npm:3.815.0"
+  version: 3.816.0
+  resolution: "@aws-sdk/client-s3@npm:3.816.0"
   dependencies:
     "@aws-crypto/sha1-browser": "npm:5.2.0"
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.812.0"
-    "@aws-sdk/credential-provider-node": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
+    "@aws-sdk/credential-provider-node": "npm:3.816.0"
     "@aws-sdk/middleware-bucket-endpoint": "npm:3.808.0"
     "@aws-sdk/middleware-expect-continue": "npm:3.804.0"
-    "@aws-sdk/middleware-flexible-checksums": "npm:3.815.0"
+    "@aws-sdk/middleware-flexible-checksums": "npm:3.816.0"
     "@aws-sdk/middleware-host-header": "npm:3.804.0"
     "@aws-sdk/middleware-location-constraint": "npm:3.804.0"
     "@aws-sdk/middleware-logger": "npm:3.804.0"
     "@aws-sdk/middleware-recursion-detection": "npm:3.804.0"
-    "@aws-sdk/middleware-sdk-s3": "npm:3.812.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.816.0"
     "@aws-sdk/middleware-ssec": "npm:3.804.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.812.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.816.0"
     "@aws-sdk/region-config-resolver": "npm:3.808.0"
-    "@aws-sdk/signature-v4-multi-region": "npm:3.812.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@aws-sdk/util-endpoints": "npm:3.808.0"
     "@aws-sdk/util-user-agent-browser": "npm:3.804.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.812.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.816.0"
     "@aws-sdk/xml-builder": "npm:3.804.0"
     "@smithy/config-resolver": "npm:^4.1.2"
     "@smithy/core": "npm:^3.3.3"
@@ -1617,26 +1617,26 @@ __metadata:
     "@smithy/util-utf8": "npm:^4.0.0"
     "@smithy/util-waiter": "npm:^4.0.3"
     tslib: "npm:^2.6.2"
-  checksum: 10/4377677e723a25d16099c8c8fb7e2e46c412f49c90d7842fcf1c06f72d78d7757f0fc57ff1d8af370358f5c76aa06b83f41fe9d4e8e8f1dca9d36926cfeade76
+  checksum: 10/4d609625b321cf5609d99e25d068aead8e1880bcffe05cdc260b48c260b9c2944b11d259e7d28727dab9012502d45798828ecc16bf67f7996a4015fae6d1fe83
   languageName: node
   linkType: hard
 
-"@aws-sdk/client-sso@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/client-sso@npm:3.812.0"
+"@aws-sdk/client-sso@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/client-sso@npm:3.816.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/middleware-host-header": "npm:3.804.0"
     "@aws-sdk/middleware-logger": "npm:3.804.0"
     "@aws-sdk/middleware-recursion-detection": "npm:3.804.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.812.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.816.0"
     "@aws-sdk/region-config-resolver": "npm:3.808.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@aws-sdk/util-endpoints": "npm:3.808.0"
     "@aws-sdk/util-user-agent-browser": "npm:3.804.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.812.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.816.0"
     "@smithy/config-resolver": "npm:^4.1.2"
     "@smithy/core": "npm:^3.3.3"
     "@smithy/fetch-http-handler": "npm:^5.0.2"
@@ -1663,13 +1663,13 @@ __metadata:
     "@smithy/util-retry": "npm:^4.0.3"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/ac9e66341712730e98bf98686c244c5ee191750b6c9d320fe0c24cb5de01b75c55ab028338132322f2d2cd78c615fd2aa220800cf8630cdc40bc617a82beb24f
+  checksum: 10/4e3ed107d0d976ab68952f0bfea4820e070efca6d1e83357cda274f8380375dc30bd8f7f9373633659b929bc5cc4140c06cf516828ed0c88254aeac17fb2e59f
   languageName: node
   linkType: hard
 
-"@aws-sdk/core@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/core@npm:3.812.0"
+"@aws-sdk/core@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/core@npm:3.816.0"
   dependencies:
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/core": "npm:^3.3.3"
@@ -1682,28 +1682,28 @@ __metadata:
     "@smithy/util-middleware": "npm:^4.0.2"
     fast-xml-parser: "npm:4.4.1"
     tslib: "npm:^2.6.2"
-  checksum: 10/139b282ef3e02732671973b5c0544a9e680de11568163f41ac140e61ed83ef42254b78b3480237c100e876b4e34a0b18cf1239a47e479c1c969b390fd37a151e
+  checksum: 10/2b6c4188969e00af0f4d77ed88b8b23b4654c0e66b3356ae062a0d40ab6831c78db1473efd20514c182f8d4033ce2728b0425a292c57246ceb22a177c17d970f
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-env@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-env@npm:3.812.0"
+"@aws-sdk/credential-provider-env@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-env@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/2bb06d5d7bc340e99629d4b170256478e20bad9fb78f76d435c2402323e829a8d777f5f4cb34822233b9233e07b38325872739f1c6f2d6af0a9c937d1c139e77
+  checksum: 10/0fcc1f287bfd4daa650b5d72a83c87c031f7b99e1877bd2ff78efc4d756b30e1f69770f2034294da1da05466b961cd4596a848b8e3295d8abf6502abdc48b35f
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-http@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-http@npm:3.812.0"
+"@aws-sdk/credential-provider-http@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-http@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/fetch-http-handler": "npm:^5.0.2"
     "@smithy/node-http-handler": "npm:^4.0.4"
@@ -1713,92 +1713,92 @@ __metadata:
     "@smithy/types": "npm:^4.2.0"
     "@smithy/util-stream": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/bd349fbe6cd581e5f651176a31f48b40ba5c076fc75305dbe59b41bf7c5e952e82c4ff541fb25b319021c44a2ddde8611e5944ffd059051a3d096fb0250a2b95
+  checksum: 10/ddc59373a984a1df1cb4efa50027d01dba0d7031b3d0d720edd8bf03d35e4c6ff2333fd8310603c7cc034308124f4f0412e3ca52d7c3d12dad6b0528de11fea0
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-ini@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-ini@npm:3.812.0"
+"@aws-sdk/credential-provider-ini@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
-    "@aws-sdk/credential-provider-env": "npm:3.812.0"
-    "@aws-sdk/credential-provider-http": "npm:3.812.0"
-    "@aws-sdk/credential-provider-process": "npm:3.812.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.812.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.812.0"
-    "@aws-sdk/nested-clients": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
+    "@aws-sdk/credential-provider-env": "npm:3.816.0"
+    "@aws-sdk/credential-provider-http": "npm:3.816.0"
+    "@aws-sdk/credential-provider-process": "npm:3.816.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.816.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.816.0"
+    "@aws-sdk/nested-clients": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/credential-provider-imds": "npm:^4.0.4"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/f9e1ec43c734dfbc6c3f013e0a64bb95037df8f92c876e21c21e06a3de5c49e87f8a7ec03af876c812a7f811632bf21c185ac184f509d8dcad39c3de88d7dcca
+  checksum: 10/bbbdb0ad91caa95e50efab5e716d764c76c13aa47f5a8fb6060aeae68260b959f8db5dc3dbf50a5eaf4a79fae6b7965b2cef12e3bb87a9c82a1b87ed225fa6f3
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-node@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-node@npm:3.812.0"
+"@aws-sdk/credential-provider-node@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-node@npm:3.816.0"
   dependencies:
-    "@aws-sdk/credential-provider-env": "npm:3.812.0"
-    "@aws-sdk/credential-provider-http": "npm:3.812.0"
-    "@aws-sdk/credential-provider-ini": "npm:3.812.0"
-    "@aws-sdk/credential-provider-process": "npm:3.812.0"
-    "@aws-sdk/credential-provider-sso": "npm:3.812.0"
-    "@aws-sdk/credential-provider-web-identity": "npm:3.812.0"
+    "@aws-sdk/credential-provider-env": "npm:3.816.0"
+    "@aws-sdk/credential-provider-http": "npm:3.816.0"
+    "@aws-sdk/credential-provider-ini": "npm:3.816.0"
+    "@aws-sdk/credential-provider-process": "npm:3.816.0"
+    "@aws-sdk/credential-provider-sso": "npm:3.816.0"
+    "@aws-sdk/credential-provider-web-identity": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/credential-provider-imds": "npm:^4.0.4"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/ec98de8815c9f9152d0a7b6d8681da1d7de8ee4933604bd2bad28a911b88204d969693f25d4e0f42affd1cd2b87cae6a27f94ff5d9de9b046c7ad4ec126e06ce
+  checksum: 10/dbd0a668514053533e1b520e3b114c98e9731e5ce61010cdd402255f2afab6557d82f97d3dcd89a300883e2d625cdceab8a620669fd5e6c4520cf2fde225f847
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-process@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-process@npm:3.812.0"
+"@aws-sdk/credential-provider-process@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-process@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/7f595deb460089335b772fb6260cf107d8096c9fd3290995d704817f4b8f6acaa78476be54f33333baafb4a160056767958ed089d31d46223bcf4d01a1a1175c
+  checksum: 10/f52781ce364a37b7187a10f1f4beb5977e58fc8a2eedb1c67afd6f5cd1f07495be5f928a5aa1731a3b5874d86bb198754d6d81ef5a3b3a4e58bf4c35f16bc479
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-sso@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-sso@npm:3.812.0"
+"@aws-sdk/credential-provider-sso@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.816.0"
   dependencies:
-    "@aws-sdk/client-sso": "npm:3.812.0"
-    "@aws-sdk/core": "npm:3.812.0"
-    "@aws-sdk/token-providers": "npm:3.812.0"
+    "@aws-sdk/client-sso": "npm:3.816.0"
+    "@aws-sdk/core": "npm:3.816.0"
+    "@aws-sdk/token-providers": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/2b3ab88d1c76a6e402659a5798177b2e5276c243ed6195396dd332ebbbead23cc876987c8d3ab55bd455251198a3a527c9c4ba1e1e8b96ea2084ec0fda2f8ed9
+  checksum: 10/f1e09df4ae1993efd02b0f425b13ae99524c969060975b9cfe96428fae52b2e2d6fc472a264c1adf01de54632bf0f3cb135f759103ac80b5fa9d9693b92cf992
   languageName: node
   linkType: hard
 
-"@aws-sdk/credential-provider-web-identity@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.812.0"
+"@aws-sdk/credential-provider-web-identity@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
-    "@aws-sdk/nested-clients": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
+    "@aws-sdk/nested-clients": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/ff8a90114bb89015a0e64ae794bf369b339aaa98e1cea06dc6458f071441fe0019a5dc104e5a8123619a468178af8438c0acf3f7d3ff07c215e0bf5648bb74bd
+  checksum: 10/6239d5b97cbef3ce13cd814c8ed880d62e1831ea8116ba43773ffb5c87da920d967e5e7a75e40f08a3c25903576ac5e321e4f4d3957f441be201c45329d02163
   languageName: node
   linkType: hard
 
@@ -1829,14 +1829,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-flexible-checksums@npm:3.815.0":
-  version: 3.815.0
-  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.815.0"
+"@aws-sdk/middleware-flexible-checksums@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/middleware-flexible-checksums@npm:3.816.0"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
     "@aws-crypto/crc32c": "npm:5.2.0"
     "@aws-crypto/util": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/is-array-buffer": "npm:^4.0.0"
     "@smithy/node-config-provider": "npm:^4.1.1"
@@ -1846,7 +1846,7 @@ __metadata:
     "@smithy/util-stream": "npm:^4.2.0"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/022678c06d06c0a6bc1dc1b95bc809b4c0618d1a6b2b1ea53f5ee16a0d255607bf0914d7729d5b514420057953d7df518f8b34b75538986ffb3def39d03f4001
+  checksum: 10/84868f8a4d6ec900e3b047b11ab9c142baed235d80f2539742ff148b88f112d75a23e1cef8fc85772e86e6fc7572e01b97091a317fc10ad0e5b4c26ad672e12c
   languageName: node
   linkType: hard
 
@@ -1896,11 +1896,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-sdk-s3@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.812.0"
+"@aws-sdk/middleware-sdk-s3@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@aws-sdk/util-arn-parser": "npm:3.804.0"
     "@smithy/core": "npm:^3.3.3"
@@ -1914,7 +1914,7 @@ __metadata:
     "@smithy/util-stream": "npm:^4.2.0"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/1980d1dcd9b200d5ca60d90606a05253d7fa95e80cc0f2abb0732bedbd5d2694c0ffaff7c0f81030fc8edaf36fa8b303f4ff70282cd8f4c5512ae4a4ec34139e
+  checksum: 10/9b8c6096ab730f91555f62f734daa67d8f8bd536b0cfa04a3108ad59c94d7e09cc27f70d48f8a592b47e77c7c569ba2a7447a281ca3509592fe02ec4f42e7a06
   languageName: node
   linkType: hard
 
@@ -1929,37 +1929,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/middleware-user-agent@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/middleware-user-agent@npm:3.812.0"
+"@aws-sdk/middleware-user-agent@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/middleware-user-agent@npm:3.816.0"
   dependencies:
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@aws-sdk/util-endpoints": "npm:3.808.0"
     "@smithy/core": "npm:^3.3.3"
     "@smithy/protocol-http": "npm:^5.1.0"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/1a6cca781735b9d4883b0e7d9f12e1739c9417563823be98631a68c5339fe604ff286551ba246a3be0c758736c803c475125529775b088489377d25e09392402
+  checksum: 10/1b5fafbd21b1cf96309c5063472d3a91c8e202e1762bf965310da3723bc191eccc891e1d89b3602a312b051ce8221ec029d13215920dfb42502c897478da3ef9
   languageName: node
   linkType: hard
 
-"@aws-sdk/nested-clients@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/nested-clients@npm:3.812.0"
+"@aws-sdk/nested-clients@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/nested-clients@npm:3.816.0"
   dependencies:
     "@aws-crypto/sha256-browser": "npm:5.2.0"
     "@aws-crypto/sha256-js": "npm:5.2.0"
-    "@aws-sdk/core": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
     "@aws-sdk/middleware-host-header": "npm:3.804.0"
     "@aws-sdk/middleware-logger": "npm:3.804.0"
     "@aws-sdk/middleware-recursion-detection": "npm:3.804.0"
-    "@aws-sdk/middleware-user-agent": "npm:3.812.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.816.0"
     "@aws-sdk/region-config-resolver": "npm:3.808.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@aws-sdk/util-endpoints": "npm:3.808.0"
     "@aws-sdk/util-user-agent-browser": "npm:3.804.0"
-    "@aws-sdk/util-user-agent-node": "npm:3.812.0"
+    "@aws-sdk/util-user-agent-node": "npm:3.816.0"
     "@smithy/config-resolver": "npm:^4.1.2"
     "@smithy/core": "npm:^3.3.3"
     "@smithy/fetch-http-handler": "npm:^5.0.2"
@@ -1986,7 +1986,7 @@ __metadata:
     "@smithy/util-retry": "npm:^4.0.3"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/14c8752d9ca42a0806c7814634400bfc4286f99cd78600cd833f224e3aa7d86daa38e063bf7456f7c6a930e4eac8094da4ccea50563c62e4ad17ab469ea46054
+  checksum: 10/e53ac743e38dd1e690f1e32b36d5c1d5838417277e3e2a58738d77def101865a5834ee3891bbc361d12c02eb481e9da55050bac5832cde06ee779cd5ebac502b
   languageName: node
   linkType: hard
 
@@ -2005,10 +2005,10 @@ __metadata:
   linkType: hard
 
 "@aws-sdk/s3-request-presigner@npm:^3.779.0":
-  version: 3.815.0
-  resolution: "@aws-sdk/s3-request-presigner@npm:3.815.0"
+  version: 3.816.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.816.0"
   dependencies:
-    "@aws-sdk/signature-v4-multi-region": "npm:3.812.0"
+    "@aws-sdk/signature-v4-multi-region": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@aws-sdk/util-format-url": "npm:3.804.0"
     "@smithy/middleware-endpoint": "npm:^4.1.6"
@@ -2016,35 +2016,36 @@ __metadata:
     "@smithy/smithy-client": "npm:^4.2.6"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/70ca28f9a8b8c83042f7761b3cb807c0a7eb90f965d8d270bf84c837c0406b56fa8a4d02123ecace70644ffc3fb8700c8b5f35abf34da7a80568e65e533fd493
+  checksum: 10/7ea2af6790bb8576745d041f67fbb879959aedfd769b82856d1dd7df8c458e179d81abf62d0d14cf84b2124fea92db447cdd9bfde2f90bdc2bfb4bda0fe8e70b
   languageName: node
   linkType: hard
 
-"@aws-sdk/signature-v4-multi-region@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.812.0"
+"@aws-sdk/signature-v4-multi-region@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.816.0"
   dependencies:
-    "@aws-sdk/middleware-sdk-s3": "npm:3.812.0"
+    "@aws-sdk/middleware-sdk-s3": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/protocol-http": "npm:^5.1.0"
     "@smithy/signature-v4": "npm:^5.1.0"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/ad194ca922172fd9b86370abfc78fa027bbbca9317e99fc2807f8498b07775acde5a02439a31e27239f86580937b0d7cd08ee0c51103d8572b9a29991bcce07a
+  checksum: 10/a433c59ce1609813dec8ebb46bafbf0d1a8a9a55c2f47bf2766244c23ead7a8850bf731fc3a1e1f3e0270d89d41b48c5bc5c3041e6b3fa6ebd9611160e5efd89
   languageName: node
   linkType: hard
 
-"@aws-sdk/token-providers@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/token-providers@npm:3.812.0"
+"@aws-sdk/token-providers@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/token-providers@npm:3.816.0"
   dependencies:
-    "@aws-sdk/nested-clients": "npm:3.812.0"
+    "@aws-sdk/core": "npm:3.816.0"
+    "@aws-sdk/nested-clients": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/property-provider": "npm:^4.0.2"
     "@smithy/shared-ini-file-loader": "npm:^4.0.2"
     "@smithy/types": "npm:^4.2.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/f19a9b07cea9f02ec5ed47521c94a994c311cfad000c93b40c91548e461a1ee3abbeaf04c3b6995e123b3119af4bdbbaf8ddcaa37c91f788c5b7466636f85975
+  checksum: 10/26f0e804c11b04d8a31eb87de7a7d4a19e300cd74e962aafcdc0d60a20c4c10809ca1a4c118c77ad1a1d79dcf281f3357d7f5d39e345ca05872a0b3412f09117
   languageName: node
   linkType: hard
 
@@ -2112,11 +2113,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-sdk/util-user-agent-node@npm:3.812.0":
-  version: 3.812.0
-  resolution: "@aws-sdk/util-user-agent-node@npm:3.812.0"
+"@aws-sdk/util-user-agent-node@npm:3.816.0":
+  version: 3.816.0
+  resolution: "@aws-sdk/util-user-agent-node@npm:3.816.0"
   dependencies:
-    "@aws-sdk/middleware-user-agent": "npm:3.812.0"
+    "@aws-sdk/middleware-user-agent": "npm:3.816.0"
     "@aws-sdk/types": "npm:3.804.0"
     "@smithy/node-config-provider": "npm:^4.1.1"
     "@smithy/types": "npm:^4.2.0"
@@ -2126,7 +2127,7 @@ __metadata:
   peerDependenciesMeta:
     aws-crt:
       optional: true
-  checksum: 10/805400e8d8d49c263a01a9169ece6d12cb8c0523e766abf8ed997fac791d6f16b6c6ab0f0683166def43a0f82ac524f8817e384dc5e5c074cea2b5dd182c19a1
+  checksum: 10/96ac27c29054912103420c6d2b5997d04f60ec135ee3b4c26ce09a241cbba1de74a39217278186be91e44ab936f0a2b302644d2365265a8b53669b3599dc289e
   languageName: node
   linkType: hard
 
@@ -5365,7 +5366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:^1.4.0, @emnapi/core@npm:^1.4.3":
+"@emnapi/core@npm:^1.4.3":
   version: 1.4.3
   resolution: "@emnapi/core@npm:1.4.3"
   dependencies:
@@ -5375,7 +5376,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:^1.2.0, @emnapi/runtime@npm:^1.4.0, @emnapi/runtime@npm:^1.4.3":
+"@emnapi/runtime@npm:^1.2.0, @emnapi/runtime@npm:^1.4.3":
   version: 1.4.3
   resolution: "@emnapi/runtime@npm:1.4.3"
   dependencies:
@@ -5818,6 +5819,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "@eslint/core@npm:0.14.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10/d9b060cf97468150675ddf4fb3db55edaa32467e0adf9f80919a5bfd15d0835ad7765456f4397ec2d16b0a1bb702af63f6d4712f94194d34fea118231ae1e2db
+  languageName: node
+  linkType: hard
+
 "@eslint/eslintrc@npm:^3.3.1":
   version: 3.3.1
   resolution: "@eslint/eslintrc@npm:3.3.1"
@@ -5835,14 +5845,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:9.26.0":
-  version: 9.26.0
-  resolution: "@eslint/js@npm:9.26.0"
-  checksum: 10/863d35df8f6675250bb5a917037e0f6833965437eba4c4649633fd0b55a93e8d727bcd36e9b5cc82047898ee9348cb40363e196f333914ae3a6bb36159495212
-  languageName: node
-  linkType: hard
-
-"@eslint/js@npm:^9.16.0":
+"@eslint/js@npm:9.27.0, @eslint/js@npm:^9.16.0":
   version: 9.27.0
   resolution: "@eslint/js@npm:9.27.0"
   checksum: 10/cdbe380fd31bb325b9ec65ae310fb92a57efb796d3cc5d8bc9dafef447d634c64e497bedade6a49e0cf44a5b14560ab6ac9ed9da5a38e2415b31ae01ae5b758e
@@ -5856,13 +5859,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.2.7, @eslint/plugin-kit@npm:^0.2.8":
+"@eslint/plugin-kit@npm:^0.2.7":
   version: 0.2.8
   resolution: "@eslint/plugin-kit@npm:0.2.8"
   dependencies:
     "@eslint/core": "npm:^0.13.0"
     levn: "npm:^0.4.1"
   checksum: 10/2e7fe7a88ebdbbf805e9e7265347b7dcfb6bf50beec314def997572b2e8ae4a7b9504fb67b1698a70c348a0dd87251d1e9028292a96fd49b58cb5277d88bdea7
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@eslint/plugin-kit@npm:0.3.1"
+  dependencies:
+    "@eslint/core": "npm:^0.14.0"
+    levn: "npm:^0.4.1"
+  checksum: 10/ab0c4cecadc6c38c7ae5f71b9831d3521d08237444d8f327751d1133a4369ccd42093a1c06b26fd6c311015807a27d95a0184a761d1cdd264b090896dcf0addb
   languageName: node
   linkType: hard
 
@@ -5979,15 +5992,15 @@ __metadata:
   linkType: hard
 
 "@gerrit0/mini-shiki@npm:^3.2.2":
-  version: 3.4.0
-  resolution: "@gerrit0/mini-shiki@npm:3.4.0"
+  version: 3.4.2
+  resolution: "@gerrit0/mini-shiki@npm:3.4.2"
   dependencies:
-    "@shikijs/engine-oniguruma": "npm:^3.4.0"
-    "@shikijs/langs": "npm:^3.4.0"
-    "@shikijs/themes": "npm:^3.4.0"
-    "@shikijs/types": "npm:^3.4.0"
+    "@shikijs/engine-oniguruma": "npm:^3.4.2"
+    "@shikijs/langs": "npm:^3.4.2"
+    "@shikijs/themes": "npm:^3.4.2"
+    "@shikijs/types": "npm:^3.4.2"
     "@shikijs/vscode-textmate": "npm:^10.0.2"
-  checksum: 10/2e116b8a6cb4d63db0fc8d96ba696befb4b4d66d4eaf4673c2585e798ae871e7e7cc581252cdc08169e5c19ae1aa496d93286da7626a36f7b0d298c660178855
+  checksum: 10/64c6d1be3f25ca83df41ccb0b53989912f4b40c2dcf0895229ee03ec59f7cac6ba95a7905894bed63a027ce9f42f67eb6edf9a269bf3ce70933395c5b655d15b
   languageName: node
   linkType: hard
 
@@ -6289,9 +6302,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/batch-execute@npm:^9.0.15":
-  version: 9.0.15
-  resolution: "@graphql-tools/batch-execute@npm:9.0.15"
+"@graphql-tools/batch-execute@npm:^9.0.16":
+  version: 9.0.16
+  resolution: "@graphql-tools/batch-execute@npm:9.0.16"
   dependencies:
     "@graphql-tools/utils": "npm:^10.8.1"
     "@whatwg-node/promise-helpers": "npm:^1.3.0"
@@ -6299,7 +6312,7 @@ __metadata:
     tslib: "npm:^2.8.1"
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10/462fd023f63e61777900ccdd91ab28c7b28faeb93cdb44adc52fb5603afbb5184a50f200e6a8441986ac8851471d54d46959bb4f7e9151c0ca1e0457637979a3
+  checksum: 10/25779b7becd0c89ce189cbb8aefc3afa49648f80ce8cac40c76c9a77a4c6a8e164b7a497a43ad2391fcdffdabbb9fe9e626dad44d7da85c72b08ad19e532250e
   languageName: node
   linkType: hard
 
@@ -6318,11 +6331,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/delegate@npm:^10.2.17":
-  version: 10.2.17
-  resolution: "@graphql-tools/delegate@npm:10.2.17"
+"@graphql-tools/delegate@npm:^10.2.18":
+  version: 10.2.18
+  resolution: "@graphql-tools/delegate@npm:10.2.18"
   dependencies:
-    "@graphql-tools/batch-execute": "npm:^9.0.15"
+    "@graphql-tools/batch-execute": "npm:^9.0.16"
     "@graphql-tools/executor": "npm:^1.4.7"
     "@graphql-tools/schema": "npm:^10.0.11"
     "@graphql-tools/utils": "npm:^10.8.1"
@@ -6333,7 +6346,7 @@ __metadata:
     tslib: "npm:^2.8.1"
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10/95ac5f92ed1ce43c4c6562a185328a419a81937c61a40e8a20101fa5083366e3b7d9fb48c08f7c44f6aceaff23421d7bcdd52a6a3328984806ab32b5b726deb8
+  checksum: 10/416f3dab356965da1aca41424b81019a2ca9702020cc6e7336418964264582f529a4f79642345e5434266cea0dce84b3adae2f53e78fbbfe925752a5ca8aeced
   languageName: node
   linkType: hard
 
@@ -6685,17 +6698,17 @@ __metadata:
   linkType: hard
 
 "@graphql-tools/wrap@npm:^10.0.16":
-  version: 10.0.35
-  resolution: "@graphql-tools/wrap@npm:10.0.35"
+  version: 10.0.36
+  resolution: "@graphql-tools/wrap@npm:10.0.36"
   dependencies:
-    "@graphql-tools/delegate": "npm:^10.2.17"
+    "@graphql-tools/delegate": "npm:^10.2.18"
     "@graphql-tools/schema": "npm:^10.0.11"
     "@graphql-tools/utils": "npm:^10.8.1"
     "@whatwg-node/promise-helpers": "npm:^1.3.0"
     tslib: "npm:^2.8.1"
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-  checksum: 10/eb129b9ef0a46e19d21f3baf283279295249ab4de23856cb87de95a3d24e951bbdecd9203f07440761e8dfc63ea41e39576b6f9f410d2d16a36a34ac08f6ac97
+  checksum: 10/17bffdee2199ece2967043404b1ab0054a420e4e1c170ff02b134b911e8db8a21c811c5d65426ceeeced086ca4ce5293ab8dd70d9fcb0ebbfdc900fd7c05db5b
   languageName: node
   linkType: hard
 
@@ -6709,12 +6722,12 @@ __metadata:
   linkType: hard
 
 "@grpc/grpc-js@npm:^1.1.8, @grpc/grpc-js@npm:^1.7.1":
-  version: 1.13.3
-  resolution: "@grpc/grpc-js@npm:1.13.3"
+  version: 1.13.4
+  resolution: "@grpc/grpc-js@npm:1.13.4"
   dependencies:
     "@grpc/proto-loader": "npm:^0.7.13"
     "@js-sdsl/ordered-map": "npm:^4.4.2"
-  checksum: 10/0b5016baf063ae115972b9765b53ade072a6feb5bf45ddbbc24f2aab6e69ebb6069792cf0451fb6e08eaf58a837e1916b8f04740008fa6550bf8442ee2588305
+  checksum: 10/f1eb910ff78ddffa03870f69efccdbb30c1349571b759ee7fe971d3dc727d900748922a841bb7406e87e7130fb68e6346b0bd929a1a35b5caebe994df08e4df5
   languageName: node
   linkType: hard
 
@@ -6791,9 +6804,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-darwin-arm64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-darwin-arm64@npm:0.34.1"
+"@img/sharp-darwin-arm64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-darwin-arm64@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-darwin-arm64": "npm:1.1.0"
   dependenciesMeta:
@@ -6815,9 +6828,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-darwin-x64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-darwin-x64@npm:0.34.1"
+"@img/sharp-darwin-x64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-darwin-x64@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-darwin-x64": "npm:1.1.0"
   dependenciesMeta:
@@ -6958,9 +6971,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linux-arm64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-linux-arm64@npm:0.34.1"
+"@img/sharp-linux-arm64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-linux-arm64@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-linux-arm64": "npm:1.1.0"
   dependenciesMeta:
@@ -6982,9 +6995,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linux-arm@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-linux-arm@npm:0.34.1"
+"@img/sharp-linux-arm@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-linux-arm@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-linux-arm": "npm:1.1.0"
   dependenciesMeta:
@@ -7006,9 +7019,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linux-s390x@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-linux-s390x@npm:0.34.1"
+"@img/sharp-linux-s390x@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-linux-s390x@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-linux-s390x": "npm:1.1.0"
   dependenciesMeta:
@@ -7030,9 +7043,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linux-x64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-linux-x64@npm:0.34.1"
+"@img/sharp-linux-x64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-linux-x64@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-linux-x64": "npm:1.1.0"
   dependenciesMeta:
@@ -7054,9 +7067,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linuxmusl-arm64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.1"
+"@img/sharp-linuxmusl-arm64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-linuxmusl-arm64@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-linuxmusl-arm64": "npm:1.1.0"
   dependenciesMeta:
@@ -7078,9 +7091,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-linuxmusl-x64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-linuxmusl-x64@npm:0.34.1"
+"@img/sharp-linuxmusl-x64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-linuxmusl-x64@npm:0.34.2"
   dependencies:
     "@img/sharp-libvips-linuxmusl-x64": "npm:1.1.0"
   dependenciesMeta:
@@ -7099,12 +7112,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-wasm32@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-wasm32@npm:0.34.1"
+"@img/sharp-wasm32@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-wasm32@npm:0.34.2"
   dependencies:
-    "@emnapi/runtime": "npm:^1.4.0"
+    "@emnapi/runtime": "npm:^1.4.3"
   conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@img/sharp-win32-arm64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-win32-arm64@npm:0.34.2"
+  conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -7115,9 +7135,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-win32-ia32@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-win32-ia32@npm:0.34.1"
+"@img/sharp-win32-ia32@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-win32-ia32@npm:0.34.2"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
@@ -7129,9 +7149,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@img/sharp-win32-x64@npm:0.34.1":
-  version: 0.34.1
-  resolution: "@img/sharp-win32-x64@npm:0.34.1"
+"@img/sharp-win32-x64@npm:0.34.2":
+  version: 0.34.2
+  resolution: "@img/sharp-win32-x64@npm:0.34.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -7835,24 +7855,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:^1.8.0":
-  version: 1.11.1
-  resolution: "@modelcontextprotocol/sdk@npm:1.11.1"
-  dependencies:
-    content-type: "npm:^1.0.5"
-    cors: "npm:^2.8.5"
-    cross-spawn: "npm:^7.0.3"
-    eventsource: "npm:^3.0.2"
-    express: "npm:^5.0.1"
-    express-rate-limit: "npm:^7.5.0"
-    pkce-challenge: "npm:^5.0.0"
-    raw-body: "npm:^3.0.0"
-    zod: "npm:^3.23.8"
-    zod-to-json-schema: "npm:^3.24.1"
-  checksum: 10/bf388e3f5082839ccf32eb4f16e086ead71310f30c3103ff99f337d7bcfc6da6b3377dc9bd64ac9b862969487081c36889faea02c5c30805695e8addac96b9a8
-  languageName: node
-  linkType: hard
-
 "@msgpack/msgpack@npm:^3.0.0-beta2":
   version: 3.1.1
   resolution: "@msgpack/msgpack@npm:3.1.1"
@@ -7980,148 +7982,148 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-android-arm-eabi@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-android-arm-eabi@npm:1.4.2"
+"@napi-rs/lzma-android-arm-eabi@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-android-arm-eabi@npm:1.4.3"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-android-arm64@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-android-arm64@npm:1.4.2"
+"@napi-rs/lzma-android-arm64@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-android-arm64@npm:1.4.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-darwin-arm64@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-darwin-arm64@npm:1.4.2"
+"@napi-rs/lzma-darwin-arm64@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-darwin-arm64@npm:1.4.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-darwin-x64@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-darwin-x64@npm:1.4.2"
+"@napi-rs/lzma-darwin-x64@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-darwin-x64@npm:1.4.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-freebsd-x64@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-freebsd-x64@npm:1.4.2"
+"@napi-rs/lzma-freebsd-x64@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-freebsd-x64@npm:1.4.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-arm-gnueabihf@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-arm-gnueabihf@npm:1.4.2"
+"@napi-rs/lzma-linux-arm-gnueabihf@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-arm-gnueabihf@npm:1.4.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-arm64-gnu@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-arm64-gnu@npm:1.4.2"
+"@napi-rs/lzma-linux-arm64-gnu@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-arm64-gnu@npm:1.4.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-arm64-musl@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-arm64-musl@npm:1.4.2"
+"@napi-rs/lzma-linux-arm64-musl@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-arm64-musl@npm:1.4.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-ppc64-gnu@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-ppc64-gnu@npm:1.4.2"
+"@napi-rs/lzma-linux-ppc64-gnu@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-ppc64-gnu@npm:1.4.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-riscv64-gnu@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-riscv64-gnu@npm:1.4.2"
+"@napi-rs/lzma-linux-riscv64-gnu@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-riscv64-gnu@npm:1.4.3"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-s390x-gnu@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-s390x-gnu@npm:1.4.2"
+"@napi-rs/lzma-linux-s390x-gnu@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-s390x-gnu@npm:1.4.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-x64-gnu@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-x64-gnu@npm:1.4.2"
+"@napi-rs/lzma-linux-x64-gnu@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-x64-gnu@npm:1.4.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-linux-x64-musl@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-linux-x64-musl@npm:1.4.2"
+"@napi-rs/lzma-linux-x64-musl@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-linux-x64-musl@npm:1.4.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-wasm32-wasi@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-wasm32-wasi@npm:1.4.2"
+"@napi-rs/lzma-wasm32-wasi@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-wasm32-wasi@npm:1.4.3"
   dependencies:
-    "@napi-rs/wasm-runtime": "npm:^0.2.9"
+    "@napi-rs/wasm-runtime": "npm:^0.2.10"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-win32-arm64-msvc@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-win32-arm64-msvc@npm:1.4.2"
+"@napi-rs/lzma-win32-arm64-msvc@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-win32-arm64-msvc@npm:1.4.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-win32-ia32-msvc@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-win32-ia32-msvc@npm:1.4.2"
+"@napi-rs/lzma-win32-ia32-msvc@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-win32-ia32-msvc@npm:1.4.3"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@napi-rs/lzma-win32-x64-msvc@npm:1.4.2":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma-win32-x64-msvc@npm:1.4.2"
+"@napi-rs/lzma-win32-x64-msvc@npm:1.4.3":
+  version: 1.4.3
+  resolution: "@napi-rs/lzma-win32-x64-msvc@npm:1.4.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@napi-rs/lzma@npm:^1.4.1":
-  version: 1.4.2
-  resolution: "@napi-rs/lzma@npm:1.4.2"
+  version: 1.4.3
+  resolution: "@napi-rs/lzma@npm:1.4.3"
   dependencies:
-    "@napi-rs/lzma-android-arm-eabi": "npm:1.4.2"
-    "@napi-rs/lzma-android-arm64": "npm:1.4.2"
-    "@napi-rs/lzma-darwin-arm64": "npm:1.4.2"
-    "@napi-rs/lzma-darwin-x64": "npm:1.4.2"
-    "@napi-rs/lzma-freebsd-x64": "npm:1.4.2"
-    "@napi-rs/lzma-linux-arm-gnueabihf": "npm:1.4.2"
-    "@napi-rs/lzma-linux-arm64-gnu": "npm:1.4.2"
-    "@napi-rs/lzma-linux-arm64-musl": "npm:1.4.2"
-    "@napi-rs/lzma-linux-ppc64-gnu": "npm:1.4.2"
-    "@napi-rs/lzma-linux-riscv64-gnu": "npm:1.4.2"
-    "@napi-rs/lzma-linux-s390x-gnu": "npm:1.4.2"
-    "@napi-rs/lzma-linux-x64-gnu": "npm:1.4.2"
-    "@napi-rs/lzma-linux-x64-musl": "npm:1.4.2"
-    "@napi-rs/lzma-wasm32-wasi": "npm:1.4.2"
-    "@napi-rs/lzma-win32-arm64-msvc": "npm:1.4.2"
-    "@napi-rs/lzma-win32-ia32-msvc": "npm:1.4.2"
-    "@napi-rs/lzma-win32-x64-msvc": "npm:1.4.2"
+    "@napi-rs/lzma-android-arm-eabi": "npm:1.4.3"
+    "@napi-rs/lzma-android-arm64": "npm:1.4.3"
+    "@napi-rs/lzma-darwin-arm64": "npm:1.4.3"
+    "@napi-rs/lzma-darwin-x64": "npm:1.4.3"
+    "@napi-rs/lzma-freebsd-x64": "npm:1.4.3"
+    "@napi-rs/lzma-linux-arm-gnueabihf": "npm:1.4.3"
+    "@napi-rs/lzma-linux-arm64-gnu": "npm:1.4.3"
+    "@napi-rs/lzma-linux-arm64-musl": "npm:1.4.3"
+    "@napi-rs/lzma-linux-ppc64-gnu": "npm:1.4.3"
+    "@napi-rs/lzma-linux-riscv64-gnu": "npm:1.4.3"
+    "@napi-rs/lzma-linux-s390x-gnu": "npm:1.4.3"
+    "@napi-rs/lzma-linux-x64-gnu": "npm:1.4.3"
+    "@napi-rs/lzma-linux-x64-musl": "npm:1.4.3"
+    "@napi-rs/lzma-wasm32-wasi": "npm:1.4.3"
+    "@napi-rs/lzma-win32-arm64-msvc": "npm:1.4.3"
+    "@napi-rs/lzma-win32-ia32-msvc": "npm:1.4.3"
+    "@napi-rs/lzma-win32-x64-msvc": "npm:1.4.3"
   dependenciesMeta:
     "@napi-rs/lzma-android-arm-eabi":
       optional: true
@@ -8157,7 +8159,7 @@ __metadata:
       optional: true
     "@napi-rs/lzma-win32-x64-msvc":
       optional: true
-  checksum: 10/8532bcde3889ae949b2088460b9cbc9550b9f9cd00d17b263b8e8977ec766b67ba561b1aba0dd6f85e4853cb7a29c69f9cdd025080bbe6e530bb16e1509706cb
+  checksum: 10/27db72aa340f415f0ff0dd06c9246b1d21795d15d65f3bfeb4a18cd4281532db1a882d965fe0dbf6f90faddd49d05740e311121c65041ff91117cc09f1680969
   languageName: node
   linkType: hard
 
@@ -8657,14 +8659,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^0.2.5, @napi-rs/wasm-runtime@npm:^0.2.7, @napi-rs/wasm-runtime@npm:^0.2.9":
-  version: 0.2.9
-  resolution: "@napi-rs/wasm-runtime@npm:0.2.9"
+"@napi-rs/wasm-runtime@npm:^0.2.10, @napi-rs/wasm-runtime@npm:^0.2.5, @napi-rs/wasm-runtime@npm:^0.2.7, @napi-rs/wasm-runtime@npm:^0.2.9":
+  version: 0.2.10
+  resolution: "@napi-rs/wasm-runtime@npm:0.2.10"
   dependencies:
-    "@emnapi/core": "npm:^1.4.0"
-    "@emnapi/runtime": "npm:^1.4.0"
+    "@emnapi/core": "npm:^1.4.3"
+    "@emnapi/runtime": "npm:^1.4.3"
     "@tybys/wasm-util": "npm:^0.9.0"
-  checksum: 10/8ebc7d85e11e1b8d71908d5615ff24b27ef7af8287d087fb5cff5a3e545915c7545998d976a9cd6a4315dab4ba0f609439fbe6408fec3afebd288efb0dbdc135
+  checksum: 10/1e4cf77891390825b1756eb5e302035b80c9dd21959417c4e4ed063eacfb6df9f42dfc001bf0fa9c9dbd0a7374342502feaa0a59103e7ea9aa5b318732280a49
   languageName: node
   linkType: hard
 
@@ -10569,9 +10571,9 @@ __metadata:
   linkType: hard
 
 "@opentelemetry/semantic-conventions@npm:^1.22.0, @opentelemetry/semantic-conventions@npm:^1.27.0, @opentelemetry/semantic-conventions@npm:^1.28.0, @opentelemetry/semantic-conventions@npm:^1.30.0":
-  version: 1.33.0
-  resolution: "@opentelemetry/semantic-conventions@npm:1.33.0"
-  checksum: 10/c20899b6d1959d55656f3ace8e90f172a696921e174d6d784a1ef500f958bd235be69df997a9ec298f4761a26d3f3a9f312726cbe0f5e39ab7bc4d43803c0fc9
+  version: 1.34.0
+  resolution: "@opentelemetry/semantic-conventions@npm:1.34.0"
+  checksum: 10/1892b4cc69c9e00456c809604a980e32696563e96463ff5f9d07e72d5aca73836a7378090509f28f54445ac6e072d2343a888c9d64d9ce287198e899082ff7aa
   languageName: node
   linkType: hard
 
@@ -12372,13 +12374,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.23.0":
-  version: 1.23.0
-  resolution: "@remix-run/router@npm:1.23.0"
-  checksum: 10/0a9f02c26c150d8210b05927c43d2f57ee8b7f812c81abb76df1721c7367ef692e54f4044981e756ce13d0619fb3c6a9b1514524d69aea9b32bfaf565299a8c7
-  languageName: node
-  linkType: hard
-
 "@repeaterjs/repeater@npm:^3.0.4, @repeaterjs/repeater@npm:^3.0.6":
   version: 3.0.6
   resolution: "@repeaterjs/repeater@npm:3.0.6"
@@ -12422,6 +12417,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/pluginutils@npm:1.0.0-beta.9":
+  version: 1.0.0-beta.9
+  resolution: "@rolldown/pluginutils@npm:1.0.0-beta.9"
+  checksum: 10/6d28647e1c186b0e31e07666b850a609efcf5cd5fb0ab57730f932bf57dd2ff9dec15407422e2207503463cbe2fdb4759aaf735f27cb3bbdcca6a083e78a32c0
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^5.0.2, @rollup/pluginutils@npm:^5.1.3, @rollup/pluginutils@npm:^5.1.4":
   version: 5.1.4
   resolution: "@rollup/pluginutils@npm:5.1.4"
@@ -12438,142 +12440,142 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.40.2"
+"@rollup/rollup-android-arm-eabi@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.41.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-android-arm64@npm:4.40.2"
+"@rollup/rollup-android-arm64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.41.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.40.2"
+"@rollup/rollup-darwin-arm64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.41.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-darwin-x64@npm:4.40.2"
+"@rollup/rollup-darwin-x64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.41.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-arm64@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-freebsd-arm64@npm:4.40.2"
+"@rollup/rollup-freebsd-arm64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.41.0"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-freebsd-x64@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-freebsd-x64@npm:4.40.2"
+"@rollup/rollup-freebsd-x64@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.41.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.40.2"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.41.0"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.40.2"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.41.0"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.40.2"
+"@rollup/rollup-linux-arm64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.40.2"
+"@rollup/rollup-linux-arm64-musl@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.41.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-loongarch64-gnu@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.40.2"
+"@rollup/rollup-linux-loongarch64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-loongarch64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=loong64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.40.2"
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.41.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.40.2"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-musl@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.40.2"
+"@rollup/rollup-linux-riscv64-musl@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.41.0"
   conditions: os=linux & cpu=riscv64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.40.2"
+"@rollup/rollup-linux-s390x-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.41.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.40.2"
+"@rollup/rollup-linux-x64-gnu@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.41.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.40.2"
+"@rollup/rollup-linux-x64-musl@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.41.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.40.2"
+"@rollup/rollup-win32-arm64-msvc@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.41.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.40.2"
+"@rollup/rollup-win32-ia32-msvc@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.41.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.40.2":
-  version: 4.40.2
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.40.2"
+"@rollup/rollup-win32-x64-msvc@npm:4.41.0":
+  version: 4.41.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.41.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -12964,7 +12966,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/engine-oniguruma@npm:3.4.2, @shikijs/engine-oniguruma@npm:^3.4.0":
+"@shikijs/engine-oniguruma@npm:3.4.2, @shikijs/engine-oniguruma@npm:^3.4.2":
   version: 3.4.2
   resolution: "@shikijs/engine-oniguruma@npm:3.4.2"
   dependencies:
@@ -12974,7 +12976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/langs@npm:3.4.2, @shikijs/langs@npm:^3.4.0":
+"@shikijs/langs@npm:3.4.2, @shikijs/langs@npm:^3.4.2":
   version: 3.4.2
   resolution: "@shikijs/langs@npm:3.4.2"
   dependencies:
@@ -12983,7 +12985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/themes@npm:3.4.2, @shikijs/themes@npm:^3.4.0":
+"@shikijs/themes@npm:3.4.2, @shikijs/themes@npm:^3.4.2":
   version: 3.4.2
   resolution: "@shikijs/themes@npm:3.4.2"
   dependencies:
@@ -12992,7 +12994,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@shikijs/types@npm:3.4.2, @shikijs/types@npm:^3.4.0":
+"@shikijs/types@npm:3.4.2, @shikijs/types@npm:^3.4.2":
   version: 3.4.2
   resolution: "@shikijs/types@npm:3.4.2"
   dependencies:
@@ -13148,7 +13150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/abort-controller@npm:^4.0.2, @smithy/abort-controller@npm:^4.0.3":
+"@smithy/abort-controller@npm:^4.0.3":
   version: 4.0.3
   resolution: "@smithy/abort-controller@npm:4.0.3"
   dependencies:
@@ -13219,58 +13221,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-codec@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/eventstream-codec@npm:4.0.2"
+"@smithy/eventstream-codec@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@smithy/eventstream-codec@npm:4.0.3"
   dependencies:
     "@aws-crypto/crc32": "npm:5.2.0"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     "@smithy/util-hex-encoding": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/4da77caabc6dfe317153cff5899c03244c24ae9965939f2b0a0e7543bfb3c5266e8a13ce1de2c16c5ed2e16d8245017a74da15b31de42e51dcad465be4c16cdf
+  checksum: 10/d5ca5c9a8f1d1f59112a539117414ed68c515680f8ff6413363efae5305396c51df53c9febc2985ec2b46d985ca642c8f25a8bc8c9882e142d40564523b98164
   languageName: node
   linkType: hard
 
 "@smithy/eventstream-serde-browser@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/eventstream-serde-browser@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/eventstream-serde-browser@npm:4.0.3"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.0.2"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/eventstream-serde-universal": "npm:^4.0.3"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/8ff3b826c338e314265897155d8580dfd342070f0ae53171bacf3d32f0324f9f6f20044731f5dab8cb14e66a5a57600f55a0b52412fbfc02c5ab61f238b1b700
+  checksum: 10/a0e37ef21abfc128f70ffc9bab6a237877b1e527c6c53b410e54d851279e5d335b1dee1504760097340c24b76a3f1d97ad3a692214516eb396b8061881a2ff9f
   languageName: node
   linkType: hard
 
 "@smithy/eventstream-serde-config-resolver@npm:^4.1.0":
-  version: 4.1.0
-  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.1.0"
+  version: 4.1.1
+  resolution: "@smithy/eventstream-serde-config-resolver@npm:4.1.1"
   dependencies:
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/b25359b5d36904205a529bd8ef18e40508e094d9dbb8d2d8f79af1c5135402817dd153985fd5db71355d45d92d1bd7c412fc9474e55b742e15e9bc6577b20d42
+  checksum: 10/b82c2e3fd858b2ae4a1aa1f4569a3e27cb1364503ded547de320b05db74b9ceaa90570a0066cda6523b23c63e06edb9eba9f719ea7efa2efbeba055ac22c4cb2
   languageName: node
   linkType: hard
 
 "@smithy/eventstream-serde-node@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/eventstream-serde-node@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/eventstream-serde-node@npm:4.0.3"
   dependencies:
-    "@smithy/eventstream-serde-universal": "npm:^4.0.2"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/eventstream-serde-universal": "npm:^4.0.3"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/890c2206eb18178184b35761641610ee96dd7c9a313d5f34591cda649cf268d6f4a34993897b9ba8ca28b87efd4a937d345abe9ca4ca7d92ed188e0c4f002198
+  checksum: 10/80f17f15cb98ef5fb1a67a1bcbaffb82aa6b405c6faceafb0d60facb8e6730961ed672e0265644cec8765f33333c9a59ab07d37e63eeefbdd890a493e5c11bc9
   languageName: node
   linkType: hard
 
-"@smithy/eventstream-serde-universal@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/eventstream-serde-universal@npm:4.0.2"
+"@smithy/eventstream-serde-universal@npm:^4.0.3":
+  version: 4.0.3
+  resolution: "@smithy/eventstream-serde-universal@npm:4.0.3"
   dependencies:
-    "@smithy/eventstream-codec": "npm:^4.0.2"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/eventstream-codec": "npm:^4.0.3"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/ef14ca4431ad952f0fa91df3c9e319859419b68128adc30f408335860ba1ad085059677f525d7d31ab65eb3c9f4359798d25176918661f53863c14f15fa2b22a
+  checksum: 10/11f5beaf3ccd8cb3fed50817f1f4c9a08d536b862d1164c0cc3cd851c83170ea498a6bad81f220971eb9d1ebb5a5600475b7ab762fb30db57495dbc20a9e7db1
   languageName: node
   linkType: hard
 
@@ -13288,47 +13290,47 @@ __metadata:
   linkType: hard
 
 "@smithy/hash-blob-browser@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/hash-blob-browser@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/hash-blob-browser@npm:4.0.3"
   dependencies:
     "@smithy/chunked-blob-reader": "npm:^5.0.0"
     "@smithy/chunked-blob-reader-native": "npm:^4.0.0"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/c553c78e31a843d71b91c33bdf5de902c350c4fefa536d90248a465faa77a2a118cb5aa399b10908f6aedfaf1829f4c526ab67b5b6353339b409908e2bc7df57
+  checksum: 10/39142baed14117629f54df6fedc89ad6dcad7c81315f4a730f6eb57c5ed0ed7b43ab2c7568d29736116f1138a2df9ff29199bbc861322a5e2817dabd25cdb5d1
   languageName: node
   linkType: hard
 
 "@smithy/hash-node@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/hash-node@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/hash-node@npm:4.0.3"
   dependencies:
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     "@smithy/util-buffer-from": "npm:^4.0.0"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/54055312753d310c2a4e6db26843b0a24949aeedd2b4bb190c707f201b085c3acee10caaf29602b67e0ac189296d4ca426d4135dca1b38f4681c3b9c1d3b5680
+  checksum: 10/9f9aa9fb25cc91416e0548018b594eaa968a1d294d4ae632b55108aa6388123f7ded52a7b20144e1b735dc3f8a34755dba2754e2d4691413007ed5d29aff77f0
   languageName: node
   linkType: hard
 
 "@smithy/hash-stream-node@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/hash-stream-node@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/hash-stream-node@npm:4.0.3"
   dependencies:
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/8dca62058ff3b18b10abdfdee88b22bb780008bf3c86f9570ae3d213579e6920faf47b7144ef438a28294033cd01f01bf3cee8f3dd9e997132867f74cad4f2f3
+  checksum: 10/f6f684279278986fd8f961841f9e0f3c89a3de06accf904c0c1501a8c5723b9e12ee6878ac6923ea280bbdfeaeffad34a6b8505e097ecf2ce90d68900c3e1be8
   languageName: node
   linkType: hard
 
 "@smithy/invalid-dependency@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/invalid-dependency@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/invalid-dependency@npm:4.0.3"
   dependencies:
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/d37a8760d8f667c22b5693340772447937837d20c0d5fdd3c398afb6335f72e3b19feb6511bc6082e7dd7ce567ca007aeb52bb2ef10ef6e7b2d2a8ff5b22ff3d
+  checksum: 10/155d1097c9faf61bc728ba179965283e7010583b5c4873a240becc6e8ec2a88fe9b13efb4b720ceb2b67a04d46b11bd82236640cbe87d04c303cab922c1b3c11
   languageName: node
   linkType: hard
 
@@ -13351,24 +13353,24 @@ __metadata:
   linkType: hard
 
 "@smithy/md5-js@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/md5-js@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/md5-js@npm:4.0.3"
   dependencies:
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/types": "npm:^4.3.0"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/c70f4197e0d9b3203d5a5e74c5c10c4c21802abb8db742783feff82ae5072249a7aa60d208ce7603dd3d5bbca89c0d0dc912944d109a9a03dfe36b22ac032720
+  checksum: 10/5d08258feb591579b2c5aff0b9ee4e25a40f2dddb5593fb50e6d14a7c7e6c5c8b3d190e050b4b80510793f79a41ad4a7ca947725004023c3bce3f35acfb13eed
   languageName: node
   linkType: hard
 
 "@smithy/middleware-content-length@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "@smithy/middleware-content-length@npm:4.0.2"
+  version: 4.0.3
+  resolution: "@smithy/middleware-content-length@npm:4.0.3"
   dependencies:
-    "@smithy/protocol-http": "npm:^5.1.0"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/protocol-http": "npm:^5.1.1"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/58c0b60955dfd3ec148e446cc6df03b226458334d35742e615633fa20ed8f690a4120f34e95afaa4d00cbbaa7875de86790094431b565bb063321759ff18e4f2
+  checksum: 10/65f13e41243417ed078d11c5b380831fc13b911f30dc7b9110f3d425455e19bd270e62b63ea5bc1cffc2cd17f73eda2669d3802560ffeac9508a683bdf8d7aab
   languageName: node
   linkType: hard
 
@@ -13512,18 +13514,18 @@ __metadata:
   linkType: hard
 
 "@smithy/signature-v4@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "@smithy/signature-v4@npm:5.1.0"
+  version: 5.1.1
+  resolution: "@smithy/signature-v4@npm:5.1.1"
   dependencies:
     "@smithy/is-array-buffer": "npm:^4.0.0"
-    "@smithy/protocol-http": "npm:^5.1.0"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/protocol-http": "npm:^5.1.1"
+    "@smithy/types": "npm:^4.3.0"
     "@smithy/util-hex-encoding": "npm:^4.0.0"
-    "@smithy/util-middleware": "npm:^4.0.2"
+    "@smithy/util-middleware": "npm:^4.0.3"
     "@smithy/util-uri-escape": "npm:^4.0.0"
     "@smithy/util-utf8": "npm:^4.0.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/c89c34a2551122679ce167fc11fa1d6012246a1b74c8022d9a1fe119db8eeb7cd44b2da8682044c395f0bfafb06e30ff5dd402e44c8759427fffadc8d1f249a3
+  checksum: 10/b23ab5f94d9891cfa3562d4999c058534a543e8f01109267af39657f2e559dcc2b2c6c4aa102acad3c4e0e553a144edbd038d1abc0a9338c0e49ee4523e5bd6e
   languageName: node
   linkType: hard
 
@@ -13735,13 +13737,13 @@ __metadata:
   linkType: hard
 
 "@smithy/util-waiter@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "@smithy/util-waiter@npm:4.0.3"
+  version: 4.0.4
+  resolution: "@smithy/util-waiter@npm:4.0.4"
   dependencies:
-    "@smithy/abort-controller": "npm:^4.0.2"
-    "@smithy/types": "npm:^4.2.0"
+    "@smithy/abort-controller": "npm:^4.0.3"
+    "@smithy/types": "npm:^4.3.0"
     tslib: "npm:^2.6.2"
-  checksum: 10/c65a82748a99134282d906d0633717eae1ac61df1b07c8f2d30e1ef776b1dd2b367da1088d39e19570a3e110dfe33467952bf5362fddcc4de28329ffe2aa9438
+  checksum: 10/9a85370918f6e5a12c5b9a4d1822edf98d5e772e5c2ffdbff394b846f6a29efe54167a14344a4a69a527ee75ccc9350fb4e9be6b54b635c0a66e5c71e8c41b36
   languageName: node
   linkType: hard
 
@@ -14223,7 +14225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.10.1, @swc/core@npm:^1.11.21":
+"@swc/core@npm:^1.10.1, @swc/core@npm:^1.11.22":
   version: 1.11.29
   resolution: "@swc/core@npm:1.11.29"
   dependencies:
@@ -15296,9 +15298,9 @@ __metadata:
   linkType: hard
 
 "@types/lodash@npm:*":
-  version: 4.17.16
-  resolution: "@types/lodash@npm:4.17.16"
-  checksum: 10/9a8bb7471a7521bd65d528e1bd14f79819a3eeb6f8a35a8a44649a7d773775c0813e93fd93bd32ccf350bb076c0bf02c6d47877c4625f526f6dd4d283c746aec
+  version: 4.17.17
+  resolution: "@types/lodash@npm:4.17.17"
+  checksum: 10/496459a3cb1a0733bb60532de3899ad6297717af0b9b26ad6821154b2005fec86f29ccd47a2e6f4da4a8c7c818bb8ae73901144e8057ea86b7b02a3d7bb9d13f
   languageName: node
   linkType: hard
 
@@ -15478,13 +15480,13 @@ __metadata:
   linkType: hard
 
 "@types/pg@npm:*":
-  version: 8.15.1
-  resolution: "@types/pg@npm:8.15.1"
+  version: 8.15.2
+  resolution: "@types/pg@npm:8.15.2"
   dependencies:
     "@types/node": "npm:*"
     pg-protocol: "npm:*"
     pg-types: "npm:^4.0.1"
-  checksum: 10/9d9153fef9b6ea6bf68d63067e133bbe88f19b3ea9e821f1d9feab26ca01009d1288da05e9f2ce8a4fda1af39880f0cd75931dcee6c2e7b35b94e247548ba5f1
+  checksum: 10/71780b829e43d4fcb1498c9271a8faccd8db5f5aaced9e7f86cba8fa44778739f025262dd32a151dffcda9045a74c7b14792674675e92e55c2a9dcbf8b493fed
   languageName: node
   linkType: hard
 
@@ -15517,9 +15519,9 @@ __metadata:
   linkType: hard
 
 "@types/qs@npm:*":
-  version: 6.9.18
-  resolution: "@types/qs@npm:6.9.18"
-  checksum: 10/152fab96efd819cc82ae67c39f089df415da6deddb48f1680edaaaa4e86a2a597de7b2ff0ad391df66d11a07006a08d52c9405e86b8cb8f3d5ba15881fe56cc7
+  version: 6.14.0
+  resolution: "@types/qs@npm:6.14.0"
+  checksum: 10/1909205514d22b3cbc7c2314e2bd8056d5f05dfb21cf4377f0730ee5e338ea19957c41735d5e4806c746176563f50005bbab602d8358432e25d900bdf4970826
   languageName: node
   linkType: hard
 
@@ -16124,8 +16126,8 @@ __metadata:
   linkType: hard
 
 "@vercel/nft@npm:^0.29.2":
-  version: 0.29.2
-  resolution: "@vercel/nft@npm:0.29.2"
+  version: 0.29.3
+  resolution: "@vercel/nft@npm:0.29.3"
   dependencies:
     "@mapbox/node-pre-gyp": "npm:^2.0.0"
     "@rollup/pluginutils": "npm:^5.1.3"
@@ -16141,33 +16143,35 @@ __metadata:
     resolve-from: "npm:^5.0.0"
   bin:
     nft: out/cli.js
-  checksum: 10/6ae416b263a0ded96675346ab71c502a7ed6fbdce24ac79e68b43da741b05e165f3ea2e327dad1bc77261d91e7cd60c87005bdefd51991d190347efa71f38837
+  checksum: 10/ba983252cae1e4b454e59affab2b561f985c2dc1befa9b218f2325a8f6f7fb5d4e310968627d9228c4fad95a53fd0cab22a7d45100720463a7512ba76d93e675
   languageName: node
   linkType: hard
 
 "@vitejs/plugin-react-swc@npm:^3.7.2":
-  version: 3.9.0
-  resolution: "@vitejs/plugin-react-swc@npm:3.9.0"
+  version: 3.10.0
+  resolution: "@vitejs/plugin-react-swc@npm:3.10.0"
   dependencies:
-    "@swc/core": "npm:^1.11.21"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.9"
+    "@swc/core": "npm:^1.11.22"
   peerDependencies:
     vite: ^4 || ^5 || ^6
-  checksum: 10/545dddee3c2f7f35f37c680f79bebb98f3968209470ec56c594556410d498b41cf86df60d2ab9a56c69b02bef12ee3198371becc804b85172ec97ee0d2d7633d
+  checksum: 10/99ecf71de8f5a854bb2fc8813a6cff6bbc94477f76b0805e75515842e6c7c5674fd368ea81428b481812f19ee88a2cde226b4c304974adb54b36e2a41467bd02
   languageName: node
   linkType: hard
 
 "@vitejs/plugin-react@npm:^4.3.4":
-  version: 4.4.1
-  resolution: "@vitejs/plugin-react@npm:4.4.1"
+  version: 4.5.0
+  resolution: "@vitejs/plugin-react@npm:4.5.0"
   dependencies:
     "@babel/core": "npm:^7.26.10"
     "@babel/plugin-transform-react-jsx-self": "npm:^7.25.9"
     "@babel/plugin-transform-react-jsx-source": "npm:^7.25.9"
+    "@rolldown/pluginutils": "npm:1.0.0-beta.9"
     "@types/babel__core": "npm:^7.20.5"
     react-refresh: "npm:^0.17.0"
   peerDependencies:
     vite: ^4.2.0 || ^5.0.0 || ^6.0.0
-  checksum: 10/bce482d4ecd98d1b15323968ff9ad0a6162a6770fab31f380bb77b5f410319c1848e5cf03d3ccd798e3fc74cdb38ae4dc023cd92576378c81b4d55b1f28b1f1c
+  checksum: 10/0a1c4815fb5a404681443f6e3c4b5a82ec4527dc9fb606f9282bbff5d487b9af5e3433eee2386d4582045bcd691d1aca93df3cbf558164b763b7464710544fe8
   languageName: node
   linkType: hard
 
@@ -16628,24 +16632,24 @@ __metadata:
   linkType: hard
 
 "@whatwg-node/fetch@npm:^0.10.0, @whatwg-node/fetch@npm:^0.10.4":
-  version: 0.10.7
-  resolution: "@whatwg-node/fetch@npm:0.10.7"
+  version: 0.10.8
+  resolution: "@whatwg-node/fetch@npm:0.10.8"
   dependencies:
-    "@whatwg-node/node-fetch": "npm:^0.7.19"
+    "@whatwg-node/node-fetch": "npm:^0.7.21"
     urlpattern-polyfill: "npm:^10.0.0"
-  checksum: 10/7784ecdef6a8d6f71994de37aa89064221045d5b02c2c2e38286eb79c6960158a96ae9b2b4f7ed8cf9943300fc73a58888dc034c1836b29afd7a517058195390
+  checksum: 10/53b3b35c8c725cbc2da6dce1135db6a374bac6bebd7dd572a41ead25f8c2158069cd35a7fc89030e68af25db17ffe79370def024296b1085a7d8af6b89da518d
   languageName: node
   linkType: hard
 
-"@whatwg-node/node-fetch@npm:^0.7.19":
-  version: 0.7.19
-  resolution: "@whatwg-node/node-fetch@npm:0.7.19"
+"@whatwg-node/node-fetch@npm:^0.7.21":
+  version: 0.7.21
+  resolution: "@whatwg-node/node-fetch@npm:0.7.21"
   dependencies:
     "@fastify/busboy": "npm:^3.1.1"
     "@whatwg-node/disposablestack": "npm:^0.0.6"
     "@whatwg-node/promise-helpers": "npm:^1.3.2"
     tslib: "npm:^2.6.3"
-  checksum: 10/bba076758c50afd321726152569ae32688ea8e4883d637d6e0d375279a90b3653435d3bed7b1c263243f9a7328d59e47bb96412a3c8874039d7f9610631b2018
+  checksum: 10/68257f2bb4642bfbbfbdb9c7285ebfa829901dabb111d52809ed98dc4f9e355eda030122aee313464c8eb503c01ecc66398a1949922245122d32434a026579d6
   languageName: node
   linkType: hard
 
@@ -16781,7 +16785,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.14.1, acorn@npm:^8.4.1, acorn@npm:^8.6.0, acorn@npm:^8.7.1, acorn@npm:^8.8.1, acorn@npm:^8.8.2":
+"acorn@npm:^8.11.0, acorn@npm:^8.14.0, acorn@npm:^8.14.1, acorn@npm:^8.4.1, acorn@npm:^8.6.0, acorn@npm:^8.7.1, acorn@npm:^8.8.1":
   version: 8.14.1
   resolution: "acorn@npm:8.14.1"
   bin:
@@ -17183,11 +17187,11 @@ __metadata:
   linkType: hard
 
 "aria-hidden@npm:^1.2.4":
-  version: 1.2.4
-  resolution: "aria-hidden@npm:1.2.4"
+  version: 1.2.6
+  resolution: "aria-hidden@npm:1.2.6"
   dependencies:
     tslib: "npm:^2.0.0"
-  checksum: 10/df4bc15423aaaba3729a7d40abcbf6d3fffa5b8fd5eb33d3ac8b7da0110c47552fca60d97f2e1edfbb68a27cae1da499f1c3896966efb3e26aac4e3b57e3cc8b
+  checksum: 10/1914e5a36225dccdb29f0b88cc891eeca736cdc5b0c905ab1437b90b28b5286263ed3a221c75b7dc788f25b942367be0044b2ac8ccf073a72e07a50b1d964202
   languageName: node
   linkType: hard
 
@@ -18201,9 +18205,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001579, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001716":
-  version: 1.0.30001717
-  resolution: "caniuse-lite@npm:1.0.30001717"
-  checksum: 10/e47dfd8707ea305baa177f3d3d531df614f5a9ac6335363fc8f86f0be4caf79f5734f3f68b601fee4edd9d79f1e5ffc0931466bb894bf955ed6b1dd5a1c34b1d
+  version: 1.0.30001718
+  resolution: "caniuse-lite@npm:1.0.30001718"
+  checksum: 10/e172a4c156f743cc947e659f353ad9edb045725cc109a02cc792dcbf98569356ebfa4bb4356e3febf87427aab0951c34c1ee5630629334f25ae6f76de7d86fd0
   languageName: node
   linkType: hard
 
@@ -18503,8 +18507,8 @@ __metadata:
   linkType: hard
 
 "chromatic@npm:^11.15.0":
-  version: 11.28.2
-  resolution: "chromatic@npm:11.28.2"
+  version: 11.28.3
+  resolution: "chromatic@npm:11.28.3"
   peerDependencies:
     "@chromatic-com/cypress": ^0.*.* || ^1.0.0
     "@chromatic-com/playwright": ^0.*.* || ^1.0.0
@@ -18517,7 +18521,7 @@ __metadata:
     chroma: dist/bin.js
     chromatic: dist/bin.js
     chromatic-cli: dist/bin.js
-  checksum: 10/d5dc1d407157fb5dcdf1e43276d64731e8a95addfc29006771b34e60b126adbe54f1357886a391195edf4ebdff515bd82af36a357009f59f141ad634afe47389
+  checksum: 10/b9a544e16588f8a99cb19c2f5b4951e89772de4fc26e38b860e0cc83f0baa4e591391f24081b14bdba8cf353a722a788763d26dba316710326674b7123a3c00a
   languageName: node
   linkType: hard
 
@@ -20526,9 +20530,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.149":
-  version: 1.5.151
-  resolution: "electron-to-chromium@npm:1.5.151"
-  checksum: 10/99c95f6c4c03ac69df9f771fdb901f70848ef6685cfcb0f455ead951439264791cb25f3e074f32224aba5d7fdf9d0bb6e5de07b1c9e01b7d51f64d038365a7c1
+  version: 1.5.157
+  resolution: "electron-to-chromium@npm:1.5.157"
+  checksum: 10/806cbb515f17d6599369d184032f21b5cc2bf4194267c08a5b134eb9a6c2fc291c87acda5c0baccd6f3833fb543b74b7edc5767d5594dec92c626a153797e7cf
   languageName: node
   linkType: hard
 
@@ -20576,15 +20580,15 @@ __metadata:
   linkType: hard
 
 "electron@npm:^36.0.0":
-  version: 36.2.1
-  resolution: "electron@npm:36.2.1"
+  version: 36.3.1
+  resolution: "electron@npm:36.3.1"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/2dbcac9208c6a513b75ef92a969441407e44fb11377a3d831d3e043d3c5e1bf927badc475a490b554e6007995f1a28db9d833044202d21d629bb84587745dbf7
+  checksum: 10/8b0e1d3d2ea74f9878ba18502a193da74ba4666429fed2bcd3ad102c5d6c369e138d3de3530a8d3ccc3d152ec28b9f056f35f23482ddc640c33019ada134995a
   languageName: node
   linkType: hard
 
@@ -21035,8 +21039,8 @@ __metadata:
   linkType: hard
 
 "eslint-import-resolver-typescript@npm:^4.0.0":
-  version: 4.3.4
-  resolution: "eslint-import-resolver-typescript@npm:4.3.4"
+  version: 4.3.5
+  resolution: "eslint-import-resolver-typescript@npm:4.3.5"
   dependencies:
     debug: "npm:^4.4.0"
     get-tsconfig: "npm:^4.10.0"
@@ -21053,13 +21057,13 @@ __metadata:
       optional: true
     eslint-plugin-import-x:
       optional: true
-  checksum: 10/3620479c17bfbe7d40706c06e15a559a0a626af16bec3fe3046644ca84a5b49d5b8996753e5caf1b4f3de2140dbde5dc852aa3ea5fc4f459c080400b23af9e7e
+  checksum: 10/8f40c472b2d14da6c1a50244b443e8fd23a15244a8e829f99f861344a568e3fc2736480a670083212240af2b261aa604146ff3dcdd97d2e6cee00a1609cd2c03
   languageName: node
   linkType: hard
 
 "eslint-plugin-import-x@npm:^4.5.0":
-  version: 4.11.1
-  resolution: "eslint-plugin-import-x@npm:4.11.1"
+  version: 4.12.2
+  resolution: "eslint-plugin-import-x@npm:4.12.2"
   dependencies:
     "@typescript-eslint/utils": "npm:^8.31.0"
     comment-parser: "npm:^1.4.1"
@@ -21074,7 +21078,7 @@ __metadata:
     unrs-resolver: "npm:^1.7.0"
   peerDependencies:
     eslint: ^8.57.0 || ^9.0.0
-  checksum: 10/98e7f4a92f3d3c830d0776aa2da66e4f3628c6a73b18edbfbd70c6091b82149aa8966fd7db6884b4490aceeb4bc906e82988a755b66351a1bbfb89111e8d72b0
+  checksum: 10/ad227d569f3bcff2532f11fd4985095c0cfa7b8757655c8eec70c50753b4ab771591c8431df561761295376f18cbfd020b05d287369de1bbd0418ca6aad271f6
   languageName: node
   linkType: hard
 
@@ -21205,21 +21209,20 @@ __metadata:
   linkType: hard
 
 "eslint@npm:^9.16.0":
-  version: 9.26.0
-  resolution: "eslint@npm:9.26.0"
+  version: 9.27.0
+  resolution: "eslint@npm:9.27.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.2.0"
     "@eslint-community/regexpp": "npm:^4.12.1"
     "@eslint/config-array": "npm:^0.20.0"
     "@eslint/config-helpers": "npm:^0.2.1"
-    "@eslint/core": "npm:^0.13.0"
+    "@eslint/core": "npm:^0.14.0"
     "@eslint/eslintrc": "npm:^3.3.1"
-    "@eslint/js": "npm:9.26.0"
-    "@eslint/plugin-kit": "npm:^0.2.8"
+    "@eslint/js": "npm:9.27.0"
+    "@eslint/plugin-kit": "npm:^0.3.1"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
-    "@modelcontextprotocol/sdk": "npm:^1.8.0"
     "@types/estree": "npm:^1.0.6"
     "@types/json-schema": "npm:^7.0.15"
     ajv: "npm:^6.12.4"
@@ -21244,7 +21247,6 @@ __metadata:
     minimatch: "npm:^3.1.2"
     natural-compare: "npm:^1.4.0"
     optionator: "npm:^0.9.3"
-    zod: "npm:^3.24.2"
   peerDependencies:
     jiti: "*"
   peerDependenciesMeta:
@@ -21252,7 +21254,7 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10/b87092cb7e87f1d0963475c1a1e15e551842ea122925cf13231e742fae565bf3582029a5b0b4aecf793f25c26ee0be3ee1f32190bc361e0c3f3633b9cbace948
+  checksum: 10/75f02b851c6f8534d1289de1bd957637a56725754bea03a0a710d6740a036aca81d5e600557633fca7ab774275aa94044ca05772f88c4f464cd42834eff37145
   languageName: node
   linkType: hard
 
@@ -21398,22 +21400,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.1":
-  version: 3.0.1
-  resolution: "eventsource-parser@npm:3.0.1"
-  checksum: 10/2730c54c3cb47d55d2967f2ece843f9fc95d8a11c2fef6fece8d17d9080193cbe3cd9ac7b04a325977f63cbf8c1664fdd0512dec1aec601666a5c5bd8564b61f
-  languageName: node
-  linkType: hard
-
-"eventsource@npm:^3.0.2":
-  version: 3.0.7
-  resolution: "eventsource@npm:3.0.7"
-  dependencies:
-    eventsource-parser: "npm:^3.0.1"
-  checksum: 10/e034915bc97068d1d38617951afd798e6776d6a3a78e36a7569c235b177c7afc2625c9fe82656f7341ab72c7eeecb3fd507b7f88e9328f2448872ff9c4742bb6
-  languageName: node
-  linkType: hard
-
 "exa-js@npm:^1.6.13":
   version: 1.7.2
   resolution: "exa-js@npm:1.7.2"
@@ -21490,7 +21476,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-rate-limit@npm:^7.1.5, express-rate-limit@npm:^7.5.0":
+"express-rate-limit@npm:^7.1.5":
   version: 7.5.0
   resolution: "express-rate-limit@npm:7.5.0"
   peerDependencies:
@@ -22515,11 +22501,11 @@ __metadata:
   linkType: hard
 
 "get-tsconfig@npm:^4.10.0, get-tsconfig@npm:^4.7.5":
-  version: 4.10.0
-  resolution: "get-tsconfig@npm:4.10.0"
+  version: 4.10.1
+  resolution: "get-tsconfig@npm:4.10.1"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10/5259b5c99a1957114337d9d0603b4a305ec9e29fa6cac7d2fbf634ba6754a0cc88bfd281a02416ce64e604b637d3cb239185381a79a5842b17fb55c097b38c4b
+  checksum: 10/04d63f47fdecaefbd1f73ec02949be4ec4db7d6d9fbc8d4e81f9a4bb1c6f876e48943712f2f9236643d3e4d61d9a7b06da08564d08b034631ebe3f5605bef237
   languageName: node
   linkType: hard
 
@@ -22913,7 +22899,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-ws@npm:6.0.4, graphql-ws@npm:^6.0.3":
+"graphql-ws@npm:6.0.4":
   version: 6.0.4
   resolution: "graphql-ws@npm:6.0.4"
   peerDependencies:
@@ -22929,6 +22915,28 @@ __metadata:
     ws:
       optional: true
   checksum: 10/9cfd6bdf03a65c2b390e049b0e6ce43dd3e428eb7df74afaad45bbfe1f074687a507509f5ab3f9467fea90a7fbe468558621e8c7be06729ea9dc56e116f236da
+  languageName: node
+  linkType: hard
+
+"graphql-ws@npm:^6.0.3":
+  version: 6.0.5
+  resolution: "graphql-ws@npm:6.0.5"
+  peerDependencies:
+    "@fastify/websocket": ^10 || ^11
+    crossws: ~0.3
+    graphql: ^15.10.1 || ^16
+    uWebSockets.js: ^20
+    ws: ^8
+  peerDependenciesMeta:
+    "@fastify/websocket":
+      optional: true
+    crossws:
+      optional: true
+    uWebSockets.js:
+      optional: true
+    ws:
+      optional: true
+  checksum: 10/33767813faf574ec225f52ffdf3cd4ef78acfb4905e82116afe0fe4adcd438ae3886f12b8ced588376dfaa26d50a6ad2dd30596547ed0a93c190fc4495ab91d2
   languageName: node
   linkType: hard
 
@@ -23232,8 +23240,8 @@ __metadata:
   linkType: hard
 
 "html-validate@npm:^9.0.0":
-  version: 9.5.3
-  resolution: "html-validate@npm:9.5.3"
+  version: 9.5.4
+  resolution: "html-validate@npm:9.5.4"
   dependencies:
     "@html-validate/stylish": "npm:^4.1.0"
     "@sidvind/better-ajv-errors": "npm:4.0.0"
@@ -23259,7 +23267,7 @@ __metadata:
       optional: true
   bin:
     html-validate: bin/html-validate.mjs
-  checksum: 10/a942989c66898bf13a030fb0cf2dc565777e601409a9eb7a149f51e101aec2aef26dd921aeca56961815e1bf00bb72955b8e166e1b417309d7737a092f89d92b
+  checksum: 10/39c2308e2b8ebc098ecbe68c89e8af5f0283450eaf16e27055a89380ff9bb15abc95ca38085cc1a9b7a303301a3215f683cd5db4b72ccc6bd438e5dec418a9da
   languageName: node
   linkType: hard
 
@@ -24497,11 +24505,11 @@ __metadata:
   linkType: hard
 
 "jackspeak@npm:^4.0.1":
-  version: 4.1.0
-  resolution: "jackspeak@npm:4.1.0"
+  version: 4.1.1
+  resolution: "jackspeak@npm:4.1.1"
   dependencies:
     "@isaacs/cliui": "npm:^8.0.2"
-  checksum: 10/d3ad964e87a3d66ec86b6d466ff150cf3472bbda738a9c4f882ece96c7fb59f0013be1f6cad17cbedd36260741db6cf8912b8e037cd7c7eb72b3532246e54f77
+  checksum: 10/ffceb270ec286841f48413bfb4a50b188662dfd599378ce142b6540f3f0a66821dc9dcb1e9ebc55c6c3b24dc2226c96e5819ba9bd7a241bd29031b61911718c7
   languageName: node
   linkType: hard
 
@@ -25606,12 +25614,12 @@ __metadata:
   linkType: hard
 
 "log-symbols@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "log-symbols@npm:7.0.0"
+  version: 7.0.1
+  resolution: "log-symbols@npm:7.0.1"
   dependencies:
     is-unicode-supported: "npm:^2.0.0"
     yoctocolors: "npm:^2.1.1"
-  checksum: 10/a6cb6e90bfe9f0774a09ff783e2035cd7e375a42757d7e401b391916a67f6da382f4966b57dda89430faaebe2ed13803ea867e104f8d67caf66082943a7153f0
+  checksum: 10/0862313d84826b551582e39659b8586c56b65130c5f4f976420e2c23985228334f2a26fc4251ac22bf0a5b415d9430e86bf332557d934c10b036f9a549d63a09
   languageName: node
   linkType: hard
 
@@ -26329,14 +26337,14 @@ __metadata:
   linkType: hard
 
 "memfs@npm:^4.6.0":
-  version: 4.17.1
-  resolution: "memfs@npm:4.17.1"
+  version: 4.17.2
+  resolution: "memfs@npm:4.17.2"
   dependencies:
     "@jsonjoy.com/json-pack": "npm:^1.0.3"
     "@jsonjoy.com/util": "npm:^1.3.0"
     tree-dump: "npm:^1.0.1"
     tslib: "npm:^2.0.0"
-  checksum: 10/ba0db64196bbe2891a2e0faa76bb93cde1cc3443f8ce74d18e8e320c33f4346cf6c430d432b0707bbd5d7c1b88ddab38723cf8e4db9f93627f0c7b0f00c456b5
+  checksum: 10/105175204e74e836460fbf18e431bc24def3f5ea7ecd94d644f35992dc28b5a4c5f425849dd5f342878ef0ba032508c05b2756e026491635a59fc7f631cbfcde
   languageName: node
   linkType: hard
 
@@ -27228,14 +27236,14 @@ __metadata:
   linkType: hard
 
 "msgpackr@npm:^1.11.2":
-  version: 1.11.2
-  resolution: "msgpackr@npm:1.11.2"
+  version: 1.11.4
+  resolution: "msgpackr@npm:1.11.4"
   dependencies:
     msgpackr-extract: "npm:^3.0.2"
   dependenciesMeta:
     msgpackr-extract:
       optional: true
-  checksum: 10/7602f1e91e5ba13f4289ec9cab0d3f3db87d4ed323bebcb40a0c43ba2f6153192bffb63a5bb4755faacb6e0985f307c35084f40eaba1c325b7035da91381f01a
+  checksum: 10/131d9d676c8b931fb522550913afd390d361bd9dde993e9927f5ad35d58d9165c940433800b69a2caff556db632c3c510bc064cc3a5776e1c2d63a7cb280a470
   languageName: node
   linkType: hard
 
@@ -27359,9 +27367,9 @@ __metadata:
   linkType: hard
 
 "nano-spawn@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "nano-spawn@npm:1.0.1"
-  checksum: 10/be4a26653e356eabf27c53bddc2205d38f4631523b08e7edc1c64d838320f191b96bd28a570dc939b29f7b036fc06f78f6b70f2341ba9221e2e677548220191b
+  version: 1.0.2
+  resolution: "nano-spawn@npm:1.0.2"
+  checksum: 10/6ce9e60846d2e37c0e3cd048472683c81dbcaadef9ebe73bfc8754ee7da2a574f724436d3dcdeda5d807aedc857cc8cbc278a9882529164b5ef4b170b95cfe0b
   languageName: node
   linkType: hard
 
@@ -27384,11 +27392,11 @@ __metadata:
   linkType: hard
 
 "napi-postinstall@npm:^0.2.2":
-  version: 0.2.3
-  resolution: "napi-postinstall@npm:0.2.3"
+  version: 0.2.4
+  resolution: "napi-postinstall@npm:0.2.4"
   bin:
     napi-postinstall: lib/cli.js
-  checksum: 10/168525a8b80610c9f7dfe18feb40a86a6dc473d939c805eaa53a74bb1645ad9c3784904e41901f5f956f0147069d30a0b44e1bca5d73e94d8bbc112f36ae6eb7
+  checksum: 10/286785f884b872102fb284847ecc693101f70126b1fc7a97e19293929ce7f08802b41f89398015cce0797070ea3ce6871939a3c1e693c04cf594f7939dbe8cfb
   languageName: node
   linkType: hard
 
@@ -28765,9 +28773,9 @@ __metadata:
   linkType: hard
 
 "pg-protocol@npm:*":
-  version: 1.9.5
-  resolution: "pg-protocol@npm:1.9.5"
-  checksum: 10/690b18d421fda1a004dcc07fe5aa06d3511775aae6ea424586e039c7954c463bc358bb00a93d064ccee16d378a7a9c27102fef348eee30f3d5d4105ff3d4151c
+  version: 1.10.0
+  resolution: "pg-protocol@npm:1.10.0"
+  checksum: 10/975184d9f67dd2325afc8b5e79008c39bbdf6baf43db1158a90a9c624c86d0ca51cff68031759e196739d2e04b90a6a4749b42206ab7b9aca03a25243a7c2094
   languageName: node
   linkType: hard
 
@@ -28857,13 +28865,6 @@ __metadata:
     "@napi-rs/nice":
       optional: true
   checksum: 10/b5dc82d311b216739b12e084dfb9a2f1352a01164687129f108ad01901135c4a0dc5a86204bb69e81d4df0699b6567158202ae8465c212186841f0ee05f596f1
-  languageName: node
-  linkType: hard
-
-"pkce-challenge@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "pkce-challenge@npm:5.0.0"
-  checksum: 10/e60c06a0e0481cb82f80072053d5c479a7490758541c4226460450285dd5d72a995c44b3c553731ca7c2f64cc34b35f1d2e5f9de08d276b59899298f9efe1ddf
   languageName: node
   linkType: hard
 
@@ -29606,8 +29607,8 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.2.5, protobufjs@npm:^7.3.0":
-  version: 7.5.1
-  resolution: "protobufjs@npm:7.5.1"
+  version: 7.5.2
+  resolution: "protobufjs@npm:7.5.2"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -29621,7 +29622,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10/e9f502a2e31831d7cb4e00864f1d134d96236983f7fd426954e3d6ea0392f02df35d7b30f6b706b94b2a91d884126ca78380c250aea6997a0d4a7dbc360427ef
+  checksum: 10/b19adca6f2fd02099d9d51c4bff154947290bd5887364c5cf7227b67d8960644a60c077fcab5889512de6313149d9b429d58d6a57d8793da12a7358196073445
   languageName: node
   linkType: hard
 
@@ -29967,8 +29968,8 @@ __metadata:
   linkType: hard
 
 "react-i18next@npm:^15.2.0":
-  version: 15.5.1
-  resolution: "react-i18next@npm:15.5.1"
+  version: 15.5.2
+  resolution: "react-i18next@npm:15.5.2"
   dependencies:
     "@babel/runtime": "npm:^7.25.0"
     html-parse-stringify: "npm:^3.0.1"
@@ -29983,7 +29984,7 @@ __metadata:
       optional: true
     typescript:
       optional: true
-  checksum: 10/19b9ecb1df2eb611c79a27c0f0e9ba7b93933ff7f3c2413507df5f514057b1f860df676157a3eafd5bd76726eb820c1f2ddb8f6be42c39152f2d585864344f01
+  checksum: 10/16e2e71177290ec3e3ca71403d101c511e0a0111f6eaabf5a84477fb5588cc83e27e5fc23d5f4404e6d3ca9f187752c349dd827d386218add27a169e9930fc63
   languageName: node
   linkType: hard
 
@@ -30067,8 +30068,8 @@ __metadata:
   linkType: hard
 
 "react-remove-scroll@npm:^2.6.3":
-  version: 2.6.3
-  resolution: "react-remove-scroll@npm:2.6.3"
+  version: 2.7.0
+  resolution: "react-remove-scroll@npm:2.7.0"
   dependencies:
     react-remove-scroll-bar: "npm:^2.3.7"
     react-style-singleton: "npm:^2.2.3"
@@ -30081,7 +30082,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/react":
       optional: true
-  checksum: 10/d4dfd38e4381fa6059c8b810568b2d3a31fe21168bb3e2f57d1b1885ee08736fbd5a3fd83936faef0d17031c9c4175a1af83885bfc6c4280611f025447b19a4c
+  checksum: 10/6fa65227b101f097be17126dbefdaaa170b39f8e4f53b4e90f058501e14047215de7eea7ce4516aa18b9daaee5b32e84abf0360dd7f0156d8017da64c8cc84e0
   languageName: node
   linkType: hard
 
@@ -30095,67 +30096,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:6.30.0":
-  version: 6.30.0
-  resolution: "react-router-dom@npm:6.30.0"
-  dependencies:
-    "@remix-run/router": "npm:1.23.0"
-    react-router: "npm:6.30.0"
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10/e161e39d56ee799553d0bc6c8f19c901ee8cdbae218094f41cbc18f3262cb4d5e9f8381bd47a7e59d30e55c0cdd0a6803aa98537f2f9122efbce5c66a3041a35
-  languageName: node
-  linkType: hard
-
-"react-router-dom@npm:^6.28.0":
-  version: 6.30.1
-  resolution: "react-router-dom@npm:6.30.1"
-  dependencies:
-    "@remix-run/router": "npm:1.23.0"
-    react-router: "npm:6.30.1"
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10/d61f04a36ca8a0a61e71bac2616f3f0d4142ced4a473d872738ca363b43d042f4d6dc249e7f7ae1c06f89599277e2fde11583d61cf6b34e999e79caf845acb37
-  languageName: node
-  linkType: hard
-
-"react-router-dom@npm:^7.5.1":
-  version: 7.6.0
-  resolution: "react-router-dom@npm:7.6.0"
-  dependencies:
-    react-router: "npm:7.6.0"
-  peerDependencies:
-    react: ">=18"
-    react-dom: ">=18"
-  checksum: 10/e24b9c6cb04448e3f3effb79399294aeffc22e9b99e179befa861bd2f5464d6e6a1caaf2971aeded9cbdb7fd279552ed43aa3043cc823186f95fdc8b1d84fa27
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.0":
-  version: 6.30.0
-  resolution: "react-router@npm:6.30.0"
-  dependencies:
-    "@remix-run/router": "npm:1.23.0"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10/2a449f2769b7b001f9ea16108b83cd014b50c621a378ef2a99bb823a418833bc1b213f5f1665c97ecbdfa9391f9593693ace09a292969aa7259a45070b5e066a
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.1":
-  version: 6.30.1
-  resolution: "react-router@npm:6.30.1"
-  dependencies:
-    "@remix-run/router": "npm:1.23.0"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10/880d6cafd6376dd1e624f6f600b7a208c4142d60eaea66241980ef57260c237b3465c3ff96b28f21ae354410345bbbb1817c3bba083012aade6626027d53506f
-  languageName: node
-  linkType: hard
-
-"react-router@npm:7.6.0":
+"react-router@npm:^7.6.0":
   version: 7.6.0
   resolution: "react-router@npm:7.6.0"
   dependencies:
@@ -30852,29 +30793,29 @@ __metadata:
   linkType: hard
 
 "rollup@npm:^4.34.9":
-  version: 4.40.2
-  resolution: "rollup@npm:4.40.2"
+  version: 4.41.0
+  resolution: "rollup@npm:4.41.0"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.40.2"
-    "@rollup/rollup-android-arm64": "npm:4.40.2"
-    "@rollup/rollup-darwin-arm64": "npm:4.40.2"
-    "@rollup/rollup-darwin-x64": "npm:4.40.2"
-    "@rollup/rollup-freebsd-arm64": "npm:4.40.2"
-    "@rollup/rollup-freebsd-x64": "npm:4.40.2"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.40.2"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.40.2"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.40.2"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.40.2"
-    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.40.2"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.40.2"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.40.2"
-    "@rollup/rollup-linux-riscv64-musl": "npm:4.40.2"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.40.2"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.40.2"
-    "@rollup/rollup-linux-x64-musl": "npm:4.40.2"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.40.2"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.40.2"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.40.2"
+    "@rollup/rollup-android-arm-eabi": "npm:4.41.0"
+    "@rollup/rollup-android-arm64": "npm:4.41.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.41.0"
+    "@rollup/rollup-darwin-x64": "npm:4.41.0"
+    "@rollup/rollup-freebsd-arm64": "npm:4.41.0"
+    "@rollup/rollup-freebsd-x64": "npm:4.41.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.41.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.41.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.41.0"
+    "@rollup/rollup-linux-loongarch64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-riscv64-musl": "npm:4.41.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.41.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.41.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.41.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.41.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.41.0"
     "@types/estree": "npm:1.0.7"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
@@ -30922,7 +30863,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10/ab767c56e37410257864e051fccbdaf448ac7774129bf39295de716af816c49e0247e72749959969efbd892fc64e096880fa269764adf765579100e81abf5e7c
+  checksum: 10/1534638aabb425355ee4c8c4596ed2a765c6af2bdc2faf3f01d46981ce95b2d27b9477fdcba705002944fce9372272e99e325aff82e7e1aba924d5a50de8e8b5
   languageName: node
   linkType: hard
 
@@ -31475,11 +31416,11 @@ __metadata:
   linkType: hard
 
 "sharp@npm:^0.34.1":
-  version: 0.34.1
-  resolution: "sharp@npm:0.34.1"
+  version: 0.34.2
+  resolution: "sharp@npm:0.34.2"
   dependencies:
-    "@img/sharp-darwin-arm64": "npm:0.34.1"
-    "@img/sharp-darwin-x64": "npm:0.34.1"
+    "@img/sharp-darwin-arm64": "npm:0.34.2"
+    "@img/sharp-darwin-x64": "npm:0.34.2"
     "@img/sharp-libvips-darwin-arm64": "npm:1.1.0"
     "@img/sharp-libvips-darwin-x64": "npm:1.1.0"
     "@img/sharp-libvips-linux-arm": "npm:1.1.0"
@@ -31489,18 +31430,19 @@ __metadata:
     "@img/sharp-libvips-linux-x64": "npm:1.1.0"
     "@img/sharp-libvips-linuxmusl-arm64": "npm:1.1.0"
     "@img/sharp-libvips-linuxmusl-x64": "npm:1.1.0"
-    "@img/sharp-linux-arm": "npm:0.34.1"
-    "@img/sharp-linux-arm64": "npm:0.34.1"
-    "@img/sharp-linux-s390x": "npm:0.34.1"
-    "@img/sharp-linux-x64": "npm:0.34.1"
-    "@img/sharp-linuxmusl-arm64": "npm:0.34.1"
-    "@img/sharp-linuxmusl-x64": "npm:0.34.1"
-    "@img/sharp-wasm32": "npm:0.34.1"
-    "@img/sharp-win32-ia32": "npm:0.34.1"
-    "@img/sharp-win32-x64": "npm:0.34.1"
+    "@img/sharp-linux-arm": "npm:0.34.2"
+    "@img/sharp-linux-arm64": "npm:0.34.2"
+    "@img/sharp-linux-s390x": "npm:0.34.2"
+    "@img/sharp-linux-x64": "npm:0.34.2"
+    "@img/sharp-linuxmusl-arm64": "npm:0.34.2"
+    "@img/sharp-linuxmusl-x64": "npm:0.34.2"
+    "@img/sharp-wasm32": "npm:0.34.2"
+    "@img/sharp-win32-arm64": "npm:0.34.2"
+    "@img/sharp-win32-ia32": "npm:0.34.2"
+    "@img/sharp-win32-x64": "npm:0.34.2"
     color: "npm:^4.2.3"
-    detect-libc: "npm:^2.0.3"
-    semver: "npm:^7.7.1"
+    detect-libc: "npm:^2.0.4"
+    semver: "npm:^7.7.2"
   dependenciesMeta:
     "@img/sharp-darwin-arm64":
       optional: true
@@ -31538,11 +31480,13 @@ __metadata:
       optional: true
     "@img/sharp-wasm32":
       optional: true
+    "@img/sharp-win32-arm64":
+      optional: true
     "@img/sharp-win32-ia32":
       optional: true
     "@img/sharp-win32-x64":
       optional: true
-  checksum: 10/aecb960c0780b56134bfef01b7aeaa4e6650320a8a1f491237b45e900fc670830ee5d0600f30e51878328109db82e376bb526931d07a2e9358510ef30ab5abe8
+  checksum: 10/8c7a6f20d58849a6e33bc69c4525f471d57eb3dea0072331b55ab12bae4b8bd8b99b65264aeaec38e54d52d692db13e3261f6e7bc29430b39b507c409838cbb0
   languageName: node
   linkType: hard
 
@@ -32423,9 +32367,9 @@ __metadata:
   linkType: hard
 
 "strnum@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "strnum@npm:2.1.0"
-  checksum: 10/6237ecc0740816bb3088d89d8c17692f69b8c2a3d6bf25d6437ea40999d9afe28d1882496521d703804ce1ad3eeef71390073a6d39287ba1586d85ea360daa29
+  version: 2.1.1
+  resolution: "strnum@npm:2.1.1"
+  checksum: 10/d5fe6e4333cddc17569331048e403e876ffcf629989815f0359b0caf05dae9441b7eef3d7dd07427313ac8b3f05a8f60abc1f61efc15f97245dbc24028362bc9
   languageName: node
   linkType: hard
 
@@ -32720,9 +32664,9 @@ __metadata:
   linkType: hard
 
 "tapable@npm:^2.0.0, tapable@npm:^2.1.1, tapable@npm:^2.2.0, tapable@npm:^2.2.1":
-  version: 2.2.1
-  resolution: "tapable@npm:2.2.1"
-  checksum: 10/1769336dd21481ae6347611ca5fca47add0962fd8e80466515032125eca0084a4f0ede11e65341b9c0018ef4e1cf1ad820adbb0fba7cc99865c6005734000b0a
+  version: 2.2.2
+  resolution: "tapable@npm:2.2.2"
+  checksum: 10/065a0dc44aba1b32020faa1c27c719e8f76e5345347515d8494bf158524f36e9f22ad9eaa5b5494f9d5d67bf0640afdd5698505948c46d720b6b7e69d19349a6
   languageName: node
   linkType: hard
 
@@ -32804,16 +32748,16 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.10.0, terser@npm:^5.31.1":
-  version: 5.39.0
-  resolution: "terser@npm:5.39.0"
+  version: 5.39.2
+  resolution: "terser@npm:5.39.2"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
-    acorn: "npm:^8.8.2"
+    acorn: "npm:^8.14.0"
     commander: "npm:^2.20.0"
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10/d84aff642398329f7179bbeaca28cac76a86100e2372d98d39d9b86c48023b6b9f797d983d6e7c0610b3f957c53d01ada1befa25d625614cb2ccd20714f1e98b
+  checksum: 10/07fd3533858c42f01e942964818727cdeba59c3d49431066b68d640b57f7e854e5c473dc77a4ef38378ad288a8fa0c322bf56801fee6651b1fe4dc9d2b6869f0
   languageName: node
   linkType: hard
 
@@ -33158,11 +33102,11 @@ __metadata:
   linkType: hard
 
 "tree-dump@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "tree-dump@npm:1.0.2"
+  version: 1.0.3
+  resolution: "tree-dump@npm:1.0.3"
   peerDependencies:
     tslib: 2
-  checksum: 10/ddcde4da9ded8edc2fa77fc9153ef8d7fba9cd5f813db27c30c7039191b50e1512b7106f0f4fe7ccaa3aa69f85b4671eda7ed0b9f9d34781eb26ebe4593ad4eb
+  checksum: 10/cf382e61cfb5e3ff8f03425b5bc1923e8f0e385b3a02f43d9d0a32d09da9984477e0f2a7698628662263d1d3f1af17e33486c77ff454978f0f9f07fb5d1fe9a2
   languageName: node
   linkType: hard
 
@@ -33695,9 +33639,9 @@ __metadata:
   linkType: hard
 
 "universal-user-agent@npm:^7.0.0, universal-user-agent@npm:^7.0.2":
-  version: 7.0.2
-  resolution: "universal-user-agent@npm:7.0.2"
-  checksum: 10/3f02cb6de0bb9fbaf379566bd0320d8e46af6e4358a2e88fce7e70687ed7b48b37f479d728bb22f4204a518e363f3038ac4841c033af1ee2253f6428a6c67e53
+  version: 7.0.3
+  resolution: "universal-user-agent@npm:7.0.3"
+  checksum: 10/c497e85f8b11eb8fa4dce584d7a39cc98710164959f494cafc3c269b51abb20fff269951838efd7424d15f6b3d001507f3cb8b52bb5676fdb642019dfd17e63e
   languageName: node
   linkType: hard
 
@@ -34434,12 +34378,12 @@ __metadata:
   linkType: hard
 
 "watchpack@npm:^2.4.1":
-  version: 2.4.2
-  resolution: "watchpack@npm:2.4.2"
+  version: 2.4.4
+  resolution: "watchpack@npm:2.4.4"
   dependencies:
     glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
-  checksum: 10/6bd4c051d9af189a6c781c3158dcb3069f432a0c144159eeb0a44117412105c61b2b683a5c9eebc4324625e0e9b76536387d0ba354594fa6cbbdf1ef60bee4c3
+  checksum: 10/cfa3473fc12a1a1b88123056941e90c462a67aedc10b242229eeeccdd45ed0b763c3b591caaffb0f7d77295b539b5518bb1ad3bcd891ae6505dfeae4cf51fd15
   languageName: node
   linkType: hard
 
@@ -35047,11 +34991,11 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^2.3.1, yaml@npm:^2.5.1, yaml@npm:^2.7.1":
-  version: 2.7.1
-  resolution: "yaml@npm:2.7.1"
+  version: 2.8.0
+  resolution: "yaml@npm:2.8.0"
   bin:
     yaml: bin.mjs
-  checksum: 10/af57658d37c5efae4bac7204589b742ae01878a278554d632f01012868cf7fa66cba09b39140f12e7f6ceecc693ae52bcfb737596c4827e6e233338cb3a9528e
+  checksum: 10/7d4bd9c10d0e467601f496193f2ac254140f8e36f96f5ff7f852b9ce37974168eb7354f4c36dc8837dde527a2043d004b6aff48818ec24a69ab2dd3c6b6c381c
   languageName: node
   linkType: hard
 
@@ -35171,10 +35115,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.8, zod@npm:^3.24.1, zod@npm:^3.24.2":
-  version: 3.25.20
-  resolution: "zod@npm:3.25.20"
-  checksum: 10/530819cc55a4f5c1e9ce1e0507b8ca12dda1a30ef6f08272d99eb918112f840aec8404832326faab36e6838efc35c5a376302843a1b5ddced073ff6cd80ea601
+"zod@npm:^3.23.8, zod@npm:^3.24.1":
+  version: 3.25.23
+  resolution: "zod@npm:3.25.23"
+  checksum: 10/9152f700b4ed951795199455939a61a73d2435002a6ea1ddd664acc838a10c40452334e967f6fe8ae84cce201a4f042f4ab96a7dbe858ed0169c25498ad7121d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Replace react-router-dom with react-router
>In v7 we no longer need "react-router-dom" as the packages have been simplified. You can import everything from "react-router"  [source](https://reactrouter.com/upgrading/v6#upgrade-to-v7:~:text=In%20v7%20we%20no%20longer%20need%20%22react%2Drouter%2Ddom%22%20as%20the%20packages%20have%20been%20simplified.%20You%20can%20import%20everything%20from%20%22react%2Drouter%22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new navigation hook that provides improved error handling for asynchronous navigation actions.

- **Refactor**
  - Migrated all frontend packages from `react-router-dom` to `react-router` version 7, updating imports and routing logic throughout the application.
  - Updated navigation helpers and routing logic to use new navigation methods and error handling patterns.
  - Improved lazy-loading and route structure in several app modules for better maintainability.
  - Simplified router provider usage by removing fallback UI elements and experimental future flags.
  - Standardized navigation calls by replacing `openPage` with `jumpToPage` and `jumpToAll` where appropriate.

- **Bug Fixes**
  - Enhanced navigation error handling to provide user-friendly notifications on navigation failures.

- **Chores**
  - Updated dependencies across all frontend packages to use the latest `react-router` version.
  - Adjusted peer dependencies and Sentry integrations to support React Router v7.
  - Added export for the new async navigation hook in the core utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->