### PR TITLE
chore(mobile): enable ai button feature flag for canary only

### DIFF
--- a/packages/frontend/apps/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/frontend/apps/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "51e535dcf5439c01396d668a9598748ea86c7c1a",
-        "version" : "1.20.0"
+        "revision" : "6ecc75281dab2fa231cb0d5fed3a3713826fecae",
+        "version" : "1.21.0"
       }
     },
     {
@@ -25,15 +25,6 @@
       "state" : {
         "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
         "version" : "0.16.0"
-      }
-    },
-    {
-      "identity" : "sqlite.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/SQLite.swift.git",
-      "state" : {
-        "revision" : "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
-        "version" : "0.15.3"
       }
     },
     {

--- a/packages/frontend/apps/ios/App/Packages/AffineGraphQL/Package.resolved
+++ b/packages/frontend/apps/ios/App/Packages/AffineGraphQL/Package.resolved
@@ -5,17 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "e98e9d3b398b6005149074d51b097e31aaa44f63",
-        "version" : "1.17.0"
-      }
-    },
-    {
-      "identity" : "sqlite.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/SQLite.swift.git",
-      "state" : {
-        "revision" : "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
-        "version" : "0.15.3"
+        "revision" : "6ecc75281dab2fa231cb0d5fed3a3713826fecae",
+        "version" : "1.21.0"
       }
     }
   ],

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -249,7 +249,7 @@ export const AFFINE_FLAGS = {
     category: 'affine',
     displayName: 'Enable AI Button',
     description: 'Enable AI Button on mobile',
-    configurable: BUILD_CONFIG.isMobileEdition,
+    configurable: BUILD_CONFIG.isMobileEdition && isCanaryBuild,
     defaultState: false,
   },
   enable_turbo_renderer: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated Apollo iOS dependency to version 1.21.0 and removed the SQLite.swift dependency in the iOS app workspace.
- **New Features**
  - The "Enable Mobile AI Button" feature flag is now configurable only for mobile canary builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->