### PR TITLE
chore(server): disable indexer on self-host by default

### DIFF
--- a/.devcontainer/build.sh
+++ b/.devcontainer/build.sh
@@ -6,6 +6,7 @@ yarn install
 
 # Build Server Dependencies
 yarn affine @affine/server-native build
+yarn affine @affine/reader build
 
 # Create database
 yarn affine @affine/server prisma migrate reset -f

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       DATABASE_URL: postgresql://affine:affine@db:5432/affine
       REDIS_SERVER_HOST: redis
+      AFFINE_INDEXER_SEARCH_ENDPOINT: http://indexer:9308
 
   db:
     image: pgvector/pgvector:pg16
@@ -23,5 +24,19 @@ services:
   redis:
     image: redis
 
+  indexer:
+    image: manticoresearch/manticore:${MANTICORE_VERSION:-9.2.14}
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - manticoresearch_data:/var/lib/manticore
+
 volumes:
   postgres-data:
+  manticoresearch_data:

--- a/.docker/selfhost/.env.example
+++ b/.docker/selfhost/.env.example
@@ -21,8 +21,3 @@ CONFIG_LOCATION=~/.affine/self-host/config
 DB_USERNAME=affine
 DB_PASSWORD=
 DB_DATABASE=affine
-
-# indexer search provider manticoresearch version
-MANTICORE_VERSION=9.2.14
-# position of the manticoresearch data to persist 
-MANTICORE_DATA_LOCATION=~/.affine/self-host/manticore

--- a/.docker/selfhost/compose.yml
+++ b/.docker/selfhost/compose.yml
@@ -10,8 +10,6 @@ services:
         condition: service_healthy
       postgres:
         condition: service_healthy
-      indexer:
-        condition: service_healthy
       affine_migration:
         condition: service_completed_successfully
     volumes:
@@ -23,7 +21,7 @@ services:
     environment:
       - REDIS_SERVER_HOST=redis
       - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
-      - AFFINE_INDEXER_SEARCH_ENDPOINT=http://indexer:9308
+      - AFFINE_INDEXER_ENABLED=false
     restart: unless-stopped
 
   affine_migration:
@@ -39,13 +37,11 @@ services:
     environment:
       - REDIS_SERVER_HOST=redis
       - DATABASE_URL=postgresql://${DB_USERNAME}:${DB_PASSWORD}@postgres:5432/${DB_DATABASE:-affine}
-      - AFFINE_INDEXER_SEARCH_ENDPOINT=http://indexer:9308
+      - AFFINE_INDEXER_ENABLED=false
     depends_on:
       postgres:
         condition: service_healthy
       redis:
-        condition: service_healthy
-      indexer:
         condition: service_healthy
 
   redis:
@@ -74,27 +70,6 @@ services:
     healthcheck:
       test:
         ['CMD', 'pg_isready', '-U', "${DB_USERNAME}", '-d', "${DB_DATABASE:-affine}"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    restart: unless-stopped
-
-  indexer:
-    image: manticoresearch/manticore:${MANTICORE_VERSION:-9.2.14}
-    container_name: affine_indexer
-    volumes:
-      - ${MANTICORE_DATA_LOCATION}:/var/lib/manticore
-    ulimits:
-      nproc: 65535
-      nofile:
-        soft: 65535
-        hard: 65535
-      memlock:
-        soft: -1
-        hard: -1
-    healthcheck:
-      test:
-        ['CMD', 'wget', '-O-', 'http://127.0.0.1:9308']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docs/developing-server.md
+++ b/docs/developing-server.md
@@ -22,7 +22,7 @@ cp ./.docker/dev/.env.example ./.docker/dev/.env
 docker compose -f ./.docker/dev/compose.yml up
 ```
 
-#### Notify
+### Notify
 
 > Starting from AFFiNE 0.20, compose.yml includes a breaking change: the default database image has switched from `postgres:16` to `pgvector/pgvector:pg16`. If you were previously using another major version of Postgres, please change the number after `pgvector/pgvector:pg` to the major version you are using.
 
@@ -108,6 +108,6 @@ yarn affine server prisma studio
 
 ### Seed the db
 
-```
+```sh
 yarn affine server seed -h
 ```


### PR DESCRIPTION
enable indexer using `compose.indexer.yml` on self-host:

```bash
docker compose -f compose.yml -f compose.indexer.yml up
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the build process in the development container to include building the reader package.
  - Added and configured a Manticore Search indexer service in the development container.
  - Removed the indexer service and related environment variables from the self-hosted Docker Compose setup and environment example file.

- **Documentation**
  - Improved documentation formatting for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->