### PR TITLE
fix(editor): prevent cursor jumping to title when pressing backspace on the begin of edgeless note

### DIFF
--- a/tests/affine-local/e2e/blocksuite/edgeless/note.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/edgeless/note.spec.ts
@@ -7,6 +7,7 @@ import {
   getEdgelessSelectedIds,
   getPageMode,
   getSelectedXYWH,
+  isDocTitleFocused,
   locateEditorContainer,
   locateModeSwitchButton,
   locateToolbar,
@@ -426,6 +427,14 @@ test.describe('note block rendering', () => {
       note,
       'should show collapsed content when dragging is finished'
     ).toHaveCSS('overflow-y', 'visible');
+  });
+
+  test('cursor should not jump to page block title from note block', async ({
+    page,
+  }) => {
+    await createEdgelessNoteBlock(page, [50, 50]);
+    await pressBackspace(page);
+    expect(await isDocTitleFocused(page)).toBeFalsy();
   });
 });
 

--- a/tests/kit/src/utils/editor.ts
+++ b/tests/kit/src/utils/editor.ts
@@ -69,6 +69,14 @@ export function locateDocTitle(page: Page, editorIndex = 0) {
   return locateEditorContainer(page, editorIndex).locator('doc-title');
 }
 
+export function isDocTitleFocused(page: Page, editorIndex = 0) {
+  return locateDocTitle(page, editorIndex)
+    .locator('.inline-editor')
+    .evaluate(inlineEditor => {
+      return document.activeElement === inlineEditor;
+    });
+}
+
 export async function focusDocTitle(page: Page, editorIndex = 0) {
   await locateDocTitle(page, editorIndex).locator('.inline-editor').focus();
 }


### PR DESCRIPTION
Close [BS-3492](https://linear.app/affine-design/issue/BS-3492/白板上的note，在开头按退格键，光标会到page-block的title上)

### Before

https://github.com/user-attachments/assets/334504f2-30f3-4ce2-ba60-a2688a811b53

### After

https://github.com/user-attachments/assets/be26be6c-6cfc-4f69-82b7-1127e0d10a1a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved behavior when deleting a note block to ensure the cursor focus does not incorrectly jump to the page title after pressing backspace.

- **Tests**
  - Added a new test to verify that focus remains within the note block after deletion, preventing unwanted cursor movement to the page title.
  - Introduced a utility to check if the document title is focused during tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->