### PR TITLE
feat(core): draft filter skip method step if there is only one method

### DIFF
--- a/packages/frontend/core/src/components/filter/conditions/condition.tsx
+++ b/packages/frontend/core/src/components/filter/conditions/condition.tsx
@@ -39,6 +39,7 @@ export const Condition = ({
       <FilterOptionsGroup
         isDraft={isDraft}
         onDraftCompleted={onDraftCompleted}
+        initialStep={methods && methods.length > 1 ? 0 : 1}
         items={[
           methods &&
             (({ onDraftCompleted, menuRef }) => {

--- a/packages/frontend/core/src/components/filter/options.tsx
+++ b/packages/frontend/core/src/components/filter/options.tsx
@@ -13,10 +13,12 @@ export const FilterOptionsGroup = ({
   isDraft,
   onDraftCompleted,
   items,
+  initialStep = 0,
 }: {
   isDraft?: boolean;
   onDraftCompleted?: () => void;
   items?: FilterOptionsGroupChildren[];
+  initialStep?: number;
 }) => {
   const stepCount =
     items?.filter(v => {
@@ -27,7 +29,7 @@ export const FilterOptionsGroup = ({
     }).length ?? 0;
 
   const childRefs = useRef<(MenuRef | null)[]>([]);
-  const [currentStep, setCurrentStep] = useState(0);
+  const [currentStep, setCurrentStep] = useState(initialStep);
 
   const handleNextStep = useCallback(() => {
     // Add a small delay between steps to prevent the next menu from automatically closing due to the previous menu's close event


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Filter options can now start from a specified step, improving flexibility when multiple filtering methods are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->