### PR TITLE
fix(nbstore): update workspace blob quota query

### DIFF
--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1701,6 +1701,21 @@ export const verifyEmailMutation = {
 }`,
 };
 
+export const workspaceBlobQuotaQuery = {
+  id: 'workspaceBlobQuotaQuery' as const,
+  op: 'workspaceBlobQuota',
+  query: `query workspaceBlobQuota($id: String!) {
+  workspace(id: $id) {
+    quota {
+      blobLimit
+      humanReadable {
+        blobLimit
+      }
+    }
+  }
+}`,
+};
+
 export const getWorkspaceConfigQuery = {
   id: 'getWorkspaceConfigQuery' as const,
   op: 'getWorkspaceConfig',

--- a/packages/common/graphql/src/graphql/workspace-blob-quota.gql
+++ b/packages/common/graphql/src/graphql/workspace-blob-quota.gql
@@ -1,0 +1,10 @@
+query workspaceBlobQuota($id: String!) {
+  workspace(id: $id) {
+    quota {
+      blobLimit
+      humanReadable {
+        blobLimit
+      }
+    }
+  }
+}

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -4387,6 +4387,25 @@ export type VerifyEmailMutation = {
   verifyEmail: boolean;
 };
 
+export type WorkspaceBlobQuotaQueryVariables = Exact<{
+  id: Scalars['String']['input'];
+}>;
+
+export type WorkspaceBlobQuotaQuery = {
+  __typename?: 'Query';
+  workspace: {
+    __typename?: 'WorkspaceType';
+    quota: {
+      __typename?: 'WorkspaceQuotaType';
+      blobLimit: number;
+      humanReadable: {
+        __typename?: 'WorkspaceQuotaHumanReadableType';
+        blobLimit: string;
+      };
+    };
+  };
+};
+
 export type GetWorkspaceConfigQueryVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
@@ -4866,6 +4885,11 @@ export type Queries =
       name: 'subscriptionQuery';
       variables: SubscriptionQueryVariables;
       response: SubscriptionQuery;
+    }
+  | {
+      name: 'workspaceBlobQuotaQuery';
+      variables: WorkspaceBlobQuotaQueryVariables;
+      response: WorkspaceBlobQuotaQuery;
     }
   | {
       name: 'getWorkspaceConfigQuery';

--- a/packages/common/nbstore/src/impls/cloud/blob.ts
+++ b/packages/common/nbstore/src/impls/cloud/blob.ts
@@ -4,7 +4,7 @@ import {
   listBlobsQuery,
   releaseDeletedBlobsMutation,
   setBlobMutation,
-  workspaceQuotaQuery,
+  workspaceBlobQuotaQuery,
 } from '@affine/graphql';
 
 import {
@@ -161,7 +161,7 @@ export class CloudBlobStorage extends BlobStorageBase {
     }
     try {
       const res = await this.connection.gql({
-        query: workspaceQuotaQuery,
+        query: workspaceBlobQuotaQuery,
         variables: { id: this.options.id },
       });
 


### PR DESCRIPTION
Change the query for querying quota of Cloud Blob Storage.

The original query used new fields, which caused errors in the old version of the server. This PR uses a simpler query to ensure compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve a workspace's blob storage quota, including both the raw limit and a human-readable format, via a new query.

- **Bug Fixes**
  - Updated quota retrieval to use the new blob-specific quota query for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->