### PR TITLE
chore(editor): improve index of new edgeless note from dnd

### DIFF
--- a/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/drag-event-watcher.ts
@@ -30,6 +30,7 @@ import {
 import {
   captureEventTarget,
   type DropTarget as DropResult,
+  findNoteBlockModel,
   getBlockComponentsExcludeSubtrees,
   getRectByBlockComponent,
   getScrollContainer,
@@ -1247,20 +1248,50 @@ export class DragEventWatcher {
             console.error
           );
         }
-      } else {
-        // create note to wrap the snapshot
-        const noteId = store.addBlock(
-          'affine:note',
-          {
-            xywh: new Bound(
-              point.x,
-              point.y,
-              DEFAULT_NOTE_WIDTH,
-              DEFAULT_NOTE_HEIGHT
-            ).serialize(),
-          },
-          this.widget.store.root!
-        );
+      }
+      // create note to wrap the snapshot
+      else {
+        const originalModel = store.getModelById(snapshot.content[0].id);
+        const originalNote = originalModel
+          ? findNoteBlockModel(originalModel)
+          : null;
+
+        let noteId: string;
+        if (originalNote) {
+          const placement =
+            originalNote.children[0].id === snapshot.content[0].id
+              ? 'before'
+              : 'after';
+
+          noteId = store.addSiblingBlocks(
+            originalNote,
+            [
+              {
+                flavour: 'affine:note',
+                xywh: new Bound(
+                  point.x,
+                  point.y,
+                  DEFAULT_NOTE_WIDTH,
+                  DEFAULT_NOTE_HEIGHT
+                ).serialize(),
+              },
+            ],
+            placement
+          )[0];
+        } else {
+          noteId = store.addBlock(
+            'affine:note',
+            {
+              xywh: new Bound(
+                point.x,
+                point.y,
+                DEFAULT_NOTE_WIDTH,
+                DEFAULT_NOTE_HEIGHT
+              ).serialize(),
+            },
+            this.widget.store.root!
+          );
+        }
 
         this._dropToModel(
           {


### PR DESCRIPTION
Close [BS-3500](https://linear.app/affine-design/issue/BS-3500/剪刀没问题了，通过拖动形成的段落能不能也有同样的表现？)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop behavior by inserting new note blocks as siblings when appropriate, preserving the structure during block moves.

- **Tests**
  - Enabled and extended tests to verify drag-and-drop functionality across multiple notes and maintain the relative order of note content during drag operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->