### PR TITLE
chore(editor): add telemetry for note, embed doc and linked doc

### DIFF
--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/configs/toolbar.ts
@@ -317,6 +317,15 @@ const builtinSurfaceToolbarConfig = {
             parentModel: lastVisibleNote,
           })
           .run();
+
+        ctx.track('BlockCreated', {
+          page: 'whiteboard editor',
+          module: 'toolbar',
+          segment: 'toolbar',
+          blockType: 'affine:embed-linked-doc',
+          control: 'toolbar:general',
+          other: 'insert to page',
+        });
       },
     },
     {
@@ -412,6 +421,15 @@ const builtinSurfaceToolbarConfig = {
             return next();
           })
           .run();
+
+        ctx.track('CanvasElementAdded', {
+          page: 'whiteboard editor',
+          type: 'note',
+          module: 'toolbar',
+          segment: 'toolbar',
+          control: 'conversation',
+          other: 'duplicate as note',
+        });
       },
     },
     captionAction,

--- a/blocksuite/affine/blocks/note/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/note/src/configs/toolbar.ts
@@ -90,6 +90,15 @@ const builtinSurfaceToolbarConfig = {
               ? NoteDisplayMode.DocAndEdgeless
               : NoteDisplayMode.EdgelessOnly;
           setDisplayMode(ctx, firstModel, newMode);
+
+          ctx.track('BlockCreated', {
+            page: 'whiteboard editor',
+            module: 'toolbar',
+            segment: 'toolbar',
+            blockType: 'affine:note',
+            control: 'toolbar:general',
+            other: `display in page: ${newMode === NoteDisplayMode.EdgelessOnly ? 'off' : 'on'}`,
+          });
         };
 
         return {

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
@@ -1268,7 +1268,19 @@ export class DragEventWatcher {
             content,
           },
           noteId
-        ).catch(console.error);
+        )
+          .then(() => {
+            const telemetry = this.std.getOptional(TelemetryProvider);
+            telemetry?.track('CanvasElementAdded', {
+              page: 'whiteboard editor',
+              module: 'canvas',
+              segment: 'whiteboard',
+              control: 'canvas:drop',
+              type: 'note',
+              other: 'split-from-note',
+            });
+          })
+          .catch(console.error);
       }
     }
   };


### PR DESCRIPTION
Close [BS-3480](https://linear.app/affine-design/issue/BS-3480/event-tracking)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added telemetry tracking to toolbar actions for embedding documents, duplicating notes, and toggling note display modes.
  - Telemetry events now track when new note blocks are created from drag-and-drop actions on the whiteboard.

- **Chores**
  - Improved event tracking for user interactions to enhance analytics and usage insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->