### PR TITLE
fix(electron): potential app crash on quit

### DIFF
--- a/packages/frontend/apps/electron/src/main/windows-manager/tab-views.ts
+++ b/packages/frontend/apps/electron/src/main/windows-manager/tab-views.ts
@@ -865,6 +865,7 @@ export class WebContentViewsManager {
     // shell process do not need to connect to helper process
     if (type !== 'shell') {
       view.webContents.on('did-finish-load', () => {
+        unsub();
         unsub = helperProcessManager.connectRenderer(view.webContents);
       });
     } else {
@@ -879,7 +880,6 @@ export class WebContentViewsManager {
     }
 
     view.webContents.on('destroyed', () => {
-      unsub();
       this.webViewsMap$.next(
         new Map(
           [...this.tabViewsMap.entries()].filter(([key]) => key !== viewId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability during shutdown by preventing potential crashes when removing audio property listeners on macOS.
	- Suppressed unnecessary error logs related to device listener removal during system shutdown.
	- Enhanced handling of internal subscriptions to avoid redundant operations and improve reliability when loading or destroying views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->