### PR TITLE
fix: peekable in edgeless mode

### DIFF
--- a/tests/kit/src/utils/page-logic.ts
+++ b/tests/kit/src/utils/page-logic.ts
@@ -75,6 +75,20 @@ export const createLinkedPage = async (page: Page, pageName?: string) => {
     .click();
 };
 
+export const createSyncedPageInEdgeless = async (
+  page: Page,
+  pageName?: string
+) => {
+  await page.keyboard.type('@', { delay: 50 });
+  const cmdkPopover = page.locator('[data-testid="cmdk-quick-search"]');
+  await expect(cmdkPopover).toBeVisible();
+  await type(page, pageName || 'Untitled');
+
+  await cmdkPopover
+    .locator('[cmdk-item][data-value="creation:create-page"]')
+    .click();
+};
+
 export const createTodayPage = async (page: Page) => {
   // fixme: workaround for @ popover not showing up when editor is not ready
   await page.waitForTimeout(500);


### PR DESCRIPTION
Fixes [BS-3374](https://linear.app/affine-design/issue/BS-3374/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved control over peek view activation in "edgeless" editor mode to ensure it only triggers when interacting directly with the relevant element.
- **Bug Fixes**
  - Prevented peek view from opening when the target content is visually covered by a canvas shape in edgeless mode.
- **Tests**
  - Added end-to-end test confirming peek view does not open if content is overlapped by canvas elements.
- **Chores**
  - Added utility function to streamline creating synced pages in edgeless mode for testing purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->