### PR TITLE
fix(electron): recorded audio is not correctly rendered after saved as attachment

### DIFF
--- a/packages/frontend/apps/electron-renderer/src/app/effects/recording.ts
+++ b/packages/frontend/apps/electron-renderer/src/app/effects/recording.ts
@@ -51,33 +51,35 @@ export function setupRecordingEvents(frameworkProvider: FrameworkProvider) {
         const docProps: DocProps = {
           onStoreLoad: (doc, { noteId }) => {
             (async () => {
-              // name + timestamp(readable) + extension
-              const attachmentName =
-                (status.appName ?? 'System Audio') + ' ' + timestamp + '.opus';
-
-              // add size and sourceId to the attachment later
-              const attachmentId = doc.addBlock(
-                'affine:attachment',
-                {
-                  name: attachmentName,
-                  type: 'audio/opus',
-                },
-                noteId
-              );
-
-              const model = doc.getBlock(attachmentId)
-                ?.model as AttachmentBlockModel;
-
-              if (model && status.filepath) {
+              if (status.filepath) {
                 // it takes a while to save the blob, so we show the attachment first
                 const { blobId, blob } = await saveRecordingBlob(
                   doc.workspace.blobSync,
                   status.filepath
                 );
 
-                model.props.size = blob.size;
-                model.props.sourceId = blobId;
-                model.props.embed = true;
+                // name + timestamp(readable) + extension
+                const attachmentName =
+                  (status.appName ?? 'System Audio') +
+                  ' ' +
+                  timestamp +
+                  '.opus';
+
+                // add size and sourceId to the attachment later
+                const attachmentId = doc.addBlock(
+                  'affine:attachment',
+                  {
+                    name: attachmentName,
+                    type: 'audio/opus',
+                    size: blob.size,
+                    sourceId: blobId,
+                    embed: true,
+                  },
+                  noteId
+                );
+
+                const model = doc.getBlock(attachmentId)
+                  ?.model as AttachmentBlockModel;
 
                 if (!aiEnabled) {
                   return;


### PR DESCRIPTION
fix AF-2611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for adding audio attachments after a recording is ready, ensuring all details (name, type, size, source, embed) are included at creation for a smoother and more reliable user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->