### PR TITLE
feat(core): add new doc button in new all docs header

### DIFF
--- a/packages/frontend/core/src/components/explorer/display-menu/index.tsx
+++ b/packages/frontend/core/src/components/explorer/display-menu/index.tsx
@@ -10,7 +10,6 @@ import type {
   OrderByParams,
 } from '@affine/core/modules/collection-rules/types';
 import { useI18n } from '@affine/i18n';
-import { ArrowDownSmallIcon } from '@blocksuite/icons/rc';
 import type React from 'react';
 import { useCallback } from 'react';
 
@@ -122,11 +121,7 @@ export const ExplorerDisplayMenuButton = ({
       }
       {...menuProps}
     >
-      <Button
-        className={className}
-        style={style}
-        suffix={<ArrowDownSmallIcon />}
-      >
+      <Button className={className} style={style}>
         {t['com.affine.explorer.display-menu.button']()}
       </Button>
     </Menu>

--- a/packages/frontend/core/src/desktop/pages/workspace/all-page/all-page-header.css.ts
+++ b/packages/frontend/core/src/desktop/pages/workspace/all-page/all-page-header.css.ts
@@ -29,3 +29,9 @@ export const viewToggleItem = style({
     },
   },
 });
+
+export const newPageButtonLabel = style({
+  fontSize: '12px',
+  color: cssVarV2.text.primary,
+  fontWeight: 500,
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "New Page" button in the workspace header, allowing users to quickly create different types of pages or import documents directly from the header.

- **Style**
  - Introduced a new style for the "New Page" button label, ensuring consistent appearance with the app's theme.

- **Refactor**
  - Updated the display menu button to remove the arrow icon, displaying only the localized text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->