### PR TITLE
feat(core): workspace attachment uploading & error

### DIFF
--- a/packages/frontend/core/src/modules/workspace-indexer-embedding/types.ts
+++ b/packages/frontend/core/src/modules/workspace-indexer-embedding/types.ts
@@ -1,10 +1,31 @@
-export interface AttachmentFile {
+export interface PersistedAttachmentFile {
   fileId: string;
   fileName: string;
   mimeType: string;
   size: number;
   createdAt: string;
+  status: 'uploaded';
 }
+
+export interface LocalAttachmentFile {
+  localId: string;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  createdAt: number;
+  status: 'uploading' | 'error';
+}
+
+export interface UploadingAttachmentFile extends LocalAttachmentFile {
+  status: 'uploading';
+}
+
+export interface ErrorAttachmentFile extends LocalAttachmentFile {
+  status: 'error';
+  errorMessage: string;
+}
+
+export type AttachmentFile = PersistedAttachmentFile | LocalAttachmentFile;
 
 export interface IgnoredDoc {
   docId: string;

--- a/packages/frontend/core/src/modules/workspace-indexer-embedding/utils.ts
+++ b/packages/frontend/core/src/modules/workspace-indexer-embedding/utils.ts
@@ -1,0 +1,38 @@
+import type {
+  AttachmentFile,
+  ErrorAttachmentFile,
+  LocalAttachmentFile,
+  PersistedAttachmentFile,
+  UploadingAttachmentFile,
+} from './types';
+
+export function isPersistedAttachment(
+  attachment: AttachmentFile
+): attachment is PersistedAttachmentFile {
+  return 'fileId' in attachment;
+}
+
+export function isErrorAttachment(
+  attachment: AttachmentFile
+): attachment is ErrorAttachmentFile {
+  return 'errorMessage' in attachment;
+}
+
+export function isUploadingAttachment(
+  attachment: AttachmentFile
+): attachment is UploadingAttachmentFile {
+  return 'localId' in attachment && attachment.status === 'uploading';
+}
+
+export function isLocalAttachment(
+  attachment: AttachmentFile
+): attachment is LocalAttachmentFile {
+  return 'localId' in attachment;
+}
+
+export function getAttachmentId(attachment: AttachmentFile): string {
+  if (isPersistedAttachment(attachment)) {
+    return attachment.fileId;
+  }
+  return attachment.localId;
+}

--- a/packages/frontend/core/src/modules/workspace-indexer-embedding/view/attachments.tsx
+++ b/packages/frontend/core/src/modules/workspace-indexer-embedding/view/attachments.tsx
@@ -1,14 +1,27 @@
-import { Loading, useConfirmModal } from '@affine/component';
+import { Loading, Tooltip, useConfirmModal } from '@affine/component';
 import { Pagination } from '@affine/component/setting-components';
 import { useI18n } from '@affine/i18n';
 import { getAttachmentFileIconRC } from '@blocksuite/affine/components/icons';
 import { cssVarV2 } from '@blocksuite/affine/shared/theme';
-import { CloseIcon } from '@blocksuite/icons/rc';
+import { CloseIcon, WarningIcon } from '@blocksuite/icons/rc';
+import clsx from 'clsx';
 import { useCallback } from 'react';
 
 import { COUNT_PER_PAGE } from '../constants';
-import type { AttachmentFile } from '../types';
+import type {
+  AttachmentFile,
+  ErrorAttachmentFile,
+  PersistedAttachmentFile,
+  UploadingAttachmentFile,
+} from '../types';
 import {
+  getAttachmentId,
+  isErrorAttachment,
+  isPersistedAttachment,
+  isUploadingAttachment,
+} from '../utils';
+import {
+  attachmentError,
   attachmentItem,
   attachmentOperation,
   attachmentsWrapper,
@@ -18,7 +31,6 @@ import {
 interface AttachmentsProps {
   attachments: AttachmentFile[];
   totalCount: number;
-  isLoading: boolean;
   onPageChange: (offset: number) => void;
   onDelete: (id: string) => void;
 }
@@ -28,6 +40,50 @@ interface AttachmentItemProps {
   onDelete: (id: string) => void;
 }
 
+const UploadingItem: React.FC<{ attachment: UploadingAttachmentFile }> = ({
+  attachment,
+}) => {
+  return (
+    <div
+      className={attachmentTitle}
+      data-testid="workspace-embedding-setting-attachment-uploading-item"
+    >
+      <Loading />
+      {attachment.fileName}
+    </div>
+  );
+};
+
+const ErrorItem: React.FC<{ attachment: ErrorAttachmentFile }> = ({
+  attachment,
+}) => {
+  return (
+    <Tooltip content={attachment.errorMessage}>
+      <div
+        className={attachmentTitle}
+        data-testid="workspace-embedding-setting-attachment-error-item"
+      >
+        <WarningIcon />
+        {attachment.fileName}
+      </div>
+    </Tooltip>
+  );
+};
+
+const PersistedItem: React.FC<{ attachment: PersistedAttachmentFile }> = ({
+  attachment,
+}) => {
+  const Icon = getAttachmentFileIconRC(attachment.mimeType);
+  return (
+    <div
+      className={attachmentTitle}
+      data-testid="workspace-embedding-setting-attachment-persisted-item"
+    >
+      <Icon style={{ marginRight: 4 }} /> {attachment.fileName}
+    </div>
+  );
+};
+
 const AttachmentItem: React.FC<AttachmentItemProps> = ({
   attachment,
   onDelete,
@@ -36,6 +92,11 @@ const AttachmentItem: React.FC<AttachmentItemProps> = ({
   const { openConfirmModal } = useConfirmModal();
 
   const handleDelete = useCallback(() => {
+    if (isErrorAttachment(attachment)) {
+      onDelete(getAttachmentId(attachment));
+      return;
+    }
+
     openConfirmModal({
       title:
         t[
@@ -50,20 +111,25 @@ const AttachmentItem: React.FC<AttachmentItemProps> = ({
         variant: 'error',
       },
       onConfirm: () => {
-        onDelete(attachment.fileId);
+        onDelete(getAttachmentId(attachment));
       },
     });
-  }, [onDelete, attachment.fileId, openConfirmModal, t]);
+  }, [onDelete, attachment, openConfirmModal, t]);
 
-  const Icon = getAttachmentFileIconRC(attachment.mimeType);
   return (
     <div
-      className={attachmentItem}
+      className={clsx(attachmentItem, {
+        [attachmentError]: isErrorAttachment(attachment),
+      })}
       data-testid="workspace-embedding-setting-attachment-item"
     >
-      <div className={attachmentTitle}>
-        <Icon style={{ marginRight: 4 }} /> {attachment.fileName}
-      </div>
+      {isUploadingAttachment(attachment) ? (
+        <UploadingItem attachment={attachment} />
+      ) : isErrorAttachment(attachment) ? (
+        <ErrorItem attachment={attachment} />
+      ) : isPersistedAttachment(attachment) ? (
+        <PersistedItem attachment={attachment} />
+      ) : null}
       <div className={attachmentOperation}>
         <CloseIcon
           data-testid="workspace-embedding-setting-attachment-delete-button"
@@ -79,7 +145,6 @@ const AttachmentItem: React.FC<AttachmentItemProps> = ({
 export const Attachments: React.FC<AttachmentsProps> = ({
   attachments,
   totalCount,
-  isLoading,
   onDelete,
   onPageChange,
 }) => {
@@ -95,17 +160,13 @@ export const Attachments: React.FC<AttachmentsProps> = ({
       className={attachmentsWrapper}
       data-testid="workspace-embedding-setting-attachment-list"
     >
-      {isLoading ? (
-        <Loading />
-      ) : (
-        attachments.map(attachment => (
-          <AttachmentItem
-            key={attachment.fileId}
-            attachment={attachment}
-            onDelete={onDelete}
-          />
-        ))
-      )}
+      {attachments.map(attachment => (
+        <AttachmentItem
+          key={getAttachmentId(attachment)}
+          attachment={attachment}
+          onDelete={onDelete}
+        />
+      ))}
       <Pagination
         totalCount={totalCount}
         countPerPage={COUNT_PER_PAGE}

--- a/packages/frontend/core/src/modules/workspace-indexer-embedding/view/styles-css.ts
+++ b/packages/frontend/core/src/modules/workspace-indexer-embedding/view/styles-css.ts
@@ -23,6 +23,7 @@ export const attachmentItem = css({
   alignItems: 'center',
   padding: '4px',
   gap: '4px',
+  color: cssVar('textPrimaryColor'),
   border: `0.5px solid ${cssVar('borderColor')}`,
   borderRadius: '4px',
   flex: 'none',
@@ -33,10 +34,14 @@ export const attachmentItem = css({
 export const attachmentTitle = css({
   fontSize: '14px',
   fontWeight: 400,
-  color: cssVar('textPrimaryColor'),
   display: 'flex',
   alignItems: 'center',
   gap: '4px',
+});
+
+export const attachmentError = css({
+  color: cssVarV2('status/error'),
+  backgroundColor: cssVarV2('layer/background/error'),
 });
 
 export const attachmentOperation = css({

--- a/tests/affine-cloud-copilot/e2e/utils/settings-panel-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/settings-panel-utils.ts
@@ -87,23 +87,35 @@ export class SettingsPanelUtils {
 
     while (count > 0) {
       const attachmentItem = await page.getByTestId(itemId).first();
+      const hasErrorItem = await attachmentItem
+        .getByTestId('workspace-embedding-setting-attachment-error-item')
+        .isVisible();
       await attachmentItem
         .getByTestId('workspace-embedding-setting-attachment-delete-button')
         .click();
-      await page.getByTestId('confirm-modal-confirm').click();
+
+      if (!hasErrorItem) {
+        await page.getByTestId('confirm-modal-confirm').click();
+      }
       await page.waitForTimeout(1000);
       count = await page.getByTestId(itemId).count();
     }
   }
 
-  public static async removeAttachment(page: Page, attachment: string) {
+  public static async removeAttachment(
+    page: Page,
+    attachment: string,
+    shouldConfirm = true
+  ) {
     const attachmentItem = await page
       .getByTestId('workspace-embedding-setting-attachment-item')
       .filter({ hasText: attachment });
     await attachmentItem
       .getByTestId('workspace-embedding-setting-attachment-delete-button')
       .click();
-    await page.getByTestId('confirm-modal-confirm').click();
+    if (shouldConfirm) {
+      await page.getByTestId('confirm-modal-confirm').click();
+    }
     await page
       .getByTestId('workspace-embedding-setting-attachment-item')
       .filter({ hasText: attachment })


### PR DESCRIPTION
### TL;DR

feat: optimize workspace attachment uploading & error display

![截屏2025-05-16 15.29.43.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyktQ6Qwc7H6TiRCFoYN/2408fe5e-e54d-44a8-882c-91e1b26bb660.png)

### What Changes
#### 
Support for Workspace Attachment Uploading & Error Handling
* Added support for three attachment states: uploading (local), upload failed (local error), and uploaded (persisted). The frontend UI now displays real-time upload progress and error messages.
* Attachments that fail to upload can be deleted directly without confirmation.
* Merged display of uploading and uploaded attachments for a smoother user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Attachments now show real-time upload status including uploading, error, and uploaded states.
  - Users can remove failed (error) attachments instantly without confirmation.
  - Attachment list merges uploading and uploaded files, displaying up to 10 items.
- **Bug Fixes**
  - Improved error handling and messaging for failed attachment uploads.
- **Style**
  - Enhanced visual styling for error attachments with distinct colors and backgrounds.
- **Tests**
  - Added tests simulating slow network uploads, upload failures, and direct removal of error attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->