### PR TITLE
fix(server): skip embedding when not configured

### DIFF
--- a/blocksuite/framework/global/src/env/index.ts
+++ b/blocksuite/framework/global/src/env/index.ts
@@ -1,5 +1,5 @@
 const agent = globalThis.navigator?.userAgent ?? '';
-const platform = globalThis.navigator?.platform;
+const platform = globalThis.navigator?.platform || globalThis.process?.platform;
 
 export const IS_WEB =
   typeof window !== 'undefined' && typeof document !== 'undefined';
@@ -17,13 +17,13 @@ export const IS_IOS =
   IS_SAFARI &&
   (/Mobile\/\w+/.test(agent) || globalThis.navigator?.maxTouchPoints > 2);
 
-export const IS_MAC = /Mac/i.test(platform);
+export const IS_MAC = /Mac/i.test(platform) || /darwin/.test(platform);
 
 export const IS_IPAD =
   /iPad/i.test(platform) ||
   /iPad/i.test(agent) ||
   (/Macintosh/i.test(agent) && globalThis.navigator?.maxTouchPoints > 2);
 
-export const IS_WINDOWS = /Win/.test(platform);
+export const IS_WINDOWS = /Win/.test(platform) || /win32/.test(platform);
 
 export const IS_MOBILE = IS_IOS || IS_IPAD || IS_ANDROID;

--- a/packages/backend/server/src/plugins/copilot/context/job.ts
+++ b/packages/backend/server/src/plugins/copilot/context/job.ts
@@ -52,9 +52,11 @@ export class CopilotContextDocJob {
   private async setup() {
     this.supportEmbedding =
       await this.models.copilotContext.checkEmbeddingAvailable();
-    this.client = new OpenAIEmbeddingClient(
-      this.config.copilot.providers.openai
-    );
+    if (this.supportEmbedding && this.config.copilot.providers.openai.apiKey) {
+      this.client = new OpenAIEmbeddingClient(
+        this.config.copilot.providers.openai
+      );
+    }
   }
 
   // public this client to allow overriding in tests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by conditionally initializing the embedding client only when support and API key are available, preventing potential errors.
  - Enhanced platform detection logic for better accuracy across different environments, including macOS and Windows systems.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->