### PR TITLE
fix(editor): canvas element missing rotate during zooming

### DIFF
--- a/blocksuite/affine/blocks/surface/src/renderer/dom-renderer.ts
+++ b/blocksuite/affine/blocks/surface/src/renderer/dom-renderer.ts
@@ -46,8 +46,6 @@ type RendererOptions = {
 const PLACEHOLDER_RESET_STYLES = {
   border: 'none',
   borderRadius: '0',
-  transform: '',
-  transformOrigin: '',
   boxShadow: 'none',
   opacity: '1',
 };
@@ -58,6 +56,7 @@ function calculatePlaceholderRect(
   zoom: number
 ) {
   return {
+    transform: elementModel.rotate ? `rotate(${elementModel.rotate}deg)` : '',
     left: `${(elementModel.x - viewportBounds.x) * zoom}px`,
     top: `${(elementModel.y - viewportBounds.y) * zoom}px`,
     width: `${elementModel.w * zoom}px`,


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/9dc15043-941a-425e-b92d-2cd6b6eef1fa

After:

https://github.com/user-attachments/assets/91d8d563-5935-465a-bfe3-ff6e1e812438



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Placeholders now visually reflect rotation based on the element's rotation property.

- **Style**
  - Updated placeholder rendering to support rotated display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->