### PR TITLE
fix(core): add loading status to share page button

### DIFF
--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/general-access/public-page-button.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/general-access/public-page-button.tsx
@@ -21,6 +21,9 @@ export const PublicDoc = ({ disabled }: { disabled?: boolean }) => {
   const t = useI18n();
   const shareInfoService = useService(ShareInfoService);
   const isSharedPage = useLiveData(shareInfoService.shareInfo.isShared$);
+  const isRevalidating = useLiveData(
+    shareInfoService.shareInfo.isRevalidating$
+  );
 
   useEffect(() => {
     shareInfoService.shareInfo.revalidate();
@@ -135,6 +138,8 @@ export const PublicDoc = ({ disabled }: { disabled?: boolean }) => {
             contentStyle={{
               width: '100%',
             }}
+            loading={isRevalidating}
+            disabled={isRevalidating}
           >
             {isSharedPage
               ? t['com.affine.share-menu.option.link.readonly']()


### PR DESCRIPTION
close AF-2615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved the share menu's user experience by showing a loading indicator and disabling the public page button during revalidation. This prevents user interaction while the share info is updating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->