### PR TITLE
fix(editor): should reset state when refreshing blob url

### DIFF
--- a/blocksuite/affine/components/src/resource/resource.ts
+++ b/blocksuite/affine/components/src/resource/resource.ts
@@ -178,6 +178,9 @@ export class ResourceController implements Disposable {
   }
 
   async refreshUrlWith(type?: string) {
+    // Resets the state.
+    this.state$.value = {};
+
     const url = await this.createUrlWith(type);
     if (!url) return;
 


### PR DESCRIPTION
Closes: [BS-3454](https://linear.app/affine-design/issue/BS-3454/点击-reload-后应该隐藏-attachment-embed-view-左下角-status（待新状态）)