### PR TITLE
feat(core): add default group and order

### DIFF
--- a/packages/frontend/core/src/components/explorer/context.ts
+++ b/packages/frontend/core/src/components/explorer/context.ts
@@ -11,6 +11,15 @@ const DefaultDisplayPreference: ExplorerDisplayPreference = {
     'system:createdBy',
     'system:tags',
   ],
+  orderBy: {
+    type: 'system',
+    key: 'updatedAt',
+    desc: true,
+  },
+  groupBy: {
+    type: 'system',
+    key: 'updatedAt',
+  },
   showDocIcon: true,
   showDocPreview: true,
   quickFavorite: true,

--- a/packages/frontend/core/src/components/page-list/docs/select-page.tsx
+++ b/packages/frontend/core/src/components/page-list/docs/select-page.tsx
@@ -49,6 +49,8 @@ export const SelectPage = memo(function SelectPage({
       quickFavorite: true,
       showMoreOperation: false,
       showDragHandle: false,
+      groupBy: undefined,
+      orderBy: undefined,
     });
   });
 
@@ -132,6 +134,11 @@ export const SelectPage = memo(function SelectPage({
             value: 'false',
           },
         ],
+        orderBy: {
+          type: 'system',
+          key: 'updatedAt',
+          desc: true,
+        },
       })
       .subscribe(result => {
         docExplorerContextValue.groups$.next(result.groups);

--- a/packages/frontend/core/src/components/workspace-property-types/created-updated-at.tsx
+++ b/packages/frontend/core/src/components/workspace-property-types/created-updated-at.tsx
@@ -11,6 +11,7 @@ const toRelativeDate = (time: string | number) => {
   return i18nTime(time, {
     relative: {
       max: [1, 'day'],
+      accuracy: 'day',
     },
     absolute: {
       accuracy: 'day',
@@ -54,12 +55,39 @@ export const UpdatedAtValue = MetaDateValueFactory({
   type: 'updatedDate',
 });
 
-export const CreatedAtGroupHeader = (props: GroupHeaderProps) => {
-  return <PlainTextDocGroupHeader {...props} />;
+export const CreatedAtGroupHeader = ({
+  groupId,
+  docCount,
+}: GroupHeaderProps) => {
+  const date = groupId ? toRelativeDate(groupId) : 'No Date';
+  return (
+    <PlainTextDocGroupHeader
+      style={{ textTransform: 'capitalize' }}
+      groupId={groupId}
+      docCount={docCount}
+    >
+      {date}
+    </PlainTextDocGroupHeader>
+  );
 };
 
-export const UpdatedAtGroupHeader = (props: GroupHeaderProps) => {
-  return <PlainTextDocGroupHeader {...props} />;
+export const UpdatedAtGroupHeader = ({
+  groupId,
+  docCount,
+}: GroupHeaderProps) => {
+  const t = useI18n();
+  const date = groupId
+    ? toRelativeDate(groupId)
+    : t['com.affine.all-docs.group.updated-at.never-updated']();
+  return (
+    <PlainTextDocGroupHeader
+      style={{ textTransform: 'capitalize' }}
+      groupId={groupId}
+      docCount={docCount}
+    >
+      {date}
+    </PlainTextDocGroupHeader>
+  );
 };
 
 export const CreateAtDocListProperty = ({ doc }: { doc: DocRecord }) => {

--- a/packages/frontend/core/src/desktop/dialogs/collection-editor/rules-mode.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/collection-editor/rules-mode.tsx
@@ -55,6 +55,8 @@ export const RulesMode = ({
       showDragHandle: false,
       showMoreOperation: false,
       quickFavorite: true,
+      groupBy: undefined,
+      orderBy: undefined,
     })
   );
 
@@ -76,6 +78,11 @@ export const RulesMode = ({
             value: 'false',
           },
         ],
+        orderBy: {
+          type: 'system',
+          key: 'updatedAt',
+          desc: true,
+        },
       })
       .subscribe(rules => {
         setRulesPageIds(rules.groups.flatMap(group => group.items));

--- a/packages/frontend/core/src/desktop/pages/workspace/trash-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/trash-page.tsx
@@ -60,6 +60,8 @@ export const TrashPage = () => {
       quickFavorite: false,
       quickDeletePermanently: true,
       quickRestore: true,
+      groupBy: undefined,
+      orderBy: undefined,
     })
   );
 

--- a/packages/frontend/core/src/mobile/pages/workspace/all.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/all.tsx
@@ -19,6 +19,8 @@ const AllDocs = () => {
       displayProperties: ['createdAt', 'updatedAt', 'tags'],
       view: 'masonry',
       showDragHandle: false,
+      groupBy: undefined,
+      orderBy: undefined,
     })
   );
   const collectionRulesService = useService(CollectionRulesService);
@@ -43,8 +45,8 @@ const AllDocs = () => {
           },
         ],
         orderBy: {
-          type: 'property',
-          key: 'createdAt',
+          type: 'system',
+          key: 'updatedAt',
           desc: true,
         },
       })

--- a/packages/frontend/core/src/mobile/views/all-docs/collection/detail.tsx
+++ b/packages/frontend/core/src/mobile/views/all-docs/collection/detail.tsx
@@ -36,6 +36,8 @@ const CollectionDocs = ({ collection }: { collection: Collection }) => {
       displayProperties: ['createdAt', 'updatedAt', 'tags'],
       view: 'masonry',
       showDragHandle: false,
+      groupBy: undefined,
+      orderBy: undefined,
     })
   );
   const groups = useLiveData(explorerContextValue.groups$);

--- a/packages/frontend/core/src/mobile/views/all-docs/tag/detail.tsx
+++ b/packages/frontend/core/src/mobile/views/all-docs/tag/detail.tsx
@@ -20,6 +20,8 @@ const TagDocs = ({ tag }: { tag: Tag }) => {
       displayProperties: ['createdAt', 'updatedAt', 'tags'],
       view: 'masonry',
       showDragHandle: false,
+      groupBy: undefined,
+      orderBy: undefined,
     })
   );
   const collectionRulesService = useService(CollectionRulesService);
@@ -50,8 +52,8 @@ const TagDocs = ({ tag }: { tag: Tag }) => {
           },
         ],
         orderBy: {
-          type: 'property',
-          key: 'createdAt',
+          type: 'system',
+          key: 'updatedAt',
           desc: true,
         },
       })

--- a/packages/frontend/core/src/modules/doc/services/docs.ts
+++ b/packages/frontend/core/src/modules/doc/services/docs.ts
@@ -164,6 +164,7 @@ export class DocsService extends Service {
       middleware.afterCreate?.(docRecord, options);
     }
     docRecord.setCreatedAt(Date.now());
+    docRecord.setUpdatedAt(Date.now());
     this.eventBus.emit(DocCreated, {
       doc: docRecord,
       docCreateOptions: options,

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -7145,6 +7145,10 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.all-docs.group.is-not-checked"](): string;
     /**
+      * `Never updated`
+      */
+    ["com.affine.all-docs.group.updated-at.never-updated"](): string;
+    /**
       * `core`
       */
     core(): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1782,6 +1782,7 @@
   "com.affine.all-docs.group.is-not-journal": "Not Journal",
   "com.affine.all-docs.group.is-checked": "Checked",
   "com.affine.all-docs.group.is-not-checked": "Unchecked",
+  "com.affine.all-docs.group.updated-at.never-updated": "Never updated",
   "core": "core",
   "dark": "Dark",
   "invited you to join": "invited you to join",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Documents are now grouped and sorted by their last updated date by default, improving organization and navigation.
  - Added a "Never updated" label for documents that have not been updated, with localization support.

- **Bug Fixes**
  - Ensured that newly created documents have their "updated at" timestamp set upon creation.

- **Style**
  - Group headers for creation and update dates now display capitalized, user-friendly labels.

- **Documentation**
  - Added new localization strings for improved clarity in document grouping labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->