### PR TITLE
fix(editor): toc viewer no update after delete heading in edgeless mode

### DIFF
--- a/blocksuite/affine/fragments/outline/src/body/outline-notice.ts
+++ b/blocksuite/affine/fragments/outline/src/body/outline-notice.ts
@@ -7,7 +7,7 @@ import { effect, signal } from '@preact/signals-core';
 import { html, nothing } from 'lit';
 
 import { type TocContext, tocContext } from '../config';
-import { getNotesFromDoc } from '../utils/query';
+import { getNotesFromStore } from '../utils/query';
 import * as styles from './outline-notice.css';
 
 export const AFFINE_OUTLINE_NOTICE = 'affine-outline-notice';
@@ -31,7 +31,7 @@ export class OutlineNotice extends SignalWatcher(
         }
 
         const shouldShowNotice =
-          getNotesFromDoc(this._context.editor$.value.store, [
+          getNotesFromStore(this._context.editor$.value.store, [
             NoteDisplayMode.DocOnly,
           ]).length > 0;
 

--- a/blocksuite/affine/fragments/outline/src/outline-viewer.ts
+++ b/blocksuite/affine/fragments/outline/src/outline-viewer.ts
@@ -200,6 +200,7 @@ export class OutlineViewer extends SignalWatcher(
       )
     );
 
+    // title update
     this.disposables.add(
       this.editor.store.workspace.meta.docMetaUpdated.subscribe(() => {
         this.requestUpdate();

--- a/blocksuite/affine/fragments/outline/src/utils/query.ts
+++ b/blocksuite/affine/fragments/outline/src/utils/query.ts
@@ -9,15 +9,15 @@ import type { BlockModel, Store } from '@blocksuite/store';
 
 import { headingKeys } from '../config.js';
 
-export function getNotesFromDoc(
-  doc: Store,
+export function getNotesFromStore(
+  store: Store,
   modes: NoteDisplayMode[] = [
     NoteDisplayMode.DocAndEdgeless,
     NoteDisplayMode.DocOnly,
     NoteDisplayMode.EdgelessOnly,
   ]
 ) {
-  const rootModel = doc.root;
+  const rootModel = store.root;
   if (!rootModel) return [];
 
   const notes: NoteBlockModel[] = [];
@@ -59,7 +59,7 @@ export function getHeadingBlocksFromNote(
 }
 
 export function getHeadingBlocksFromDoc(
-  doc: Store,
+  store: Store,
   modes: NoteDisplayMode[] = [
     NoteDisplayMode.DocAndEdgeless,
     NoteDisplayMode.DocOnly,
@@ -67,6 +67,6 @@ export function getHeadingBlocksFromDoc(
   ],
   ignoreEmpty = false
 ) {
-  const notes = getNotesFromDoc(doc, modes);
+  const notes = getNotesFromStore(store, modes);
   return notes.map(note => getHeadingBlocksFromNote(note, ignoreEmpty)).flat();
 }

--- a/packages/frontend/core/src/blocksuite/outline-viewer/index.tsx
+++ b/packages/frontend/core/src/blocksuite/outline-viewer/index.tsx
@@ -15,31 +15,22 @@ export const EditorOutlineViewer = ({
 }) => {
   const outlineViewerRef = useRef<OutlineViewer | null>(null);
 
-  const onRefChange = useCallback((container: HTMLDivElement | null) => {
-    if (container) {
-      if (outlineViewerRef.current === null) {
-        console.error('outline viewer should be initialized');
-        return;
+  const onRefChange = useCallback(
+    (container: HTMLDivElement | null) => {
+      if (container && editor) {
+        if (outlineViewerRef.current) {
+          outlineViewerRef.current.remove();
+        }
+        outlineViewerRef.current = new OutlineViewer();
+        outlineViewerRef.current.editor = editor;
+        outlineViewerRef.current.toggleOutlinePanel = openOutlinePanel ?? null;
+        container.append(outlineViewerRef.current);
       }
+    },
+    [editor, openOutlinePanel]
+  );
 
-      container.append(outlineViewerRef.current);
-    }
-  }, []);
-
-  if (!editor || !show) return;
-
-  if (!outlineViewerRef.current) {
-    outlineViewerRef.current = new OutlineViewer();
-  }
-  if (outlineViewerRef.current.editor !== editor) {
-    outlineViewerRef.current.editor = editor;
-  }
-  if (
-    outlineViewerRef.current.toggleOutlinePanel !== openOutlinePanel &&
-    openOutlinePanel
-  ) {
-    outlineViewerRef.current.toggleOutlinePanel = openOutlinePanel;
-  }
+  if (!editor || !show) return null;
 
   return <div className={styles.root} ref={onRefChange} />;
 };

--- a/tests/affine-local/e2e/blocksuite/outline/outline-viewer.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/outline/outline-viewer.spec.ts
@@ -179,6 +179,25 @@ test('should hide edgeless-only note headings', async ({ page }) => {
   await expect(h1InPanel).toContainText(['Heading 1']);
 });
 
+test('outline viewer should update after change heading in edgeless mode', async ({
+  page,
+}) => {
+  await createTitle(page);
+  await pressEnter(page);
+
+  await type(page, '# ');
+  await type(page, 'Heading 1');
+
+  await clickEdgelessModeButton(page);
+  const note = page.locator('affine-edgeless-note');
+  await note.dblclick();
+  await type(page, '# New Heading');
+  await clickPageModeButton(page);
+
+  const indicators = getIndicators(page);
+  await expect(indicators).toHaveCount(3);
+});
+
 test('outline viewer should be useable in doc peek preview', async ({
   page,
 }) => {


### PR DESCRIPTION
Close [BS-3494](https://linear.app/affine-design/issue/BS-3494/在白板删除note的标题，切回page模式，toc没更新)

Other changes: `doc` -> `store`

### Before

https://github.com/user-attachments/assets/ddce20b9-eda2-414b-9452-d8d54a811cf1

### After



https://github.com/user-attachments/assets/7124b8a1-9ab4-4e09-b0ff-7ea2cc9613c2



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization of the outline viewer to ensure updates after editing headings in edgeless mode.
- **Tests**
  - Added an end-to-end test verifying that the outline viewer correctly reflects changes made in edgeless mode.
- **Refactor**
  - Streamlined outline viewer component lifecycle management for better initialization and cleanup.
  - Updated data source references from document to store across outline-related features for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->