### PR TITLE
fix(core): audio block actions not showing

### DIFF
--- a/packages/frontend/core/src/blocksuite/attachment-viewer/audio/audio-block.css.ts
+++ b/packages/frontend/core/src/blocksuite/attachment-viewer/audio/audio-block.css.ts
@@ -1,6 +1,6 @@
 import { cssVar } from '@toeverything/theme';
 import { cssVarV2 } from '@toeverything/theme/v2';
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 export const root = style({
   display: 'flex',
@@ -48,4 +48,10 @@ export const reloadButton = style({
 
 export const reloadButtonIcon = style({
   fontSize: 16,
+});
+
+/** Render our own border for audio block  */
+globalStyle(`.affine-attachment-container:has(${root})`, {
+  border: 'none',
+  overflow: 'visible',
 });

--- a/packages/frontend/core/src/modules/media/entities/audio-transcription-job.ts
+++ b/packages/frontend/core/src/modules/media/entities/audio-transcription-job.ts
@@ -244,6 +244,7 @@ export class AudioTranscriptionJob extends Entity<{
       const result: TranscriptionResult = {
         summary: claimedJob.summary ?? '',
         title: claimedJob.title ?? '',
+        actions: claimedJob.actions ?? '',
         segments:
           claimedJob.transcription?.map(segment => ({
             speaker: segment.speaker,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated audio block containers to remove borders and allow visible overflow, improving the appearance of audio attachments.

- **Bug Fixes**
  - Ensured that the actions field is always present in audio transcription job results, defaulting to an empty string when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->