### PR TITLE
fix: selection rect should reflect viewport change

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/clipboard/clipboard.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/clipboard/clipboard.ts
@@ -209,9 +209,10 @@ export class EdgelessClipboardController extends PageClipboard {
         await addImages(this.std, imageFiles, {
           point,
           maxWidth: MAX_IMAGE_WIDTH,
+          shouldTransformPoint: false,
         });
       } else {
-        await addAttachments(this.std, [...files], point);
+        await addAttachments(this.std, [...files], point, false);
       }
 
       this.std.getOptional(TelemetryProvider)?.track('CanvasElementAdded', {
@@ -227,11 +228,7 @@ export class EdgelessClipboardController extends PageClipboard {
 
     if (isUrlInClipboard(data)) {
       const url = data.getData('text/plain');
-      const lastMousePos = this.toolManager.lastMousePos$.peek();
-      const [x, y] = this.gfx.viewport.toModelCoord(
-        lastMousePos.x,
-        lastMousePos.y
-      );
+      const { x, y } = this.toolManager.lastMousePos$.peek();
 
       // try to interpret url as affine doc url
       const parseDocUrlService = this.std.getOptional(ParseDocUrlProvider);
@@ -562,11 +559,7 @@ export class EdgelessClipboardController extends PageClipboard {
   }
 
   private async _pasteTextContentAsNote(content: BlockSnapshot[] | string) {
-    const lastMousePos = this.toolManager.lastMousePos$.peek();
-    const [x, y] = this.gfx.viewport.toModelCoord(
-      lastMousePos.x,
-      lastMousePos.y
-    );
+    const { x, y } = this.toolManager.lastMousePos$.peek();
 
     const noteProps = {
       xywh: new Bound(

--- a/blocksuite/affine/blocks/root/src/edgeless/clipboard/command.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/clipboard/command.ts
@@ -52,9 +52,7 @@ export const createElementsFromClipboardDataCommand: Command<Input, Output> = (
     let oldCommonBound, pasteX, pasteY;
     {
       const lastMousePos = toolManager.lastMousePos$.peek();
-      pasteCenter =
-        pasteCenter ??
-        gfx.viewport.toModelCoord(lastMousePos.x, lastMousePos.y);
+      pasteCenter = pasteCenter ?? [lastMousePos.x, lastMousePos.y];
       const [modelX, modelY] = pasteCenter;
       oldCommonBound = edgelessElementsBoundFromRawData(elementsRawData);
 

--- a/blocksuite/affine/blocks/surface/src/renderer/tool-overlay.ts
+++ b/blocksuite/affine/blocks/surface/src/renderer/tool-overlay.ts
@@ -26,7 +26,7 @@ export class ToolOverlay extends Overlay {
       this.gfx.viewport.viewportUpdated.pipe(startWith(null)).subscribe(() => {
         // when viewport is updated, we should keep the overlay in the same position
         // to get last mouse position and convert it to model coordinates
-        const pos = this.gfx.tool.lastMousePos$.value;
+        const pos = this.gfx.tool.lastMouseViewPos$.value;
         const [x, y] = this.gfx.viewport.toModelCoord(pos.x, pos.y);
         this.x = x;
         this.y = y;

--- a/blocksuite/affine/gfx/mindmap/src/toolbar/mindmap-tool-button.ts
+++ b/blocksuite/affine/gfx/mindmap/src/toolbar/mindmap-tool-button.ts
@@ -315,7 +315,7 @@ export class EdgelessMindmapToolButton extends EdgelessToolbarToolMixin(
           }
           this.setEdgelessTool(EmptyTool);
           const icon = this.mindmapElement;
-          const { x, y } = gfx.tool.lastMousePos$.peek();
+          const { x, y } = gfx.tool.lastMouseViewPos$.peek();
           const { viewport } = this.edgeless.std.get(ViewportElementProvider);
           const { left, top } = viewport;
           const clientPos = { x: x + left, y: y + top };

--- a/blocksuite/affine/gfx/shape/src/draggable/shape-draggable.ts
+++ b/blocksuite/affine/gfx/shape/src/draggable/shape-draggable.ts
@@ -258,7 +258,7 @@ export class EdgelessToolbarShapeDraggable extends EdgelessToolbarToolMixin(
               console.error('Edgeless toolbar Shape element not found');
               return;
             }
-            const { x, y } = this.gfx.tool.lastMousePos$.peek();
+            const { x, y } = this.gfx.tool.lastMouseViewPos$.peek();
             const { viewport } = this.edgeless.std.get(ViewportElementProvider);
             const { left, top } = viewport;
             const clientPos = { x: x + left, y: y + top };

--- a/blocksuite/affine/gfx/shape/src/shape-tool.ts
+++ b/blocksuite/affine/gfx/shape/src/shape-tool.ts
@@ -117,24 +117,24 @@ export class ShapeTool extends BaseTool<ShapeToolOption> {
 
     if (spacePressed && this._spacePressedCtx) {
       const {
-        startX,
-        startY,
         w,
         h,
+        startX,
+        startY,
         endX: pressedX,
         endY: pressedY,
       } = this._spacePressedCtx.draggingArea;
-      const curDraggingArea = controller.draggingViewArea$.peek();
-      const { endX: lastX, endY: lastY } = curDraggingArea;
+      const { endX: lastX, endY: lastY } = controller.draggingArea$.peek();
       const dx = lastX - pressedX;
       const dy = lastY - pressedY;
 
-      this.controller.draggingViewArea$.value = {
-        ...curDraggingArea,
+      this.controller.draggingArea$.value = {
         x: Math.min(startX + dx, lastX),
         y: Math.min(startY + dy, lastY),
         w,
         h,
+        endX: endX + dx,
+        endY: endY + dy,
         startX: startX + dx,
         startY: startY + dy,
       };
@@ -306,7 +306,7 @@ export class ShapeTool extends BaseTool<ShapeToolOption> {
 
         if (spacePressed && this._draggingElementId) {
           this._spacePressedCtx = {
-            draggingArea: this.controller.draggingViewArea$.peek(),
+            draggingArea: this.controller.draggingArea$.peek(),
           };
         }
       })

--- a/blocksuite/affine/widgets/edgeless-dragging-area/src/edgeless-dragging-area-rect.ts
+++ b/blocksuite/affine/widgets/edgeless-dragging-area/src/edgeless-dragging-area-rect.ts
@@ -36,7 +36,7 @@ export class EdgelessDraggingAreaRectWidget extends WidgetComponent<RootBlockMod
   }
 
   override render() {
-    const rect = this.gfx.tool.draggingViewArea$.value;
+    const rect = this.gfx.tool.draggingViewportArea$.value;
     const tool = this.gfx.tool.currentTool$.value;
 
     if (

--- a/blocksuite/framework/std/src/gfx/viewport.ts
+++ b/blocksuite/framework/std/src/gfx/viewport.ts
@@ -591,8 +591,20 @@ export class Viewport {
     return new Bound(x, y, w / this.zoom, h / this.zoom);
   }
 
-  toModelCoord(viewX: number, viewY: number): IVec {
-    const { viewportX, viewportY, zoom, viewScale } = this;
+  toModelCoord(
+    viewX: number,
+    viewY: number,
+    zoom = this.zoom,
+    center?: IPoint
+  ): IVec {
+    const { viewScale } = this;
+    const viewportX = center
+      ? center.x - this.width / 2 / zoom
+      : this.viewportX;
+    const viewportY = center
+      ? center.y - this.height / 2 / zoom
+      : this.viewportY;
+
     return [
       viewportX + viewX / zoom / viewScale,
       viewportY + viewY / zoom / viewScale,


### PR DESCRIPTION
Fixes [BS-3349](https://linear.app/affine-design/issue/BS-3349/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved edge scrolling during selection dragging for smoother and more responsive viewport navigation.
  - Dragging area and mouse position tracking now update reactively with viewport changes, ensuring more accurate selection and movement.

- **Refactor**
  - Unified and clarified coordinate handling for dragging and mouse position, with clearer naming and separation between model and browser coordinates.
  - Simplified selection logic and removed unnecessary accumulated state for cleaner and more maintainable behavior.
  - Enhanced flexibility in coordinate conversion by allowing viewport transformations relative to arbitrary zoom and center.
  - Streamlined clipboard paste handling by simplifying mouse position extraction and adjusting attachment options.
  - Updated references to use consistent dragging area sources and viewport-relative mouse positions across tools and components.

- **Bug Fixes**
  - Enhanced overlay and dragging area accuracy by updating position calculations and coordinate transformations.
  - Fixed paste operations to correctly handle mouse position without unnecessary coordinate conversions.
  - Corrected drag initiation positions in toolbar and shape dragging to align with viewport-relative coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->