### PR TITLE
fix(editor): notion text adapter should handle text without styles correctly

### DIFF
--- a/blocksuite/affine/all/src/__tests__/adapters/notion-text.unit.spec.ts
+++ b/blocksuite/affine/all/src/__tests__/adapters/notion-text.unit.spec.ts
@@ -106,4 +106,65 @@ describe('notion-text to snapshot', () => {
     });
     expect(nanoidReplacement(target!)).toEqual(sliceSnapshot);
   });
+
+  test('notion text with empty styles array', () => {
+    const notionText =
+      '{"blockType":"text","editing":[["a "],["bold text",[["b"]]],[" hello world"]],"selection":{"startIndex":0,"endIndex":23},"action":"copy"}';
+
+    const sliceSnapshot: SliceSnapshot = {
+      type: 'slice',
+      content: [
+        {
+          type: 'block',
+          id: 'matchesReplaceMap[0]',
+          flavour: 'affine:note',
+          props: {
+            xywh: '[0,0,800,95]',
+            background: DefaultTheme.noteBackgrounColor,
+            index: 'a0',
+            hidden: false,
+            displayMode: 'both',
+          },
+          children: [
+            {
+              type: 'block',
+              id: 'matchesReplaceMap[1]',
+              flavour: 'affine:paragraph',
+              props: {
+                type: 'text',
+                text: {
+                  '$blocksuite:internal:text$': true,
+                  delta: [
+                    {
+                      insert: 'a ',
+                    },
+                    {
+                      insert: 'bold text',
+                      attributes: {
+                        bold: true,
+                      },
+                    },
+                    {
+                      insert: ' hello world',
+                    },
+                  ],
+                },
+              },
+              children: [],
+            },
+          ],
+        },
+      ],
+      workspaceId: '',
+      pageId: '',
+    };
+
+    const ntAdapter = new NotionTextAdapter(createJob(), provider);
+    const target = ntAdapter.toSliceSnapshot({
+      file: notionText,
+      workspaceId: '',
+      pageId: '',
+    });
+    expect(nanoidReplacement(target!)).toEqual(sliceSnapshot);
+  });
 });


### PR DESCRIPTION
Closes: [BS-3486](https://linear.app/affine-design/issue/BS-3486/粘贴从-notion-复制的内容出错)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Notion text segments with empty or invalid style arrays, ensuring plain text and styled text are both processed correctly and preventing errors from malformed input.  
- **Tests**
  - Added a test case to verify correct conversion of Notion text with empty styles arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->