### PR TITLE
feat(core): show stop modal if clickoutside during generating

### DIFF
--- a/tests/affine-cloud-copilot/e2e/chat-with/text.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/chat-with/text.spec.ts
@@ -21,6 +21,21 @@ test.describe('AIChatWith/Text', () => {
     await expect(page.getByTestId('ai-generating')).not.toBeVisible();
   });
 
+  test('should support stop generating when click outside', async ({
+    loggedInPage: page,
+    utils,
+  }) => {
+    await utils.editor.askAIWithText(page, 'Panda');
+    await page.getByTestId('action-generate-image').click();
+    await expect(page.getByTestId('ai-generating')).toBeVisible();
+    await page.mouse.click(0, 0);
+    await expect(
+      page.getByText('AI is generating content. Do you want to stop generating')
+    ).toBeVisible();
+    await page.getByTestId('confirm-modal-confirm').click();
+    await expect(page.getByTestId('ai-generating')).not.toBeVisible();
+  });
+
   test('should support copy answer', async ({ loggedInPage: page, utils }) => {
     const { translate } = await utils.editor.askAIWithText(page, 'Apple');
     const { answer } = await translate('German');


### PR DESCRIPTION
### TL;DR

feat: show stop model if click-outside during ai generating

>CLOSE AI-89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a confirmation dialog when attempting to stop AI content generation by clicking outside the panel, ensuring users can confirm or cancel the stop action.

- **Tests**
  - Introduced an end-to-end test to verify the confirmation dialog appears and AI generation stops as expected when clicking outside during generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->