### PR TITLE
refactor(editor): rename doc to store on block components

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -79,7 +79,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
   };
 
   copy = () => {
-    const slice = Slice.fromModels(this.doc, [this.model]);
+    const slice = Slice.fromModels(this.store, [this.model]);
     this.std.clipboard.copySlice(slice).catch(console.error);
     toast(this.host, 'Copied to clipboard');
   };
@@ -133,9 +133,9 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
 
     this.refreshData();
 
-    if (!this.model.props.style && !this.doc.readonly) {
-      this.doc.withoutTransact(() => {
-        this.doc.updateBlock(this.model, {
+    if (!this.model.props.style && !this.store.readonly) {
+      this.store.withoutTransact(() => {
+        this.store.updateBlock(this.model, {
           style: AttachmentBlockStyles[1],
         });
       });

--- a/blocksuite/affine/blocks/bookmark/src/bookmark-block.ts
+++ b/blocksuite/affine/blocks/bookmark/src/bookmark-block.ts
@@ -127,7 +127,10 @@ export class BookmarkBlockComponent extends CaptionedBlockComponent<BookmarkBloc
   handleClick = (event: MouseEvent) => {
     event.stopPropagation();
 
-    if (this.model.parent?.flavour !== 'affine:surface' && !this.doc.readonly) {
+    if (
+      this.model.parent?.flavour !== 'affine:surface' &&
+      !this.store.readonly
+    ) {
       this.selectBlock();
     }
   };
@@ -184,7 +187,7 @@ export class BookmarkBlockComponent extends CaptionedBlockComponent<BookmarkBloc
     ) {
       // When the doc is readonly, and the preview data not provided
       // We should fetch the preview data and update the local link preview data
-      if (this.doc.readonly) {
+      if (this.store.readonly) {
         this._updateLocalLinkPreview();
         return;
       }

--- a/blocksuite/affine/blocks/bookmark/src/components/bookmark-card.ts
+++ b/blocksuite/affine/blocks/bookmark/src/components/bookmark-card.ts
@@ -61,7 +61,7 @@ export class BookmarkCard extends SignalWatcher(
 
     const theme = this.bookmark.std.get(ThemeProvider).theme;
     const { LoadingIcon, EmbedCardBannerIcon } = getEmbedCardIcons(theme);
-    const imageProxyService = this.bookmark.doc.get(ImageProxyService);
+    const imageProxyService = this.bookmark.store.get(ImageProxyService);
 
     const titleIcon = this.loading
       ? LoadingIcon

--- a/blocksuite/affine/blocks/bookmark/src/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/bookmark/src/configs/slash-menu.ts
@@ -26,7 +26,7 @@ const bookmarkSlashMenuConfig: SlashMenuConfig = {
         model.store.schema.flavourSchemaMap.has('affine:bookmark'),
       action: ({ std, model }) => {
         const { host } = std;
-        const parentModel = host.doc.getParent(model);
+        const parentModel = host.store.getParent(model);
         if (!parentModel) {
           return;
         }

--- a/blocksuite/affine/blocks/bookmark/src/utils.ts
+++ b/blocksuite/affine/blocks/bookmark/src/utils.ts
@@ -15,7 +15,7 @@ export async function refreshBookmarkUrlData(
   try {
     bookmarkElement.loading = true;
 
-    const linkPreviewer = bookmarkElement.doc.get(LinkPreviewerService);
+    const linkPreviewer = bookmarkElement.store.get(LinkPreviewerService);
     const bookmarkUrlData = await linkPreviewer.query(
       bookmarkElement.model.props.url,
       signal
@@ -32,7 +32,7 @@ export async function refreshBookmarkUrlData(
 
     if (signal?.aborted) return;
 
-    bookmarkElement.doc.updateBlock(bookmarkElement.model, {
+    bookmarkElement.store.updateBlock(bookmarkElement.model, {
       title,
       description,
       icon,

--- a/blocksuite/affine/blocks/code/src/code-block.ts
+++ b/blocksuite/affine/blocks/code/src/code-block.ts
@@ -68,7 +68,7 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
   }
 
   get readonly() {
-    return this.doc.readonly;
+    return this.store.readonly;
   }
 
   get langs() {
@@ -226,7 +226,7 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
         return;
       },
       Tab: ctx => {
-        if (this.doc.readonly) return;
+        if (this.store.readonly) return;
         const state = ctx.get('keyboardState');
         const event = state.raw;
         const inlineEditor = this.inlineEditor;
@@ -337,7 +337,7 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
         return;
       },
       Enter: () => {
-        this.doc.captureSync();
+        this.store.captureSync();
         return true;
       },
       'Mod-Enter': () => {
@@ -348,11 +348,16 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
         if (!inlineRange || !inlineEditor) return;
         const isEnd = model.props.text.length === inlineRange.index;
         if (!isEnd) return;
-        const parent = this.doc.getParent(model);
+        const parent = this.store.getParent(model);
         if (!parent) return;
         const index = parent.children.indexOf(model);
         if (index === -1) return;
-        const id = this.doc.addBlock('affine:paragraph', {}, parent, index + 1);
+        const id = this.store.addBlock(
+          'affine:paragraph',
+          {},
+          parent,
+          index + 1
+        );
         focusTextModel(std, id);
         return true;
       },
@@ -406,10 +411,10 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
           })}
           .yText=${this.model.props.text.yText}
           .inlineEventSource=${this.topContenteditableElement ?? nothing}
-          .undoManager=${this.doc.history}
+          .undoManager=${this.store.history}
           .attributesSchema=${this.inlineManager.getSchema()}
           .attributeRenderer=${this.inlineManager.getRenderer()}
-          .readonly=${this.doc.readonly}
+          .readonly=${this.store.readonly}
           .inlineRangeProvider=${this._inlineRangeProvider}
           .enableClipboard=${false}
           .enableUndoRedo=${false}
@@ -442,7 +447,7 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
   }
 
   setWrap(wrap: boolean) {
-    this.doc.updateBlock(this.model, { wrap });
+    this.store.updateBlock(this.model, { wrap });
   }
 
   @query('rich-text')

--- a/blocksuite/affine/blocks/code/src/code-toolbar/components/lang-button.ts
+++ b/blocksuite/affine/blocks/code/src/code-toolbar/components/lang-button.ts
@@ -49,7 +49,7 @@ export class LanguageListButton extends WithDisposable(
   private _abortController?: AbortController;
 
   private readonly _clickLangBtn = () => {
-    if (this.blockComponent.doc.readonly) return;
+    if (this.blockComponent.store.readonly) return;
     if (this._abortController) {
       // Close the language list if it's already opened.
       this._abortController.abort();
@@ -71,7 +71,7 @@ export class LanguageListButton extends WithDisposable(
           sortedBundledLanguages.splice(index, 1);
           sortedBundledLanguages.unshift(item);
         }
-        this.blockComponent.doc.transact(() => {
+        this.blockComponent.store.transact(() => {
           this.blockComponent.model.props.language$.value = item.name;
         });
       },
@@ -134,10 +134,10 @@ export class LanguageListButton extends WithDisposable(
       </div>`}
       height="24px"
       @click=${this._clickLangBtn}
-      ?disabled=${this.blockComponent.doc.readonly}
+      ?disabled=${this.blockComponent.store.readonly}
     >
       <span class="lang-button-icon" slot="suffix">
-        ${!this.blockComponent.doc.readonly ? ArrowDownIcon : nothing}
+        ${!this.blockComponent.store.readonly ? ArrowDownIcon : nothing}
       </span>
     </icon-button> `;
   }

--- a/blocksuite/affine/blocks/code/src/code-toolbar/components/preview-button.ts
+++ b/blocksuite/affine/blocks/code/src/code-toolbar/components/preview-button.ts
@@ -50,9 +50,9 @@ export class PreviewButton extends WithDisposable(SignalWatcher(LitElement)) {
   `;
 
   private readonly _toggle = (value: boolean) => {
-    if (this.blockComponent.doc.readonly) return;
+    if (this.blockComponent.store.readonly) return;
 
-    this.blockComponent.doc.updateBlock(this.blockComponent.model, {
+    this.blockComponent.store.updateBlock(this.blockComponent.model, {
       preview: value,
     });
   };

--- a/blocksuite/affine/blocks/code/src/code-toolbar/context.ts
+++ b/blocksuite/affine/blocks/code/src/code-toolbar/context.ts
@@ -8,7 +8,7 @@ export class CodeBlockToolbarContext extends MenuContext {
   };
 
   get doc() {
-    return this.blockComponent.doc;
+    return this.blockComponent.store;
   }
 
   get host() {

--- a/blocksuite/affine/blocks/data-view/src/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/data-view/src/configs/slash-menu.ts
@@ -26,16 +26,16 @@ export const dataViewSlashMenuConfig: SlashMenuConfig = {
 
       action: ({ model, std }) => {
         const { host } = std;
-        const parent = host.doc.getParent(model);
+        const parent = host.store.getParent(model);
         if (!parent) return;
         const index = parent.children.indexOf(model);
-        const id = host.doc.addBlock(
+        const id = host.store.addBlock(
           'affine:data-view',
           {},
-          host.doc.getParent(model),
+          host.store.getParent(model),
           index + 1
         );
-        const dataViewModel = host.doc.getBlock(id)!;
+        const dataViewModel = host.store.getBlock(id)!;
 
         const dataView = std.view.getBlock(
           dataViewModel.id

--- a/blocksuite/affine/blocks/data-view/src/data-source.ts
+++ b/blocksuite/affine/blocks/data-view/src/data-source.ts
@@ -60,7 +60,7 @@ export class BlockQueryDataSource extends DataSourceBase {
   }
 
   get workspace() {
-    return this.host.doc.workspace;
+    return this.host.store.workspace;
   }
 
   constructor(

--- a/blocksuite/affine/blocks/data-view/src/data-view-block.ts
+++ b/blocksuite/affine/blocks/data-view/src/data-view-block.ts
@@ -104,7 +104,7 @@ export class DataViewBlockComponent extends CaptionedBlockComponent<DataViewBloc
             prefix: CopyIcon,
             name: 'Copy',
             select: () => {
-              const slice = Slice.fromModels(this.doc, [this.model]);
+              const slice = Slice.fromModels(this.store, [this.model]);
               this.std.clipboard.copySlice(slice).catch(console.error);
             },
           }),
@@ -119,9 +119,9 @@ export class DataViewBlockComponent extends CaptionedBlockComponent<DataViewBloc
                 name: 'Delete Database',
                 select: () => {
                   this.model.children.slice().forEach(block => {
-                    this.doc.deleteBlock(block);
+                    this.store.deleteBlock(block);
                   });
-                  this.doc.deleteBlock(this.model);
+                  this.store.deleteBlock(this.model);
                 },
               }),
             ],
@@ -237,7 +237,7 @@ export class DataViewBlockComponent extends CaptionedBlockComponent<DataViewBloc
   }
 
   private renderDatabaseOps() {
-    if (this.doc.readonly) {
+    if (this.store.readonly) {
       return nothing;
     }
     return html` <div class="database-ops" @click="${this._clickDatabaseOps}">

--- a/blocksuite/affine/blocks/database/src/data-source.ts
+++ b/blocksuite/affine/blocks/database/src/data-source.ts
@@ -568,20 +568,20 @@ export const convertToDatabase = (host: EditorHost, viewType: string) => {
   const firstModel = selectedModels?.[0];
   if (!firstModel) return;
 
-  host.doc.captureSync();
+  host.store.captureSync();
 
-  const parentModel = host.doc.getParent(firstModel);
+  const parentModel = host.store.getParent(firstModel);
   if (!parentModel) {
     return;
   }
 
-  const id = host.doc.addBlock(
+  const id = host.store.addBlock(
     'affine:database',
     {},
     parentModel,
     parentModel.children.indexOf(firstModel)
   );
-  const databaseModel = host.doc.getBlock(id)?.model as
+  const databaseModel = host.store.getBlock(id)?.model as
     | DatabaseBlockModel
     | undefined;
   if (!databaseModel) {
@@ -589,7 +589,7 @@ export const convertToDatabase = (host: EditorHost, viewType: string) => {
   }
   const datasource = new DatabaseBlockDataSource(databaseModel);
   datasource.viewManager.viewAdd(viewType);
-  host.doc.moveBlocks(selectedModels, databaseModel);
+  host.store.moveBlocks(selectedModels, databaseModel);
 
   const selectionManager = host.selection;
   selectionManager.clear();

--- a/blocksuite/affine/blocks/database/src/database-block.ts
+++ b/blocksuite/affine/blocks/database/src/database-block.ts
@@ -120,7 +120,7 @@ export class DatabaseBlockComponent extends CaptionedBlockComponent<DatabaseBloc
           prefix: CopyIcon(),
           name: 'Copy',
           select: () => {
-            const slice = Slice.fromModels(this.doc, [this.model]);
+            const slice = Slice.fromModels(this.store, [this.model]);
             this.std.clipboard
               .copySlice(slice)
               .then(() => {
@@ -139,9 +139,9 @@ export class DatabaseBlockComponent extends CaptionedBlockComponent<DatabaseBloc
               name: 'Delete Database',
               select: () => {
                 this.model.children.slice().forEach(block => {
-                  this.doc.deleteBlock(block);
+                  this.store.deleteBlock(block);
                 });
-                this.doc.deleteBlock(this.model);
+                this.store.deleteBlock(this.model);
               },
             }),
           ],
@@ -258,18 +258,18 @@ export class DatabaseBlockComponent extends CaptionedBlockComponent<DatabaseBloc
       );
       return () => {
         this.indicator.remove();
-        const model = this.doc.getBlock(id)?.model;
+        const model = this.store.getBlock(id)?.model;
         const target = result.modelState.model;
-        let parent = this.doc.getParent(target.id);
+        let parent = this.store.getParent(target.id);
         const shouldInsertIn = result.placement === 'in';
         if (shouldInsertIn) {
           parent = target;
         }
         if (model && target && parent) {
           if (shouldInsertIn) {
-            this.doc.moveBlocks([model], parent);
+            this.store.moveBlocks([model], parent);
           } else {
-            this.doc.moveBlocks(
+            this.store.moveBlocks(
               [model],
               parent,
               target,

--- a/blocksuite/affine/blocks/database/src/detail-panel/block-renderer.ts
+++ b/blocksuite/affine/blocks/database/src/detail-panel/block-renderer.ts
@@ -74,7 +74,7 @@ export class BlockRenderer
   }
 
   get model() {
-    return this.host?.doc.getBlock(this.rowId)?.model;
+    return this.host?.store.getBlock(this.rowId)?.model;
   }
 
   override connectedCallback() {

--- a/blocksuite/affine/blocks/edgeless-text/src/edgeless-text-block.ts
+++ b/blocksuite/affine/blocks/edgeless-text/src/edgeless-text-block.ts
@@ -44,7 +44,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
   `;
 
   private readonly _resizeObserver = new ResizeObserver(() => {
-    if (this.doc.readonly) {
+    if (this.store.readonly) {
       return;
     }
 
@@ -60,7 +60,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
     const rect = this._textContainer.getBoundingClientRect();
     bound.h = rect.height / this.gfx.viewport.zoom;
 
-    this.doc.updateBlock(this.model, {
+    this.store.updateBlock(this.model, {
       xywh: bound.serialize(),
     });
   }
@@ -73,7 +73,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
       EDGELESS_TEXT_BLOCK_MIN_WIDTH * this.gfx.viewport.zoom
     );
 
-    this.doc.updateBlock(this.model, {
+    this.store.updateBlock(this.model, {
       xywh: bound.serialize(),
     });
   }
@@ -169,7 +169,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
           !firstChild ||
           !matchModels(firstChild, [ListBlockModel, ParagraphBlockModel])
         ) {
-          newParagraphId = this.doc.addBlock(
+          newParagraphId = this.store.addBlock(
             'affine:paragraph',
             {},
             this.model.id,
@@ -182,7 +182,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
           !lastChild ||
           !matchModels(lastChild, [ListBlockModel, ParagraphBlockModel])
         ) {
-          newParagraphId = this.doc.addBlock(
+          newParagraphId = this.store.addBlock(
             'affine:paragraph',
             {},
             this.model.id
@@ -284,7 +284,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
           }
 
           if (this.model.children.length === 0) {
-            const blockId = this.doc.addBlock(
+            const blockId = this.store.addBlock(
               'affine:paragraph',
               { type: 'text' },
               this.model.id
@@ -339,7 +339,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
       minWidth: !hasMaxWidth ? '220px' : undefined,
     };
 
-    this.contentEditable = String(editing && !this.doc.readonly$.value);
+    this.contentEditable = String(editing && !this.store.readonly$.value);
 
     return html`
       <div

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/configs/slash-menu.ts
@@ -25,7 +25,7 @@ const linkedDocSlashMenuConfig: SlashMenuConfig = {
       when: ({ model }) =>
         model.store.schema.flavourSchemaMap.has('affine:embed-linked-doc'),
       action: ({ std, model }) => {
-        const newDoc = createDefaultDoc(std.host.doc.workspace);
+        const newDoc = createDefaultDoc(std.host.store.workspace);
         insertContent(std, model, REFERENCE_NODE, {
           reference: {
             type: 'LinkedPage',

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -49,7 +49,7 @@ import { styles } from './styles.js';
 import { getEmbedLinkedDocIcons } from './utils.js';
 
 @Peekable({
-  enableOn: ({ doc }: EmbedLinkedDocBlockComponent) => !doc.readonly,
+  enableOn: ({ store }: EmbedLinkedDocBlockComponent) => !store.readonly,
 })
 export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinkedDocModel> {
   static override styles = styles;
@@ -124,7 +124,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
   };
 
   private readonly _setDocUpdatedAt = () => {
-    const meta = this.doc.workspace.meta.getDocMeta(this.model.props.pageId);
+    const meta = this.store.workspace.meta.getDocMeta(this.model.props.pageId);
     if (meta) {
       const date = meta.updatedDate || meta.createDate;
       this._docUpdatedAt = new Date(date);
@@ -249,7 +249,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
   }
 
   get readonly() {
-    return this.doc.readonly;
+    return this.store.readonly;
   }
 
   get isCitation() {
@@ -504,7 +504,7 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
 
       this._setDocUpdatedAt();
       this.disposables.add(
-        this.doc.workspace.slots.docListUpdated.subscribe(() => {
+        this.store.workspace.slots.docListUpdated.subscribe(() => {
           this._setDocUpdatedAt();
         })
       );
@@ -563,8 +563,8 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
     if (linkedDoc && style === 'horizontalThin') {
       bound.w = EMBED_CARD_WIDTH.horizontal;
       bound.h = EMBED_CARD_HEIGHT.horizontal;
-      this.doc.withoutTransact(() => {
-        this.doc.updateBlock(this.model, {
+      this.store.withoutTransact(() => {
+        this.store.updateBlock(this.model, {
           xywh: bound.serialize(),
           style: 'horizontal',
         });
@@ -572,8 +572,8 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
     } else if (!linkedDoc && style === 'horizontal') {
       bound.w = EMBED_CARD_WIDTH.horizontalThin;
       bound.h = EMBED_CARD_HEIGHT.horizontalThin;
-      this.doc.withoutTransact(() => {
-        this.doc.updateBlock(this.model, {
+      this.store.withoutTransact(() => {
+        this.store.updateBlock(this.model, {
           xywh: bound.serialize(),
           style: 'horizontalThin',
         });

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -48,7 +48,7 @@ import type { EmbedSyncedDocCard } from './components/embed-synced-doc-card.js';
 import { blockStyles } from './styles.js';
 
 @Peekable({
-  enableOn: ({ doc }: EmbedSyncedDocBlockComponent) => !doc.readonly,
+  enableOn: ({ store }: EmbedSyncedDocBlockComponent) => !store.readonly,
 })
 export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSyncedDocModel> {
   static override styles = blockStyles;
@@ -348,7 +348,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
 
   open = (event?: Partial<DocLinkClickedEvent>) => {
     const pageId = this.model.props.pageId;
-    if (pageId === this.doc.id) return;
+    if (pageId === this.store.id) return;
 
     this.std
       .getOptional(RefNodeSlotsProvider)
@@ -413,7 +413,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
     let editorHost: EditorHost | null = this.host;
     while (editorHost && !this._cycle) {
       this._cycle =
-        !!editorHost && editorHost.doc.id === this.model.props.pageId;
+        !!editorHost && editorHost.store.id === this.model.props.pageId;
       editorHost = editorHost.parentElement?.closest('editor-host') ?? null;
     }
   }
@@ -482,7 +482,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
   }
 
   private _setDocUpdatedAt() {
-    const meta = this.doc.workspace.meta.getDocMeta(this.model.props.pageId);
+    const meta = this.store.workspace.meta.getDocMeta(this.model.props.pageId);
     if (meta) {
       const date = meta.updatedDate || meta.createDate;
       this._docUpdatedAt = new Date(date);
@@ -518,7 +518,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
 
     this._setDocUpdatedAt();
     this.disposables.add(
-      this.doc.workspace.slots.docListUpdated.subscribe(() => {
+      this.store.workspace.slots.docListUpdated.subscribe(() => {
         this._setDocUpdatedAt();
       })
     );

--- a/blocksuite/affine/blocks/embed/src/common/insert-embed-card.ts
+++ b/blocksuite/affine/blocks/embed/src/common/insert-embed-card.ts
@@ -46,10 +46,10 @@ export function insertEmbedCard(
   if (blockId) {
     const block = host.view.getBlock(blockId);
     if (!block) return;
-    const parent = host.doc.getParent(block.model);
+    const parent = host.store.getParent(block.model);
     if (!parent) return;
     const index = parent.children.indexOf(block.model);
-    const cardId = host.doc.addBlock(
+    const cardId = host.store.addBlock(
       flavour as never,
       props,
       parent,

--- a/blocksuite/affine/blocks/embed/src/embed-figma-block/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-figma-block/configs/slash-menu.ts
@@ -22,7 +22,7 @@ export const embedFigmaSlashMenuConfig: SlashMenuConfig = {
       action: ({ std, model }) => {
         (async () => {
           const { host } = std;
-          const parentModel = host.doc.getParent(model);
+          const parentModel = host.store.getParent(model);
           if (!parentModel) {
             return;
           }

--- a/blocksuite/affine/blocks/embed/src/embed-figma-block/embed-figma-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-figma-block/embed-figma-block.ts
@@ -49,8 +49,8 @@ export class EmbedFigmaBlockComponent extends EmbedBlockComponent<EmbedFigmaMode
     this._cardStyle = this.model.props.style;
 
     if (!this.model.props.title) {
-      this.doc.withoutTransact(() => {
-        this.doc.updateBlock(this.model, {
+      this.store.withoutTransact(() => {
+        this.store.updateBlock(this.model, {
           title: 'Figma',
         });
       });

--- a/blocksuite/affine/blocks/embed/src/embed-github-block/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-github-block/configs/slash-menu.ts
@@ -22,7 +22,7 @@ export const embedGithubSlashMenuConfig: SlashMenuConfig = {
       action: ({ std, model }) => {
         (async () => {
           const { host } = std;
-          const parentModel = host.doc.getParent(model);
+          const parentModel = host.store.getParent(model);
           if (!parentModel) {
             return;
           }

--- a/blocksuite/affine/blocks/embed/src/embed-github-block/embed-github-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-github-block/embed-github-block.ts
@@ -83,12 +83,12 @@ export class EmbedGithubBlockComponent extends EmbedBlockComponent<
       !this.model.props.repo ||
       !this.model.props.githubId
     ) {
-      this.doc.withoutTransact(() => {
+      this.store.withoutTransact(() => {
         const url = this.model.props.url;
         const urlMatch = url.match(githubUrlRegex);
         if (urlMatch) {
           const [, owner, repo, githubType, githubId] = urlMatch;
-          this.doc.updateBlock(this.model, {
+          this.store.updateBlock(this.model, {
             owner,
             repo,
             githubType: githubType === 'issue' ? 'issue' : 'pr',
@@ -98,7 +98,7 @@ export class EmbedGithubBlockComponent extends EmbedBlockComponent<
       });
     }
 
-    this.doc.withoutTransact(() => {
+    this.store.withoutTransact(() => {
       if (!this.model.props.description && !this.model.props.title) {
         this.refreshData();
       } else {
@@ -132,7 +132,7 @@ export class EmbedGithubBlockComponent extends EmbedBlockComponent<
 
     const loading = this.loading;
     const theme = this.std.get(ThemeProvider).theme;
-    const imageProxyService = this.doc.get(ImageProxyService);
+    const imageProxyService = this.store.get(ImageProxyService);
     const { LoadingIcon, EmbedCardBannerIcon } = getEmbedCardIcons(theme);
     const titleIcon = loading ? LoadingIcon : GithubIcon;
     const statusIcon = status

--- a/blocksuite/affine/blocks/embed/src/embed-github-block/utils.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-github-block/utils.ts
@@ -110,7 +110,7 @@ export async function refreshEmbedGithubUrlData(
 
     if (signal?.aborted) return;
 
-    embedGithubElement.doc.updateBlock(embedGithubElement.model, {
+    embedGithubElement.store.updateBlock(embedGithubElement.model, {
       image,
       status,
       statusReason,
@@ -144,7 +144,7 @@ export async function refreshEmbedGithubStatus(
 
   if (!githubApiData.status || signal?.aborted) return;
 
-  embedGithubElement.doc.updateBlock(embedGithubElement.model, {
+  embedGithubElement.store.updateBlock(embedGithubElement.model, {
     status: githubApiData.status,
     statusReason: githubApiData.statusReason,
     createdAt: githubApiData.createdAt,

--- a/blocksuite/affine/blocks/embed/src/embed-iframe-block/commands/insert-embed-iframe-with-url.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-iframe-block/commands/insert-embed-iframe-with-url.ts
@@ -56,10 +56,10 @@ export const insertEmbedIframeWithUrlCommand: Command<
   if (selectedBlockId) {
     const block = host.view.getBlock(selectedBlockId);
     if (!block) return;
-    const parent = host.doc.getParent(block.model);
+    const parent = host.store.getParent(block.model);
     if (!parent) return;
     const index = parent.children.indexOf(block.model);
-    newBlockId = host.doc.addBlock(flavour, props, parent, index + 1);
+    newBlockId = host.store.addBlock(flavour, props, parent, index + 1);
   } else {
     // When there is no selected block and in edgeless mode
     // We should insert the embed iframe block to surface

--- a/blocksuite/affine/blocks/embed/src/embed-iframe-block/embed-iframe-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-iframe-block/embed-iframe-block.ts
@@ -177,7 +177,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
 
       // update model
       const iframeUrl = this._getIframeUrl(embedData) ?? currentIframeUrl;
-      this.doc.updateBlock(this.model, {
+      this.store.updateBlock(this.model, {
         iframeUrl,
         title: embedData?.title || previewData?.title,
         description: embedData?.description || previewData?.description,
@@ -373,7 +373,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
 
     // if the iframe url is not set, refresh the data to get the iframe url
     if (!this.model.props.iframeUrl) {
-      this.doc.withoutTransact(() => {
+      this.store.withoutTransact(() => {
         this.refreshData().catch(console.error);
       });
     } else {
@@ -452,7 +452,7 @@ export class EmbedIframeBlockComponent extends CaptionedBlockComponent<EmbedIfra
   };
 
   get readonly() {
-    return this.doc.readonly;
+    return this.store.readonly;
   }
 
   get selectionManager() {

--- a/blocksuite/affine/blocks/embed/src/embed-loom-block/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-loom-block/configs/slash-menu.ts
@@ -22,7 +22,7 @@ export const embedLoomSlashMenuConfig: SlashMenuConfig = {
       action: ({ std, model }) => {
         (async () => {
           const { host } = std;
-          const parentModel = host.doc.getParent(model);
+          const parentModel = host.store.getParent(model);
           if (!parentModel) {
             return;
           }

--- a/blocksuite/affine/blocks/embed/src/embed-loom-block/embed-loom-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-loom-block/embed-loom-block.ts
@@ -60,12 +60,12 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
     this._cardStyle = this.model.props.style;
 
     if (!this.model.props.videoId) {
-      this.doc.withoutTransact(() => {
+      this.store.withoutTransact(() => {
         const url = this.model.props.url;
         const urlMatch = url.match(loomUrlRegex);
         if (urlMatch) {
           const [, videoId] = urlMatch;
-          this.doc.updateBlock(this.model, {
+          this.store.updateBlock(this.model, {
             videoId,
           });
         }
@@ -73,7 +73,7 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
     }
 
     if (!this.model.props.description && !this.model.props.title) {
-      this.doc.withoutTransact(() => {
+      this.store.withoutTransact(() => {
         this.refreshData();
       });
     }
@@ -93,7 +93,7 @@ export class EmbedLoomBlockComponent extends EmbedBlockComponent<
 
     const loading = this.loading;
     const theme = this.std.get(ThemeProvider).theme;
-    const imageProxyService = this.doc.get(ImageProxyService);
+    const imageProxyService = this.store.get(ImageProxyService);
     const { LoadingIcon, EmbedCardBannerIcon } = getEmbedCardIcons(theme);
     const titleIcon = loading ? LoadingIcon : LoomIcon;
     const titleText = loading ? 'Loading...' : title;

--- a/blocksuite/affine/blocks/embed/src/embed-loom-block/utils.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-loom-block/utils.ts
@@ -62,7 +62,7 @@ export async function refreshEmbedLoomUrlData(
 
     if (signal?.aborted) return;
 
-    embedLoomElement.doc.updateBlock(embedLoomElement.model, {
+    embedLoomElement.store.updateBlock(embedLoomElement.model, {
       title,
       description,
       image,

--- a/blocksuite/affine/blocks/embed/src/embed-youtube-block/configs/slash-menu.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-youtube-block/configs/slash-menu.ts
@@ -22,7 +22,7 @@ export const embedYoutubeSlashMenuConfig: SlashMenuConfig = {
       action: ({ std, model }) => {
         (async () => {
           const { host } = std;
-          const parentModel = host.doc.getParent(model);
+          const parentModel = host.store.getParent(model);
           if (!parentModel) {
             return;
           }

--- a/blocksuite/affine/blocks/embed/src/embed-youtube-block/embed-youtube-block.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-youtube-block/embed-youtube-block.ts
@@ -63,12 +63,12 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
     this._cardStyle = this.model.props.style;
 
     if (!this.model.props.videoId) {
-      this.doc.withoutTransact(() => {
+      this.store.withoutTransact(() => {
         const url = this.model.props.url;
         const urlMatch = url.match(youtubeUrlRegex);
         if (urlMatch) {
           const [, videoId] = urlMatch;
-          this.doc.updateBlock(this.model, {
+          this.store.updateBlock(this.model, {
             videoId,
           });
         }
@@ -76,7 +76,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
     }
 
     if (!this.model.props.description && !this.model.props.title) {
-      this.doc.withoutTransact(() => {
+      this.store.withoutTransact(() => {
         this.refreshData();
       });
     }
@@ -107,7 +107,7 @@ export class EmbedYoutubeBlockComponent extends EmbedBlockComponent<
 
     const loading = this.loading;
     const theme = this.std.get(ThemeProvider).theme;
-    const imageProxyService = this.doc.get(ImageProxyService);
+    const imageProxyService = this.store.get(ImageProxyService);
     const { LoadingIcon, EmbedCardBannerIcon } = getEmbedCardIcons(theme);
     const titleIcon = loading ? LoadingIcon : YoutubeIcon;
     const titleText = loading ? 'Loading...' : title;

--- a/blocksuite/affine/blocks/embed/src/embed-youtube-block/utils.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-youtube-block/utils.ts
@@ -97,7 +97,7 @@ export async function refreshEmbedYoutubeUrlData(
 
     if (signal?.aborted) return;
 
-    embedYoutubeElement.doc.updateBlock(embedYoutubeElement.model, {
+    embedYoutubeElement.store.updateBlock(embedYoutubeElement.model, {
       image,
       title,
       description,

--- a/blocksuite/affine/blocks/frame/src/edgeless-toolbar/presentation-toolbar.ts
+++ b/blocksuite/affine/blocks/frame/src/edgeless-toolbar/presentation-toolbar.ts
@@ -176,7 +176,7 @@ export class PresentationToolbar extends EdgelessToolbarToolMixin(
   private _exitPresentation() {
     // When exit presentation mode, we need to set the tool to default or pan
     // And exit fullscreen
-    if (this.edgeless.doc.readonly) {
+    if (this.edgeless.store.readonly) {
       this.setEdgelessTool(PanTool, { panning: false });
     } else {
       this.setEdgelessTool(DefaultTool);
@@ -316,7 +316,7 @@ export class PresentationToolbar extends EdgelessToolbarToolMixin(
           this.edgelessTool.toolType === PresentTool &&
           this._fullScreenMode
         ) {
-          if (this.edgeless.doc.readonly) {
+          if (this.edgeless.store.readonly) {
             this.setEdgelessTool(PanTool, { panning: false });
           } else {
             this.setEdgelessTool(DefaultTool);

--- a/blocksuite/affine/blocks/frame/src/edgeless-toolbar/quick-tool.ts
+++ b/blocksuite/affine/blocks/frame/src/edgeless-toolbar/quick-tool.ts
@@ -10,7 +10,7 @@ export const frameQuickTool = QuickToolExtension('frame', ({ block, gfx }) => {
       .edgeless=${block}
     ></edgeless-frame-tool-button>`,
     menu: buildFrameDenseMenu(block, gfx),
-    enable: !block.doc.readonly,
+    enable: !block.store.readonly,
     priority: 90,
   };
 });

--- a/blocksuite/affine/blocks/frame/src/frame-block.ts
+++ b/blocksuite/affine/blocks/frame/src/frame-block.ts
@@ -13,7 +13,7 @@ export class FrameBlockComponent extends GfxBlockComponent<FrameBlockModel> {
     super.connectedCallback();
 
     this._disposables.add(
-      this.doc.slots.blockUpdated.subscribe(({ type, id }) => {
+      this.store.slots.blockUpdated.subscribe(({ type, id }) => {
         if (id === this.model.id && type === 'update') {
           this.requestUpdate();
         }

--- a/blocksuite/affine/blocks/frame/src/present/frame-order-button.ts
+++ b/blocksuite/affine/blocks/frame/src/present/frame-order-button.ts
@@ -38,7 +38,7 @@ export class EdgelessFrameOrderButton extends WithDisposable(LitElement) {
   }
 
   protected override render() {
-    const { readonly } = this.edgeless.doc;
+    const { readonly } = this.edgeless.store;
     return html`
       <style>
         .edgeless-frame-order-button svg {

--- a/blocksuite/affine/blocks/frame/src/present/frame-order-menu.ts
+++ b/blocksuite/affine/blocks/frame/src/present/frame-order-menu.ts
@@ -193,7 +193,7 @@ export class EdgelessFrameOrderMenu extends SignalWatcher(
           this.crud.updateElement(frame.id, {
             presentationIndex: generateKeyBetweenV2(before, after),
           });
-          this.edgeless.doc.captureSync();
+          this.edgeless.store.captureSync();
 
           this.requestUpdate();
         }

--- a/blocksuite/affine/blocks/image/src/components/page-image-block.ts
+++ b/blocksuite/affine/blocks/image/src/components/page-image-block.ts
@@ -65,7 +65,7 @@ export class ImageBlockPageComponent extends WithDisposable(ShadowlessElement) {
   private _isDragging = false;
 
   private get _doc() {
-    return this.block.doc;
+    return this.block.store;
   }
 
   private get _host() {
@@ -128,21 +128,21 @@ export class ImageBlockPageComponent extends WithDisposable(ShadowlessElement) {
         return true;
       },
       Delete: ctx => {
-        if (this._host.doc.readonly || !this._isSelected) return;
+        if (this._host.store.readonly || !this._isSelected) return;
 
         addParagraph(ctx);
         this._doc.deleteBlock(this._model);
         return true;
       },
       Backspace: ctx => {
-        if (this._host.doc.readonly || !this._isSelected) return;
+        if (this._host.store.readonly || !this._isSelected) return;
 
         addParagraph(ctx);
         this._doc.deleteBlock(this._model);
         return true;
       },
       Enter: ctx => {
-        if (this._host.doc.readonly || !this._isSelected) return;
+        if (this._host.store.readonly || !this._isSelected) return;
 
         addParagraph(ctx);
         return true;

--- a/blocksuite/affine/blocks/image/src/utils.ts
+++ b/blocksuite/affine/blocks/image/src/utils.ts
@@ -108,7 +108,7 @@ export async function resetImageSize(
   const xywh = bound.serialize();
   const props: Partial<ImageBlockProps> = { ...imageSize, xywh };
 
-  block.doc.updateBlock(model, props);
+  block.store.updateBlock(model, props);
 }
 
 function convertToPng(blob: Blob): Promise<Blob | null> {
@@ -193,7 +193,7 @@ export async function copyImageBlob(
 export async function turnImageIntoCardView(
   block: ImageBlockComponent | ImageEdgelessBlockComponent
 ) {
-  const doc = block.doc;
+  const doc = block.store;
   if (!doc.schema.flavourSchemaMap.has('affine:attachment')) {
     console.error('The attachment flavour is not supported!');
     return;

--- a/blocksuite/affine/blocks/latex/src/latex-block.ts
+++ b/blocksuite/affine/blocks/latex/src/latex-block.ts
@@ -77,7 +77,7 @@ export class LatexBlockComponent extends CaptionedBlockComponent<LatexBlockModel
 
     this.disposables.addFromEvent(this, 'click', () => {
       // should not open editor or select block in readonly mode
-      if (this.doc.readonly) {
+      if (this.store.readonly) {
         return;
       }
 

--- a/blocksuite/affine/blocks/list/src/commands/convert-to-numbered-list.ts
+++ b/blocksuite/affine/blocks/list/src/commands/convert-to-numbered-list.ts
@@ -13,12 +13,12 @@ export const convertToNumberedListCommand: Command<
 > = (ctx, next) => {
   const { std, id, order, stopCapturing = true } = ctx;
   const host = std.host as EditorHost;
-  const doc = host.doc;
+  const doc = host.store;
 
   const model = doc.getBlock(id)?.model;
   if (!model || !model.text) return;
 
-  if (stopCapturing) host.doc.captureSync();
+  if (stopCapturing) host.store.captureSync();
 
   const listConvertedId = toNumberedList(std, model, order);
 

--- a/blocksuite/affine/blocks/list/src/commands/split-list.ts
+++ b/blocksuite/affine/blocks/list/src/commands/split-list.ts
@@ -15,7 +15,7 @@ export const splitListCommand: Command<{
 }> = (ctx, next) => {
   const { blockId, inlineIndex, std } = ctx;
   const host = std.host as EditorHost;
-  const doc = host.doc;
+  const doc = host.store;
 
   const model = doc.getBlock(blockId)?.model;
   if (!model || !matchModels(model, [ListBlockModel])) {

--- a/blocksuite/affine/blocks/list/src/list-block.ts
+++ b/blocksuite/affine/blocks/list/src/list-block.ts
@@ -39,22 +39,22 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
     e.preventDefault();
 
     if (this.model.props.type === 'toggle') {
-      if (this.doc.readonly) {
+      if (this.store.readonly) {
         this._readonlyCollapsed = !this._readonlyCollapsed;
       } else {
-        this.doc.captureSync();
-        this.doc.updateBlock(this.model, {
+        this.store.captureSync();
+        this.store.updateBlock(this.model, {
           collapsed: !this.model.props.collapsed,
         });
       }
 
       return;
     } else if (this.model.props.type === 'todo') {
-      if (this.doc.readonly) return;
+      if (this.store.readonly) return;
 
-      this.doc.captureSync();
+      this.store.captureSync();
       const checkedPropObj = { checked: !this.model.props.checked };
-      this.doc.updateBlock(this.model, checkedPropObj);
+      this.store.updateBlock(this.model, checkedPropObj);
       if (this.model.props.checked) {
         const checkEl = this.querySelector('.affine-list-block__todo-prefix');
         if (checkEl) {
@@ -120,7 +120,7 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
         const order = this.model.props.order$.value;
         // old numbered list has no order
         if (type === 'numbered' && !Number.isInteger(order)) {
-          correctNumberedListsOrderToPrev(this.doc, this.model, false);
+          correctNumberedListsOrderToPrev(this.store, this.model, false);
         }
         // if list is not numbered, order should be null
         if (type !== 'numbered' && order !== null) {
@@ -138,7 +138,7 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
 
   override renderBlock(): TemplateResult<1> {
     const { model, _onClickIcon } = this;
-    const collapsed = this.doc.readonly
+    const collapsed = this.store.readonly
       ? this._readonlyCollapsed
       : model.props.collapsed;
 
@@ -169,11 +169,11 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
                 <blocksuite-toggle-button
                   .collapsed=${collapsed}
                   .updateCollapsed=${(value: boolean) => {
-                    if (this.doc.readonly) {
+                    if (this.store.readonly) {
                       this._readonlyCollapsed = value;
                     } else {
-                      this.doc.captureSync();
-                      this.doc.updateBlock(this.model, {
+                      this.store.captureSync();
+                      this.store.updateBlock(this.model, {
                         collapsed: value,
                       });
                     }
@@ -185,12 +185,12 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
           <rich-text
             .yText=${this.model.props.text.yText}
             .inlineEventSource=${this.topContenteditableElement ?? nothing}
-            .undoManager=${this.doc.history}
+            .undoManager=${this.store.history}
             .attributeRenderer=${this.attributeRenderer}
             .attributesSchema=${this.attributesSchema}
             .markdownMatches=${this.inlineManager?.markdownMatches}
             .embedChecker=${this.embedChecker}
-            .readonly=${this.doc.readonly}
+            .readonly=${this.store.readonly}
             .inlineRangeProvider=${this._inlineRangeProvider}
             .enableClipboard=${false}
             .enableUndoRedo=${false}

--- a/blocksuite/affine/blocks/note/src/commands/block-type.ts
+++ b/blocksuite/affine/blocks/note/src/commands/block-type.ts
@@ -68,7 +68,7 @@ export const updateBlockType: Command<
 
   const blockModels = selectedBlocks.map(ele => ele.model);
 
-  const hasSameDoc = selectedBlocks.every(block => block.doc === doc);
+  const hasSameDoc = selectedBlocks.every(block => block.store === doc);
   if (!hasSameDoc) {
     // doc check
     console.error(

--- a/blocksuite/affine/blocks/note/src/components/edgeless-note-background.ts
+++ b/blocksuite/affine/blocks/note/src/components/edgeless-note-background.ts
@@ -66,7 +66,7 @@ export class EdgelessNoteBackground extends SignalWatcher(
   }
 
   get doc() {
-    return this.std.host.doc;
+    return this.std.host.store;
   }
 
   private _tryAddParagraph(x: number, y: number) {
@@ -137,7 +137,7 @@ export class EdgelessNoteBackground extends SignalWatcher(
     const y = clamp(e.y, rect.top + offsetY, rect.bottom - offsetY);
     handleNativeRangeAtPoint(x, y);
 
-    if (this.std.host.doc.readonly) return;
+    if (this.std.host.store.readonly) return;
 
     this._tryAddParagraph(x, y);
   }

--- a/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
@@ -298,7 +298,7 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
               .note=${this.model}
             ></edgeless-page-block-title>
             <div
-              contenteditable=${String(!this.doc.readonly$.value)}
+              contenteditable=${String(!this.store.readonly$.value)}
               class="edgeless-note-page-content"
             >
               ${this.renderPageContent()}
@@ -362,7 +362,7 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
           }
 
           if (this.model.children.length === 0) {
-            const blockId = this.doc.addBlock(
+            const blockId = this.store.addBlock(
               'affine:paragraph',
               { type: 'text' },
               this.model.id

--- a/blocksuite/affine/blocks/paragraph/src/paragraph-block.ts
+++ b/blocksuite/affine/blocks/paragraph/src/paragraph-block.ts
@@ -125,7 +125,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
     this.disposables.add(
       effect(() => {
         const composing = this._composing.value;
-        if (composing || this.doc.readonly) {
+        if (composing || this.store.readonly) {
           this._displayPlaceholder.value = false;
           return;
         }
@@ -197,7 +197,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
             nearestHeading &&
             nearestHeading.props.type.startsWith('h') &&
             nearestHeading.props.collapsed &&
-            !this.doc.readonly
+            !this.store.readonly
           ) {
             nearestHeading.props.collapsed = false;
           }
@@ -215,7 +215,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
 
   override renderBlock(): TemplateResult<1> {
     const { type$ } = this.model.props;
-    const collapsed = this.doc.readonly
+    const collapsed = this.store.readonly
       ? this._readonlyCollapsed
       : this.model.props.collapsed;
     const collapsedSiblings = this.collapsedSiblings;
@@ -278,11 +278,11 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
                 <blocksuite-toggle-button
                   .collapsed=${collapsed}
                   .updateCollapsed=${(value: boolean) => {
-                    if (this.doc.readonly) {
+                    if (this.store.readonly) {
                       this._readonlyCollapsed = value;
                     } else {
-                      this.doc.captureSync();
-                      this.doc.updateBlock(this.model, {
+                      this.store.captureSync();
+                      this.store.updateBlock(this.model, {
                         collapsed: value,
                       });
                     }
@@ -293,12 +293,12 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
           <rich-text
             .yText=${this.model.props.text.yText}
             .inlineEventSource=${this.topContenteditableElement ?? nothing}
-            .undoManager=${this.doc.history}
+            .undoManager=${this.store.history}
             .attributesSchema=${this.attributesSchema}
             .attributeRenderer=${this.attributeRenderer}
             .markdownMatches=${this.inlineManager?.markdownMatches}
             .embedChecker=${this.embedChecker}
-            .readonly=${this.doc.readonly}
+            .readonly=${this.store.readonly}
             .inlineRangeProvider=${this._inlineRangeProvider}
             .enableClipboard=${false}
             .enableUndoRedo=${false}

--- a/blocksuite/affine/blocks/root/src/edgeless/components/auto-complete/auto-complete-panel.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/components/auto-complete/auto-complete-panel.ts
@@ -174,7 +174,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
       presentationIndex: frameMgr.generatePresentationIndex(),
     });
     const id = this.crud.addBlock('affine:frame', props, surfaceBlockModel);
-    edgeless.doc.captureSync();
+    edgeless.store.captureSync();
     const frame = this.crud.getElementById(id);
     if (!frame) return;
 
@@ -190,7 +190,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
   }
 
   private _addNote() {
-    const { doc } = this.edgeless;
+    const { store } = this.edgeless;
     const target = this._getTargetXYWH(
       DEFAULT_NOTE_WIDTH,
       DEFAULT_NOTE_OVERLAY_HEIGHT
@@ -203,13 +203,13 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
       {
         xywh: serializeXYWH(...xywh),
       },
-      doc.root?.id
+      store.root?.id
     );
-    const note = doc.getBlock(id)?.model;
+    const note = store.getBlock(id)?.model;
     if (!matchModels(note, [NoteBlockModel])) {
       return;
     }
-    doc.addBlock('affine:paragraph', { type: 'text' }, id);
+    store.addBlock('affine:paragraph', { type: 'text' }, id);
     const group = this.currentSource.group;
 
     if (group instanceof GroupElementModel) {
@@ -251,7 +251,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
       elements: [id],
       editing: true,
     });
-    edgeless.doc.captureSync();
+    edgeless.store.captureSync();
   }
 
   private _addText() {
@@ -260,7 +260,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
     const { xywh, position } = target;
     const bound = Bound.fromXYWH(xywh);
 
-    const textFlag = this.edgeless.doc
+    const textFlag = this.edgeless.store
       .get(FeatureFlagService)
       .getFlag('enable_edgeless_text');
     if (textFlag) {
@@ -287,7 +287,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
         elements: [textId],
         editing: false,
       });
-      this.edgeless.doc.captureSync();
+      this.edgeless.store.captureSync();
     } else {
       const textId = this.crud.addElement(CanvasElementType.TEXT, {
         xywh: bound.serialize(),
@@ -316,7 +316,7 @@ export class EdgelessAutoCompletePanel extends WithDisposable(LitElement) {
         elements: [textId],
         editing: false,
       });
-      this.edgeless.doc.captureSync();
+      this.edgeless.store.captureSync();
 
       mountTextElementEditor(textElement, this.edgeless);
     }

--- a/blocksuite/affine/blocks/root/src/edgeless/components/auto-complete/edgeless-auto-complete.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/components/auto-complete/edgeless-auto-complete.ts
@@ -371,7 +371,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
   }
 
   private _generateElementOnClick(type: Direction) {
-    const { doc } = this.edgeless;
+    const { store } = this.edgeless;
     const bound = this._computeNextBound(type);
     const id = createEdgelessElement(this.edgeless, this.current, bound);
     if (!id) return;
@@ -393,7 +393,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
         this.edgeless
       );
     } else {
-      const model = doc.getModelById(id);
+      const model = store.getModelById(id);
       if (!model) {
         return;
       }

--- a/blocksuite/affine/blocks/root/src/edgeless/components/auto-complete/utils.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/components/auto-complete/utils.ts
@@ -288,8 +288,8 @@ export function createEdgelessElement(
     if (!id) return null;
     element = crud.getElementById(id);
   } else {
-    const { doc } = edgeless;
-    id = doc.addBlock(
+    const { store } = edgeless;
+    id = store.addBlock(
       'affine:note',
       {
         background: current.props.background,
@@ -299,7 +299,7 @@ export function createEdgelessElement(
       },
       edgeless.model.id
     );
-    const note = doc.getBlock(id)?.model;
+    const note = store.getBlock(id)?.model;
     if (!note) {
       throw new BlockSuiteError(
         ErrorCode.GfxBlockElementError,
@@ -307,10 +307,10 @@ export function createEdgelessElement(
       );
     }
     assertType<NoteBlockModel>(note);
-    doc.updateBlock(note, () => {
+    store.updateBlock(note, () => {
       note.props.edgeless.collapse = true;
     });
-    doc.addBlock('affine:paragraph', {}, note.id);
+    store.addBlock('affine:paragraph', {}, note.id);
 
     element = note;
   }

--- a/blocksuite/affine/blocks/root/src/edgeless/components/note-slicer/index.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/components/note-slicer/index.ts
@@ -152,7 +152,7 @@ export class NoteSlicer extends WidgetComponent<RootBlockModel> {
 
   private _sliceNote() {
     if (!this._anchorNote || !this._noteBlockIds.length) return;
-    const doc = this.doc;
+    const doc = this.store;
 
     const {
       index: originalIndex,
@@ -177,7 +177,7 @@ export class NoteSlicer extends WidgetComponent<RootBlockModel> {
     const sliceVerticalPos =
       this._divingLinePositions[this._activeSlicerIndex].y;
     const newY = this.gfx.viewport.toModelCoord(x, sliceVerticalPos)[1];
-    const newNoteId = this.doc.addBlock(
+    const newNoteId = this.store.addBlock(
       'affine:note',
       {
         background,
@@ -364,7 +364,7 @@ export class NoteSlicer extends WidgetComponent<RootBlockModel> {
 
   override render() {
     if (
-      this.doc.readonly ||
+      this.store.readonly ||
       this._hidden ||
       this._isResizing ||
       !this._anchorNote ||

--- a/blocksuite/affine/blocks/root/src/edgeless/components/rects/edgeless-selected-rect.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/components/rects/edgeless-selected-rect.ts
@@ -477,7 +477,7 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
   private readonly _onDragEnd = () => {
     this.slots.dragEnd.next();
 
-    this.doc.transact(() => {
+    this.store.transact(() => {
       this._dragEndCallback.forEach(cb => cb());
     });
 
@@ -1210,7 +1210,7 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
     this._isHeightLimit = bound.h === NOTE_MIN_HEIGHT * scale;
 
     if (bound.h > NOTE_MIN_HEIGHT * scale) {
-      this.doc.updateBlock(element, () => {
+      this.store.updateBlock(element, () => {
         element.props.edgeless.collapse = true;
         element.props.edgeless.collapsedHeight = bound.h / scale;
       });
@@ -1393,7 +1393,7 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
     }
 
     _disposables.add(
-      this.doc.slots.blockUpdated.subscribe(this._updateOnElementChange)
+      this.store.slots.blockUpdated.subscribe(this._updateOnElementChange)
     );
 
     _disposables.add(
@@ -1464,14 +1464,14 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
     const {
       block,
       gfx,
-      doc,
+      store,
       resizeMode,
       _resizeManager,
       _selectedRect,
       _updateCursor,
     } = this;
 
-    const hasResizeHandles = !selection.editing && !doc.readonly;
+    const hasResizeHandles = !selection.editing && !store.readonly;
     const inoperable = selection.inoperable;
     const hasElementLocked = elements.some(element => element.isLocked());
     const handlers = [];
@@ -1578,7 +1578,7 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<
         }
       </style>
 
-      ${!doc.readonly && !inoperable && this._canAutoComplete()
+      ${!store.readonly && !inoperable && this._canAutoComplete()
         ? html`<edgeless-auto-complete
             .current=${this.selection.selectedElements[0]}
             .edgeless=${block}

--- a/blocksuite/affine/blocks/root/src/edgeless/configs/toolbar/render-linked-doc.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/configs/toolbar/render-linked-doc.ts
@@ -52,8 +52,8 @@ export function createLinkedDocFromEdgelessElements(
   elements: GfxModel[],
   docTitle?: string
 ) {
-  const _doc = host.doc.workspace.createDoc();
-  const transformer = host.doc.getTransformer();
+  const _doc = host.store.workspace.createDoc();
+  const transformer = host.store.getTransformer();
   const linkedDoc = _doc.getStore();
   linkedDoc.load(() => {
     const rootId = linkedDoc.addBlock('affine:page', {

--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
@@ -465,7 +465,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           !event.metaKey
         ) {
           const elements = selection.selectedElements;
-          const doc = this.rootComponent.doc;
+          const doc = this.rootComponent.store;
 
           if (isSingleMindMapNode(elements)) {
             const target = gfx.getElementById(

--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
@@ -407,7 +407,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
               elements[0].id
             ) as ShapeElementModel;
             if (target.text) {
-              this.doc.transact(() => {
+              this.store.transact(() => {
                 target.text!.delete(0, target.text!.length);
                 target.text!.insert(0, key);
               });
@@ -467,7 +467,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
     this._initPanEvent();
     this._initPinchEvent();
 
-    if (this.doc.readonly) {
+    if (this.store.readonly) {
       this.gfx.tool.setTool(PanTool, { panning: true });
     } else {
       this.gfx.tool.setTool(DefaultTool);

--- a/blocksuite/affine/blocks/root/src/edgeless/utils/crud.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/utils/crud.ts
@@ -25,10 +25,10 @@ export function deleteElements(
 
   set.forEach(element => {
     if (isNoteBlock(element)) {
-      const children = edgeless.doc.root?.children ?? [];
+      const children = edgeless.store.root?.children ?? [];
       // FIXME: should always keep at least 1 note
       if (children.length > 1) {
-        edgeless.doc.deleteBlock(element);
+        edgeless.store.deleteBlock(element);
       }
     } else {
       service.removeElement(element.id);

--- a/blocksuite/affine/blocks/root/src/keyboard/keyboard-manager.ts
+++ b/blocksuite/affine/blocks/root/src/keyboard/keyboard-manager.ts
@@ -74,7 +74,7 @@ export class PageKeyboardManager {
   }
 
   private get _doc() {
-    return this.rootComponent.doc;
+    return this.rootComponent.store;
   }
 
   private get _selection() {
@@ -143,7 +143,7 @@ export class PageKeyboardManager {
       return;
     }
 
-    const doc = rootComponent.host.doc;
+    const doc = rootComponent.host.store;
     const autofill = getTitleFromSelectedModels(
       selectedModels.map(toDraftModel)
     );

--- a/blocksuite/affine/blocks/root/src/page/page-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/page/page-root-block.ts
@@ -117,7 +117,7 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
       focusTextModel(this.std, firstText.id);
       return { id: firstText.id, created: false };
     } else {
-      const newFirstParagraphId = this.doc.addBlock(
+      const newFirstParagraphId = this.store.addBlock(
         'affine:paragraph',
         {},
         defaultNote,
@@ -131,7 +131,7 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
   keyboardManager: PageKeyboardManager | null = null;
 
   prependParagraphWithText = (text: Text) => {
-    const newFirstParagraphId = this.doc.addBlock(
+    const newFirstParagraphId = this.store.addBlock(
       'affine:paragraph',
       { text },
       this._getDefaultNoteBlock(),
@@ -157,16 +157,17 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
   }
 
   private _createDefaultNoteBlock() {
-    const { doc } = this;
+    const { store } = this;
 
-    const noteId = doc.addBlock('affine:note', {}, doc.root?.id);
-    return doc.getModelById(noteId) as NoteBlockModel;
+    const noteId = store.addBlock('affine:note', {}, store.root?.id);
+    return store.getModelById(noteId) as NoteBlockModel;
   }
 
   private _getDefaultNoteBlock() {
     return (
-      this.doc.root?.children.find(child => child.flavour === 'affine:note') ??
-      this._createDefaultNoteBlock()
+      this.store.root?.children.find(
+        child => child.flavour === 'affine:note'
+      ) ?? this._createDefaultNoteBlock()
     );
   }
 
@@ -230,16 +231,16 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
         );
         if (!sel) return;
         let model: BlockModel | null = null;
-        let current = this.doc.getModelById(sel.blockId);
+        let current = this.store.getModelById(sel.blockId);
         while (current && !model) {
           if (current.flavour === 'affine:note') {
             model = current;
           } else {
-            current = this.doc.getParent(current);
+            current = this.store.getParent(current);
           }
         }
         if (!model) return;
-        const prevNote = this.doc.getPrev(model);
+        const prevNote = this.store.getPrev(model);
         if (!prevNote || prevNote.flavour !== 'affine:note') {
           const isFirstText = sel.is(TextSelection) && sel.start.index === 0;
           const isBlock = sel.is(BlockSelection);
@@ -248,7 +249,7 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
           }
           return;
         }
-        const notes = this.doc.getModelsByFlavour('affine:note');
+        const notes = this.store.getModelsByFlavour('affine:note');
         const index = notes.indexOf(prevNote);
         if (index !== 0) return;
 
@@ -409,7 +410,7 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
       return !(isNote && displayOnEdgeless);
     });
 
-    this.contentEditable = String(!this.doc.readonly$.value);
+    this.contentEditable = String(!this.store.readonly$.value);
 
     return html`
       <div class="affine-page-root-block-container">${children} ${widgets}</div>

--- a/blocksuite/affine/blocks/surface-ref/src/surface-ref-block.ts
+++ b/blocksuite/affine/blocks/surface-ref/src/surface-ref-block.ts
@@ -146,14 +146,14 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
   private _initHotkey() {
     const selection = this.host.selection;
     const addParagraph = () => {
-      if (!this.doc.getParent(this.model)) return;
+      if (!this.store.getParent(this.model)) return;
 
-      const [paragraphId] = this.doc.addSiblingBlocks(this.model, [
+      const [paragraphId] = this.store.addSiblingBlocks(this.model, [
         {
           flavour: 'affine:paragraph',
         },
       ]);
-      const model = this.doc.getModelById(paragraphId);
+      const model = this.store.getModelById(paragraphId);
       if (!model) return;
 
       requestConnectedFrame(() => {
@@ -185,7 +185,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
 
   private _initReferencedModel() {
     const findReferencedModel = (): [GfxModel | null, string] => {
-      if (!this.model.props.reference) return [null, this.doc.id];
+      if (!this.model.props.reference) return [null, this.store.id];
       const referenceId = this.model.props.reference;
 
       const find = (doc: Store): [GfxModel | null, string] => {
@@ -203,7 +203,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
       };
 
       // find current doc first
-      let result = find(this.doc);
+      let result = find(this.store);
       if (result[0]) return result;
 
       for (const doc of this.std.workspace.docs.values()) {
@@ -211,7 +211,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
         if (result[0]) return result;
       }
 
-      return [null, this.doc.id];
+      return [null, this.store.id];
     };
 
     const init = () => {
@@ -220,7 +220,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
       this._referencedModel =
         referencedModel && referencedModel.xywh ? referencedModel : null;
       // TODO(@L-Sun): clear query cache
-      const doc = this.doc.workspace.getDoc(docId);
+      const doc = this.store.workspace.getDoc(docId);
       this._previewDoc = doc?.getStore({ readonly: true }) ?? null;
     };
 
@@ -249,7 +249,7 @@ export class SurfaceRefBlockComponent extends BlockComponent<SurfaceRefBlockMode
 
     if (this._referencedModel instanceof GfxBlockElementModel) {
       this._disposables.add(
-        this.doc.slots.blockUpdated.subscribe(({ type, id }) => {
+        this.store.slots.blockUpdated.subscribe(({ type, id }) => {
           if (type === 'delete' && id === this.model.props.reference) {
             init();
           }

--- a/blocksuite/affine/blocks/surface/src/extensions/export-manager/export-manager.ts
+++ b/blocksuite/affine/blocks/surface/src/extensions/export-manager/export-manager.ts
@@ -542,7 +542,7 @@ type RootBlockComponent = BlockComponent & {
 function getRootByEditorHost(
   editorHost: EditorHost
 ): RootBlockComponent | null {
-  const model = editorHost.doc.root;
+  const model = editorHost.store.root;
   if (!model) return null;
   const root = editorHost.view.getBlock(model.id);
   return root as RootBlockComponent | null;

--- a/blocksuite/affine/components/src/block-zero-width/index.ts
+++ b/blocksuite/affine/components/src/block-zero-width/index.ts
@@ -17,12 +17,13 @@ export class BlockZeroWidth extends LitElement {
 
   _handleClick = (e: MouseEvent) => {
     stopPropagation(e);
-    if (this.block.doc.readonly) return;
-    const nextBlock = this.block.doc.getNext(this.block.model);
+    if (this.block.store.readonly) return;
+    const nextBlock = this.block.store.getNext(this.block.model);
     if (nextBlock?.flavour !== 'affine:paragraph') {
-      const [paragraphId] = this.block.doc.addSiblingBlocks(this.block.model, [
-        { flavour: 'affine:paragraph' },
-      ]);
+      const [paragraphId] = this.block.store.addSiblingBlocks(
+        this.block.model,
+        [{ flavour: 'affine:paragraph' }]
+      );
       const std = this.block.std;
       std.selection.setGroup('note', [
         std.selection.create(TextSelection, {

--- a/blocksuite/affine/components/src/caption/block-caption.ts
+++ b/blocksuite/affine/components/src/caption/block-caption.ts
@@ -3,10 +3,10 @@ import { stopPropagation } from '@blocksuite/affine-shared/utils';
 import { WithDisposable } from '@blocksuite/global/lit';
 import type { BlockStdScope } from '@blocksuite/std';
 import {
-  docContext,
   modelContext,
   ShadowlessElement,
   stdContext,
+  storeContext,
   TextSelection,
 } from '@blocksuite/std';
 import { RANGE_SYNC_EXCLUDE_ATTR } from '@blocksuite/std/inline';
@@ -168,7 +168,7 @@ export class BlockCaptionEditor<
   @state()
   accessor display = false;
 
-  @consume({ context: docContext })
+  @consume({ context: storeContext })
   accessor doc!: Store;
 
   @query('.block-caption-editor')

--- a/blocksuite/affine/components/src/caption/captioned-block-component.ts
+++ b/blocksuite/affine/components/src/caption/captioned-block-component.ts
@@ -62,7 +62,7 @@ export class CaptionedBlockComponent<
             .selected=${this.selected$.value}
           ></affine-block-selection>`
         : null}
-      ${this.useZeroWidth && !this.doc.readonly
+      ${this.useZeroWidth && !this.store.readonly
         ? html`<block-zero-width .block=${this}></block-zero-width>`
         : nothing}
     </div>`;

--- a/blocksuite/affine/components/src/embed-card-modal/embed-card-create-modal.ts
+++ b/blocksuite/affine/components/src/embed-card-modal/embed-card-create-modal.ts
@@ -46,7 +46,7 @@ export class EmbedCardCreateModal extends SignalWatcher(
         flavour = embedOptions.flavour;
       }
 
-      this.host.doc.addBlock(
+      this.host.store.addBlock(
         flavour as never,
         {
           url,

--- a/blocksuite/affine/components/src/toast/create.ts
+++ b/blocksuite/affine/components/src/toast/create.ts
@@ -18,11 +18,11 @@ export const createToastContainer = (editorHost: EditorHost) => {
   `;
   const template = html`<div class="toast-container" style="${styles}"></div>`;
   const element = htmlToElement<HTMLDivElement>(template);
-  const { std, doc } = editorHost;
+  const { std, store } = editorHost;
 
   let container = document.body;
-  if (doc.root) {
-    const rootComponent = std.view.getBlock(doc.root.id) as BlockComponent & {
+  if (store.root) {
+    const rootComponent = std.view.getBlock(store.root.id) as BlockComponent & {
       viewportElement: HTMLElement;
     };
     if (rootComponent) {

--- a/blocksuite/affine/fragments/frame-panel/src/body/frame-panel-body.ts
+++ b/blocksuite/affine/fragments/frame-panel/src/body/frame-panel-body.ts
@@ -156,7 +156,7 @@ export class FramePanelBody extends SignalWatcher(
   };
 
   get frames() {
-    const frames = this.editorHost.doc
+    const frames = this.editorHost.store
       .getBlocksByFlavour('affine:frame')
       .map(block => block.model as FrameBlockModel);
     return frames.sort(compare);
@@ -318,7 +318,7 @@ export class FramePanelBody extends SignalWatcher(
         before = newIndex;
       });
 
-      this.editorHost.doc.captureSync();
+      this.editorHost.store.captureSync();
       this._updateFrames();
     }
   }
@@ -392,9 +392,9 @@ export class FramePanelBody extends SignalWatcher(
 
   override updated(_changedProperties: PropertyValues) {
     if (_changedProperties.has('editorHost') && this.editorHost) {
-      this._setDocDisposables(this.editorHost.doc);
+      this._setDocDisposables(this.editorHost.store);
       // after switch to edgeless mode, should update the selection
-      if (this.editorHost.doc.id === this._lastEdgelessRootId) {
+      if (this.editorHost.store.id === this._lastEdgelessRootId) {
         this._gfx.selection.set({
           elements: this._selected,
           editing: false,
@@ -402,7 +402,7 @@ export class FramePanelBody extends SignalWatcher(
       } else {
         this._selected = this._selected.length ? [] : this._selected;
       }
-      this._lastEdgelessRootId = this.editorHost.doc.id;
+      this._lastEdgelessRootId = this.editorHost.store.id;
     }
   }
 

--- a/blocksuite/affine/fragments/outline/src/body/outline-notice.ts
+++ b/blocksuite/affine/fragments/outline/src/body/outline-notice.ts
@@ -31,7 +31,7 @@ export class OutlineNotice extends SignalWatcher(
         }
 
         const shouldShowNotice =
-          getNotesFromDoc(this._context.editor$.value.doc, [
+          getNotesFromDoc(this._context.editor$.value.store, [
             NoteDisplayMode.DocOnly,
           ]).length > 0;
 

--- a/blocksuite/affine/fragments/outline/src/body/outline-panel-body.ts
+++ b/blocksuite/affine/fragments/outline/src/body/outline-panel-body.ts
@@ -92,7 +92,7 @@ export class OutlinePanelBody extends SignalWatcher(
   }
 
   private get doc() {
-    return this.editor.doc;
+    return this.editor.store;
   }
 
   get viewportPadding(): [number, number, number, number] {
@@ -262,14 +262,14 @@ export class OutlinePanelBody extends SignalWatcher(
 
   private _watchSelectedNotes() {
     return effect(() => {
-      const { std, doc } = this.editor;
+      const { std, store } = this.editor;
       const docModeService = this.editor.std.get(DocModeProvider);
       const mode = docModeService.getEditorMode();
       if (mode !== 'edgeless') return;
 
       const currSelectedNotes = std.selection
         .filter(SurfaceSelection)
-        .map(({ blockId }) => doc.getBlock(blockId)?.model)
+        .map(({ blockId }) => store.getBlock(blockId)?.model)
         .filter(model => {
           return !!model && matchModels(model, [NoteBlockModel]);
         });

--- a/blocksuite/affine/fragments/outline/src/mobile-outline-panel.ts
+++ b/blocksuite/affine/fragments/outline/src/mobile-outline-panel.ts
@@ -168,10 +168,10 @@ export class MobileOutlineMenu extends SignalWatcher(
   override render() {
     const docModeService = this.editor.std.get(DocModeProvider);
     const mode = docModeService.getEditorMode();
-    if (this.editor.doc.root === null || mode === 'edgeless') return nothing;
+    if (this.editor.store.root === null || mode === 'edgeless') return nothing;
 
     const headingBlocks = getHeadingBlocksFromDoc(
-      this.editor.doc,
+      this.editor.store,
       [NoteDisplayMode.DocAndEdgeless, NoteDisplayMode.DocOnly],
       true
     );
@@ -179,7 +179,7 @@ export class MobileOutlineMenu extends SignalWatcher(
     if (headingBlocks.length === 0) return nothing;
 
     const items = [
-      ...(this.editor.doc.meta?.title !== '' ? [this.editor.doc.root] : []),
+      ...(this.editor.store.meta?.title !== '' ? [this.editor.store.root] : []),
       ...headingBlocks,
     ];
 

--- a/blocksuite/affine/fragments/outline/src/outline-viewer.ts
+++ b/blocksuite/affine/fragments/outline/src/outline-viewer.ts
@@ -201,7 +201,7 @@ export class OutlineViewer extends SignalWatcher(
     );
 
     this.disposables.add(
-      this.editor.doc.workspace.meta.docMetaUpdated.subscribe(() => {
+      this.editor.store.workspace.meta.docMetaUpdated.subscribe(() => {
         this.requestUpdate();
       })
     );
@@ -223,10 +223,10 @@ export class OutlineViewer extends SignalWatcher(
   override render() {
     const docModeService = this.editor.std.get(DocModeProvider);
     const mode = docModeService.getEditorMode();
-    if (this.editor.doc.root === null || mode === 'edgeless') return nothing;
+    if (this.editor.store.root === null || mode === 'edgeless') return nothing;
 
     const headingBlocks = getHeadingBlocksFromDoc(
-      this.editor.doc,
+      this.editor.store,
       [NoteDisplayMode.DocAndEdgeless, NoteDisplayMode.DocOnly],
       true
     );
@@ -234,7 +234,7 @@ export class OutlineViewer extends SignalWatcher(
     if (headingBlocks.length === 0) return nothing;
 
     const items = [
-      ...(this.editor.doc.meta?.title !== '' ? [this.editor.doc.root] : []),
+      ...(this.editor.store.meta?.title !== '' ? [this.editor.store.root] : []),
       ...headingBlocks,
     ];
 

--- a/blocksuite/affine/fragments/outline/src/utils/scroll.ts
+++ b/blocksuite/affine/fragments/outline/src/utils/scroll.ts
@@ -13,7 +13,7 @@ export function scrollToBlock(host: EditorHost, blockId: string) {
   const mode = docModeService.getEditorMode();
   if (mode === 'edgeless') return;
 
-  if (host.doc.root?.id === blockId) {
+  if (host.store.root?.id === blockId) {
     const docTitle = getDocTitleByEditorHost(host);
     if (!docTitle) return;
 
@@ -60,12 +60,12 @@ export const observeActiveHeadingDuringScroll = (
     const host = getEditor();
 
     const headings = getHeadingBlocksFromDoc(
-      host.doc,
+      host.store,
       [NoteDisplayMode.DocAndEdgeless, NoteDisplayMode.DocOnly],
       true
     );
 
-    let activeHeadingId = host.doc.root?.id ?? null;
+    let activeHeadingId = host.store.root?.id ?? null;
     headings.forEach(heading => {
       if (isBlockBeforeViewportCenter(heading.id, host)) {
         activeHeadingId = heading.id;
@@ -87,7 +87,7 @@ let highlightTimeoutId: ReturnType<typeof setTimeout> | null = null;
 function highlightBlock(host: EditorHost, blockId: string) {
   const emptyClear = () => {};
 
-  if (host.doc.root?.id === blockId) return emptyClear;
+  if (host.store.root?.id === blockId) return emptyClear;
 
   const rootComponent = host.querySelector<
     HTMLElement & { viewport: Viewport }

--- a/blocksuite/affine/gfx/brush/src/toolbar/components/pen/pen-menu.ts
+++ b/blocksuite/affine/gfx/brush/src/toolbar/components/pen/pen-menu.ts
@@ -163,7 +163,7 @@ export class EdgelessPenMenu extends EdgelessToolbarToolMixin(
             .theme=${theme}
             .palettes=${DefaultTheme.StrokeColorShortPalettes}
             .shouldKeepColor=${true}
-            .hasTransparent=${!this.edgeless.doc
+            .hasTransparent=${!this.edgeless.store
               .get(FeatureFlagService)
               .getFlag('enable_color_picker')}
           ></edgeless-color-panel>

--- a/blocksuite/affine/gfx/connector/src/components/connector-handle.ts
+++ b/blocksuite/affine/gfx/connector/src/components/connector-handle.ts
@@ -9,8 +9,8 @@ import { WithDisposable } from '@blocksuite/global/lit';
 import {
   type BlockComponent,
   type BlockStdScope,
-  docContext,
   stdContext,
+  storeContext,
 } from '@blocksuite/std';
 import { GfxControllerIdentifier } from '@blocksuite/std/gfx';
 import type { Store } from '@blocksuite/store';
@@ -154,7 +154,7 @@ export class EdgelessConnectorHandle extends WithDisposable(LitElement) {
   accessor connector!: ConnectorElementModel;
 
   @consume({
-    context: docContext,
+    context: storeContext,
   })
   accessor doc!: Store;
 

--- a/blocksuite/affine/gfx/connector/src/toolbar/connector-menu.ts
+++ b/blocksuite/affine/gfx/connector/src/toolbar/connector-menu.ts
@@ -137,7 +137,7 @@ export class EdgelessConnectorMenu extends EdgelessToolbarToolMixin(
             .value=${stroke}
             .theme=${this._theme$.value}
             .palettes=${DefaultTheme.StrokeColorShortPalettes}
-            .hasTransparent=${!this.edgeless.doc
+            .hasTransparent=${!this.edgeless.store
               .get(FeatureFlagService)
               .getFlag('enable_color_picker')}
             @select=${(e: ColorEvent) =>

--- a/blocksuite/affine/gfx/mindmap/src/toolbar/basket-elements.ts
+++ b/blocksuite/affine/gfx/mindmap/src/toolbar/basket-elements.ts
@@ -115,7 +115,7 @@ export const textRender: DraggableTool['render'] = async (bound, edgeless) => {
   const w = 100;
   const h = 32;
 
-  const flag = edgeless.doc
+  const flag = edgeless.store
     .get(FeatureFlagService)
     .getFlag('enable_edgeless_text');
   let id: string;
@@ -135,7 +135,7 @@ export const textRender: DraggableTool['render'] = async (bound, edgeless) => {
       text: new Y.Text(),
     }) as string;
 
-    edgeless.doc.captureSync();
+    edgeless.store.captureSync();
     const textElement = crud.getElementById(id);
     if (!(textElement instanceof TextElementModel)) {
       console.error('Cannot mount text editor on a non-text element');

--- a/blocksuite/affine/gfx/shape/src/draggable/shape-menu.ts
+++ b/blocksuite/affine/gfx/shape/src/draggable/shape-menu.ts
@@ -194,7 +194,7 @@ export class EdgelessShapeMenu extends SignalWatcher(
             .value=${fillColor}
             .theme=${this._theme$.value}
             .palettes=${DefaultTheme.FillColorShortPalettes}
-            .hasTransparent=${!this.edgeless.doc
+            .hasTransparent=${!this.edgeless.store
               .get(FeatureFlagService)
               .getFlag('enable_color_picker')}
             @select=${(e: ColorEvent) => this._setFillColor(e.detail)}

--- a/blocksuite/affine/gfx/text/src/commands/insert-edgeless-text.ts
+++ b/blocksuite/affine/gfx/text/src/commands/insert-edgeless-text.ts
@@ -24,7 +24,7 @@ export const insertEdgelessTextCommand: Command<
 > = (ctx, next) => {
   const { std, x, y } = ctx;
   const host = std.host;
-  const doc = host.doc;
+  const doc = host.store;
   const surface = getSurfaceBlock(doc);
   if (!surface) {
     next();

--- a/blocksuite/affine/gfx/text/src/edgeless-text-editor.ts
+++ b/blocksuite/affine/gfx/text/src/edgeless-text-editor.ts
@@ -83,7 +83,7 @@ export function addText(edgeless: BlockComponent, event: PointerEventState) {
       });
     if (!id) return;
 
-    edgeless.doc.captureSync();
+    edgeless.store.captureSync();
     const textElement = crud.getElementById(id);
     if (!textElement) return;
     if (textElement instanceof TextElementModel) {

--- a/blocksuite/affine/inlines/latex/src/markdown.ts
+++ b/blocksuite/affine/inlines/latex/src/markdown.ts
@@ -34,7 +34,7 @@ export const LatexExtension = InlineMarkdownExtension<AffineTextAttributes>({
         inlineEditor.rootElement.closest<BlockComponent>('[data-block-id]');
       if (!blockComponent) return;
 
-      const doc = blockComponent.doc;
+      const doc = blockComponent.store;
       const parentComponent = blockComponent.parentComponent;
       if (!parentComponent) return;
 

--- a/blocksuite/affine/shared/src/__tests__/commands/block-crud/get-first-block.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/commands/block-crud/get-first-block.unit.spec.ts
@@ -73,7 +73,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         flavour: 'affine:list',
@@ -93,7 +93,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         flavour: ['affine:list', 'affine:code'],
@@ -114,7 +114,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         role: 'content',
         flavour: 'affine:list',
@@ -153,7 +153,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         role: 'hub',
@@ -173,7 +173,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         role: 'hub',
@@ -193,7 +193,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         flavour: 'affine:list',
@@ -217,7 +217,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-2')?.model;
+      const note = host.store.getBlock('note-2')?.model;
 
       const [_, { firstBlock }] = host.command.exec(getFirstBlockCommand, {
         role: 'content',

--- a/blocksuite/affine/shared/src/__tests__/commands/block-crud/get-last-block.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/commands/block-crud/get-last-block.unit.spec.ts
@@ -73,7 +73,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         flavour: 'affine:list',
@@ -93,7 +93,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         flavour: ['affine:list', 'affine:code'],
@@ -114,7 +114,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         role: 'content',
         flavour: 'affine:list',
@@ -153,7 +153,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         role: 'hub',
@@ -173,7 +173,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         role: 'hub',
@@ -193,7 +193,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-1')?.model;
+      const note = host.store.getBlock('note-1')?.model;
 
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         flavour: 'affine:list',
@@ -217,7 +217,7 @@ describe('commands/block-crud', () => {
         </affine-page>
       `;
 
-      const note = host.doc.getBlock('note-2')?.model;
+      const note = host.store.getBlock('note-2')?.model;
 
       const [_, { lastBlock }] = host.command.exec(getLastBlockCommand, {
         role: 'content',

--- a/blocksuite/affine/shared/src/__tests__/helpers/affine-template.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/helpers/affine-template.unit.spec.ts
@@ -12,17 +12,17 @@ describe('helpers/affine-template', () => {
       </affine-page>
     `;
 
-    expect(host.doc).toBeDefined();
+    expect(host.store).toBeDefined();
 
-    const pageBlock = host.doc.getBlock('page');
+    const pageBlock = host.store.getBlock('page');
     expect(pageBlock).toBeDefined();
     expect(pageBlock?.flavour).toBe('affine:page');
 
-    const noteBlock = host.doc.getBlock('note');
+    const noteBlock = host.store.getBlock('note');
     expect(noteBlock).toBeDefined();
     expect(noteBlock?.flavour).toBe('affine:note');
 
-    const paragraphBlock = host.doc.getBlock('paragraph-1');
+    const paragraphBlock = host.store.getBlock('paragraph-1');
     expect(paragraphBlock).toBeDefined();
     expect(paragraphBlock?.flavour).toBe('affine:paragraph');
   });
@@ -38,16 +38,17 @@ describe('helpers/affine-template', () => {
       </affine-page>
     `;
 
-    const noteBlocks = host.doc.getBlocksByFlavour('affine:note');
-    const paragraphBlocks = host.doc.getBlocksByFlavour('affine:paragraph');
-    const listBlocks = host.doc.getBlocksByFlavour('affine:list');
+    const noteBlocks = host.store.getBlocksByFlavour('affine:note');
+    const paragraphBlocks = host.store.getBlocksByFlavour('affine:paragraph');
+    const listBlocks = host.store.getBlocksByFlavour('affine:list');
 
     expect(noteBlocks.length).toBe(1);
     expect(paragraphBlocks.length).toBe(2);
     expect(listBlocks.length).toBe(1);
 
     const noteBlock = noteBlocks[0];
-    const noteChildren = host.doc.getBlock(noteBlock.id)?.model.children || [];
+    const noteChildren =
+      host.store.getBlock(noteBlock.id)?.model.children || [];
     expect(noteChildren.length).toBe(3);
 
     expect(noteChildren[0].flavour).toBe('affine:paragraph');
@@ -64,10 +65,10 @@ describe('helpers/affine-template', () => {
       </affine-page>
     `;
 
-    const paragraphBlocks = host.doc.getBlocksByFlavour('affine:paragraph');
+    const paragraphBlocks = host.store.getBlocksByFlavour('affine:paragraph');
     expect(paragraphBlocks.length).toBe(1);
 
-    const paragraphBlock = host.doc.getBlock(paragraphBlocks[0].id);
+    const paragraphBlock = host.store.getBlock(paragraphBlocks[0].id);
     const paragraphText = paragraphBlock?.model.text?.toString() || '';
     expect(paragraphText).toBe('');
   });

--- a/blocksuite/affine/shared/src/__tests__/helpers/create-test-host.ts
+++ b/blocksuite/affine/shared/src/__tests__/helpers/create-test-host.ts
@@ -229,10 +229,10 @@ export function createTestHost(doc: Store): EditorHost {
   };
 
   const host = {
-    doc: doc,
+    store: doc,
     std: std as any,
   };
-  host.doc = doc;
+  host.store = doc;
   host.std = std as any;
 
   std.host = host;

--- a/blocksuite/affine/shared/src/commands/block-crud/get-first-content-block.ts
+++ b/blocksuite/affine/shared/src/commands/block-crud/get-first-content-block.ts
@@ -23,7 +23,7 @@ export const getFirstBlockCommand: Command<
     firstBlock: BlockModel | null;
   }
 > = (ctx, next) => {
-  const root = ctx.root || ctx.std.host.doc.root;
+  const root = ctx.root || ctx.std.host.store.root;
   if (!root) {
     next({
       firstBlock: null,

--- a/blocksuite/affine/shared/src/commands/block-crud/get-last-content-block.ts
+++ b/blocksuite/affine/shared/src/commands/block-crud/get-last-content-block.ts
@@ -23,7 +23,7 @@ export const getLastBlockCommand: Command<
     lastBlock: BlockModel | null;
   }
 > = (ctx, next) => {
-  const root = ctx.root || ctx.std.host.doc.root;
+  const root = ctx.root || ctx.std.host.store.root;
   if (!root) {
     next({
       lastBlock: null,

--- a/blocksuite/affine/widgets/drag-handle/src/helpers/preview-helper.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/helpers/preview-helper.ts
@@ -35,13 +35,13 @@ export class PreviewHelper {
         if (!selectedIds.includes(parent)) {
           ids.push({ viewType: 'bypass', id: parent });
         }
-        parent = this.widget.doc.getParent(parent)?.id ?? null;
+        parent = this.widget.store.getParent(parent)?.id ?? null;
       } while (parent && !ids.map(({ id }) => id).includes(parent));
     });
 
     // The children of the selected blocks should be rendered as Display
     const addChildren = (id: string) => {
-      const model = this.widget.doc.getBlock(id)?.model;
+      const model = this.widget.store.getBlock(id)?.model;
       if (!model) {
         return;
       }
@@ -68,7 +68,7 @@ export class PreviewHelper {
     const docModeService = std.get(DocModeProvider);
     const editorSetting = std.get(EditorSettingProvider);
     const query = this._calculateQuery(blockIds as string[]);
-    const store = widget.doc.doc.getStore({ query });
+    const store = widget.store.doc.getStore({ query });
     let previewSpec = widget.std
       .get(ViewExtensionManagerIdentifier)
       .get('preview-page');

--- a/blocksuite/affine/widgets/drag-handle/src/utils.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/utils.ts
@@ -79,7 +79,7 @@ export const containChildBlock = (
       if (currentBlock.id === block.model.id) {
         return true;
       }
-      currentBlock = block.doc.getParent(currentBlock.id);
+      currentBlock = block.store.getParent(currentBlock.id);
     }
     return false;
   });

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
@@ -501,7 +501,7 @@ export class DragEventWatcher {
       // can't drop edgeless content on the same doc
       if (
         dragPayload.bsEntity?.fromMode === 'gfx' &&
-        dragPayload.from?.docId === this.widget.doc.id
+        dragPayload.from?.docId === this.widget.store.id
       ) {
         return;
       }
@@ -550,7 +550,7 @@ export class DragEventWatcher {
 
     // drop on the same place, do nothing
     if (
-      (dragPayload.from?.docId === this.widget.doc.id &&
+      (dragPayload.from?.docId === this.widget.store.id &&
         result.placement === 'after' &&
         parent.children[index]?.id === snapshot.content[0].id) ||
       (result.placement === 'before' &&
@@ -566,7 +566,7 @@ export class DragEventWatcher {
     ) {
       snapshot.content = snapshot.content.filter(
         block =>
-          dragPayload.from?.docId !== this.widget.doc.id ||
+          dragPayload.from?.docId !== this.widget.store.id ||
           block.id !== parent.id
       );
       if (snapshot.content.length) {
@@ -590,7 +590,7 @@ export class DragEventWatcher {
       matchModels(parent, [NoteBlockModel])
     ) {
       // if the snapshot comes from the same doc, just create a surface-ref block
-      if (dragPayload.from?.docId === this.widget.doc.id) {
+      if (dragPayload.from?.docId === this.widget.store.id) {
         let largestElem!: {
           size: number;
           id: string;
@@ -1194,7 +1194,7 @@ export class DragEventWatcher {
         };
 
         this._rewriteSnapshotXYWH(pageSnapshot, point, true);
-        this._dropToModel(pageSnapshot, this.widget.doc.root!.id)
+        this._dropToModel(pageSnapshot, this.widget.store.root!.id)
           .then(slices => {
             slices?.content.forEach((block, idx) => {
               if (block.flavour === 'affine:embed-iframe') {
@@ -1259,7 +1259,7 @@ export class DragEventWatcher {
               DEFAULT_NOTE_HEIGHT
             ).serialize(),
           },
-          this.widget.doc.root!
+          this.widget.store.root!
         );
 
         this._dropToModel(
@@ -1508,7 +1508,7 @@ export class DragEventWatcher {
            */
           if (source.data.bsEntity?.type === 'blocks') {
             return (
-              source.data.from?.docId !== widget.doc.id ||
+              source.data.from?.docId !== widget.store.id ||
               source.data.bsEntity.modelIds.every(id => id !== view.model.id)
             );
           }

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/edgeless-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/edgeless-watcher.ts
@@ -91,7 +91,7 @@ export class EdgelessWatcher {
 
   updateAnchorElement = () => {
     if (!this.widget.isConnected) return;
-    if (this.widget.doc.readonly || this.widget.mode === 'page') {
+    if (this.widget.store.readonly || this.widget.mode === 'page') {
       this.widget.hide();
       return;
     }
@@ -100,7 +100,11 @@ export class EdgelessWatcher {
     const editing = selection.editing;
     const selectedElements = selection.selectedElements;
 
-    if (editing || selectedElements.length !== 1 || this.widget.doc.readonly) {
+    if (
+      editing ||
+      selectedElements.length !== 1 ||
+      this.widget.store.readonly
+    ) {
       this.widget.hide();
       return;
     }

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/page-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/page-watcher.ts
@@ -13,7 +13,7 @@ export class PageWatcher {
     const { disposables } = this.widget;
 
     disposables.add(
-      this.widget.doc.slots.blockUpdated.subscribe(() => this.widget.hide())
+      this.widget.store.slots.blockUpdated.subscribe(() => this.widget.hide())
     );
 
     disposables.add(

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/pointer-event-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/pointer-event-watcher.ts
@@ -41,7 +41,7 @@ export class PointerEventWatcher {
   }
 
   private readonly _canEditing = (noteBlock: BlockComponent) => {
-    if (noteBlock.doc.id !== this.widget.doc.id) return false;
+    if (noteBlock.store.id !== this.widget.store.id) return false;
 
     if (this.widget.mode === 'page') return true;
 
@@ -178,7 +178,7 @@ export class PointerEventWatcher {
 
     this.widget.anchorBlockId.value = blockId;
 
-    if (insideDatabaseTable(closestBlock) || this.widget.doc.readonly) {
+    if (insideDatabaseTable(closestBlock) || this.widget.store.readonly) {
       this.widget.hide();
       return;
     }
@@ -226,7 +226,7 @@ export class PointerEventWatcher {
     ctx => {
       if (this._isPointerDown) return;
       if (
-        this.widget.doc.readonly ||
+        this.widget.store.readonly ||
         this.widget.dragging ||
         !this.widget.isConnected
       ) {

--- a/blocksuite/affine/widgets/edgeless-auto-connect/src/index.ts
+++ b/blocksuite/affine/widgets/edgeless-auto-connect/src/index.ts
@@ -317,7 +317,7 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<RootBlockModel> {
       })
     );
     this._disposables.add(
-      this.doc.slots.blockUpdated.subscribe(payload => {
+      this.store.slots.blockUpdated.subscribe(payload => {
         if (payload.flavour === 'affine:surface-ref') {
           switch (payload.type) {
             case 'add':
@@ -585,7 +585,7 @@ export class EdgelessAutoConnectWidget extends WidgetComponent<RootBlockModel> {
   }
 
   override render() {
-    const advancedVisibilityEnabled = this.doc
+    const advancedVisibilityEnabled = this.store
       .get(FeatureFlagService)
       .getFlag('enable_advanced_block_visibility');
 

--- a/blocksuite/affine/widgets/edgeless-toolbar/src/edgeless-toolbar.ts
+++ b/blocksuite/affine/widgets/edgeless-toolbar/src/edgeless-toolbar.ts
@@ -660,7 +660,7 @@ export class EdgelessToolbarWidget extends WidgetComponent<RootBlockModel> {
 
   override render() {
     const type = this.edgelessTool;
-    if (this.doc.readonly && type !== 'frameNavigator') {
+    if (this.store.readonly && type !== 'frameNavigator') {
       return nothing;
     }
 

--- a/blocksuite/affine/widgets/frame-title/src/affine-frame-title-widget.ts
+++ b/blocksuite/affine/widgets/frame-title/src/affine-frame-title-widget.ts
@@ -10,7 +10,7 @@ export const AFFINE_FRAME_TITLE_WIDGET = 'affine-frame-title-widget';
 
 export class AffineFrameTitleWidget extends WidgetComponent<RootBlockModel> {
   private get _frames() {
-    return Object.values(this.doc.blocks.value)
+    return Object.values(this.store.blocks.value)
       .map(({ model }) => model)
       .filter(model => model instanceof FrameBlockModel);
   }

--- a/blocksuite/affine/widgets/frame-title/src/edgeless-frame-title-editor.ts
+++ b/blocksuite/affine/widgets/frame-title/src/edgeless-frame-title-editor.ts
@@ -120,7 +120,7 @@ export class EdgelessFrameTitleEditor extends WithDisposable(
   }
 
   override render() {
-    const rootBlockId = this.editorHost.doc.root?.id;
+    const rootBlockId = this.editorHost.store.root?.id;
     if (!rootBlockId) return nothing;
 
     const viewport = this.gfx.viewport;

--- a/blocksuite/affine/widgets/keyboard-toolbar/src/widget.ts
+++ b/blocksuite/affine/widgets/keyboard-toolbar/src/widget.ts
@@ -110,9 +110,9 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent<RootBlockModel>
 
   override render() {
     if (
-      this.doc.readonly ||
+      this.store.readonly ||
       !IS_MOBILE ||
-      !this.doc
+      !this.store
         .get(FeatureFlagService)
         .getFlag('enable_mobile_keyboard_toolbar')
     )

--- a/blocksuite/affine/widgets/linked-doc/src/config.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/config.ts
@@ -78,7 +78,7 @@ export function createLinkedDocMenuGroup(
   editorHost: EditorHost,
   inlineEditor: AffineInlineEditor
 ) {
-  const doc = editorHost.doc;
+  const doc = editorHost.store;
   const { docMetas } = doc.workspace.meta;
   const filteredDocList = docMetas
     .filter(({ id }) => id !== doc.id)
@@ -122,7 +122,7 @@ export function createNewDocMenuGroup(
   editorHost: EditorHost,
   inlineEditor: AffineInlineEditor
 ): LinkedMenuGroup {
-  const doc = editorHost.doc;
+  const doc = editorHost.store;
   const docName = query || DEFAULT_DOC_NAME;
   const displayDocName =
     docName.slice(0, DISPLAY_NAME_LENGTH) +

--- a/blocksuite/affine/widgets/linked-doc/src/widget.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/widget.ts
@@ -307,7 +307,7 @@ export class AffineLinkedDocWidget extends WidgetComponent<RootBlockModel> {
 
     this._updateInputRects();
 
-    const enableMobile = this.doc
+    const enableMobile = this.store
       .get(FeatureFlagService)
       .getFlag('enable_mobile_linked_doc_menu');
     this._mode$.value = enableMobile ? mode : 'desktop';

--- a/blocksuite/affine/widgets/page-dragging-area/src/utils.ts
+++ b/blocksuite/affine/widgets/page-dragging-area/src/utils.ts
@@ -118,7 +118,7 @@ export function getSelectingBlockPaths(
   // eslint-disable-next-line @typescript-eslint/prefer-for-of
   for (let i = 0; i < blocks.length; i++) {
     const block = blocks[i];
-    const parent = blocks[i].element.doc.getParent(block.element.model);
+    const parent = blocks[i].element.store.getParent(block.element.model);
     const parentId = parent?.id;
     if (parentId) {
       const isParentInBlocks = blocks.some(

--- a/blocksuite/affine/widgets/remote-selection/src/doc/doc-remote-selection.ts
+++ b/blocksuite/affine/widgets/remote-selection/src/doc/doc-remote-selection.ts
@@ -58,7 +58,7 @@ export class AffineDocRemoteSelectionWidget extends WidgetComponent {
   private _remoteColorManager: RemoteColorManager | null = null;
 
   private readonly _remoteSelections = computed(() => {
-    const status = this.doc.awarenessStore.getStates();
+    const status = this.store.awarenessStore.getStates();
     return [...this.std.selection.remoteSelections.entries()].map(
       ([id, selections]) => {
         return {

--- a/blocksuite/affine/widgets/remote-selection/src/edgeless/index.ts
+++ b/blocksuite/affine/widgets/remote-selection/src/edgeless/index.ts
@@ -90,7 +90,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetComponent<RootBlockMode
   private readonly _updateRemoteCursor = () => {
     const remoteCursors: EdgelessRemoteSelectionWidget['_remoteCursors'] =
       new Map();
-    const status = this.doc.awarenessStore.getStates();
+    const status = this.store.awarenessStore.getStates();
 
     this.selection.remoteCursorSelectionMap.forEach(
       (cursorSelection, clientId) => {
@@ -177,7 +177,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetComponent<RootBlockMode
   override connectedCallback() {
     super.connectedCallback();
 
-    const { _disposables, doc } = this;
+    const { _disposables, store } = this;
 
     if (this.surface) {
       _disposables.add(
@@ -192,7 +192,7 @@ export class EdgelessRemoteSelectionWidget extends WidgetComponent<RootBlockMode
     }
 
     _disposables.add(
-      doc.slots.blockUpdated.subscribe(this._updateOnElementChange)
+      store.slots.blockUpdated.subscribe(this._updateOnElementChange)
     );
 
     _disposables.add(

--- a/blocksuite/affine/widgets/slash-menu/src/config.ts
+++ b/blocksuite/affine/widgets/slash-menu/src/config.ts
@@ -82,13 +82,18 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         group: '8_Actions@0',
         action: ({ std, model }) => {
           const { host } = std;
-          const previousSiblingModel = host.doc.getPrev(model);
+          const previousSiblingModel = host.store.getPrev(model);
           if (!previousSiblingModel) return;
 
-          const parentModel = host.doc.getParent(previousSiblingModel);
+          const parentModel = host.store.getParent(previousSiblingModel);
           if (!parentModel) return;
 
-          host.doc.moveBlocks([model], parentModel, previousSiblingModel, true);
+          host.store.moveBlocks(
+            [model],
+            parentModel,
+            previousSiblingModel,
+            true
+          );
         },
       },
       {
@@ -99,13 +104,13 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         group: '8_Actions@1',
         action: ({ std, model }) => {
           const { host } = std;
-          const nextSiblingModel = host.doc.getNext(model);
+          const nextSiblingModel = host.store.getNext(model);
           if (!nextSiblingModel) return;
 
-          const parentModel = host.doc.getParent(nextSiblingModel);
+          const parentModel = host.store.getParent(nextSiblingModel);
           if (!parentModel) return;
 
-          host.doc.moveBlocks([model], parentModel, nextSiblingModel, false);
+          host.store.moveBlocks([model], parentModel, nextSiblingModel, false);
         },
       },
       {
@@ -139,7 +144,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
             return;
           }
           const { host } = std;
-          const parent = host.doc.getParent(model);
+          const parent = host.store.getParent(model);
           if (!parent) {
             console.error(
               'Failed to duplicate block! Parent not found: ' +
@@ -152,7 +157,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
           const index = parent.children.indexOf(model);
 
           // FIXME: this clone is not correct
-          host.doc.addBlock(
+          host.store.addBlock(
             model.flavour,
             {
               type: (model as ParagraphBlockModel).props.type,
@@ -163,7 +168,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
               ),
               checked: (model as ListBlockModel).props.checked,
             },
-            host.doc.getParent(model),
+            host.store.getParent(model),
             index
           );
         },
@@ -176,7 +181,7 @@ export const defaultSlashMenuConfig: SlashMenuConfig = {
         tooltip: slashMenuToolTips['Delete'],
         group: '8_Actions@4',
         action: ({ std, model }) => {
-          std.host.doc.deleteBlock(model);
+          std.host.store.deleteBlock(model);
         },
       },
     ];

--- a/blocksuite/affine/widgets/slash-menu/src/widget.ts
+++ b/blocksuite/affine/widgets/slash-menu/src/widget.ts
@@ -76,7 +76,7 @@ export class AffineSlashMenuWidget extends WidgetComponent {
     const textSelection = this.host.selection.find(TextSelection);
     if (!textSelection) return;
 
-    const model = this.host.doc.getBlock(textSelection.blockId)?.model;
+    const model = this.host.store.getBlock(textSelection.blockId)?.model;
     if (!model) return;
 
     return getInlineEditorByModel(this.std, model);

--- a/blocksuite/framework/std/src/event/dispatcher.ts
+++ b/blocksuite/framework/std/src/event/dispatcher.ts
@@ -299,7 +299,7 @@ export class UIEventDispatcher extends LifeCycleWatcher {
     return (
       element instanceof HTMLInputElement ||
       element instanceof HTMLTextAreaElement ||
-      (element instanceof EditorHost && !element.doc.readonly) ||
+      (element instanceof EditorHost && !element.store.readonly) ||
       (element as HTMLElement).isContentEditable
     );
   }

--- a/blocksuite/framework/std/src/inline/range/range-binding.ts
+++ b/blocksuite/framework/std/src/inline/range/range-binding.ts
@@ -22,7 +22,7 @@ export class RangeBinding {
     let parent: BlockModel | null = block;
     while (parent) {
       path.unshift(parent.id);
-      parent = this.host.doc.getParent(parent);
+      parent = this.host.store.getParent(parent);
     }
 
     return path;
@@ -54,7 +54,7 @@ export class RangeBinding {
 
     event.preventDefault();
 
-    this.host.doc.transact(() => {
+    this.host.store.transact(() => {
       startText.delete(from.index, from.length);
       startText.insert(event.data ?? '', from.index);
       endText.delete(0, to.length);
@@ -65,9 +65,9 @@ export class RangeBinding {
         // delete from lowest to highest
         .reverse()
         .forEach(block => {
-          const parent = this.host.doc.getParent(block.model);
+          const parent = this.host.store.getParent(block.model);
           if (!parent) return;
-          this.host.doc.deleteBlock(block.model, {
+          this.host.store.deleteBlock(block.model, {
             bringChildrenTo: parent,
           });
         });
@@ -129,9 +129,9 @@ export class RangeBinding {
       this.host.requestUpdate();
       await this.host.updateComplete;
 
-      this.host.doc.captureSync();
+      this.host.store.captureSync();
 
-      this.host.doc.transact(() => {
+      this.host.store.transact(() => {
         endText.delete(0, to.length);
         startText.delete(from.index, from.length);
         startText.insert(event.data, from.index);
@@ -142,9 +142,9 @@ export class RangeBinding {
           // delete from lowest to highest
           .reverse()
           .forEach(block => {
-            const parent = this.host.doc.getParent(block.model);
+            const parent = this.host.store.getParent(block.model);
             if (!parent) return;
-            this.host.doc.deleteBlock(block.model, {
+            this.host.store.deleteBlock(block.model, {
               bringChildrenTo: parent,
             });
           });
@@ -256,7 +256,7 @@ export class RangeBinding {
       return;
     }
 
-    const model = this.host.doc.getModelById(textSelection.blockId);
+    const model = this.host.store.getModelById(textSelection.blockId);
     // If the model is not found, the selection maybe in another editor
     if (!model) return;
 

--- a/blocksuite/framework/std/src/scope/std-scope.ts
+++ b/blocksuite/framework/std/src/scope/std-scope.ts
@@ -152,7 +152,7 @@ export class BlockStdScope {
   render() {
     const element = new EditorHost();
     element.std = this;
-    element.doc = this.store;
+    element.store = this.store;
     this._host = element;
     this._lifeCycleWatchers.forEach(watcher => {
       watcher.rendered();

--- a/blocksuite/framework/std/src/view/element/block-component.ts
+++ b/blocksuite/framework/std/src/view/element/block-component.ts
@@ -20,12 +20,12 @@ import {
   modelContext,
   serviceContext,
 } from './consts.js';
-import { docContext, stdContext } from './lit-host.js';
+import { stdContext, storeContext } from './lit-host.js';
 import { ShadowlessElement } from './shadowless-element.js';
 import type { WidgetComponent } from './widget-component.js';
 
 @requiredProperties({
-  doc: PropTypes.instanceOf(Store),
+  store: PropTypes.instanceOf(Store),
   std: PropTypes.object,
   widgets: PropTypes.recordOf(PropTypes.object),
 })
@@ -86,7 +86,7 @@ export class BlockComponent<
   }
 
   get isVersionMismatch() {
-    const schema = this.doc.schema.flavourSchemaMap.get(this.model.flavour);
+    const schema = this.store.schema.flavourSchemaMap.get(this.model.flavour);
     if (!schema) {
       console.warn(
         `Schema not found for block ${this.model.id}, flavour ${this.model.flavour}`
@@ -109,7 +109,7 @@ export class BlockComponent<
     if (this._model) {
       return this._model;
     }
-    const model = this.doc.getModelById<Model>(this.blockId);
+    const model = this.store.getModelById<Model>(this.blockId);
     if (!model) {
       throw new BlockSuiteError(
         ErrorCode.MissingViewModelError,
@@ -131,7 +131,7 @@ export class BlockComponent<
   }
 
   get rootComponent(): BlockComponent | null {
-    const rootId = this.doc.root?.id;
+    const rootId = this.store.root?.id;
     if (!rootId) {
       return null;
     }
@@ -173,7 +173,9 @@ export class BlockComponent<
       this.isVersionMismatch,
       () => {
         const actualVersion = this.model.version;
-        const schema = this.doc.schema.flavourSchemaMap.get(this.model.flavour);
+        const schema = this.store.schema.flavourSchemaMap.get(
+          this.model.flavour
+        );
         const expectedVersion = schema?.version ?? -1;
         return this.renderVersionMismatch(expectedVersion, actualVersion);
       },
@@ -290,8 +292,8 @@ export class BlockComponent<
   @state()
   private accessor _service: Service | null = null;
 
-  @consume({ context: docContext })
-  accessor doc!: Store;
+  @consume({ context: storeContext })
+  accessor store!: Store;
 
   @property({ attribute: false })
   accessor viewType: BlockViewType = 'display';

--- a/blocksuite/framework/std/src/view/element/gfx-block-component.ts
+++ b/blocksuite/framework/std/src/view/element/gfx-block-component.ts
@@ -56,7 +56,7 @@ function handleGfxConnection(instance: GfxBlockComponent) {
   );
 
   instance.disposables.add(
-    instance.doc.slots.blockUpdated.subscribe(({ type, id }) => {
+    instance.store.slots.blockUpdated.subscribe(({ type, id }) => {
       if (id === instance.model.id && type === 'update') {
         updateTransform(instance);
       }

--- a/blocksuite/framework/std/src/view/element/lit-host.ts
+++ b/blocksuite/framework/std/src/view/element/lit-host.ts
@@ -25,11 +25,11 @@ import type { ViewStore } from '../view-store.js';
 import { BLOCK_ID_ATTR, WIDGET_ID_ATTR } from './consts.js';
 import { ShadowlessElement } from './shadowless-element.js';
 
-export const docContext = createContext<Store>('doc');
+export const storeContext = createContext<Store>('store');
 export const stdContext = createContext<BlockStdScope>('std');
 
 @requiredProperties({
-  doc: PropTypes.instanceOf(Store),
+  store: PropTypes.instanceOf(Store),
   std: PropTypes.object,
 })
 export class EditorHost extends SignalWatcher(
@@ -46,11 +46,11 @@ export class EditorHost extends SignalWatcher(
 
   private readonly _renderModel = (model: BlockModel): TemplateResult => {
     const { flavour } = model;
-    const block = this.doc.getBlock(model.id);
+    const block = this.store.getBlock(model.id);
     if (!block || block.blockViewType === 'hidden') {
       return html`${nothing}`;
     }
-    const schema = this.doc.schema.flavourSchemaMap.get(flavour);
+    const schema = this.store.schema.flavourSchemaMap.get(flavour);
     const view = this.std.getView(flavour);
     if (!schema || !view) {
       console.warn(`Cannot find render flavour ${flavour}.`);
@@ -112,7 +112,7 @@ export class EditorHost extends SignalWatcher(
   override connectedCallback() {
     super.connectedCallback();
 
-    if (!this.doc.root) {
+    if (!this.store.root) {
       throw new BlockSuiteError(
         ErrorCode.NoRootModelError,
         'This doc is missing root block. Please initialize the default block structure before connecting the editor to DOM.'
@@ -131,7 +131,7 @@ export class EditorHost extends SignalWatcher(
   override async getUpdateComplete(): Promise<boolean> {
     try {
       const result = await super.getUpdateComplete();
-      const rootModel = this.doc.root;
+      const rootModel = this.store.root;
       if (!rootModel) return result;
 
       const view = this.std.getView(rootModel.flavour);
@@ -175,15 +175,15 @@ export class EditorHost extends SignalWatcher(
   }
 
   override render() {
-    const { root } = this.doc;
+    const { root } = this.store;
     if (!root) return nothing;
 
     return this._renderModel(root);
   }
 
-  @provide({ context: docContext })
+  @provide({ context: storeContext })
   @property({ attribute: false })
-  accessor doc!: Store;
+  accessor store!: Store;
 
   @provide({ context: stdContext })
   @property({ attribute: false })

--- a/blocksuite/framework/std/src/view/element/widget-component.ts
+++ b/blocksuite/framework/std/src/view/element/widget-component.ts
@@ -8,7 +8,7 @@ import type { BlockService } from '../../extension/index.js';
 import type { BlockStdScope } from '../../scope/index.js';
 import type { BlockComponent } from './block-component.js';
 import { modelContext, serviceContext } from './consts.js';
-import { docContext, stdContext } from './lit-host.js';
+import { stdContext, storeContext } from './lit-host.js';
 
 export class WidgetComponent<
   Model extends BlockModel = BlockModel,
@@ -31,8 +31,8 @@ export class WidgetComponent<
     return this.std.view.getBlock(this.model.id) as B | null;
   }
 
-  get doc() {
-    return this._doc;
+  get store() {
+    return this._store;
   }
 
   get flavour(): string {
@@ -84,8 +84,8 @@ export class WidgetComponent<
     return null;
   }
 
-  @consume({ context: docContext })
-  private accessor _doc!: Store;
+  @consume({ context: storeContext })
+  private accessor _store!: Store;
 
   @consume({ context: modelContext })
   private accessor _model!: Model;

--- a/blocksuite/playground/apps/comment/comment-manager.ts
+++ b/blocksuite/playground/apps/comment/comment-manager.ts
@@ -30,7 +30,7 @@ export class CommentManager {
   }
 
   get commentsMap() {
-    return this.host.doc.spaceDoc.getMap<Y.Map<unknown>>('comments');
+    return this.host.store.spaceDoc.getMap<Y.Map<unknown>>('comments');
   }
 
   constructor(readonly host: EditorHost) {}
@@ -45,7 +45,7 @@ export class CommentManager {
     }
 
     const { quote, range } = parseResult;
-    const id = this.host.doc.workspace.idGenerator();
+    const id = this.host.store.workspace.idGenerator();
     const comment: Comment = {
       id,
       date: Date.now(),
@@ -66,12 +66,12 @@ export class CommentManager {
 
       const startIndex = Y.createAbsolutePositionFromRelativePosition(
         start.index,
-        this.host.doc.spaceDoc
+        this.host.store.spaceDoc
       );
       const startBlock = this.host.view.getBlock(start.id);
       const endIndex = Y.createAbsolutePositionFromRelativePosition(
         end.index,
-        this.host.doc.spaceDoc
+        this.host.store.spaceDoc
       );
       const endBlock = this.host.view.getBlock(end.id);
 

--- a/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
@@ -107,8 +107,8 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
         signal,
         control,
         where,
-        docId: host.doc.id,
-        workspaceId: host.doc.workspace.id,
+        docId: host.store.id,
+        workspaceId: host.store.workspace.id,
         webSearch: visible?.value && enabled?.value,
       } as Parameters<typeof action>[0];
       // @ts-expect-error TODO(@Peng): maybe fix this

--- a/packages/frontend/core/src/blocksuite/ai/actions/edgeless-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/edgeless-handler.ts
@@ -53,7 +53,7 @@ async function getContentFromEmbedSyncedDocModel(
   host: EditorHost,
   models: EmbedSyncedDocModel[]
 ) {
-  const slice = Slice.fromModels(host.doc, models);
+  const slice = Slice.fromModels(host.store, models);
   return (await getContentFromSlice(host, slice)).trim();
 }
 
@@ -64,7 +64,7 @@ async function getContentFromHubBlockModel(
   return (
     await Promise.all(
       models.map(model => {
-        const slice = Slice.fromModels(host.doc, model.children);
+        const slice = Slice.fromModels(host.store, model.children);
         return getContentFromSlice(host, slice);
       })
     )
@@ -195,8 +195,8 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
             where,
             models,
             host,
-            docId: host.doc.id,
-            workspaceId: host.doc.workspace.id,
+            docId: host.store.id,
+            workspaceId: host.store.workspace.id,
             webSearch: visible?.value && enabled?.value,
           } as Parameters<typeof action>[0];
 
@@ -237,8 +237,8 @@ function actionToStream<T extends keyof BlockSuitePresets.AIActions>(
           models,
           control: 'format-bar',
           host,
-          docId: host.doc.id,
-          workspaceId: host.doc.workspace.id,
+          docId: host.store.id,
+          workspaceId: host.store.workspace.id,
         } as Parameters<typeof action>[0];
 
         // @ts-expect-error TODO(@Peng): maybe fix this

--- a/packages/frontend/core/src/blocksuite/ai/actions/edgeless-response.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/edgeless-response.ts
@@ -61,7 +61,7 @@ type ErrorConfig = Exclude<
 >['errorStateConfig'];
 
 export function getToolbar(host: EditorHost) {
-  const rootBlockId = host.doc.root?.id as string;
+  const rootBlockId = host.store.root?.id as string;
   const toolbar = host.view.getWidget(
     AFFINE_TOOLBAR_WIDGET,
     rootBlockId
@@ -211,7 +211,7 @@ export function asCaption<T extends keyof BlockSuitePresets.AIActions>(
       const imageBlock = selectedElements[0];
       if (!(imageBlock instanceof ImageBlockModel)) return;
 
-      host.doc.updateBlock(imageBlock, { caption });
+      host.store.updateBlock(imageBlock, { caption });
       panel.hide();
     },
   };
@@ -223,7 +223,7 @@ function insertBelow(
   parentId: string,
   index = 0
 ) {
-  insertFromMarkdown(host, markdown, host.doc, parentId, index)
+  insertFromMarkdown(host, markdown, host.store, parentId, index)
     .then(() => {
       const gfx = host.std.get(GfxControllerIdentifier);
 
@@ -242,7 +242,7 @@ function createBlockAndInsert(
   markdown: string,
   type: 'edgelessText' | 'note'
 ) {
-  const doc = host.doc;
+  const doc = host.store;
   const edgelessCopilot = getEdgelessCopilotWidget(host);
   doc.transact(() => {
     if (!doc.root) return;
@@ -340,11 +340,11 @@ function responseToCreateImage(host: EditorHost) {
       const gfx = host.std.get(GfxControllerIdentifier);
       const [x, y] = gfx.viewport.toViewCoord(minX, minY);
 
-      host.doc.transact(() => {
+      host.store.transact(() => {
         addImages(host.std, [img], { point: [x, y] })
           .then(blockIds => {
             const imageBlockId = blockIds[0];
-            const imageBlock = host.doc.getBlock(imageBlockId);
+            const imageBlock = host.store.getBlock(imageBlockId);
             if (!imageBlock || !selectedBound) return;
 
             // Update the image width and height to the same with the selected image
@@ -356,7 +356,7 @@ function responseToCreateImage(host: EditorHost) {
               selectedBound.w,
               selectedBound.h
             );
-            host.doc.updateBlock(imageModel, { xywh: newBound.serialize() });
+            host.store.updateBlock(imageModel, { xywh: newBound.serialize() });
           })
           .catch(console.error);
       });
@@ -365,7 +365,7 @@ function responseToCreateImage(host: EditorHost) {
 }
 
 export function responseToExpandMindmap(host: EditorHost, ctx: AIContext) {
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!surface) return;
 
   const elements = ctx.get().selectedElements;
@@ -414,7 +414,7 @@ function responseToBrainstormMindmap(host: EditorHost, ctx: AIContext) {
   const gfx = host.std.get(GfxControllerIdentifier);
   const edgelessCopilot = getEdgelessCopilotWidget(host);
   const selectionRect = edgelessCopilot.selectionModelRect;
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!surface) return;
 
   const { node, style, selectedElements } = ctx.get();
@@ -440,7 +440,7 @@ function responseToBrainstormMindmap(host: EditorHost, ctx: AIContext) {
   });
   const mindmap = surface.getElementById(mindmapId) as MindmapElementModel;
 
-  host.doc.transact(() => {
+  host.store.transact(() => {
     mindmap.childElements.forEach(shape => {
       fitContent(shape as ShapeElementModel);
     });
@@ -477,7 +477,7 @@ function responseToMakeItReal(host: EditorHost, ctx: AIContext) {
   html = preprocessHtml(html);
 
   const edgelessCopilot = getEdgelessCopilotWidget(host);
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!surface) return;
 
   const data = ctx.get();
@@ -489,8 +489,8 @@ function responseToMakeItReal(host: EditorHost, ctx: AIContext) {
   edgelessCopilot.hideCopilotPanel();
   aiPanel.hide();
 
-  host.doc.transact(() => {
-    host.doc.addBlock(
+  host.store.transact(() => {
+    host.store.addBlock(
       'affine:embed-html',
       {
         html,

--- a/packages/frontend/core/src/blocksuite/ai/actions/page-response.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/page-response.ts
@@ -66,10 +66,10 @@ function responseToBrainstormMindmap(
   ctx: AIContext,
   place: Place
 ) {
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!surface) return;
 
-  host.doc.transact(() => {
+  host.store.transact(() => {
     const { node, style } = ctx.get();
     if (!node) return;
     const bound = getEdgelessContentBound(host);
@@ -106,7 +106,7 @@ function responseToBrainstormMindmap(
 }
 
 function responseToMakeItReal(host: EditorHost, ctx: AIContext, place: Place) {
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   const aiPanel = getAIPanelWidget(host);
   if (!aiPanel.answer || !surface) return;
 
@@ -116,8 +116,8 @@ function responseToMakeItReal(host: EditorHost, ctx: AIContext, place: Place) {
   const y = bound ? bound.y : 0;
   const htmlBound = new Bound(x, y + PADDING, width || 800, height || 600);
   const html = preprocessHtml(aiPanel.answer);
-  host.doc.transact(() => {
-    host.doc.addBlock(
+  host.store.transact(() => {
+    host.store.addBlock(
       'affine:embed-html',
       {
         html,
@@ -137,7 +137,7 @@ async function responseToCreateSlides(
   place: Place
 ) {
   const { contents, images = [] } = ctx.get();
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!contents || !surface) return;
 
   try {
@@ -235,11 +235,11 @@ function getSelection(host: EditorHost) {
 }
 
 function getEdgelessContentBound(host: EditorHost) {
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!surface) return;
 
   const elements = (
-    host.doc
+    host.store
       .getAllModels()
       .filter(
         model =>
@@ -262,9 +262,9 @@ function expandBound(bound: Bound, margin: number) {
 }
 
 function addSurfaceRefBlock(host: EditorHost, bound: Bound, place: Place) {
-  const surface = getSurfaceBlock(host.doc);
+  const surface = getSurfaceBlock(host.store);
   if (!surface) return;
-  const frame = host.doc.addBlock(
+  const frame = host.store.addBlock(
     'affine:frame',
     {
       title: new Text(new Y.Text('Frame')),
@@ -296,7 +296,7 @@ function addSiblingBlocks(
 ) {
   const targetModel = getTargetModel(host, place);
   if (!targetModel) return;
-  return host.doc.addSiblingBlocks(targetModel, props, place);
+  return host.store.addSiblingBlocks(targetModel, props, place);
 }
 
 function findFrameObject(obj: AffineNode): AffineNode | null {

--- a/packages/frontend/core/src/blocksuite/ai/ai-panel.ts
+++ b/packages/frontend/core/src/blocksuite/ai/ai-panel.ts
@@ -70,7 +70,7 @@ function asCaption<T extends keyof BlockSuitePresets.AIActions>(
       const imageBlock = selectedBlocks[0].model;
       if (!(imageBlock instanceof ImageBlockModel)) return;
 
-      host.doc.updateBlock(imageBlock, { caption });
+      host.store.updateBlock(imageBlock, { caption });
       panel.hide();
     },
   };
@@ -97,7 +97,7 @@ function createNewNote(host: EditorHost): AIItemConfig {
       // create a new note block at the left of the current note block
       const bound = Bound.deserialize(noteModel.xywh);
       const newBound = new Bound(bound.x - bound.w - 20, bound.y, bound.w, 72);
-      const doc = host.doc;
+      const doc = host.store;
       const panel = getAIPanelWidget(host);
       const gfx = host.std.get(GfxControllerIdentifier);
       doc.transact(() => {

--- a/packages/frontend/core/src/blocksuite/ai/blocks/ai-chat-block/ai-chat-block.ts
+++ b/packages/frontend/core/src/blocksuite/ai/blocks/ai-chat-block/ai-chat-block.ts
@@ -9,9 +9,9 @@ import { type AIChatBlockModel } from './model';
 import { AIChatBlockStyles } from './styles';
 
 @Peekable({
-  enableOn: ({ doc }: AIChatBlockComponent) => {
+  enableOn: ({ store }: AIChatBlockComponent) => {
     // Disable on mobile and readonly mode
-    return !BUILD_CONFIG.isMobileEdition && !doc.readonly;
+    return !BUILD_CONFIG.isMobileEdition && !store.readonly;
   },
 })
 export class AIChatBlockComponent extends BlockComponent<AIChatBlockModel> {

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-panel-messages.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/chat-panel-messages.ts
@@ -174,7 +174,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
 
   private _renderAIOnboarding() {
     return this.isLoading ||
-      !this.host?.doc.get(FeatureFlagService).getFlag('enable_ai_onboarding')
+      !this.host?.store.get(FeatureFlagService).getFlag('enable_ai_onboarding')
       ? nothing
       : html`<div class="onboarding-wrapper" data-testid="ai-onboarding">
           ${repeat(
@@ -328,7 +328,7 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
     disposables.add(
       docModeService.onPrimaryModeChange(
         () => this.requestUpdate(),
-        this.host.doc.id
+        this.host.store.id
       )
     );
   }
@@ -364,12 +364,12 @@ export class ChatPanelMessages extends WithDisposable(ShadowlessElement) {
       }
       this.updateContext({ messages, status: 'loading', error: null });
 
-      const { doc } = this.host;
+      const { store } = this.host;
       const stream = await AIProvider.actions.chat({
         sessionId,
         retry: true,
-        docId: doc.id,
-        workspaceId: doc.workspace.id,
+        docId: store.id,
+        workspaceId: store.workspace.id,
         host: this.host,
         stream: true,
         signal: abortController.signal,

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/chat-panel-chips.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/chat-panel-chips.ts
@@ -404,7 +404,7 @@ export class ChatPanelChips extends SignalWatcher(
       if (!contextId || !AIProvider.context) {
         throw new Error('Context not found');
       }
-      const blobId = await this.host.doc.blobSync.set(chip.file);
+      const blobId = await this.host.store.blobSync.set(chip.file);
       const contextFile = await AIProvider.context.addContextFile(chip.file, {
         contextId,
         blobId,

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-composer/ai-chat-composer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-composer/ai-chat-composer.ts
@@ -232,7 +232,7 @@ export class AIChatComposer extends SignalWatcher(
 
     const fileChips: FileChip[] = await Promise.all(
       files.map(async file => {
-        const blob = await this.host.doc.blobSync.get(file.blobId);
+        const blob = await this.host.store.blobSync.get(file.blobId);
         return {
           file: new File(blob ? [blob] : [], file.name),
           blobId: file.blobId,

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
@@ -551,9 +551,9 @@ export class AIChatInput extends SignalWatcher(WithDisposable(LitElement)) {
         sessionId,
         input: userInput,
         contexts,
-        docId: this.host.doc.id,
+        docId: this.host.store.id,
         attachments: images,
-        workspaceId: this.host.doc.workspace.id,
+        workspaceId: this.host.store.workspace.id,
         host: this.host,
         stream: true,
         signal: abortController.signal,
@@ -616,8 +616,8 @@ export class AIChatInput extends SignalWatcher(WithDisposable(LitElement)) {
     if (!last.id) {
       const sessionId = await this.getSessionId();
       const historyIds = await AIProvider.histories?.ids(
-        this.host.doc.workspace.id,
-        this.host.doc.id,
+        this.host.store.workspace.id,
+        this.host.store.id,
         { sessionId }
       );
       if (!historyIds || !historyIds[0]) return;

--- a/packages/frontend/core/src/blocksuite/ai/extensions/ai-slash-menu.ts
+++ b/packages/frontend/core/src/blocksuite/ai/extensions/ai-slash-menu.ts
@@ -30,7 +30,7 @@ export function AiSlashMenuConfigExtension() {
   const showWhenWrapper =
     (item?: AIItemConfig) =>
     ({ std }: SlashMenuContext) => {
-      const root = std.host.doc.root;
+      const root = std.host.store.root;
       if (!root) return false;
       const affineAIPanelWidget = std.view.getWidget(
         AFFINE_AI_PANEL_WIDGET,
@@ -40,7 +40,7 @@ export function AiSlashMenuConfigExtension() {
 
       const chain = std.host.command.chain();
       const docModeService = std.get(DocModeProvider);
-      const editorMode = docModeService.getPrimaryMode(std.host.doc.id);
+      const editorMode = docModeService.getPrimaryMode(std.host.store.id);
 
       return item?.showWhen?.(chain, editorMode, std.host) ?? true;
     };
@@ -80,7 +80,7 @@ export function AiSlashMenuConfigExtension() {
       icon: AIStarIcon,
       when: showWhenWrapper(),
       action: ({ std }) => {
-        const root = std.host.doc.root;
+        const root = std.host.store.root;
         if (!root) return;
         const affineAIPanelWidget = std.view.getWidget(
           AFFINE_AI_PANEL_WIDGET,

--- a/packages/frontend/core/src/blocksuite/ai/messages/mindmap.ts
+++ b/packages/frontend/core/src/blocksuite/ai/messages/mindmap.ts
@@ -56,7 +56,7 @@ export const createMindmapExecuteRenderer: (
     }
 
     ctx.set({
-      node: markdownToMindmap(answer, host.doc, host.std.store.provider),
+      node: markdownToMindmap(answer, host.store, host.std.store.provider),
     });
 
     handler(host, ctx);

--- a/packages/frontend/core/src/blocksuite/ai/peek-view/chat-block-peek-view.ts
+++ b/packages/frontend/core/src/blocksuite/ai/peek-view/chat-block-peek-view.ts
@@ -156,10 +156,10 @@ export class AIChatBlockPeekView extends LitElement {
     const lastMessage = this._historyMessages.at(-1);
     if (!lastMessage) return;
 
-    const { doc } = this.host;
+    const { store } = this.host;
     const forkSessionId = await AIProvider.forkChat?.({
-      workspaceId: doc.workspace.id,
-      docId: doc.id,
+      workspaceId: store.workspace.id,
+      docId: store.id,
       sessionId: this._sessionId,
       latestMessageId: lastMessage.id,
     });
@@ -195,9 +195,9 @@ export class AIChatBlockPeekView extends LitElement {
       return;
     }
 
-    const { doc } = this.host;
+    const { store } = this.host;
     // create a new AI chat block
-    const surfaceBlock = doc
+    const surfaceBlock = store
       .getAllModels()
       .find(block => block.flavour === 'affine:surface');
     if (!surfaceBlock) {
@@ -262,8 +262,8 @@ export class AIChatBlockPeekView extends LitElement {
       return;
     }
 
-    const { doc } = this.host;
-    const chatBlock = doc.getBlock(this._forkBlockId);
+    const { store } = this.host;
+    const chatBlock = store.getBlock(this._forkBlockId);
     if (!chatBlock) return;
 
     // Get fork session messages
@@ -276,7 +276,7 @@ export class AIChatBlockPeekView extends LitElement {
     if (!messages.length) {
       return;
     }
-    doc.updateBlock(chatBlock.model, {
+    store.updateBlock(chatBlock.model, {
       messages: JSON.stringify(messages),
     });
   };
@@ -298,12 +298,12 @@ export class AIChatBlockPeekView extends LitElement {
   private readonly _onHistoryCleared = async () => {
     const { _forkBlockId, host } = this;
     if (_forkBlockId) {
-      const surface = getSurfaceBlock(host.doc);
+      const surface = getSurfaceBlock(host.store);
       const crud = host.std.get(EdgelessCRUDIdentifier);
-      const chatBlock = host.doc.getBlock(_forkBlockId)?.model;
+      const chatBlock = host.store.getBlock(_forkBlockId)?.model;
       if (chatBlock) {
         const connectors = surface?.getConnectors(chatBlock.id);
-        host.doc.transact(() => {
+        host.store.transact(() => {
           // Delete the AI chat block
           crud.removeElement(_forkBlockId);
           // Delete the connectors
@@ -335,12 +335,12 @@ export class AIChatBlockPeekView extends LitElement {
       }
       this.updateContext({ messages, status: 'loading', error: null });
 
-      const { doc } = this.host;
+      const { store } = this.host;
       const stream = await AIProvider.actions.chat({
         sessionId: _forkSessionId,
         retry: true,
-        docId: doc.id,
-        workspaceId: doc.workspace.id,
+        docId: store.id,
+        workspaceId: store.workspace.id,
         host: this.host,
         stream: true,
         signal: abortController.signal,
@@ -505,7 +505,7 @@ export class AIChatBlockPeekView extends LitElement {
         <div class="history-clear-container">
           <ai-history-clear
             .host=${this.host}
-            .doc=${this.host.doc}
+            .doc=${this.host.store}
             .getSessionId=${this._getSessionId}
             .onHistoryCleared=${this._onHistoryCleared}
             .chatContextValue=${chatContext}
@@ -514,7 +514,7 @@ export class AIChatBlockPeekView extends LitElement {
       </div>
       <ai-chat-composer
         .host=${host}
-        .doc=${this.host.doc}
+        .doc=${this.host.store}
         .getSessionId=${this._getSessionId}
         .createSessionId=${this._createSessionId}
         .chatContextValue=${chatContext}

--- a/packages/frontend/core/src/blocksuite/ai/slides/index.ts
+++ b/packages/frontend/core/src/blocksuite/ai/slides/index.ts
@@ -56,7 +56,7 @@ export const PPTBuilder = (host: EditorHost) => {
   return {
     process: async (text: string) => {
       try {
-        const snapshot = await markdownToSnapshot(text, host.doc, host);
+        const snapshot = await markdownToSnapshot(text, host.store, host);
 
         const block = snapshot.snapshot?.content[0];
         if (!block) {
@@ -73,7 +73,7 @@ export const PPTBuilder = (host: EditorHost) => {
       return { contents, images: allImages };
     },
     done: async (text: string) => {
-      const snapshot = await markdownToSnapshot(text, host.doc, host);
+      const snapshot = await markdownToSnapshot(text, host.store, host);
       const block = snapshot.snapshot?.content[0];
       if (!block) {
         return;

--- a/packages/frontend/core/src/blocksuite/ai/utils/ai-widgets.ts
+++ b/packages/frontend/core/src/blocksuite/ai/utils/ai-widgets.ts
@@ -6,7 +6,7 @@ import {
 } from '../widgets/ai-panel/ai-panel';
 
 export const getAIPanelWidget = (host: EditorHost): AffineAIPanelWidget => {
-  const rootBlockId = host.doc.root?.id;
+  const rootBlockId = host.store.root?.id;
   if (!rootBlockId) {
     throw new Error('rootBlockId is not found');
   }

--- a/packages/frontend/core/src/blocksuite/ai/utils/edgeless.ts
+++ b/packages/frontend/core/src/blocksuite/ai/utils/edgeless.ts
@@ -48,7 +48,7 @@ export function isMindmapChild(ele: GfxModel) {
 export function getEdgelessCopilotWidget(
   host: EditorHost
 ): EdgelessCopilotWidget {
-  const rootBlockId = host.doc.root?.id as string;
+  const rootBlockId = host.store.root?.id as string;
   const copilotWidget = host.view.getWidget(
     AFFINE_EDGELESS_COPILOT_WIDGET,
     rootBlockId

--- a/packages/frontend/core/src/blocksuite/ai/utils/editor-actions.ts
+++ b/packages/frontend/core/src/blocksuite/ai/utils/editor-actions.ts
@@ -67,11 +67,11 @@ export const insert = async (
   );
   const insertIndex = below ? index + 1 : index;
 
-  const { doc } = host;
+  const { store } = host;
   const models = await insertFromMarkdown(
     host,
     content,
-    doc,
+    store,
     blockParent.model.id,
     insertIndex
   );
@@ -112,27 +112,27 @@ export const replace = async (
     host.std.command.exec(deleteTextCommand, { textSelection });
     const { snapshot, transformer } = await markdownToSnapshot(
       content,
-      host.doc,
+      host.store,
       host
     );
     if (snapshot) {
       await transformer.snapshotToSlice(
         snapshot,
-        host.doc,
+        host.store,
         firstBlockParent.model.id,
         firstIndex + 1
       );
     }
   } else {
     selectedModels.forEach(model => {
-      host.doc.deleteBlock(model);
+      host.store.deleteBlock(model);
     });
 
-    const { doc } = host;
+    const { store } = host;
     const models = await insertFromMarkdown(
       host,
       content,
-      doc,
+      store,
       firstBlockParent.model.id,
       firstIndex
     );

--- a/packages/frontend/core/src/blocksuite/ai/utils/selection-utils.ts
+++ b/packages/frontend/core/src/blocksuite/ai/utils/selection-utils.ts
@@ -133,7 +133,7 @@ export async function selectAboveBlocks(editorHost: EditorHost, num = 10) {
   let lastRootModel: BlockModel | null = null;
   while (noteModel && noteModel.flavour !== 'affine:note') {
     lastRootModel = noteModel;
-    noteModel = editorHost.doc.getParent(noteModel);
+    noteModel = editorHost.store.getParent(noteModel);
   }
   if (!noteModel || !lastRootModel) return '';
 
@@ -177,8 +177,8 @@ export async function selectAboveBlocks(editorHost: EditorHost, num = 10) {
 }
 
 export function getSurfaceElementFromEditor(editor: EditorHost) {
-  const { doc } = editor;
-  const surfaceModel = getSurfaceBlock(doc);
+  const { store } = editor;
+  const surfaceModel = getSurfaceBlock(store);
   if (!surfaceModel) return null;
 
   const surfaceId = surfaceModel.id;
@@ -224,7 +224,7 @@ export const getSelectedImagesAsBlobs = async (host: EditorHost) => {
     data.selectedBlocks?.map(async b => {
       const sourceId = (b.model as ImageBlockModel).props.sourceId;
       if (!sourceId) return null;
-      const blob = await host.doc.blobSync.get(sourceId);
+      const blob = await host.store.blobSync.get(sourceId);
       if (!blob) return null;
       return new File([blob], sourceId);
     }) ?? []
@@ -256,7 +256,7 @@ export const imageCustomInput = async (host: EditorHost) => {
   if (!(imageBlock instanceof ImageBlockModel)) return;
   if (!imageBlock.props.sourceId) return;
 
-  const blob = await host.doc.blobSync.get(imageBlock.props.sourceId);
+  const blob = await host.store.blobSync.get(imageBlock.props.sourceId);
   if (!blob) return;
 
   return {

--- a/packages/frontend/core/src/blocksuite/ai/widgets/ai-panel/ai-panel.ts
+++ b/packages/frontend/core/src/blocksuite/ai/widgets/ai-panel/ai-panel.ts
@@ -327,7 +327,7 @@ export class AffineAIPanelWidget extends WidgetComponent {
   }
 
   get viewportOverlayWidget() {
-    const rootId = this.host.doc.root?.id;
+    const rootId = this.host.store.root?.id;
     return rootId
       ? (this.host.view.getWidget(
           AFFINE_VIEWPORT_OVERLAY_WIDGET,

--- a/packages/frontend/core/src/blocksuite/ai/widgets/edgeless-copilot/index.ts
+++ b/packages/frontend/core/src/blocksuite/ai/widgets/edgeless-copilot/index.ts
@@ -85,7 +85,7 @@ export class EdgelessCopilotWidget extends WidgetComponent<RootBlockModel> {
       if (!referenceElement || !referenceElement.isConnected) return;
 
       // show ai input
-      const rootBlockId = this.host.doc.root?.id;
+      const rootBlockId = this.host.store.root?.id;
       if (!rootBlockId) return;
 
       const input = this.host.view.getWidget(

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/starter-bar.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/starter-bar.tsx
@@ -95,7 +95,7 @@ const StarterBarNotEmpty = ({ doc }: { doc: Store }) => {
     const std = editorService.editor.editorContainer$.value?.std;
     if (!std) return;
 
-    const rootBlockId = std.host.doc.root?.id;
+    const rootBlockId = std.host.store.root?.id;
     if (!rootBlockId) return;
 
     const rootComponent = std.view.getBlock(rootBlockId);

--- a/packages/frontend/core/src/blocksuite/database-block/properties/file/view.tsx
+++ b/packages/frontend/core/src/blocksuite/database-block/properties/file/view.tsx
@@ -225,7 +225,7 @@ class FileCellManager {
     this.selectCurrentCell = props.selectCurrentCell;
     this.isEditing = props.isEditing$;
     this.blobSync = this.cell?.view?.contextGet
-      ? this.cell.view.contextGet(HostContextKey)?.doc.blobSync
+      ? this.cell.view.contextGet(HostContextKey)?.store.blobSync
       : undefined;
 
     this.fileUploadManager = this.blobSync

--- a/packages/frontend/core/src/blocksuite/utils/markdown-utils.ts
+++ b/packages/frontend/core/src/blocksuite/utils/markdown-utils.ts
@@ -44,7 +44,7 @@ function processSnapshot(
   text: TextSelection,
   host: EditorHost
 ) {
-  const model = host.doc.getModelById(snapshot.id);
+  const model = host.store.getModelById(snapshot.id);
   if (!model) {
     return;
   }

--- a/packages/frontend/core/src/modules/at-menu-config/services/index.ts
+++ b/packages/frontend/core/src/modules/at-menu-config/services/index.ts
@@ -369,7 +369,7 @@ export class AtMenuConfigService extends Service {
             this.workspaceServerService.server?.scope.get(NotificationService);
           if (!notificationService) return;
 
-          const doc = block.doc;
+          const doc = block.store;
           const workspaceId = doc.workspace.id;
           const docId = doc.id;
           const mode = block.std.get(DocModeProvider).getEditorMode() ?? 'page';

--- a/tests/affine-local/e2e/blocksuite/clipboard/clipboard.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/clipboard/clipboard.spec.ts
@@ -448,7 +448,7 @@ test.describe('paste in readonly mode', () => {
       const pageRoot = document.querySelector(
         'affine-page-root'
       ) as PageRootBlockComponent;
-      pageRoot.doc.readonly = true;
+      pageRoot.store.readonly = true;
     });
 
     await setSelection(page, blockIds[0], 0, blockIds[0], 4);

--- a/tests/blocksuite/e2e/utils/actions/click.ts
+++ b/tests/blocksuite/e2e/utils/actions/click.ts
@@ -113,10 +113,10 @@ export async function switchReadonly(page: Page, value = true) {
     const defaultPage = document.querySelector(
       'affine-page-root,affine-edgeless-root'
     ) as HTMLElement & {
-      doc: Store;
+      store: Store;
     };
-    const doc = defaultPage.doc;
-    doc.readonly = _value;
+    const store = defaultPage.store;
+    store.readonly = _value;
   }, value);
 }
 

--- a/tests/blocksuite/e2e/utils/actions/misc.ts
+++ b/tests/blocksuite/e2e/utils/actions/misc.ts
@@ -1142,7 +1142,7 @@ export async function initImageState(page: Page, prependParagraph = false) {
     const imageBlob = await fetch(`${location.origin}/test-card-1.png`).then(
       response => response.blob()
     );
-    const storage = pageRoot.doc.blobSync;
+    const storage = pageRoot.store.blobSync;
     const sourceId = await storage.set(imageBlob);
     if (prepend) {
       doc.addBlock('affine:paragraph', {}, noteId);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Unified internal data access by replacing all references from `doc` to `store` across components, blocks, widgets, utilities, and tests. This standardizes how readonly state, block operations, service retrieval, and event subscriptions are handled throughout the application.
- **Tests**
  - Updated all test utilities and test cases to use `store` instead of `doc` for document-related operations.
- **Chores**
  - Updated context providers and property names to reflect the change from `doc` to `store` for improved consistency and maintainability.

No user-facing features or behaviors have changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->