### PR TITLE
refactor(nbstore): improve doc state management

### DIFF
--- a/packages/common/nbstore/src/worker/client.ts
+++ b/packages/common/nbstore/src/worker/client.ts
@@ -242,6 +242,10 @@ class WorkerDocSync implements DocSync {
     return this.client.ob$('docSync.docState', docId);
   }
 
+  async waitForSynced(docId?: string, abort?: AbortSignal): Promise<void> {
+    await this.client.call('docSync.waitForSynced', docId ?? null, abort);
+  }
+
   addPriority(docId: string, priority: number) {
     const subscription = this.client
       .ob$('docSync.addPriority', { docId, priority })

--- a/packages/common/nbstore/src/worker/consumer.ts
+++ b/packages/common/nbstore/src/worker/consumer.ts
@@ -212,6 +212,8 @@ class StoreConsumer {
           const undo = this.docSync.addPriority(docId, priority);
           return () => undo();
         }),
+      'docSync.waitForSynced': (docId, ctx) =>
+        this.docSync.waitForSynced(docId ?? undefined, ctx.signal),
       'docSync.resetSync': () => this.docSync.resetSync(),
       'blobSync.state': () => this.blobSync.state$,
       'blobSync.blobState': blobId => this.blobSync.blobState$(blobId),

--- a/packages/common/nbstore/src/worker/ops.ts
+++ b/packages/common/nbstore/src/worker/ops.ts
@@ -102,6 +102,7 @@ interface GroupedWorkerOps {
   docSync: {
     state: [void, DocSyncState];
     docState: [string, DocSyncDocState];
+    waitForSynced: [string | null, void];
     addPriority: [{ docId: string; priority: number }, boolean];
     resetSync: [void, void];
   };

--- a/packages/frontend/core/src/components/workspace-selector/workspace-card/index.tsx
+++ b/packages/frontend/core/src/components/workspace-selector/workspace-card/index.tsx
@@ -88,7 +88,7 @@ const useSyncEngineSyncProgress = (meta: WorkspaceMetadata) => {
   const engineState = useLiveData(
     useMemo(() => {
       return workspace
-        ? LiveData.from(workspace.engine.doc.state$, null).throttleTime(500)
+        ? LiveData.from(workspace.engine.doc.state$, null)
         : null;
     }, [workspace])
   );

--- a/packages/frontend/core/src/modules/import-clipper/services/import.ts
+++ b/packages/frontend/core/src/modules/import-clipper/services/import.ts
@@ -44,8 +44,8 @@ export class ImportClipperService extends Service {
       docsService.list.setPrimaryMode(docId, 'page');
       workspace.engine.doc.addPriority(workspace.id, 100);
       workspace.engine.doc.addPriority(docId, 100);
-      await workspace.engine.doc.waitForDocSynced(workspace.id);
-      await workspace.engine.doc.waitForDocSynced(docId);
+      await workspace.engine.doc.waitForSynced(workspace.id);
+      await workspace.engine.doc.waitForSynced(docId);
       disposeWorkspace();
       return docId;
     } else {

--- a/tests/affine-local/e2e/local-first-avatar.spec.ts
+++ b/tests/affine-local/e2e/local-first-avatar.spec.ts
@@ -33,7 +33,7 @@ test('should create a page with a local first avatar and remove it', async ({
     .nth(0)
     .getByTestId('workspace-avatar')
     .click();
-  await page.waitForTimeout(1000);
+  await page.waitForTimeout(2000);
   await page.getByTestId('workspace-name').click();
   await page
     .getByTestId('workspace-card')


### PR DESCRIPTION
Move the `waitForSynced` method from `frontend` to `nbstore worker` to make the wait more reliable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit tracking of document updating state to indicate when data is being applied or saved.
  - Introduced new methods to wait for update and synchronization completion with abort support.

- **Improvements**
  - Applied throttling with leading and trailing emissions to state observables for smoother UI updates.
  - Refined synchronization waiting logic for clearer separation between update completion and sync completion.
  - Removed throttling in workspace selector component for more immediate state feedback.
  - Updated import and clipper services to use the new synchronization waiting methods.
  - Simplified asynchronous waiting logic in indexer synchronization methods.

- **Bug Fixes**
  - Enhanced accuracy and reliability of document update and sync status indicators.

- **Tests**
  - Increased wait timeout in avatar selection test to improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->