### PR TITLE
chore(core): pdf viewer is enabled by default

### DIFF
--- a/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -74,9 +74,7 @@ const usePatchSpecs = (mode: DocMode) => {
   );
 
   const enablePDFEmbedPreview = useLiveData(
-    featureFlagService.flags.enable_pdf_embed_preview.$.map(
-      flag => !workspaceService.workspace.openOptions.isSharedMode && flag
-    )
+    featureFlagService.flags.enable_pdf_embed_preview.$
   );
 
   const patchedSpecs = useMemo(() => {

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -214,7 +214,7 @@ export const AFFINE_FLAGS = {
     description:
       'com.affine.settings.workspace.experimental-features.enable-pdf-embed-preview.description',
     configurable: !isMobile,
-    defaultState: false,
+    defaultState: true,
   },
   enable_editor_rtl: {
     category: 'affine',

--- a/tests/affine-cloud/e2e/share-page.spec.ts
+++ b/tests/affine-cloud/e2e/share-page.spec.ts
@@ -458,7 +458,7 @@ test('share page should support copying content', async ({ page, browser }) => {
   }
 });
 
-test('should disable opening peek view with pdf viewer in readonly and sharing modes', async ({
+test('should enable opening peek view with pdf viewer in readonly and sharing modes', async ({
   page,
   browser,
 }) => {
@@ -486,7 +486,7 @@ test('should disable opening peek view with pdf viewer in readonly and sharing m
   await switchViewButton.click();
   await embedViewButton.click();
 
-  await expect(attachment.locator('iframe')).toBeVisible();
+  await expect(attachment.locator('lit-react-portal')).toBeVisible();
 
   // enable share page and copy page link
   await enableShare(page);
@@ -506,7 +506,7 @@ test('should disable opening peek view with pdf viewer in readonly and sharing m
 
     const attachment = page2.locator('affine-attachment');
 
-    await expect(attachment.locator('iframe')).toBeVisible();
+    await expect(attachment.locator('lit-react-portal')).toBeVisible();
 
     await attachment.dblclick();
 

--- a/tests/affine-local/e2e/attachment-preview.spec.ts
+++ b/tests/affine-local/e2e/attachment-preview.spec.ts
@@ -316,7 +316,9 @@ test('should enable pointer event in pdf viewer', async ({ page }) => {
   await toolbar.getByLabel('Switch view').click();
   await toolbar.getByLabel('Embed view').click();
 
-  await attachment.locator('iframe').waitFor({ state: 'visible' });
+  await attachment
+    .locator('.affine-attachment-embed-container')
+    .waitFor({ state: 'visible' });
 
   const rect = await attachment.boundingBox();
   expect(rect).not.toBeNull();


### PR DESCRIPTION
Related to: [BS-3101](https://linear.app/affine-design/issue/BS-3101/pdf-embed-模式的选中框选-和点开看详情有比较大的问题)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - PDF embed preview is now enabled by default for all users, regardless of workspace sharing mode.

- **Bug Fixes**
  - Improved reliability of PDF viewer interaction in tests by updating the element used for visibility checks.
  - Enabled opening the PDF viewer peek view in readonly and sharing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->