### PR TITLE
fix(editor): allow space-drag in presentation mode

### DIFF
--- a/blocksuite/affine/blocks/frame/src/edgeless-toolbar/presentation-toolbar.ts
+++ b/blocksuite/affine/blocks/frame/src/edgeless-toolbar/presentation-toolbar.ts
@@ -205,10 +205,11 @@ export class PresentationToolbar extends EdgelessToolbarToolMixin(
       !forceMove
     ) {
       // Clear the flag so future navigations behave normally
-      this.gfx.tool.setTool(PresentTool, {
-        ...toolOptions,
-        restoredAfterPan: false,
-      });
+      // Here we modify the tool's activated option to avoid triggering setTool update
+      const currentTool = this.gfx.tool.currentTool$.peek();
+      if (currentTool?.activatedOption) {
+        currentTool.activatedOption.restoredAfterPan = false;
+      }
       return;
     }
 

--- a/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
+++ b/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
@@ -1,3 +1,4 @@
+import { EdgelessLegacySlotIdentifier } from '@blocksuite/affine-block-surface';
 import { on } from '@blocksuite/affine-shared/utils';
 import type { PointerEventState } from '@blocksuite/std';
 import { BaseTool, MouseButton, type ToolOptions } from '@blocksuite/std/gfx';
@@ -83,6 +84,14 @@ export class PanTool extends BaseTool<PanToolOption> {
         this.controller.setTool(toolType, finalOptions);
         this.gfx.selection.set(selectionToRestore);
       };
+
+      // If in presentation mode, disable black background after middle mouse drag
+      if (currentTool.toolType?.toolName === 'frameNavigator') {
+        const slots = this.std.get(EdgelessLegacySlotIdentifier);
+        slots.navigatorSettingUpdated.next({
+          blackBackground: false,
+        });
+      }
 
       this.controller.setTool(PanTool, {
         panning: true,

--- a/tests/blocksuite/e2e/edgeless/presentation.spec.ts
+++ b/tests/blocksuite/e2e/edgeless/presentation.spec.ts
@@ -313,4 +313,33 @@ test.describe('presentation', () => {
     await prevButton.click();
     await expect(note).toBeVisible();
   });
+
+  test('should disable black background when space+drag in presentation mode', async ({
+    page,
+  }) => {
+    await edgelessCommonSetup(page);
+    await createNote(page, [300, 100], 'hello');
+    await setEdgelessTool(page, 'frame');
+    await dragBetweenViewCoords(page, [240, 0], [800, 200]);
+
+    expect(await page.locator('affine-frame').count()).toBe(1);
+    await enterPresentationMode(page);
+    await waitNextFrame(page, 300);
+
+    await assertEdgelessTool(page, 'frameNavigator');
+
+    // Verify black background is initially visible
+    const navigatorBlackBackground = page.locator(
+      '.edgeless-navigator-black-background'
+    );
+    await expect(navigatorBlackBackground).toBeVisible();
+
+    // Press space and drag to trigger the black background disable logic
+    await page.keyboard.down('Space');
+    await dragBetweenViewCoords(page, [400, 300], [500, 400]);
+    await page.keyboard.up('Space');
+
+    await waitNextFrame(page, 100);
+    await expect(navigatorBlackBackground).toBeHidden();
+  });
 });


### PR DESCRIPTION
### TL;DR

Fix presentation mode space-drag interaction by disabling black background during panning and properly restoring presentation state.

### What changed?

- Modified how the presentation tool handles state restoration after panning
- Disabled black background during space-drag and middle-mouse panning in presentation mode
- Fixed tool state management to properly restore presentation mode after space panning
- Added direct modification of the current tool's activated options instead of triggering a full tool change

### How to test?

1. Create a frame in edgeless mode
2. Enter presentation mode
3. Press space and drag to pan around
4. Verify the black background disappears during panning
5. Verify presentation mode is properly restored after releasing space
6. Try the same with middle-mouse button dragging

### Why make this change?

The black background in presentation mode was causing visibility issues during panning operations. Additionally, the presentation state wasn't being properly restored after space-drag panning. These changes improve the user experience by making content visible during navigation while maintaining the presentation mode state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Presentation mode now automatically hides the black background overlay when dragging with the space key or middle mouse button, improving visibility during navigation.

- **Bug Fixes**
  - Improved handling of tool switching after panning in presentation mode, ensuring smoother transitions and state restoration.

- **Tests**
  - Added an end-to-end test to verify that the black background is hidden during space-drag actions in presentation mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->