### PR TITLE
fix(server): ignore email not configure error on self-host

### DIFF
--- a/packages/backend/server/src/core/mail/mailer.ts
+++ b/packages/backend/server/src/core/mail/mailer.ts
@@ -1,10 +1,12 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 
 import { EmailServiceNotConfigured, JobQueue } from '../../base';
 import { MailSender } from './sender';
 
 @Injectable()
 export class Mailer {
+  private readonly logger = new Logger(Mailer.name);
+
   constructor(
     private readonly queue: JobQueue,
     private readonly sender: MailSender
@@ -17,6 +19,13 @@ export class Mailer {
 
   async send(command: Jobs['notification.sendMail']) {
     if (!this.enabled) {
+      if (env.selfhosted) {
+        this.logger.log(
+          `Email service is not configured, skip send mail name: ${command.name}`
+        );
+        return true;
+      }
+
       throw new EmailServiceNotConfigured();
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of email sending when the mail service is not configured in self-hosted environments. Instead of displaying an error, a log message is recorded and the operation is safely skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->