### PR TITLE
feat(core): add status to pdf viewer

### DIFF
--- a/packages/frontend/core/src/blocksuite/attachment-viewer/attachment-embed-preview.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/attachment-embed-preview.tsx
@@ -6,7 +6,7 @@ import { PDFViewerEmbedded } from './pdf/pdf-viewer-embedded';
 import type { AttachmentViewerProps } from './types';
 import { getAttachmentType } from './utils';
 
-// In Embed view
+// Embed view
 export const AttachmentEmbedPreview = ({ model }: AttachmentViewerProps) => {
   const attachmentType = getAttachmentType(model);
   const element = useMemo(() => {

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/index.tsx
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/index.tsx
@@ -36,11 +36,15 @@ export const AttachmentViewerView = ({ model }: AttachmentViewerProps) => {
 };
 
 const AttachmentViewerInner = (props: AttachmentViewerBaseProps) => {
-  return props.model.props.type.endsWith('pdf') ? (
-    <AttachmentPreviewErrorBoundary>
-      <PDFViewer {...props} />
-    </AttachmentPreviewErrorBoundary>
-  ) : (
-    <AttachmentFallback {...props} />
-  );
+  const isPDF = props.model.props.type.endsWith('pdf');
+
+  if (isPDF) {
+    return (
+      <AttachmentPreviewErrorBoundary>
+        <PDFViewer {...props} />
+      </AttachmentPreviewErrorBoundary>
+    );
+  }
+
+  return <AttachmentFallback {...props} />;
 };

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/pdf/styles.css.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/pdf/styles.css.ts
@@ -89,7 +89,7 @@ export const pdfContainer = style({
   borderWidth: '1px',
   borderStyle: 'solid',
   borderColor: cssVarV2('layer/insideBorder/border'),
-  background: cssVar('--affine-background-primary-color'),
+  background: cssVar('backgroundPrimaryColor'),
   userSelect: 'none',
   contentVisibility: 'visible',
   display: 'flex',
@@ -132,8 +132,8 @@ export const pdfControlButton = style({
   height: '36px',
   borderWidth: '1px',
   borderStyle: 'solid',
-  borderColor: cssVar('--affine-border-color'),
-  background: cssVar('--affine-white'),
+  borderColor: cssVar('borderColor'),
+  background: cssVar('white'),
 });
 
 export const pdfFooter = style({
@@ -172,4 +172,54 @@ export const pdfPageCount = style({
   fontWeight: 400,
   lineHeight: '20px',
   color: cssVarV2('text/secondary'),
+});
+
+export const pdfLoadingWrapper = style({
+  margin: 'auto',
+});
+
+export const pdfStatus = style({
+  position: 'absolute',
+  left: '18px',
+  bottom: '18px',
+});
+
+export const pdfStatusButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '24px',
+  height: '24px',
+  borderRadius: '50%',
+  fontSize: '18px',
+  outline: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  color: cssVarV2('button/pureWhiteText'),
+  background: cssVarV2('status/error'),
+  boxShadow: cssVar('overlayShadow'),
+});
+
+export const pdfStatusMenu = style({
+  width: '244px',
+  gap: '8px',
+  color: cssVarV2('text/primary'),
+  lineHeight: '22px',
+});
+
+export const pdfStatusMenuFooter = style({
+  display: 'flex',
+  justifyContent: 'flex-end',
+});
+
+export const pdfReloadButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '2px 12px',
+  borderRadius: '8px',
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  outline: 'none',
+  color: cssVarV2('button/primary'),
 });

--- a/packages/frontend/core/src/modules/media/utils.ts
+++ b/packages/frontend/core/src/modules/media/utils.ts
@@ -1,49 +1,62 @@
 import type { AttachmentBlockModel } from '@blocksuite/affine/model';
 
+const imageExts = new Set([
+  'jpg',
+  'jpeg',
+  'png',
+  'gif',
+  'webp',
+  'svg',
+  'avif',
+  'tiff',
+  'bmp',
+]);
+
+const audioExts = new Set(['mp3', 'wav', 'ogg', 'flac', 'm4a', 'aac', 'opus']);
+
+const videoExts = new Set([
+  'mp4',
+  'webm',
+  'avi',
+  'mov',
+  'mkv',
+  'mpeg',
+  'ogv',
+  '3gp',
+]);
+
 export function getAttachmentType(model: AttachmentBlockModel) {
+  const type = model.props.type;
+
   // Check MIME type first
-  if (model.props.type.startsWith('image/')) {
+  if (type.startsWith('image/')) {
     return 'image';
   }
 
-  if (model.props.type.startsWith('audio/')) {
+  if (type.startsWith('audio/')) {
     return 'audio';
   }
 
-  if (model.props.type.startsWith('video/')) {
+  if (type.startsWith('video/')) {
     return 'video';
   }
 
-  if (model.props.type === 'application/pdf') {
+  if (type === 'application/pdf') {
     return 'pdf';
   }
 
   // If MIME type doesn't match, check file extension
-  const ext = model.props.name.split('.').pop()?.toLowerCase() || '';
+  const ext = model.props.name.split('.').pop()?.toLowerCase() ?? '';
 
-  if (
-    [
-      'jpg',
-      'jpeg',
-      'png',
-      'gif',
-      'webp',
-      'svg',
-      'avif',
-      'tiff',
-      'bmp',
-    ].includes(ext)
-  ) {
+  if (imageExts.has(ext)) {
     return 'image';
   }
 
-  if (['mp3', 'wav', 'ogg', 'flac', 'm4a', 'aac', 'opus'].includes(ext)) {
+  if (audioExts.has(ext)) {
     return 'audio';
   }
 
-  if (
-    ['mp4', 'webm', 'avi', 'mov', 'mkv', 'mpeg', 'ogv', '3gp'].includes(ext)
-  ) {
+  if (videoExts.has(ext)) {
     return 'video';
   }
 
@@ -55,7 +68,7 @@ export function getAttachmentType(model: AttachmentBlockModel) {
 }
 
 export async function downloadBlobToBuffer(model: AttachmentBlockModel) {
-  const sourceId = model.props.sourceId;
+  const sourceId = model.props.sourceId$.peek();
   if (!sourceId) {
     throw new Error('Attachment not found');
   }
@@ -65,6 +78,5 @@ export async function downloadBlobToBuffer(model: AttachmentBlockModel) {
     throw new Error('Attachment not found');
   }
 
-  const arrayBuffer = await blob.arrayBuffer();
-  return arrayBuffer;
+  return await blob.arrayBuffer();
 }

--- a/packages/frontend/core/src/modules/pdf/entities/pdf.ts
+++ b/packages/frontend/core/src/modules/pdf/entities/pdf.ts
@@ -37,9 +37,7 @@ export class PDF extends Entity<AttachmentBlockModel> {
   readonly state$ = LiveData.from<PDFRendererState>(
     // @ts-expect-error type alias
     from(downloadBlobToBuffer(this.props)).pipe(
-      switchMap(buffer => {
-        return this.renderer.ob$('open', { data: buffer });
-      }),
+      switchMap(data => this.renderer.ob$('open', { data })),
       map(meta => ({ status: PDFStatus.Opened, meta })),
       // @ts-expect-error type alias
       startWith({ status: PDFStatus.Opening }),

--- a/packages/frontend/core/src/modules/pdf/index.ts
+++ b/packages/frontend/core/src/modules/pdf/index.ts
@@ -15,5 +15,5 @@ export function configurePDFModule(framework: Framework) {
 
 export { PDF, type PDFRendererState, PDFStatus } from './entities/pdf';
 export { PDFPage } from './entities/pdf-page';
-export { PDFRenderer } from './renderer';
+export { type PDFMeta, PDFRenderer } from './renderer';
 export { PDFService } from './services/pdf';

--- a/packages/frontend/core/src/modules/peek-view/view/attachment-preview/index.tsx
+++ b/packages/frontend/core/src/modules/peek-view/view/attachment-preview/index.tsx
@@ -15,11 +15,14 @@ export const AttachmentPreviewPeekView = ({
 }: AttachmentPreviewModalProps) => {
   const { doc } = useEditor(docId);
   const blocksuiteDoc = doc?.blockSuiteDoc;
-  const model = useMemo(() => {
-    const model = blocksuiteDoc?.getBlock(blockId)?.model;
-    if (!model) return null;
-    return model as AttachmentBlockModel;
-  }, [blockId, blocksuiteDoc]);
+  const model = useMemo(
+    () => blocksuiteDoc?.getModelById<AttachmentBlockModel>(blockId) ?? null,
+    [blockId, blocksuiteDoc]
+  );
 
-  return model === null ? null : <AttachmentViewer model={model} />;
+  if (model) {
+    return <AttachmentViewer model={model} />;
+  }
+
+  return null;
 };

--- a/tests/affine-local/e2e/attachment-preview.spec.ts
+++ b/tests/affine-local/e2e/attachment-preview.spec.ts
@@ -355,7 +355,6 @@ test('should re-render pdf viewer', async ({ page }) => {
 
   const title = getBlockSuiteEditorTitle(page);
   await title.click();
-  await page.keyboard.type('PDF preview');
 
   await page.keyboard.press('Enter');
 
@@ -385,4 +384,79 @@ test('should re-render pdf viewer', async ({ page }) => {
   expect(newPortalId).not.toBeNull();
 
   expect(portalId).not.toEqual(newPortalId);
+});
+
+test('should display status when an error is thrown in peek view', async ({
+  context,
+  page,
+}) => {
+  await openHomePage(page);
+  await clickNewPageButton(page);
+  await waitForEmptyEditor(page);
+
+  const title = getBlockSuiteEditorTitle(page);
+  await title.click();
+
+  await page.keyboard.press('Enter');
+
+  await importAttachment(page, 'lorem-ipsum.pdf');
+
+  const attachment = page.locator('affine-attachment');
+  await attachment.click();
+
+  const toolbar = locateToolbar(page);
+
+  // Switches to embed view
+  await toolbar.getByLabel('Switch view').click();
+  await toolbar.getByLabel('Embed view').click();
+
+  await context.setOffline(true);
+
+  await attachment.dblclick();
+
+  // Peek view
+  const pdfViewer = page.getByTestId('pdf-viewer');
+  await expect(pdfViewer).toBeHidden();
+
+  const statusWrapper = page.getByTestId('pdf-viewer-status-wrapper');
+  await expect(statusWrapper).toBeVisible();
+});
+
+test('should display 404 when attachment is not found', async ({ page }) => {
+  await openHomePage(page);
+  await clickNewPageButton(page);
+  await waitForEmptyEditor(page);
+
+  const title = getBlockSuiteEditorTitle(page);
+  await title.click();
+
+  await page.keyboard.press('Enter');
+
+  await importAttachment(page, 'lorem-ipsum.pdf');
+
+  const attachment = page.locator('affine-attachment');
+  await attachment.click();
+
+  const toolbar = locateToolbar(page);
+
+  // Switches to embed view
+  await toolbar.getByLabel('Switch view').click();
+  await toolbar.getByLabel('Embed view').click();
+
+  await attachment.dblclick();
+
+  // Peek view
+  const pdfViewer = page.getByTestId('pdf-viewer');
+  await expect(pdfViewer).toBeVisible();
+
+  const statusWrapper = page.getByTestId('pdf-viewer-status-wrapper');
+  await expect(statusWrapper).toBeHidden();
+
+  await clickPeekViewControl(page, 1);
+
+  await page.goto(page.url() + 'test');
+
+  await expect(pdfViewer).toBeHidden();
+
+  await expect(page.getByTestId('not-found')).toBeVisible();
 });


### PR DESCRIPTION
Closes: [BS-3439](https://linear.app/affine-design/issue/BS-3439/pdf-独立页面split-view-中的-status-组件)
Related to: [BS-3143](https://linear.app/affine-design/issue/BS-3143/更新-loading-和错误样式)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated error handling and reload interface for PDF attachments, allowing users to retry loading PDFs when errors occur.

- **Refactor**
  - Improved PDF viewer interface with clearer loading and error states.
  - Enhanced attachment type detection for better performance and maintainability.
  - Streamlined attachment preview logic for more direct and efficient model retrieval.
  - Simplified internal PDF metadata handling and control flow for improved clarity.
  - Clarified conditional rendering logic in attachment viewer components.
  - Introduced explicit loading state management and refined rendering logic in attachment pages.

- **Style**
  - Updated and added styles for PDF viewer controls and error status display.

- **Tests**
  - Added end-to-end tests validating PDF preview error handling and attachment not-found scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->