### PR TITLE
Do not create local workspaces if disabled

### DIFF
--- a/packages/frontend/core/src/desktop/pages/index/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/index/index.tsx
@@ -1,4 +1,5 @@
 import { DesktopApiService } from '@affine/core/modules/desktop-api';
+import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { WorkspacesService } from '@affine/core/modules/workspace';
 import {
   buildShowcaseWorkspace,
@@ -127,7 +128,14 @@ export const Component = ({
     desktopApi?.handler.ui.pingAppLayoutReady().catch(console.error);
   }, [desktopApi]);
 
+  const featureFlagService = useService(FeatureFlagService);
+  const localWorkspaceEnabled =
+    featureFlagService.flags.enable_local_workspace.value;
+
   useEffect(() => {
+    if (!localWorkspaceEnabled) {
+      return;
+    }
     setCreating(true);
     createFirstAppData(workspacesService)
       .then(createdWorkspace => {
@@ -148,7 +156,7 @@ export const Component = ({
       .finally(() => {
         setCreating(false);
       });
-  }, [jumpToPage, openPage, workspacesService]);
+  }, [localWorkspaceEnabled, jumpToPage, openPage, workspacesService]);
 
   if (navigating || creating) {
     return fallback ?? <AppContainer fallback />;


### PR DESCRIPTION
On first launch, the frontend creates a local Demo Workspace. This behavior has until now ignored the `enable_local_workspace` flag, causing a local workspace to be created even if the flag is disabled. This PR changes the behavior to _not_ create a Demo Workspace if the flag is disabled. Instead, a UI is shown that offers the user to sign in.

### Suggestions for future improvement:
The UI shown when no Demo Workspace has been created is as of now very basic. I suggest to replace the UI with a more appealing one in the future.

### Addressed issues:
#8716 #10839 #12219  #12256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a feature flag to control the availability of local workspace creation. This feature will only be enabled for users when the corresponding flag is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->