### PR TITLE
fix(core): cannot abort AI chat immediately after sending a message

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
@@ -426,7 +426,7 @@ export class AIChatInput extends SignalWatcher(WithDisposable(LitElement)) {
             ? html`<span class="chat-input-icon-label">Reason</span>`
             : nothing}
         </div>
-        ${status === 'transmitting'
+        ${status === 'transmitting' || status === 'loading'
           ? html`<div @click=${this._handleAbort} data-testid="chat-panel-stop">
               ${ChatAbortIcon}
             </div>`


### PR DESCRIPTION
Close [AI-118](https://linear.app/affine-design/issue/AI-118)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The abort button in the chat input is now available during both "transmitting" and "loading" states, giving users more control to cancel ongoing actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->