### PR TITLE
fix(editor): possible race condition in viewport clipping

### DIFF
--- a/blocksuite/framework/std/src/gfx/viewport-element.ts
+++ b/blocksuite/framework/std/src/gfx/viewport-element.ts
@@ -82,7 +82,7 @@ export class GfxViewportElement extends WithDisposable(ShadowlessElement) {
       : new Set<GfxBlockElementModel>();
 
     batch(() => {
-      // Step 1: Acitvate all the blocks that should be visible
+      // Step 1: Activate all the blocks that should be visible
       shouldBeVisible.forEach(model => {
         const view = gfx.view.get(model);
         if (!isGfxBlockComponent(view)) return;

--- a/blocksuite/framework/std/src/gfx/viewport-element.ts
+++ b/blocksuite/framework/std/src/gfx/viewport-element.ts
@@ -91,7 +91,7 @@ export class GfxViewportElement extends WithDisposable(ShadowlessElement) {
 
       // Step 2: Hide all the blocks that should not be visible
       previousVisible.forEach(model => {
-        if (!shouldBeVisible.has(model)) return;
+        if (shouldBeVisible.has(model)) return;
 
         const view = gfx.view.get(model);
         if (!isGfxBlockComponent(view)) return;

--- a/blocksuite/framework/std/src/gfx/viewport-element.ts
+++ b/blocksuite/framework/std/src/gfx/viewport-element.ts
@@ -70,32 +70,36 @@ export class GfxViewportElement extends WithDisposable(ShadowlessElement) {
     if (!this.host) return;
 
     const gfx = this.host.std.get(GfxControllerIdentifier);
-    const nextVisibleModels = new Set([
-      ...this.getModelsInViewport(),
-      ...this._getSelectedModels(),
+    const currentViewportModels = this.getModelsInViewport();
+    const currentSelectedModels = this._getSelectedModels();
+    const shouldBeVisible = new Set([
+      ...currentViewportModels,
+      ...currentSelectedModels,
     ]);
 
-    batch(() => {
-      nextVisibleModels.forEach(model => {
-        const view = gfx.view.get(model);
-        if (isGfxBlockComponent(view)) {
-          view.transformState$.value = 'active';
-        }
+    const previousVisible = this._lastVisibleModels
+      ? new Set(this._lastVisibleModels)
+      : new Set<GfxBlockElementModel>();
 
-        if (this._lastVisibleModels?.has(model)) {
-          this._lastVisibleModels!.delete(model);
-        }
+    batch(() => {
+      // Step 1: Acitvate all the blocks that should be visible
+      shouldBeVisible.forEach(model => {
+        const view = gfx.view.get(model);
+        if (!isGfxBlockComponent(view)) return;
+        view.transformState$.value = 'active';
       });
 
-      this._lastVisibleModels?.forEach(model => {
+      // Step 2: Hide all the blocks that should not be visible
+      previousVisible.forEach(model => {
+        if (!shouldBeVisible.has(model)) return;
+
         const view = gfx.view.get(model);
-        if (isGfxBlockComponent(view)) {
-          view.transformState$.value = 'idle';
-        }
+        if (!isGfxBlockComponent(view)) return;
+        view.transformState$.value = 'idle';
       });
     });
 
-    this._lastVisibleModels = nextVisibleModels;
+    this._lastVisibleModels = shouldBeVisible;
   };
 
   private _lastVisibleModels?: Set<GfxBlockElementModel>;


### PR DESCRIPTION
Previous implementation was mutating `this._lastVisibleModels` during `batch`, which may lead to stale state.

This new version should help with https://linear.app/affine-design/issue/BS-3136 and https://linear.app/affine-design/issue/BS-3421, which were unable to reproduce locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal logic for managing the visibility state of block models, resulting in clearer and more reliable updates to which blocks are shown as active or idle. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->