### PR TITLE
fix(electron): disable translucent sidebar by default

### DIFF
--- a/packages/common/infra/src/atom/settings.ts
+++ b/packages/common/infra/src/atom/settings.ts
@@ -28,7 +28,7 @@ const appSettingBaseAtom = atomWithStorage<AppSetting>(
   {
     clientBorder: BUILD_CONFIG.isElectron && !environment.isWindows,
     windowFrameStyle: 'frameless',
-    enableBlurBackground: true,
+    enableBlurBackground: false,
     enableNoisyBackground: true,
     autoCheckUpdate: true,
     autoDownloadUpdate: true,


### PR DESCRIPTION
fix AF-2662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Changed the default setting for blur background effect to be disabled for new users. Existing users' preferences remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->