### PR TITLE
fix(editor): simple table will disappear when converted from a note to a linked doc

### DIFF
--- a/blocksuite/affine/blocks/table/src/table-cell.ts
+++ b/blocksuite/affine/blocks/table/src/table-cell.ts
@@ -745,7 +745,7 @@ export class TableCell extends SignalWatcher(
             padding: '8px 12px',
           })}
           .yText="${this.text}"
-          .inlineEventSource="${this.topContenteditableElement}"
+          .inlineEventSource="${this.topContenteditableElement ?? nothing}"
           .attributesSchema="${this.inlineManager?.getSchema()}"
           .attributeRenderer="${this.inlineManager?.getRenderer()}"
           .embedChecker="${this.inlineManager?.embedChecker}"


### PR DESCRIPTION
fix: https://github.com/toeverything/AFFiNE/issues/12403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of inline event sources in table cells to ensure more reliable behavior when editing rich text content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->