### PR TITLE
feat(core): add reload button to audio block

### DIFF
--- a/packages/frontend/component/src/ui/audio-player/audio-player.css.ts
+++ b/packages/frontend/component/src/ui/audio-player/audio-player.css.ts
@@ -60,8 +60,9 @@ export const spacer = style({
   flex: 1,
 });
 
-export const sizeInfo = style({
+export const description = style({
   display: 'flex',
+  gap: '8px',
   alignItems: 'center',
   fontSize: cssVar('fontXs'),
   color: cssVarV2('text/secondary'),

--- a/packages/frontend/component/src/ui/audio-player/audio-player.stories.tsx
+++ b/packages/frontend/component/src/ui/audio-player/audio-player.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import bytes from 'bytes';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { AudioPlayer, MiniAudioPlayer } from './audio-player';
 
@@ -159,6 +160,10 @@ const AudioWrapper = () => {
     }
   }, []);
 
+  const description = useMemo(() => {
+    return audioFile ? <>{bytes(audioFile.size)}</> : null;
+  }, [audioFile]);
+
   useEffect(() => {
     const audio = audioRef.current;
     if (!audio || !audioFile) return;
@@ -296,7 +301,7 @@ const AudioWrapper = () => {
           />
           <MiniAudioPlayer
             name={audioFile.name}
-            size={audioFile.size}
+            description={description}
             waveform={waveform}
             playbackState={playbackState}
             seekTime={seekTime}
@@ -311,7 +316,7 @@ const AudioWrapper = () => {
           />
           <AudioPlayer
             name={audioFile.name}
-            size={audioFile.size}
+            description={description}
             waveform={waveform}
             playbackState={playbackState}
             seekTime={seekTime}

--- a/packages/frontend/component/src/ui/audio-player/audio-player.tsx
+++ b/packages/frontend/component/src/ui/audio-player/audio-player.tsx
@@ -4,7 +4,6 @@ import {
   RewindFifteenSecondsIcon,
   VoiceIcon,
 } from '@blocksuite/icons/rc';
-import bytes from 'bytes';
 import { clamp } from 'lodash-es';
 import { type MouseEventHandler, type ReactNode, useCallback } from 'react';
 
@@ -24,7 +23,7 @@ const formatTime = (seconds: number): string => {
 export interface AudioPlayerProps {
   // Audio metadata
   name: string;
-  size: number | ReactNode; // the size entry may be used for drawing error message
+  description?: ReactNode; // Display file size or error message
   waveform: number[] | null;
   // Playback state
   playbackState: 'idle' | 'playing' | 'paused' | 'stopped';
@@ -52,7 +51,7 @@ const playbackRates = [0.5, 0.75, 1, 1.5, 1.75, 2, 3];
 
 export const AudioPlayer = ({
   name,
-  size,
+  description,
   playbackState,
   seekTime,
   duration,
@@ -108,9 +107,7 @@ export const AudioPlayer = ({
             <div className={styles.nameLabel}>{name}</div>
           </div>
           <div className={styles.upperRow}>
-            <div className={styles.sizeInfo}>
-              {typeof size === 'number' ? bytes(size) : size}
-            </div>
+            <div className={styles.description}>{description}</div>
           </div>
         </div>
         <div className={styles.upperRight}>

--- a/packages/frontend/core/src/blocksuite/attachment-viewer/audio/audio-block.css.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/audio/audio-block.css.ts
@@ -28,5 +28,24 @@ export const notesButtonIcon = style({
 });
 
 export const error = style({
+  display: 'flex',
   color: cssVarV2('aI/errorText'),
+});
+
+export const reloadButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  padding: '0 4px',
+  gap: '4px',
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  outline: 'none',
+  color: cssVarV2('button/primary'),
+  fontSize: cssVar('fontSm'),
+  fontWeight: 500,
+});
+
+export const reloadButtonIcon = style({
+  fontSize: 16,
 });

--- a/packages/frontend/core/src/components/root-app-sidebar/sidebar-audio-player.tsx
+++ b/packages/frontend/core/src/components/root-app-sidebar/sidebar-audio-player.tsx
@@ -130,7 +130,6 @@ export const SidebarAudioPlayer = () => {
       <MiniAudioPlayer
         playbackState={playbackState.state}
         name={playbackStats.name}
-        size={playbackStats.size}
         duration={playbackStats.duration}
         seekTime={seekTime}
         onPlay={handlePlay}

--- a/packages/frontend/core/src/modules/media/entities/audio-media.ts
+++ b/packages/frontend/core/src/modules/media/entities/audio-media.ts
@@ -132,6 +132,9 @@ export class AudioMedia extends Entity<AudioSource> {
     return { waveform, duration };
   });
 
+  // `MediaSession` is available
+  private readonly available = 'mediaSession' in navigator;
+
   private readonly audioElement: HTMLAudioElement;
 
   private updatePlaybackState(
@@ -194,7 +197,10 @@ export class AudioMedia extends Entity<AudioSource> {
             `Calculate audio stats time: ${performance.now() - startTime}ms`
           );
         }),
-        onStart(() => this.loading$.setValue(true)),
+        onStart(() => {
+          this.loadError$.setValue(null);
+          this.loading$.setValue(true);
+        }),
         onComplete(() => {
           this.loading$.setValue(false);
         }),
@@ -212,7 +218,7 @@ export class AudioMedia extends Entity<AudioSource> {
   }
 
   private setupMediaSession() {
-    if (!('mediaSession' in navigator)) {
+    if (!this.available) {
       return;
     }
 
@@ -237,14 +243,14 @@ export class AudioMedia extends Entity<AudioSource> {
   }
 
   private updateMediaSessionMetadata() {
-    if (!('mediaSession' in navigator) || !this.props.metadata) {
+    if (!this.available || !this.props.metadata) {
       return;
     }
     navigator.mediaSession.metadata = this.props.metadata;
   }
 
   private updateMediaSessionPositionState(seekTime: number) {
-    if (!('mediaSession' in navigator)) {
+    if (!this.available) {
       return;
     }
 
@@ -260,7 +266,7 @@ export class AudioMedia extends Entity<AudioSource> {
   }
 
   private updateMediaSessionPlaybackState(state: AudioMediaPlaybackState) {
-    if (!('mediaSession' in navigator)) {
+    if (!this.available) {
       return;
     }
 
@@ -270,7 +276,7 @@ export class AudioMedia extends Entity<AudioSource> {
   }
 
   private cleanupMediaSession() {
-    if (!('mediaSession' in navigator)) {
+    if (!this.available) {
       return;
     }
     navigator.mediaSession.metadata = null;


### PR DESCRIPTION
Related to: [BS-3143](https://linear.app/affine-design/issue/BS-3143/更新-loading-和错误样式)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a reload button with an icon for audio blocks, allowing users to retry loading audio files if an error occurs.
  - Error messages are now displayed with actionable options when audio loading fails.

- **Enhancements**
  - Audio file sizes are now shown in a human-readable format within the audio player.
  - Improved display of audio file information, including error messages and formatted descriptions.

- **Style**
  - Updated styling for audio player and audio block components, including new styles for error states and reload button.
  - Renamed and refined audio player description styling for better layout and spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->