### PR TITLE
fix(core): hidden not supported property in display menu

### DIFF
--- a/packages/frontend/core/src/components/explorer/display-menu/properties.tsx
+++ b/packages/frontend/core/src/components/explorer/display-menu/properties.tsx
@@ -5,6 +5,7 @@ import { useLiveData, useService } from '@toeverything/infra';
 import { useCallback, useMemo } from 'react';
 
 import { WorkspacePropertyName } from '../../properties';
+import { WorkspacePropertyTypes } from '../../workspace-property-types';
 import { generateExplorerPropertyList } from '../properties';
 import type { ExplorerDisplayPreference } from '../types';
 import * as styles from './properties.css';
@@ -147,7 +148,12 @@ const PropertyRenderer = ({
       : null;
   const isActive = activeKey && displayProperties.includes(activeKey);
 
-  if (!key) {
+  const showInDocList =
+    systemProperty?.showInDocList ||
+    (workspaceProperty &&
+      WorkspacePropertyTypes[workspaceProperty.type]?.showInDocList);
+
+  if (!key || !showInDocList) {
     return null;
   }
   return (

--- a/packages/frontend/core/src/components/explorer/docs-view/properties.tsx
+++ b/packages/frontend/core/src/components/explorer/docs-view/properties.tsx
@@ -113,7 +113,7 @@ export const ListViewProperties = ({ docId }: { docId: string }) => {
             if (!displayKey || !displayProperties?.includes(displayKey)) {
               return null;
             }
-            if (systemProperty) {
+            if (systemProperty && systemProperty.showInDocList) {
               return (
                 <SystemPropertyRenderer
                   doc={doc}
@@ -121,7 +121,10 @@ export const ListViewProperties = ({ docId }: { docId: string }) => {
                   key={systemProperty.type}
                 />
               );
-            } else if (workspaceProperty) {
+            } else if (
+              workspaceProperty &&
+              WorkspacePropertyTypes[workspaceProperty.type]?.showInDocList
+            ) {
               return (
                 <WorkspacePropertyRenderer
                   key={workspaceProperty.id}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Properties in the document list are now displayed only if explicitly marked to be shown, offering a more focused and relevant view.

- **Bug Fixes**
  - Enhanced filtering prevents unintended properties from appearing in the document list, improving display accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->