### PR TITLE
fix: connector issues

### DIFF
--- a/blocksuite/affine/gfx/connector/src/element-transform/connector-filter.ts
+++ b/blocksuite/affine/gfx/connector/src/element-transform/connector-filter.ts
@@ -36,6 +36,8 @@ export class ConnectorFilter extends InteractivityExtension {
         elements.sort((a, _) => (a instanceof ConnectorElementModel ? -1 : 1));
       }
 
+      context.elements = elements;
+
       return {};
     });
   }

--- a/blocksuite/affine/gfx/connector/src/text/edgeless-connector-label-editor.ts
+++ b/blocksuite/affine/gfx/connector/src/text/edgeless-connector-label-editor.ts
@@ -188,6 +188,8 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
     });
     this._resizeObserver.observe(this.richText);
 
+    this.connector.stash('labelXYWH');
+
     this.updateComplete
       .then(() => {
         if (!this.inlineEditor) return;
@@ -257,7 +259,8 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
             }
           }
 
-          connector.lableEditing = false;
+          connector.labelEditing = false;
+          connector.pop('labelXYWH');
 
           selection.set({
             elements: [],
@@ -293,7 +296,7 @@ export class EdgelessConnectorLabelEditor extends WithDisposable(
           }
         );
 
-        connector.lableEditing = true;
+        connector.labelEditing = true;
       })
       .catch(console.error);
   }

--- a/blocksuite/affine/model/src/elements/connector/connector.ts
+++ b/blocksuite/affine/model/src/elements/connector/connector.ts
@@ -278,7 +278,13 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
   }
 
   hasLabel() {
-    return Boolean(!this.lableEditing && this.labelDisplay && this.labelXYWH);
+    return Boolean(
+      !this.labelEditing &&
+        this.labelDisplay &&
+        this.labelXYWH &&
+        this.text &&
+        this.text.length
+    );
   }
 
   override includesPoint(
@@ -450,7 +456,7 @@ export class ConnectorElementModel extends GfxPrimitiveElementModel<ConnectorEle
    * Local control display and hide, mainly used in editing scenarios.
    */
   @local()
-  accessor lableEditing: boolean = false;
+  accessor labelEditing: boolean = false;
 
   @field()
   accessor mode: ConnectorMode = DEFAULT_CONNECTOR_MODE;

--- a/blocksuite/affine/widgets/edgeless-selected-rect/src/edgeless-auto-complete.ts
+++ b/blocksuite/affine/widgets/edgeless-selected-rect/src/edgeless-auto-complete.ts
@@ -744,7 +744,7 @@ export class EdgelessAutoComplete extends WithDisposable(LitElement) {
 
     if (
       this._isMoving ||
-      (this._isHover && !isShape && this._canAutoComplete())
+      (this._isHover && !isShape && !this._canAutoComplete())
     ) {
       this.removeOverlay();
       return nothing;

--- a/tests/blocksuite/e2e/utils/actions/edgeless.ts
+++ b/tests/blocksuite/e2e/utils/actions/edgeless.ts
@@ -1886,6 +1886,7 @@ export async function createConnectorElement(
     { x: start[0], y: start[1] },
     { x: end[0], y: end[1] }
   );
+  return (await getSelectedIds(page))[0];
 }
 
 export async function createFrameElement(


### PR DESCRIPTION
Fixes [BS-3161](https://linear.app/affine-design/issue/BS-3161/发现已连接的connector会响应对齐线)
Fixes [BS-3337](https://linear.app/affine-design/issue/BS-3337/connector你肿么了)
Fixes [BS-3334](https://linear.app/affine-design/issue/BS-3334/connector-不应该能够被拖拽)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected typos related to label editing state, ensuring more reliable label editing and display for connectors.
	- Fixed logic in the auto-complete overlay, improving when overlays appear during hover actions.
	- Ensured connector elements reflect filtered and sorted states correctly during drag initialization.

- **New Features**
	- Improved connector label handling by preserving and restoring label bounding box state during editing.
	- Enhanced connector movement behavior, allowing connectors to be moved only when appropriate elements are selected.
	- Updated utility function to return the ID of newly created connector elements for better test handling.

- **Tests**
	- Added end-to-end tests to verify connector movement and selection behaviors for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->