### PR TITLE
fix(core): cannot input space at the beginning of a blank paragraph

### DIFF
--- a/tests/affine-cloud-copilot/e2e/basic/guidance.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/basic/guidance.spec.ts
@@ -35,4 +35,20 @@ test.describe('AIBasic/Guidance', () => {
     await page.keyboard.press('Enter');
     await expect(page.locator('affine-ai-panel-widget')).not.toBeVisible();
   });
+
+  test('should hide AI panel and insert space back to editor when space is pressed on empty input', async ({
+    page,
+    utils,
+  }) => {
+    await utils.editor.focusToEditor(page);
+    await page.keyboard.press('Space');
+    await expect(page.locator('affine-ai-panel-widget')).toBeVisible();
+
+    await page.keyboard.press('Space');
+    await expect(page.locator('affine-ai-panel-widget')).not.toBeVisible();
+    await expect(async () => {
+      const content = await utils.editor.getEditorContent(page, false);
+      expect(content).toBe(' ');
+    }).toPass({ timeout: 5000 });
+  });
 });

--- a/tests/affine-cloud-copilot/e2e/utils/editor-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/editor-utils.ts
@@ -21,14 +21,20 @@ export class EditorUtils {
     await page.keyboard.press('Enter');
   }
 
-  public static async getEditorContent(page: Page) {
+  public static async getEditorContent(page: Page, trim = true) {
     let content = '';
     let retry = 3;
     while (!content && retry > 0) {
       const lines = await page.$$('page-editor .inline-editor');
       const contents = await Promise.all(lines.map(el => el.innerText()));
       content = contents
-        .map(c => c.replace(/[\u200B-\u200D\uFEFF]/g, '').trim())
+        .map(c => {
+          const invisibleFiltered = c.replace(/[\u200B-\u200D\uFEFF]/g, '');
+          if (trim) {
+            return invisibleFiltered.trim();
+          }
+          return invisibleFiltered;
+        })
         .filter(c => !!c)
         .join('\n');
       if (!content) {


### PR DESCRIPTION
### TL:DR

fix: cannot input space at the beginning of a blank paragraph 

> CLOSE BS-3427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved space key handling in the editor: pressing space on an empty AI input now hides the AI panel and inserts a space character back into the editor.

- **Bug Fixes**
  - Prevented the AI panel from processing empty input when space is pressed, ensuring smoother user experience.

- **Tests**
  - Added an end-to-end test verifying that pressing space on an empty AI input hides the AI panel and inserts a space.

- **Refactor**
  - Streamlined event handling logic for space key detection in the editor.

- **Chores**
  - Enhanced editor content retrieval to optionally preserve whitespace while removing invisible characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->