### PR TITLE
fix(core): setting modal max-width

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/setting/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/index.tsx
@@ -277,7 +277,7 @@ export const SettingDialog = ({
         ['data-testid' as string]: 'setting-modal',
         style: {
           maxHeight: '85vh',
-          maxWidth: '70vw',
+          maxWidth: 'calc(100dvw - 100px)',
           padding: 0,
           overflow: 'hidden',
           display: 'flex',


### PR DESCRIPTION
fix AF-2670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the maximum width of the settings modal for improved adaptability across different screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->