### PR TITLE
fix: linked doc popover selector error

### DIFF
--- a/blocksuite/affine/widgets/linked-doc/src/linked-doc-popover.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/linked-doc-popover.ts
@@ -386,7 +386,7 @@ export class LinkedDocPopover extends SignalWatcher(
     }
 
     const ele = shadowRoot.querySelector(
-      `icon-button[data-id="${this._activatedItemKey}"]`
+      `icon-button[data-id=${CSS.escape(this._activatedItemKey)}]`
     );
 
     // If the element doesn't exist, don't log a warning


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scrolling behavior to the focused item in the linked document popover, ensuring reliable navigation regardless of special characters in item identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->