### PR TITLE
fix(editor): database scroll regression on mobile safari

### DIFF
--- a/blocksuite/affine/data-view/src/view-presets/table/mobile/table-view.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/mobile/table-view.ts
@@ -29,7 +29,12 @@ export class MobileDataViewTable extends DataViewBase<
       position: relative;
       width: 100%;
       padding-bottom: 4px;
-      overflow-x: scroll;
+      /** 
+       * Disable horizontal scrolling to prevent crashes on iOS Safari
+       * See https://github.com/toeverything/AFFiNE/pull/12203
+       * and https://github.com/toeverything/blocksuite/pull/8784
+       */
+      overflow-x: hidden;
       overflow-y: hidden;
     }
 

--- a/blocksuite/affine/data-view/src/view-presets/table/pc/table-view.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/pc/table-view.ts
@@ -54,17 +54,6 @@ const styles = css`
     overflow-y: hidden;
   }
 
-  /* Disable horizontal scrolling to prevent crashes on iOS Safari */
-  affine-edgeless-root .affine-database-block-table {
-    @media (pointer: coarse) {
-      overflow: hidden;
-    }
-    @media (pointer: fine) {
-      overflow-x: scroll;
-      overflow-y: hidden;
-    }
-  }
-
   .affine-database-block-table:hover {
     padding-bottom: 0px;
   }


### PR DESCRIPTION
This won't affect desktop behavior, since the `MobileDataViewTable` is a standalone entry different with the default `DataViewTable`.

Horizontal scrolling needs to be disabled to prevent Safari render bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated table view styling on mobile to disable horizontal scrolling, improving stability on iOS Safari.
  - Removed platform-specific horizontal scrolling behavior for tables on desktop for a consistent experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->