### PR TITLE
fix(editor): disable html preview when no cross-origin isolated

### DIFF
--- a/packages/frontend/core/src/blocksuite/manager/code-block-preview.ts
+++ b/packages/frontend/core/src/blocksuite/manager/code-block-preview.ts
@@ -13,12 +13,17 @@ export class CodeBlockPreviewExtensionProvider extends ViewExtensionProvider {
 
   override effect() {
     super.effect();
-    htmlPreviewEffects();
+
+    if (window.crossOriginIsolated) {
+      htmlPreviewEffects();
+    }
   }
 
   override setup(context: ViewExtensionContext) {
     super.setup(context);
 
-    context.register(CodeBlockHtmlPreview);
+    if (window.crossOriginIsolated) {
+      context.register(CodeBlockHtmlPreview);
+    }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility by ensuring code block preview features only activate when the browser supports isolated contexts, preventing potential issues in unsupported environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->