### PR TITLE
refactor(editor): use native atob/btoa

### DIFF
--- a/blocksuite/affine/shared/src/adapters/clipboard/utils.ts
+++ b/blocksuite/affine/shared/src/adapters/clipboard/utils.ts
@@ -1,70 +1,5 @@
 import type { FileSnapshot } from './clipboard.js';
 
-const chars =
-  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
-
-// Use a lookup table to find the index.
-const lookup = typeof Uint8Array === 'undefined' ? [] : new Uint8Array(256);
-for (let i = 0; i < chars.length; i++) {
-  lookup[chars.charCodeAt(i)] = i;
-}
-
-export const encode = (arraybuffer: ArrayBuffer): string => {
-  const bytes = new Uint8Array(arraybuffer);
-  const len = bytes.length;
-  let i,
-    base64 = '';
-
-  for (i = 0; i < len; i += 3) {
-    base64 += chars[bytes[i] >> 2];
-    base64 += chars[((bytes[i] & 3) << 4) | (bytes[i + 1] >> 4)];
-    base64 += chars[((bytes[i + 1] & 15) << 2) | (bytes[i + 2] >> 6)];
-    base64 += chars[bytes[i + 2] & 63];
-  }
-
-  if (len % 3 === 2) {
-    base64 = base64.substring(0, base64.length - 1) + '=';
-  } else if (len % 3 === 1) {
-    base64 = base64.substring(0, base64.length - 2) + '==';
-  }
-
-  return base64;
-};
-
-export const decode = (base64: string): ArrayBuffer => {
-  const len = base64.length;
-  let bufferLength = base64.length * 0.75,
-    i,
-    p = 0,
-    encoded1,
-    encoded2,
-    encoded3,
-    encoded4;
-
-  if (base64[base64.length - 1] === '=') {
-    bufferLength--;
-    if (base64[base64.length - 2] === '=') {
-      bufferLength--;
-    }
-  }
-
-  const arraybuffer = new ArrayBuffer(bufferLength),
-    bytes = new Uint8Array(arraybuffer);
-
-  for (i = 0; i < len; i += 4) {
-    encoded1 = lookup[base64.charCodeAt(i)];
-    encoded2 = lookup[base64.charCodeAt(i + 1)];
-    encoded3 = lookup[base64.charCodeAt(i + 2)];
-    encoded4 = lookup[base64.charCodeAt(i + 3)];
-
-    bytes[p++] = (encoded1 << 2) | (encoded2 >> 4);
-    bytes[p++] = ((encoded2 & 15) << 4) | (encoded3 >> 2);
-    bytes[p++] = ((encoded3 & 3) << 6) | (encoded4 & 63);
-  }
-
-  return arraybuffer;
-};
-
 export async function encodeClipboardBlobs(
   map: Map<string, Blob>,
   onError?: (message: string) => void
@@ -85,7 +20,7 @@ export async function encodeClipboardBlobs(
         );
         return;
       }
-      const content = encode(await blob.arrayBuffer());
+      const content = btoa(await blob.text());
       const file: FileSnapshot = {
         name: (blob as File).name,
         type: blob.type,
@@ -108,8 +43,7 @@ export function decodeClipboardBlobs(
     return;
   }
   Object.entries<FileSnapshot>(blobs).forEach(([sourceId, file]) => {
-    const blob = new Blob([decode(file.content)]);
-    const f = new File([blob], file.name, {
+    const f = new File([atob(file.content)], file.name, {
       type: file.type,
     });
     map.set(sourceId, f);


### PR DESCRIPTION
Closes: [BS-3481](https://linear.app/affine-design/issue/BS-3481/使用-atobbtoa-处理-clipboard-数据)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Replaced custom Base64 encoding and decoding with native browser functions for improved efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->