### PR TITLE
fix(editor): math equation not being rendered correctly on electron client

### DIFF
--- a/packages/frontend/component/src/theme/global.css
+++ b/packages/frontend/component/src/theme/global.css
@@ -298,3 +298,11 @@ input {
 [contenteditable]:focus-visible {
   outline: none;
 }
+
+/* Math font may not being loaded in Electron */
+math {
+  font-family:
+    'Cambria Math' /* windows */,
+    'STIX Two Math' /* mac */,
+    math;
+}


### PR DESCRIPTION
fix #12300

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved font rendering for math content on Windows by explicitly setting the font for math elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->