### PR TITLE
feat(core): save last opened workspace id when import clipper

### DIFF
--- a/packages/frontend/core/src/desktop/pages/import-clipper/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/import-clipper/index.tsx
@@ -108,6 +108,8 @@ export const Component = () => {
 
   const handleImportToSelectedWorkspace = useAsyncCallback(async () => {
     if (clipperInputSnapshot && selectedWorkspace) {
+      // save the last opened workspace id
+      localStorage.setItem('last_workspace_id', selectedWorkspace.id);
       setImporting(true);
       try {
         await importClipperService.importToWorkspace(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The app now remembers the last selected workspace when importing, improving continuity for future imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->