### PR TITLE
fix(editor): disable iframe border in code block preview

### DIFF
--- a/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/html-preview.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/html-preview.ts
@@ -48,6 +48,7 @@ export class HTMLPreview extends SignalWatcher(WithDisposable(LitElement)) {
     .html-preview-iframe {
       width: 100%;
       height: 544px;
+      border: none;
     }
   `;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the HTML preview to remove the border around the preview iframe for a cleaner appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->