### PR TITLE
fix(core): fix all docs permissions check

### DIFF
--- a/packages/frontend/core/src/components/explorer/docs-view/docs-list.tsx
+++ b/packages/frontend/core/src/components/explorer/docs-view/docs-list.tsx
@@ -95,12 +95,14 @@ export const DocListItemComponent = memo(function DocListItemComponent({
 
 export const DocsExplorer = ({
   className,
+  disableMultiSelectToolbar,
   disableMultiDelete,
   masonryItemWidthMin,
   onRestore,
   onDelete,
 }: {
   className?: string;
+  disableMultiSelectToolbar?: boolean;
   disableMultiDelete?: boolean;
   masonryItemWidthMin?: number;
   onRestore?: (ids: string[]) => void;
@@ -244,7 +246,7 @@ export const DocsExplorer = ({
         paddingY={BUILD_CONFIG.isMobileEdition ? 12 : 0}
         paddingX={BUILD_CONFIG.isMobileEdition ? 16 : responsivePaddingX}
       />
-      {!disableMultiDelete || onRestore ? (
+      {!disableMultiSelectToolbar || onRestore ? (
         <ListFloatingToolbar
           open={!!selectMode}
           onDelete={disableMultiDelete ? undefined : handleMultiDelete}

--- a/packages/frontend/core/src/components/explorer/docs-view/more-menu.tsx
+++ b/packages/frontend/core/src/components/explorer/docs-view/more-menu.tsx
@@ -9,6 +9,7 @@ import {
 import { WorkspaceDialogService } from '@affine/core/modules/dialogs';
 import { DocsService } from '@affine/core/modules/doc';
 import { CompatibleFavoriteItemsAdapter } from '@affine/core/modules/favorite';
+import { GuardService } from '@affine/core/modules/permissions';
 import { WorkbenchService } from '@affine/core/modules/workbench';
 import { useI18n } from '@affine/i18n';
 import track from '@affine/track';
@@ -142,6 +143,9 @@ const MoveToTrash = ({ docId }: DocOperationProps) => {
   const docsService = useService(DocsService);
   const { openConfirmModal } = useConfirmModal();
   const doc = useLiveData(docsService.list.doc$(docId));
+  const guardService = useService(GuardService);
+
+  const canTrash = useLiveData(guardService.can$('Doc_Trash', docId));
 
   const onMoveToTrash = useCallback(() => {
     if (!doc) {
@@ -170,6 +174,7 @@ const MoveToTrash = ({ docId }: DocOperationProps) => {
       prefixIcon={<DeleteIcon />}
       data-testid="doc-list-operation-trash"
       onClick={onMoveToTrash}
+      disabled={!canTrash}
     >
       {t['com.affine.moveToTrash.title']()}
     </MenuItem>

--- a/packages/frontend/core/src/components/page-list/docs/select-page.tsx
+++ b/packages/frontend/core/src/components/page-list/docs/select-page.tsx
@@ -182,7 +182,7 @@ export const SelectPage = memo(function SelectPage({
         ) : null}
         {!isEmpty ? (
           <DocExplorerContext.Provider value={docExplorerContextValue}>
-            <DocsExplorer disableMultiDelete />
+            <DocsExplorer disableMultiSelectToolbar />
           </DocExplorerContext.Provider>
         ) : (
           <EmptyList search={searchText} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to disable the multi-select toolbar in the document explorer interface.

- **Improvements**
  - Enhanced permission checks for the "Move to Trash" action, ensuring users without the required permission cannot access this feature.
  - Improved error handling and user feedback when attempting to move documents to trash without proper permissions.

- **Bug Fixes**
  - Adjusted toolbar visibility logic to better reflect user permissions and settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->