### PR TITLE
fix(server): avoid infinite loop in manticoresearch

### DIFF
--- a/packages/backend/server/src/plugins/indexer/service.ts
+++ b/packages/backend/server/src/plugins/indexer/service.ts
@@ -191,6 +191,10 @@ export class IndexerService {
           },
         },
       });
+      if (result.nextCursor && result.nextCursor === cursor) {
+        // NOTE(@fengmk2): avoid infinite loop bug in manticoresearch
+        break;
+      }
       docIds.push(...result.nodes.map(node => node.fields.docId[0] as string));
       cursor = result.nextCursor;
       this.logger.debug(


### PR DESCRIPTION
close CLOUD-221

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue that could cause the document listing process to enter an infinite loop under certain conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->