### PR TITLE
fix: transparent shape should be filled correctly

### DIFF
--- a/blocksuite/affine/gfx/shape/src/toolbar/config.ts
+++ b/blocksuite/affine/gfx/shape/src/toolbar/config.ts
@@ -176,11 +176,11 @@ export const shapeToolbarConfig = {
 
           if (d.type === 'pick') {
             const value = d.detail.value;
-            const filled = isTransparent(value);
+            const filled = !isTransparent(value);
             for (const model of models) {
               const props = packColor(field, value);
               // If `filled` can be set separately, this logic can be removed
-              if (field && !model.filled) {
+              if (filled && !model.filled) {
                 const color = getTextColor(value, filled);
                 Object.assign(props, { filled, color });
               }


### PR DESCRIPTION
Fixes [BS-3526](https://linear.app/affine-design/issue/BS-3526)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the behavior when selecting fill colors for shapes, ensuring fill properties are applied only when a non-transparent color is chosen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->