### PR TITLE
fix(editor): attachment size in embed view

### DIFF
--- a/packages/frontend/core/src/blocksuite/extensions/attachment-embed-view.tsx
+++ b/packages/frontend/core/src/blocksuite/extensions/attachment-embed-view.tsx
@@ -2,6 +2,10 @@ import type { ReactToLit } from '@affine/component';
 import { AttachmentEmbedPreview } from '@affine/core/blocksuite/attachment-viewer/attachment-embed-preview';
 import { AttachmentEmbedConfigIdentifier } from '@blocksuite/affine/blocks/attachment';
 import { Bound } from '@blocksuite/affine/global/gfx';
+import {
+  EMBED_CARD_HEIGHT,
+  EMBED_CARD_WIDTH,
+} from '@blocksuite/affine/shared/consts';
 import type { ExtensionType } from '@blocksuite/affine/store';
 
 export function patchForPDFEmbedView(reactToLit: ReactToLit): ExtensionType {
@@ -14,8 +18,8 @@ export function patchForPDFEmbedView(reactToLit: ReactToLit): ExtensionType {
           model.props.size <= maxFileSize,
         action: model => {
           const bound = Bound.deserialize(model.props.xywh);
-          bound.w = 537 + 24 + 2;
-          bound.h = 759 + 46 + 24 + 2;
+          bound.w = EMBED_CARD_WIDTH.pdf;
+          bound.h = EMBED_CARD_HEIGHT.pdf;
           model.store.updateBlock(model, {
             embed: true,
             style: 'pdf',


### PR DESCRIPTION
Closes: [BS-3434](https://linear.app/affine-design/issue/BS-3434/修复-attachment-从-card-切换为-embed-尺寸问题)

<img width="1073" alt="Screenshot 2025-05-07 at 20 38 53" src="https://github.com/user-attachments/assets/9fbb7e40-3c01-4473-88d8-3469758ed06b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added dedicated embed actions for PDF and video attachments, ensuring consistent sizing and improved rendering for these media types.

- **Refactor**
  - Centralized PDF and video embed card dimensions using shared constants for more consistent and maintainable sizing.
  - Improved styling for video embeds, including better layout and responsive sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->