### PR TITLE
fix(editor): should record edgeless connector mode

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
@@ -31,7 +31,7 @@ import { mountShapeTextEditor, ShapeTool } from '@blocksuite/affine-gfx-shape';
 import { TextTool } from '@blocksuite/affine-gfx-text';
 import {
   ConnectorElementModel,
-  ConnectorMode,
+  type ConnectorMode,
   EdgelessTextBlockModel,
   GroupElementModel,
   LayoutType,
@@ -93,10 +93,18 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
           this._setEdgelessTool(TextTool);
         },
         c: () => {
-          const mode = ConnectorMode.Curve;
-          rootComponent.std.get(EditPropsStore).recordLastProps('connector', {
-            mode,
-          });
+          const editPropsStore = this.std.get(EditPropsStore);
+
+          let mode: ConnectorMode;
+          if (
+            this.gfx.tool.currentToolName$.peek() === ConnectorTool.toolName
+          ) {
+            mode = this.gfx.tool.get(ConnectorTool).getNextMode();
+            editPropsStore.recordLastProps('connector', { mode });
+          } else {
+            mode = editPropsStore.lastProps$.peek().connector.mode;
+          }
+
           this._setEdgelessTool(ConnectorTool, { mode });
         },
         h: () => {

--- a/blocksuite/affine/gfx/connector/src/connector-tool.ts
+++ b/blocksuite/affine/gfx/connector/src/connector-tool.ts
@@ -3,12 +3,10 @@ import {
   DefaultTool,
   OverlayIdentifier,
 } from '@blocksuite/affine-block-surface';
-import type {
-  Connection,
-  ConnectorElementModel,
-  ConnectorMode,
-} from '@blocksuite/affine-model';
 import {
+  type Connection,
+  type ConnectorElementModel,
+  ConnectorMode,
   GroupElementModel,
   ShapeElementModel,
   ShapeType,
@@ -222,5 +220,16 @@ export class ConnectorTool extends BaseTool<ConnectorToolOptions> {
     }
 
     this.findTargetByPoint(point);
+  }
+
+  getNextMode() {
+    switch (this.activatedOption.mode) {
+      case ConnectorMode.Curve:
+        return ConnectorMode.Orthogonal;
+      case ConnectorMode.Orthogonal:
+        return ConnectorMode.Straight;
+      case ConnectorMode.Straight:
+        return ConnectorMode.Curve;
+    }
   }
 }

--- a/tests/blocksuite/e2e/edgeless/connector/connector.spec.ts
+++ b/tests/blocksuite/e2e/edgeless/connector/connector.spec.ts
@@ -2,15 +2,18 @@ import { expect } from '@playwright/test';
 
 import {
   addBasicConnectorElement,
+  assertEdgelessConnectorToolMode,
   changeConnectorStrokeColor,
   changeConnectorStrokeStyle,
   changeConnectorStrokeWidth,
+  ConnectorMode,
   createConnectorElement,
   createShapeElement,
   dragBetweenViewCoords,
   edgelessCommonSetup as commonSetup,
   getConnectorPath,
   getConnectorPathWithInOut,
+  locatorComponentToolbar,
   pickColorAtPoints,
   rotateElementByHandle,
   selectElementInEdgeless,
@@ -21,7 +24,11 @@ import {
   triggerComponentToolbarAction,
   triggerShapeSwitch,
 } from '../../utils/actions/edgeless.js';
-import { pressBackspace, waitNextFrame } from '../../utils/actions/index.js';
+import {
+  clickView,
+  pressBackspace,
+  waitNextFrame,
+} from '../../utils/actions/index.js';
 import {
   assertConnectorPath,
   assertEdgelessNonSelectedRect,
@@ -184,6 +191,28 @@ test('change connector stroke style', async ({ page }) => {
 
   const pickedColor = await pickColorAtPoints(page, [[start.x + 20, start.y]]);
   expect(pickedColor[0]).toBe('#000000');
+});
+
+test('should record previous connector mode', async ({ page }) => {
+  await commonSetup(page);
+  await setEdgelessTool(page, 'connector');
+  await assertEdgelessConnectorToolMode(page, ConnectorMode.Curve);
+  await page.keyboard.press('c');
+  await assertEdgelessConnectorToolMode(page, ConnectorMode.Orthogonal);
+  await page.keyboard.press('c');
+  await assertEdgelessConnectorToolMode(page, ConnectorMode.Straight);
+
+  await dragBetweenViewCoords(page, [100, 100], [200, 200]);
+  await page.keyboard.press('c');
+  await assertEdgelessConnectorToolMode(page, ConnectorMode.Straight);
+
+  await setEdgelessTool(page, 'default');
+  await clickView(page, [150, 150]);
+  await triggerComponentToolbarAction(page, 'changeConnectorShape');
+  await locatorComponentToolbar(page).getByLabel('Curve').click();
+
+  await page.keyboard.press('c');
+  await assertEdgelessConnectorToolMode(page, ConnectorMode.Curve);
 });
 
 test.describe('quick connect', () => {


### PR DESCRIPTION
Close [BS-3355](https://linear.app/affine-design/issue/BS-3355/白板快捷键c没有记住上次用的connector形状)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to cycle through connector modes (Curve, Orthogonal, Straight) using the 'c' keyboard shortcut when the connector tool is active.
- **Bug Fixes**
  - Improved the logic for remembering and restoring the last used connector mode when switching between tools.
- **Tests**
  - Introduced a new end-to-end test to verify correct cycling and restoration of connector modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->