### PR TITLE
chore(server): add auto index batch size

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -834,6 +834,11 @@
           "type": "string",
           "description": "Indexer search service auth password, if not set, basic auth will be disabled. Optional for elasticsearch\n@default \"\"\n@environment `AFFINE_INDEXER_SEARCH_PASSWORD`",
           "default": ""
+        },
+        "autoIndex.batchSize": {
+          "type": "number",
+          "description": "Number of workspaces automatically indexed per batch\n@default 10",
+          "default": 10
         }
       }
     },

--- a/packages/backend/server/src/plugins/indexer/config.ts
+++ b/packages/backend/server/src/plugins/indexer/config.ts
@@ -19,6 +19,9 @@ declare global {
         username: string;
         password: string;
       };
+      autoIndex: {
+        batchSize: number;
+      };
     };
   }
 }
@@ -57,5 +60,10 @@ defineModuleConfig('indexer', {
     desc: 'Indexer search service auth password, if not set, basic auth will be disabled. Optional for elasticsearch',
     default: '',
     env: ['AFFINE_INDEXER_SEARCH_PASSWORD', 'string'],
+  },
+  'autoIndex.batchSize': {
+    desc: 'Number of workspaces automatically indexed per batch',
+    default: 10,
+    shape: z.number().int().positive().max(1000),
   },
 });

--- a/packages/backend/server/src/plugins/indexer/job.ts
+++ b/packages/backend/server/src/plugins/indexer/job.ts
@@ -121,7 +121,7 @@ export class IndexerJob {
         indexed: true,
       });
     }
-    this.logger.debug(
+    this.logger.log(
       `indexed workspace ${workspaceId} with ${missingDocIds.length} missing docs and ${deletedDocIds.length} deleted docs`
     );
   }
@@ -138,7 +138,10 @@ export class IndexerJob {
   @OnJob('indexer.autoIndexWorkspaces')
   async autoIndexWorkspaces(payload: Jobs['indexer.autoIndexWorkspaces']) {
     const startSid = payload.lastIndexedWorkspaceSid ?? 0;
-    const workspaces = await this.models.workspace.listAfterSid(startSid, 100);
+    const workspaces = await this.models.workspace.listAfterSid(
+      startSid,
+      this.config.indexer.autoIndex.batchSize
+    );
     if (workspaces.length === 0) {
       // Keep the current sid value when repeating
       return JOB_SIGNAL.Repeat;

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -289,6 +289,10 @@
       "type": "String",
       "desc": "Indexer search service auth password, if not set, basic auth will be disabled. Optional for elasticsearch",
       "env": "AFFINE_INDEXER_SEARCH_PASSWORD"
+    },
+    "autoIndex.batchSize": {
+      "type": "Number",
+      "desc": "Number of workspaces automatically indexed per batch"
     }
   },
   "oauth": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable batch size setting for automatic workspace indexing. Users can now adjust how many workspaces are indexed per batch, with a default value of 10 and support for values between 1 and 1000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->