### PR TITLE
fix(core): meeting settings issues

### DIFF
--- a/packages/frontend/apps/electron/src/main/tray/index.ts
+++ b/packages/frontend/apps/electron/src/main/tray/index.ts
@@ -220,15 +220,17 @@ class TrayState implements Disposable {
           );
         }
       }
-      items.push({
-        label: `Meetings Settings...`,
-        click: () => {
-          showMainWindow();
-          applicationMenuSubjects.openInSettingModal$.next({
-            activeTab: 'meetings',
-          });
-        },
-      });
+      if (checkRecordingAvailable()) {
+        items.push({
+          label: `Meetings Settings...`,
+          click: () => {
+            showMainWindow();
+            applicationMenuSubjects.openInSettingModal$.next({
+              activeTab: 'meetings',
+            });
+          },
+        });
+      }
 
       return items;
     };

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/index.tsx
@@ -95,13 +95,15 @@ export const useGeneralSettingList = (): GeneralSettingList => {
       });
     }
 
-    settings.push({
-      key: 'meetings',
-      title: t['com.affine.settings.meetings'](),
-      icon: <MeetingIcon />,
-      testId: 'meetings-panel-trigger',
-      beta: !meetingSettings?.enabled,
-    });
+    if (environment.isMacOs && BUILD_CONFIG.isElectron) {
+      settings.push({
+        key: 'meetings',
+        title: t['com.affine.settings.meetings'](),
+        icon: <MeetingIcon />,
+        testId: 'meetings-panel-trigger',
+        beta: !meetingSettings?.enabled,
+      });
+    }
 
     if (hasPaymentFeature) {
       settings.splice(4, 0, {

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/meetings/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/meetings/index.tsx
@@ -201,16 +201,16 @@ const MeetingsSettingsMain = () => {
         beta
         title={t['com.affine.settings.meetings']()}
         subtitle={
-          t['com.affine.settings.meetings.setting.prompt']() +
-          '\n' +
-          (
+          <>
+            {t['com.affine.settings.meetings.setting.prompt']()}
+            <br />
             <Trans
               i18nKey="com.affine.settings.meetings.setting.prompt.2"
               components={{
                 strong: <strong />,
               }}
             />
-          )
+          </>
         }
       />
 


### PR DESCRIPTION
fix AF-2606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The "meetings" settings panel is now only visible on macOS when using the Electron build.
  - The "Meetings Settings..." menu item in the recording menu appears only when recording functionality is available.

- **Style**
  - Improved the subtitle formatting in the meetings settings panel for clearer visual separation and enhanced readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->