### PR TITLE
chore: get dev server url from browser url

### DIFF
--- a/tools/cli/src/bundle.ts
+++ b/tools/cli/src/bundle.ts
@@ -106,9 +106,12 @@ const defaultDevServerConfig: DevServerConfiguration = {
   hot: false,
   liveReload: true,
   compress: !process.env.CI,
+  setupExitSignals: true,
   client: {
     overlay: process.env.DISABLE_DEV_OVERLAY === 'true' ? false : undefined,
     logging: process.env.CI ? 'none' : 'error',
+    // see: https://webpack.js.org/configuration/dev-server/#websocketurl
+    webSocketURL: 'auto://0.0.0.0:0/ws',
   },
   historyApiFallback: {
     rewrites: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved development server with automatic handling of exit signals.
  - Configured default WebSocket URL for enhanced client-server communication during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->