### PR TITLE
feat(core): add get session graphql api

### DIFF
--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -133,6 +133,9 @@ type Copilot {
   """Get the quota of the user in the workspace"""
   quota: CopilotQuota!
 
+  """Get the session by id"""
+  session(sessionId: String!): CopilotSessionType!
+
   """Get the session id list in the workspace"""
   sessionIds(docId: String, options: QueryChatSessionsInput): [String!]! @deprecated(reason: "Use `sessions` instead")
 
@@ -318,6 +321,8 @@ type CopilotQuota {
 
 type CopilotSessionType {
   id: ID!
+  model: String!
+  optionalModels: [String!]!
   parentSessionId: ID
   promptName: String!
 }

--- a/packages/common/graphql/src/graphql/copilot-session-get.gql
+++ b/packages/common/graphql/src/graphql/copilot-session-get.gql
@@ -1,11 +1,10 @@
-query getCopilotSessions(
+query getCopilotSession(
   $workspaceId: String!
-  $docId: String
-  $options: QueryChatSessionsInput
+  $sessionId: String!
 ) {
   currentUser {
     copilot(workspaceId: $workspaceId) {
-      sessions(docId: $docId, options: $options) {
+      session(sessionId: $sessionId) {
         id
         parentSessionId
         promptName

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -740,6 +740,24 @@ export const forkCopilotSessionMutation = {
 }`,
 };
 
+export const getCopilotSessionQuery = {
+  id: 'getCopilotSessionQuery' as const,
+  op: 'getCopilotSession',
+  query: `query getCopilotSession($workspaceId: String!, $sessionId: String!) {
+  currentUser {
+    copilot(workspaceId: $workspaceId) {
+      session(sessionId: $sessionId) {
+        id
+        parentSessionId
+        promptName
+        model
+        optionalModels
+      }
+    }
+  }
+}`,
+};
+
 export const updateCopilotSessionMutation = {
   id: 'updateCopilotSessionMutation' as const,
   op: 'updateCopilotSession',
@@ -758,6 +776,8 @@ export const getCopilotSessionsQuery = {
         id
         parentSessionId
         promptName
+        model
+        optionalModels
       }
     }
   }

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -174,6 +174,8 @@ export interface Copilot {
   histories: Array<CopilotHistories>;
   /** Get the quota of the user in the workspace */
   quota: CopilotQuota;
+  /** Get the session by id */
+  session: CopilotSessionType;
   /**
    * Get the session id list in the workspace
    * @deprecated Use `sessions` instead
@@ -197,6 +199,10 @@ export interface CopilotContextsArgs {
 export interface CopilotHistoriesArgs {
   docId?: InputMaybe<Scalars['String']['input']>;
   options?: InputMaybe<QueryChatHistoriesInput>;
+}
+
+export interface CopilotSessionArgs {
+  sessionId: Scalars['String']['input'];
 }
 
 export interface CopilotSessionIdsArgs {
@@ -415,6 +421,8 @@ export interface CopilotQuota {
 export interface CopilotSessionType {
   __typename?: 'CopilotSessionType';
   id: Scalars['ID']['output'];
+  model: Scalars['String']['output'];
+  optionalModels: Array<Scalars['String']['output']>;
   parentSessionId: Maybe<Scalars['ID']['output']>;
   promptName: Scalars['String']['output'];
 }
@@ -3453,6 +3461,29 @@ export type ForkCopilotSessionMutation = {
   forkCopilotSession: string;
 };
 
+export type GetCopilotSessionQueryVariables = Exact<{
+  workspaceId: Scalars['String']['input'];
+  sessionId: Scalars['String']['input'];
+}>;
+
+export type GetCopilotSessionQuery = {
+  __typename?: 'Query';
+  currentUser: {
+    __typename?: 'UserType';
+    copilot: {
+      __typename?: 'Copilot';
+      session: {
+        __typename?: 'CopilotSessionType';
+        id: string;
+        parentSessionId: string | null;
+        promptName: string;
+        model: string;
+        optionalModels: Array<string>;
+      };
+    };
+  } | null;
+};
+
 export type UpdateCopilotSessionMutationVariables = Exact<{
   options: UpdateChatSessionInput;
 }>;
@@ -3479,6 +3510,8 @@ export type GetCopilotSessionsQuery = {
         id: string;
         parentSessionId: string | null;
         promptName: string;
+        model: string;
+        optionalModels: Array<string>;
       }>;
     };
   } | null;
@@ -4996,6 +5029,11 @@ export type Queries =
       name: 'copilotQuotaQuery';
       variables: CopilotQuotaQueryVariables;
       response: CopilotQuotaQuery;
+    }
+  | {
+      name: 'getCopilotSessionQuery';
+      variables: GetCopilotSessionQueryVariables;
+      response: GetCopilotSessionQuery;
     }
   | {
       name: 'getCopilotSessionsQuery';

--- a/packages/frontend/core/src/blocksuite/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/types.ts
@@ -380,6 +380,10 @@ declare global {
         docId?: string,
         options?: { action?: boolean }
       ) => Promise<CopilotSessionType[] | undefined>;
+      getSession: (
+        workspaceId: string,
+        sessionId: string
+      ) => Promise<CopilotSessionType | undefined>;
       updateSession: (sessionId: string, promptName: string) => Promise<string>;
     }
 

--- a/packages/frontend/core/src/blocksuite/ai/provider/copilot-client.ts
+++ b/packages/frontend/core/src/blocksuite/ai/provider/copilot-client.ts
@@ -11,6 +11,7 @@ import {
   forkCopilotSessionMutation,
   getCopilotHistoriesQuery,
   getCopilotHistoryIdsQuery,
+  getCopilotSessionQuery,
   getCopilotSessionsQuery,
   type GraphQLQuery,
   listContextObjectQuery,
@@ -131,6 +132,18 @@ export class CopilotClient {
         },
       });
       return res.createCopilotMessage;
+    } catch (err) {
+      throw resolveError(err);
+    }
+  }
+
+  async getSession(workspaceId: string, sessionId: string) {
+    try {
+      const res = await this.gql({
+        query: getCopilotSessionQuery,
+        variables: { sessionId, workspaceId },
+      });
+      return res.currentUser?.copilot?.session;
     } catch (err) {
       throw resolveError(err);
     }

--- a/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
+++ b/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
@@ -579,6 +579,9 @@ Could you make a new website based on these notes and send back just the html fi
 
   AIProvider.provide('session', {
     createSession,
+    getSession: async (workspaceId: string, sessionId: string) => {
+      return client.getSession(workspaceId, sessionId);
+    },
     getSessions: async (
       workspaceId: string,
       docId?: string,


### PR DESCRIPTION
Close [AI-116](https://linear.app/affine-design/issue/AI-116)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to retrieve detailed information for a specific Copilot session by its ID, including model metadata and optional models, via the user interface and API.
  - Session data now includes additional fields such as the model used and a list of optional models.
  - Enhanced GraphQL queries and UI components to support fetching and displaying these new session details.

- **Improvements**
  - Session lists now provide richer information, including model details, for each session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->