### PR TITLE
fix: rewrite selection logic and frame selection handling logic

### DIFF
--- a/blocksuite/affine/blocks/frame/src/frame-block.ts
+++ b/blocksuite/affine/blocks/frame/src/frame-block.ts
@@ -3,6 +3,7 @@ import {
   DefaultTheme,
   type FrameBlockModel,
   FrameBlockSchema,
+  isTransparent,
 } from '@blocksuite/affine-model';
 import { ThemeProvider } from '@blocksuite/affine-shared/services';
 import { Bound } from '@blocksuite/global/gfx';
@@ -11,7 +12,6 @@ import {
   type BoxSelectionContext,
   getTopElements,
   GfxViewInteractionExtension,
-  type SelectedContext,
 } from '@blocksuite/std/gfx';
 import { cssVarV2 } from '@toeverything/theme/v2';
 import { html } from 'lit';
@@ -66,22 +66,6 @@ export class FrameBlockComponent extends GfxBlockComponent<FrameBlockModel> {
       rotate,
       zIndex: this.toZIndex(),
     };
-  }
-
-  override onSelected(context: SelectedContext): boolean | void {
-    const { x, y } = context.position;
-
-    if (
-      !context.fallback &&
-      // if the frame is selected by title, then ignore it because the title selection is handled by the title widget
-      (this.model.externalBound?.containsPoint([x, y]) ||
-        // otherwise if the frame has title, then ignore it because in this case the frame cannot be selected by frame body
-        this.model.props.title.length)
-    ) {
-      return false;
-    }
-
-    return super.onSelected(context);
   }
 
   override onBoxSelected(context: BoxSelectionContext) {
@@ -186,6 +170,18 @@ export const FrameBlockInteraction =
             context.set({
               rotatable: false,
             });
+          },
+        };
+      },
+      handleSelection: () => {
+        return {
+          selectable(context) {
+            const { model } = context;
+
+            return (
+              context.default(context) &&
+              (model.isLocked() || !isTransparent(model.props.background))
+            );
           },
         };
       },

--- a/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
@@ -13,7 +13,6 @@ import { toGfxBlockComponent } from '@blocksuite/std';
 import {
   type BoxSelectionContext,
   GfxViewInteractionExtension,
-  type SelectedContext,
 } from '@blocksuite/std/gfx';
 import { html, nothing, type PropertyValues } from 'lit';
 import { query, state } from 'lit/decorators.js';
@@ -342,69 +341,6 @@ export class EdgelessNoteBlockComponent extends toGfxBlockComponent(
     `;
   }
 
-  override onSelected(context: SelectedContext) {
-    const { selected, multiSelect, event: e } = context;
-    const { editing } = this.gfx.selection;
-    const alreadySelected = this.gfx.selection.has(this.model.id);
-
-    if (!multiSelect && selected && (alreadySelected || editing)) {
-      if (this.model.isLocked()) return;
-
-      if (alreadySelected && editing) {
-        return;
-      }
-
-      this.gfx.selection.set({
-        elements: [this.model.id],
-        editing: true,
-      });
-
-      this.updateComplete
-        .then(() => {
-          if (!this.isConnected) {
-            return;
-          }
-
-          if (this.model.children.length === 0) {
-            const blockId = this.store.addBlock(
-              'affine:paragraph',
-              { type: 'text' },
-              this.model.id
-            );
-
-            if (blockId) {
-              focusTextModel(this.std, blockId);
-            }
-          } else {
-            const rect = this.querySelector(
-              '.affine-block-children-container'
-            )?.getBoundingClientRect();
-
-            if (rect) {
-              const offsetY = 8 * this.gfx.viewport.zoom;
-              const offsetX = 2 * this.gfx.viewport.zoom;
-              const x = clamp(
-                e.clientX,
-                rect.left + offsetX,
-                rect.right - offsetX
-              );
-              const y = clamp(
-                e.clientY,
-                rect.top + offsetY,
-                rect.bottom - offsetY
-              );
-              handleNativeRangeAtPoint(x, y);
-            } else {
-              handleNativeRangeAtPoint(e.clientX, e.clientY);
-            }
-          }
-        })
-        .catch(console.error);
-    } else {
-      super.onSelected(context);
-    }
-  }
-
   override onBoxSelected(_: BoxSelectionContext) {
     return this.model.props.displayMode !== NoteDisplayMode.DocOnly;
   }
@@ -490,6 +426,72 @@ export const EdgelessNoteInteraction =
           onResizeEnd(context): void {
             context.default(context);
             model.pop('edgeless');
+          },
+        };
+      },
+      handleSelection: ({ std, gfx, view, model }) => {
+        return {
+          onSelect(context) {
+            const { selected, multiSelect, event: e } = context;
+            const { editing } = gfx.selection;
+            const alreadySelected = gfx.selection.has(model.id);
+
+            if (!multiSelect && selected && (alreadySelected || editing)) {
+              if (model.isLocked()) return;
+
+              if (alreadySelected && editing) {
+                return;
+              }
+
+              gfx.selection.set({
+                elements: [model.id],
+                editing: true,
+              });
+
+              view.updateComplete
+                .then(() => {
+                  if (!view.isConnected) {
+                    return;
+                  }
+
+                  if (model.children.length === 0) {
+                    const blockId = std.store.addBlock(
+                      'affine:paragraph',
+                      { type: 'text' },
+                      model.id
+                    );
+
+                    if (blockId) {
+                      focusTextModel(std, blockId);
+                    }
+                  } else {
+                    const rect = view
+                      .querySelector('.affine-block-children-container')
+                      ?.getBoundingClientRect();
+
+                    if (rect) {
+                      const offsetY = 8 * gfx.viewport.zoom;
+                      const offsetX = 2 * gfx.viewport.zoom;
+                      const x = clamp(
+                        e.clientX,
+                        rect.left + offsetX,
+                        rect.right - offsetX
+                      );
+                      const y = clamp(
+                        e.clientY,
+                        rect.top + offsetY,
+                        rect.bottom - offsetY
+                      );
+                      handleNativeRangeAtPoint(x, y);
+                    } else {
+                      handleNativeRangeAtPoint(e.clientX, e.clientY);
+                    }
+                  }
+                })
+                .catch(console.error);
+            } else {
+              context.default(context);
+            }
           },
         };
       },

--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-service.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-service.ts
@@ -16,7 +16,6 @@ import type {
   GfxController,
   GfxModel,
   LayerManager,
-  PointTestOptions,
   ReorderingDirection,
 } from '@blocksuite/std/gfx';
 import {
@@ -166,19 +165,6 @@ export class EdgelessRootService
     super.mounted();
     this._initSlotEffects();
     this._initReadonlyListener();
-  }
-
-  /**
-   * This method is used to pick element in group, if the picked element is in a
-   * group, we will pick the group instead. If that picked group is currently selected, then
-   * we will pick the element itself.
-   */
-  pickElementInGroup(
-    x: number,
-    y: number,
-    options?: PointTestOptions
-  ): GfxModel | null {
-    return this.gfx.getElementInGroup(x, y, options);
   }
 
   removeElement(id: string | GfxModel) {

--- a/blocksuite/affine/blocks/surface/src/tool/default-tool.ts
+++ b/blocksuite/affine/blocks/surface/src/tool/default-tool.ts
@@ -154,32 +154,6 @@ export class DefaultTool extends BaseTool {
   private _determineDragType(evt: PointerEventState): DefaultModeDragType {
     const { x, y } = this.controller.lastMousePos$.peek();
     if (this.selection.isInSelectedRect(x, y)) {
-      if (this.selection.selectedElements.length === 1) {
-        const currentHoveredElem = this._getElementInGroup(x, y);
-        let curSelected = this.selection.selectedElements[0];
-
-        // If one of the following condition is true, keep the selection:
-        // 1. if group is currently selected
-        // 2. if the selected element is descendant of the hovered element
-        // 3. not hovering any element or hovering the same element
-        //
-        // Otherwise, we update the selection to the current hovered element
-        const shouldKeepSelection =
-          isGfxGroupCompatibleModel(curSelected) ||
-          (isGfxGroupCompatibleModel(currentHoveredElem) &&
-            currentHoveredElem.hasDescendant(curSelected)) ||
-          !currentHoveredElem ||
-          currentHoveredElem === curSelected;
-
-        if (!shouldKeepSelection) {
-          curSelected = currentHoveredElem;
-          this.selection.set({
-            elements: [curSelected.id],
-            editing: false,
-          });
-        }
-      }
-
       return this.selection.editing
         ? DefaultModeDragType.NativeEditing
         : DefaultModeDragType.ContentMoving;
@@ -192,17 +166,6 @@ export class DefaultTool extends BaseTool {
         return DefaultModeDragType.Selecting;
       }
     }
-  }
-
-  private _getElementInGroup(modelX: number, modelY: number) {
-    const tryGetLockedAncestor = (e: GfxModel | null) => {
-      if (e?.isLockedByAncestor()) {
-        return e.groups.findLast(group => group.isLocked());
-      }
-      return e;
-    };
-
-    return tryGetLockedAncestor(this.gfx.getElementInGroup(modelX, modelY));
   }
 
   private initializeDragState(

--- a/blocksuite/affine/gfx/group/src/interaction-ext.ts
+++ b/blocksuite/affine/gfx/group/src/interaction-ext.ts
@@ -1,0 +1,45 @@
+import { GroupElementModel } from '@blocksuite/affine-model';
+import { InteractivityExtension } from '@blocksuite/std/gfx';
+
+export class GroupInteractionExtension extends InteractivityExtension {
+  static override key = 'group-selection';
+
+  override mounted(): void {
+    this.action.onElementSelect(context => {
+      const { candidates, suggest } = context;
+      const { activeGroup } = this.gfx.selection;
+      let target = context.target;
+
+      if (activeGroup && activeGroup.hasDescendant(target)) {
+        const groups = target.groups;
+        const activeGroupIdx = groups.indexOf(activeGroup);
+
+        if (activeGroupIdx !== -1) {
+          target =
+            groups
+              .slice(0, activeGroupIdx)
+              .findLast(
+                group =>
+                  group instanceof GroupElementModel &&
+                  candidates.includes(group)
+              ) ?? target;
+        }
+      } else {
+        const groups = target.groups;
+
+        target =
+          groups.findLast(group => {
+            return (
+              group instanceof GroupElementModel && candidates.includes(group)
+            );
+          }) ?? target;
+      }
+
+      if (target !== context.target) {
+        suggest({
+          id: target.id,
+        });
+      }
+    });
+  }
+}

--- a/blocksuite/affine/gfx/group/src/view.ts
+++ b/blocksuite/affine/gfx/group/src/view.ts
@@ -6,6 +6,7 @@ import {
 import { effects } from './effects';
 import { GroupElementRendererExtension } from './element-renderer';
 import { GroupElementView, GroupInteraction } from './element-view';
+import { GroupInteractionExtension } from './interaction-ext';
 import { groupToolbarExtension } from './toolbar/config';
 
 export class GroupViewExtension extends ViewExtensionProvider {
@@ -23,6 +24,7 @@ export class GroupViewExtension extends ViewExtensionProvider {
     if (this.isEdgeless(context.scope)) {
       context.register(groupToolbarExtension);
       context.register(GroupInteraction);
+      context.register(GroupInteractionExtension);
     }
   }
 }

--- a/blocksuite/affine/gfx/mindmap/src/view/view.ts
+++ b/blocksuite/affine/gfx/mindmap/src/view/view.ts
@@ -13,7 +13,6 @@ import {
   type BoxSelectionContext,
   GfxElementModelView,
   GfxViewInteractionExtension,
-  type SelectedContext,
 } from '@blocksuite/std/gfx';
 
 import { handleLayout } from './utils.js';
@@ -335,33 +334,6 @@ export class MindMapView extends GfxElementModelView<MindmapElementModel> {
     return collapseButton;
   }
 
-  override onSelected(context: SelectedContext): void | boolean {
-    const { position } = context;
-    const target = this.model.childElements.find(child => {
-      if (child.elementBound.containsPoint([position.x, position.y])) {
-        return true;
-      }
-
-      return false;
-    });
-
-    if (target) {
-      if (this.model.isLocked()) {
-        return super.onSelected(context);
-      }
-
-      if (context.multiSelect) {
-        this.gfx.selection.toggle(target);
-      } else {
-        this.gfx.selection.set({ elements: [target.id] });
-      }
-
-      return true;
-    }
-
-    return false;
-  }
-
   override onBoxSelected(context: BoxSelectionContext) {
     const { box } = context;
     const bound = new Bound(box.x, box.y, box.w, box.h);
@@ -383,11 +355,24 @@ export class MindMapView extends GfxElementModelView<MindmapElementModel> {
   }
 }
 
-export const MindMapInteraction = GfxViewInteractionExtension(
+export const MindMapInteraction = GfxViewInteractionExtension<MindMapView>(
   MindMapView.type,
   {
     resizeConstraint: {
       allowedHandlers: [],
+    },
+    handleSelection: () => {
+      return {
+        onSelect(context) {
+          const { model } = context;
+
+          if (model.isLocked()) {
+            return context.default(context);
+          }
+
+          return false;
+        },
+      };
     },
   }
 );

--- a/blocksuite/framework/std/src/gfx/controller.ts
+++ b/blocksuite/framework/std/src/gfx/controller.ts
@@ -26,10 +26,7 @@ import { LayerManager } from './layer.js';
 import type { PointTestOptions } from './model/base.js';
 import { GfxBlockElementModel } from './model/gfx-block-model.js';
 import type { GfxModel } from './model/model.js';
-import {
-  GfxGroupLikeElementModel,
-  GfxPrimitiveElementModel,
-} from './model/surface/element-model.js';
+import { GfxPrimitiveElementModel } from './model/surface/element-model.js';
 import type { SurfaceBlockModel } from './model/surface/surface-model.js';
 import { FIT_TO_SCREEN_PADDING, Viewport, ZOOM_INITIAL } from './viewport.js';
 
@@ -179,54 +176,6 @@ export class GfxController extends LifeCycleWatcher {
     }
 
     return last(picked) ?? null;
-  }
-
-  /**
-   * Get the top element in the given point.
-   * If the element is in a group, the group will be returned.
-   * If the group is currently selected, the child element will be returned.
-   * @param x
-   * @param y
-   * @param options
-   * @returns
-   */
-  getElementInGroup(
-    x: number,
-    y: number,
-    options?: PointTestOptions
-  ): GfxModel | null {
-    const selectionManager = this.selection;
-    const results = this.getElementByPoint(x, y, {
-      ...options,
-      all: true,
-    });
-    let picked = last(results) ?? null;
-    const { activeGroup } = selectionManager;
-    const first = picked;
-
-    if (activeGroup && picked && activeGroup.hasDescendant(picked)) {
-      let index = results.length - 1;
-
-      while (
-        picked === activeGroup ||
-        (picked instanceof GfxGroupLikeElementModel &&
-          picked.hasDescendant(activeGroup))
-      ) {
-        picked = results[--index];
-      }
-    } else if (picked) {
-      let index = results.length - 1;
-
-      while (picked.group instanceof GfxGroupLikeElementModel) {
-        if (--index < 0) {
-          picked = null;
-          break;
-        }
-        picked = results[index];
-      }
-    }
-
-    return (picked ?? first) as GfxModel | null;
   }
 
   /**

--- a/blocksuite/framework/std/src/gfx/index.ts
+++ b/blocksuite/framework/std/src/gfx/index.ts
@@ -36,7 +36,7 @@ export type {
   RotateEndContext,
   RotateMoveContext,
   RotateStartContext,
-  SelectedContext,
+  SelectContext,
 } from './interactivity/index.js';
 export {
   GfxViewEventManager,

--- a/blocksuite/framework/std/src/gfx/interactivity/extension/base.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/extension/base.ts
@@ -13,6 +13,7 @@ import type {
   ExtensionDragMoveContext,
   ExtensionDragStartContext,
 } from '../types/drag.js';
+import type { ExtensionElementSelectContext } from '../types/select.js';
 
 export const InteractivityExtensionIdentifier =
   createIdentifier<InteractivityExtension>('interactivity-extension');
@@ -118,6 +119,10 @@ type ActionContextMap = {
       | undefined
     >;
   };
+  elementSelect: {
+    context: ExtensionElementSelectContext;
+    returnType: void;
+  };
 };
 
 export class InteractivityActionAPI {
@@ -148,6 +153,18 @@ export class InteractivityActionAPI {
 
     return () => {
       return delete this._handlers['elementsClone'];
+    };
+  }
+
+  onElementSelect(
+    handler: (
+      ctx: ActionContextMap['elementSelect']['context']
+    ) => ActionContextMap['elementSelect']['returnType']
+  ) {
+    this._handlers['elementSelect'] = handler;
+
+    return () => {
+      return delete this._handlers['elementSelect'];
     };
   }
 

--- a/blocksuite/framework/std/src/gfx/interactivity/extension/view.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/extension/view.ts
@@ -15,18 +15,21 @@ import type {
   RotateEndContext,
   RotateMoveContext,
   RotateStartContext,
+  SelectableContext,
+  SelectContext,
 } from '../types/view';
 
 type ExtendedViewContext<
   T extends GfxBlockComponent | GfxElementModelView,
   Context,
+  DefaultReturnType = void,
 > = {
   /**
    * The default function of the interaction.
    * If the interaction is handled by the extension, the default function will not be executed.
    * But extension can choose to call the default function by `context.default(context)` if needed.
    */
-  default: (context: Context) => void;
+  default: (context: Context) => DefaultReturnType;
 
   model: T['model'];
 
@@ -98,6 +101,19 @@ export type GfxViewInteractionConfig<
     onRotateEnd?(
       context: RotateEndContext & ExtendedViewContext<T, RotateEndContext>
     ): void;
+  };
+
+  handleSelection?: (
+    context: Omit<ViewInteractionHandleContext<T>, 'add' | 'delete'>
+  ) => {
+    selectable?: (
+      context: SelectableContext &
+        ExtendedViewContext<T, SelectableContext, boolean>
+    ) => boolean;
+    onSelect?: (
+      context: SelectContext &
+        ExtendedViewContext<T, SelectContext, boolean | void>
+    ) => boolean | void;
   };
 };
 

--- a/blocksuite/framework/std/src/gfx/interactivity/index.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/index.ts
@@ -29,5 +29,5 @@ export type {
   RotateEndContext,
   RotateMoveContext,
   RotateStartContext,
-  SelectedContext,
+  SelectContext,
 } from './types/view.js';

--- a/blocksuite/framework/std/src/gfx/interactivity/types/select.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/types/select.ts
@@ -1,0 +1,33 @@
+import type { GfxModel } from '../../model/model';
+
+export type ExtensionElementSelectContext = {
+  /**
+   * The candidate elements for selection.
+   */
+  candidates: GfxModel[];
+
+  /**
+   * The element which is ready to be selected.
+   */
+  target: GfxModel;
+
+  /**
+   * Use to change the target element of selection.
+   * @param element
+   * @returns
+   */
+  suggest: (element: {
+    /**
+     * The suggested element id
+     */
+    id: string;
+
+    /**
+     * The priority of the suggestion. If there are multiple suggestions coming from different extensions,
+     * the one with the highest priority will be used.
+     *
+     * Default to 0.
+     */
+    priority?: number;
+  }) => void;
+};

--- a/blocksuite/framework/std/src/gfx/interactivity/types/view.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/types/view.ts
@@ -126,12 +126,7 @@ export type RotateMoveContext = RotateStartContext & {
 
 export type RotateEndContext = RotateStartContext;
 
-export type SelectedContext = {
-  /**
-   * The selected state of the element
-   */
-  selected: boolean;
-
+export type SelectableContext = {
   /**
    * Whether is multi-select, usually triggered by shift key
    */
@@ -146,14 +141,13 @@ export type SelectedContext = {
    * The model position of the event pointer
    */
   position: IPoint;
+};
 
+export type SelectContext = SelectableContext & {
   /**
-   * If the current selection is a fallback selection.
-   *
-   * E.g., if selecting a child element inside a group, the `onSelected` method will be executed on group, and
-   * the fallback is true because the it's not the original target(the child element).
+   * The selected state of the element
    */
-  fallback: boolean;
+  selected: boolean;
 };
 
 export type BoxSelectionContext = {
@@ -171,11 +165,6 @@ export type GfxViewTransformInterface = {
   onDragStart: (context: DragStartContext) => void;
   onDragMove: (context: DragMoveContext) => void;
   onDragEnd: (context: DragEndContext) => void;
-
-  /**
-   * When the element is selected by the pointer
-   */
-  onSelected: (context: SelectedContext) => void;
 
   /**
    * When the element is selected by box selection, return false to prevent the default selection behavior.

--- a/blocksuite/framework/std/src/gfx/model/surface/surface-model.ts
+++ b/blocksuite/framework/std/src/gfx/model/surface/surface-model.ts
@@ -626,6 +626,11 @@ export class SurfaceBlockModel extends BlockModel<SurfaceBlockProps> {
     return null;
   }
 
+  /**
+   * Get all groups in the group chain. The last group is the top level group.
+   * @param id
+   * @returns
+   */
   getGroups(id: string): GfxGroupModel[] {
     const groups: GfxGroupModel[] = [];
     const visited = new Set<GfxGroupModel>();

--- a/blocksuite/framework/std/src/gfx/view/view.ts
+++ b/blocksuite/framework/std/src/gfx/view/view.ts
@@ -13,7 +13,6 @@ import type {
   DragMoveContext,
   DragStartContext,
   GfxViewTransformInterface,
-  SelectedContext,
 } from '../interactivity/index.js';
 import type { GfxElementGeometry, PointTestOptions } from '../model/base.js';
 import { GfxPrimitiveElementModel } from '../model/surface/element-model.js';
@@ -208,18 +207,6 @@ export class GfxElementModelView<
 
   onDragMove({ dx, dy, currentBound }: DragMoveContext) {
     this.model.xywh = currentBound.moveDelta(dx, dy).serialize();
-  }
-
-  onSelected(context: SelectedContext): void | boolean {
-    if (this.model instanceof GfxPrimitiveElementModel) {
-      if (context.multiSelect) {
-        this.gfx.selection.toggle(this.model);
-      } else {
-        this.gfx.selection.set({ elements: [this.model.id] });
-      }
-
-      return true;
-    }
   }
 
   onBoxSelected(_: BoxSelectionContext): boolean | void {}

--- a/blocksuite/framework/std/src/view/element/gfx-block-component.ts
+++ b/blocksuite/framework/std/src/view/element/gfx-block-component.ts
@@ -9,7 +9,6 @@ import type {
   BoxSelectionContext,
   DragMoveContext,
   GfxViewTransformInterface,
-  SelectedContext,
 } from '../../gfx/interactivity/index.js';
 import type { GfxBlockElementModel } from '../../gfx/model/gfx-block-model.js';
 import { SurfaceSelection } from '../../selection/index.js';
@@ -102,16 +101,6 @@ export abstract class GfxBlockComponent<
 
   onDragEnd() {
     this.model.pop('xywh');
-  }
-
-  onSelected(context: SelectedContext): void | boolean {
-    if (context.multiSelect) {
-      this.gfx.selection.toggle(this.model);
-    } else {
-      this.gfx.selection.set({ elements: [this.model.id] });
-    }
-
-    return true;
   }
 
   onBoxSelected(_: BoxSelectionContext) {}
@@ -217,17 +206,6 @@ export function toGfxBlockComponent<
 
     onDragEnd() {
       this.model.pop('xywh');
-    }
-
-    // eslint-disable-next-line sonarjs/no-identical-functions
-    onSelected(context: SelectedContext): void | boolean {
-      if (context.multiSelect) {
-        this.gfx.selection.toggle(this.model);
-      } else {
-        this.gfx.selection.set({ elements: [this.model.id] });
-      }
-
-      return true;
     }
 
     onBoxSelected(_: BoxSelectionContext) {}

--- a/tests/blocksuite/e2e/edgeless/lock.spec.ts
+++ b/tests/blocksuite/e2e/edgeless/lock.spec.ts
@@ -194,7 +194,7 @@ test.describe('lock', () => {
     await lock.click();
     await assertEdgelessSelectedModelRect(page, [0, 0, 125, 125]); // frame outline and shape
     await pressEscape(page);
-    await clickView(page, [100, 100]);
+    await clickView(page, [90, 90]);
     await assertEdgelessSelectedModelRect(page, [0, 0, 125, 125]);
 
     await unlock.click();


### PR DESCRIPTION
Fixes [BS-3528](https://linear.app/affine-design/issue/BS-3528)
Fixes [BS-3331](https://linear.app/affine-design/issue/BS-3331/frame-移动逻辑很奇怪)

### Changed
- Remove `onSelected` method from gfx view, use `handleSelection` provided by `GfxViewInteraction` instead.
- Add `selectable` to allow model to filter out itself from selection.
- Frame can be selected by body only if it's locked or its background is not transparent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced selection behavior for frames, edgeless text, notes, and mind map elements with refined control based on lock state and background transparency.
  - Introduced group-aware selection logic promoting selection of appropriate group ancestors.
  - Added support for element selection events in interactivity extensions.

- **Bug Fixes**
  - Resolved frame selection issues by enabling selection via title clicks and restricting body selection to locked frames or those with non-transparent backgrounds.

- **Documentation**
  - Added clarifying comments for group retrieval methods.

- **Tests**
  - Updated and added end-to-end tests for frame and lock selection reflecting new selection conditions.

- **Refactor**
  - Unified and simplified selection handling by moving logic from component methods to interaction handlers and removing deprecated selection methods.
  - Streamlined selection candidate processing with extension-driven target suggestion.
  - Removed legacy group element retrieval and selection helper methods to simplify interaction logic.

- **Style**
  - Renamed types and improved type signatures for selection context and interaction configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->