### PR TITLE
fix(core): add invite members button to sidebar

### DIFF
--- a/packages/frontend/core/src/components/root-app-sidebar/index.tsx
+++ b/packages/frontend/core/src/components/root-app-sidebar/index.tsx
@@ -44,6 +44,7 @@ import {
   workspaceAndUserWrapper,
   workspaceWrapper,
 } from './index.css';
+import { InviteMembersButton } from './invite-members-button';
 import { AppSidebarJournalButton } from './journal-button';
 import { NotificationButton } from './notification-button';
 import { SidebarAudioPlayer } from './sidebar-audio-player';
@@ -211,6 +212,7 @@ export const RootAppSidebar = memo((): ReactElement => {
           >
             <span data-testid="import-modal-trigger">{t['Import']()}</span>
           </MenuItem>
+          <InviteMembersButton />
           <TemplateDocEntrance />
           <ExternalMenuLinkItem
             href="https://affine.pro/blog?tag=Release+Note"

--- a/packages/frontend/core/src/components/root-app-sidebar/invite-members-button.tsx
+++ b/packages/frontend/core/src/components/root-app-sidebar/invite-members-button.tsx
@@ -1,0 +1,36 @@
+import { MenuItem } from '@affine/core/modules/app-sidebar/views';
+import { WorkspaceDialogService } from '@affine/core/modules/dialogs';
+import { WorkspaceService } from '@affine/core/modules/workspace';
+import { useI18n } from '@affine/i18n';
+import { CollaborationIcon } from '@blocksuite/icons/rc';
+import { useService } from '@toeverything/infra';
+import { useCallback } from 'react';
+
+export const InviteMembersButton = () => {
+  const workspace = useService(WorkspaceService).workspace;
+
+  const isLocal = workspace.flavour === 'local';
+
+  const dialogService = useService(WorkspaceDialogService);
+  const onOpenInviteMembersModal = useCallback(() => {
+    dialogService.open('setting', {
+      activeTab: `workspace:members`,
+    });
+  }, [dialogService]);
+
+  const t = useI18n();
+
+  if (isLocal) {
+    return null;
+  }
+
+  return (
+    <MenuItem
+      data-testid="slider-bar-invite-members-button"
+      icon={<CollaborationIcon />}
+      onClick={onOpenInviteMembersModal}
+    >
+      {t['Invite Members']()}
+    </MenuItem>
+  );
+};


### PR DESCRIPTION
fix AF-2661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an "Invite Members" button to the sidebar, allowing users to quickly access workspace member settings (visible only for non-local workspaces).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->