### PR TITLE
refactor(editor): make citation as an view extension

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1302,6 +1302,9 @@ jobs:
           sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
           xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- yarn affine @affine-test/affine-desktop e2e
 
+      - name: Instal ffmpeg
+        run: npx playwright install ffmpeg
+
       - name: Run desktop tests
         if: ${{ matrix.spec.test && matrix.spec.os != 'ubuntu-latest' }}
         run: yarn affine @affine-test/affine-desktop e2e

--- a/blocksuite/affine/blocks/attachment/src/attachment-citation-renderer.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-citation-renderer.ts
@@ -1,0 +1,47 @@
+import { getAttachmentFileIcon } from '@blocksuite/affine-components/icons';
+import { AttachmentBlockSchema } from '@blocksuite/affine-model';
+import {
+  CitationProvider,
+  CitationRendererExtension,
+} from '@blocksuite/affine-shared/services';
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { when } from 'lit/directives/when.js';
+
+import type { AttachmentBlockComponent } from './attachment-block';
+
+export const AttachmentCitationRendererExtension = CitationRendererExtension(
+  AttachmentBlockSchema.model.flavour,
+  (block: AttachmentBlockComponent, content: unknown) => {
+    const citationService = block.std.get(CitationProvider);
+    const isCitation = citationService.isCitationModel(block.model);
+    return when(
+      isCitation,
+      () => {
+        const { selected$, containerStyleMap, onClick, model, filetype } =
+          block;
+        const { name, footnoteIdentifier } = model.props;
+        const fileTypeIcon = getAttachmentFileIcon(filetype);
+
+        return html`
+          <div
+            class=${classMap({
+              'affine-attachment-container': true,
+              focused: selected$.value,
+            })}
+            style=${containerStyleMap}
+          >
+            <affine-citation-card
+              .icon=${fileTypeIcon}
+              .citationTitle=${name}
+              .citationIdentifier=${footnoteIdentifier ?? ''}
+              .onClickCallback=${onClick}
+              .active=${selected$.value}
+            ></affine-citation-card>
+          </div>
+        `;
+      },
+      () => content
+    );
+  }
+);

--- a/blocksuite/affine/blocks/attachment/src/attachment-edgeless-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-edgeless-block.ts
@@ -22,9 +22,9 @@ export class AttachmentEdgelessBlockComponent extends toGfxBlockComponent(
     return this.std.get(EdgelessLegacySlotIdentifier);
   }
 
-  override onClick(_: MouseEvent) {
+  override onClick = (_: MouseEvent) => {
     return;
-  }
+  };
 
   override renderGfxBlock() {
     const { style$ } = this.model.props;

--- a/blocksuite/affine/blocks/attachment/src/components/rename-model.ts
+++ b/blocksuite/affine/blocks/attachment/src/components/rename-model.ts
@@ -1,6 +1,7 @@
 import { ConfirmIcon } from '@blocksuite/affine-components/icons';
 import { toast } from '@blocksuite/affine-components/toast';
 import type { AttachmentBlockModel } from '@blocksuite/affine-model';
+import { CitationProvider } from '@blocksuite/affine-shared/services';
 import type { EditorHost } from '@blocksuite/std';
 import { html } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
@@ -33,6 +34,7 @@ export const RenameModal = ({
 
   let fileName = includeExtension ? nameWithoutExtension : originalName;
   const extension = includeExtension ? originalExtension : '';
+  const citationService = editorHost.std.get(CitationProvider);
 
   const abort = () => abortController.abort();
   const onConfirm = () => {
@@ -44,6 +46,9 @@ export const RenameModal = ({
     model.store.updateBlock(model, {
       name: newFileName,
     });
+    if (citationService.isCitationModel(model)) {
+      citationService.trackEvent('Edit');
+    }
     abort();
   };
   const onInput = (e: InputEvent) => {

--- a/blocksuite/affine/blocks/attachment/src/view.ts
+++ b/blocksuite/affine/blocks/attachment/src/view.ts
@@ -7,6 +7,7 @@ import { SlashMenuConfigExtension } from '@blocksuite/affine-widget-slash-menu';
 import { BlockViewExtension, FlavourExtension } from '@blocksuite/std';
 import { literal } from 'lit/static-html.js';
 
+import { AttachmentCitationRendererExtension } from './attachment-citation-renderer.js';
 import { AttachmentBlockInteraction } from './attachment-edgeless-block.js';
 import { AttachmentDropOption } from './attachment-service.js';
 import { attachmentSlashMenuConfig } from './configs/slash-menu.js';
@@ -42,6 +43,7 @@ export class AttachmentViewExtension extends ViewExtensionProvider {
       AttachmentEmbedService,
       SlashMenuConfigExtension(flavour, attachmentSlashMenuConfig),
       ...createBuiltinToolbarConfigExtension(flavour),
+      AttachmentCitationRendererExtension,
     ]);
     if (this.isEdgeless(context.scope)) {
       context.register(EdgelessClipboardAttachmentConfig);

--- a/blocksuite/affine/blocks/bookmark/src/bookmark-citation-renderer.ts
+++ b/blocksuite/affine/blocks/bookmark/src/bookmark-citation-renderer.ts
@@ -1,0 +1,60 @@
+import { BookmarkBlockSchema } from '@blocksuite/affine-model';
+import {
+  CitationProvider,
+  CitationRendererExtension,
+} from '@blocksuite/affine-shared/services';
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { when } from 'lit/directives/when.js';
+
+import { type BookmarkBlockComponent } from './bookmark-block';
+
+export const BookmarkCitationRendererExtension =
+  CitationRendererExtension<BookmarkBlockComponent>(
+    BookmarkBlockSchema.model.flavour,
+    (block: BookmarkBlockComponent, content: unknown) => {
+      const citationService = block.std.get(CitationProvider);
+      const isCitation = citationService.isCitationModel(block.model);
+      return when(
+        isCitation,
+        () => {
+          const {
+            blockDraggable,
+            selectedStyle$,
+            selected$,
+            containerStyleMap,
+            handleClick,
+            handleDoubleClick,
+            model,
+          } = block;
+          const { url, footnoteIdentifier } = model.props;
+          const { icon, title, description } = block.linkPreview$.value;
+          const iconSrc = icon
+            ? block.imageProxyService.buildUrl(icon)
+            : undefined;
+
+          return html`
+            <div
+              draggable="${blockDraggable ? 'true' : 'false'}"
+              class=${classMap({
+                'affine-bookmark-container': true,
+                ...selectedStyle$?.value,
+              })}
+              style=${containerStyleMap}
+            >
+              <affine-citation-card
+                .icon=${iconSrc}
+                .citationTitle=${title || url}
+                .citationContent=${description ?? undefined}
+                .citationIdentifier=${footnoteIdentifier ?? ''}
+                .onClickCallback=${handleClick}
+                .onDoubleClickCallback=${handleDoubleClick}
+                .active=${selected$.value}
+              ></affine-citation-card>
+            </div>
+          `;
+        },
+        () => content
+      );
+    }
+  );

--- a/blocksuite/affine/blocks/bookmark/src/view.ts
+++ b/blocksuite/affine/blocks/bookmark/src/view.ts
@@ -6,6 +6,7 @@ import { BookmarkBlockSchema } from '@blocksuite/affine-model';
 import { BlockViewExtension, FlavourExtension } from '@blocksuite/std';
 import { literal } from 'lit/static-html.js';
 
+import { BookmarkCitationRendererExtension } from './bookmark-citation-renderer';
 import { BookmarkBlockInteraction } from './bookmark-edgeless-block';
 import { BookmarkSlashMenuConfigExtension } from './configs/slash-menu';
 import { createBuiltinToolbarConfigExtension } from './configs/toolbar';
@@ -32,6 +33,7 @@ export class BookmarkViewExtension extends ViewExtensionProvider {
           : literal`affine-bookmark`;
       }),
       BookmarkSlashMenuConfigExtension,
+      BookmarkCitationRendererExtension,
     ]);
     context.register(createBuiltinToolbarConfigExtension(flavour));
     const isEdgeless = this.isEdgeless(context.scope);

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-edgeless-linked-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-edgeless-linked-doc-block.ts
@@ -57,7 +57,7 @@ export class EmbedEdgelessLinkedDocBlockComponent extends toEdgelessEmbedBlock(
     store.deleteBlock(this.model);
   };
 
-  protected override _handleClick = (evt: MouseEvent): void => {
+  override handleClick = (evt: MouseEvent): void => {
     if (isNewTabTrigger(evt)) {
       this.open({ openMode: 'open-in-new-tab', event: evt });
     } else if (isNewViewTrigger(evt)) {

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-citation-renderer.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-citation-renderer.ts
@@ -1,0 +1,58 @@
+import { EmbedLinkedDocBlockSchema } from '@blocksuite/affine-model';
+import {
+  CitationProvider,
+  CitationRendererExtension,
+} from '@blocksuite/affine-shared/services';
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
+import { when } from 'lit/directives/when.js';
+
+import type { EmbedLinkedDocBlockComponent } from './embed-linked-doc-block';
+
+export const EmbedLinkedDocCitationRendererExtension =
+  CitationRendererExtension(
+    EmbedLinkedDocBlockSchema.model.flavour,
+    (block: EmbedLinkedDocBlockComponent, content: unknown) => {
+      const citationService = block.std.get(CitationProvider);
+      const isCitation = citationService.isCitationModel(block.model);
+      return when(
+        isCitation,
+        () => {
+          const {
+            model,
+            icon$,
+            title$,
+            selected$,
+            handleClick,
+            handleDoubleClick,
+            blockDraggable,
+            selectedStyle$,
+            embedContainerStyle,
+          } = block;
+          const { footnoteIdentifier } = model.props;
+
+          return html`<div
+            draggable="${blockDraggable ? 'true' : 'false'}"
+            class=${classMap({
+              'embed-block-container': true,
+              ...selectedStyle$?.value,
+            })}
+            style=${styleMap({
+              ...embedContainerStyle,
+            })}
+          >
+            <affine-citation-card
+              .icon=${icon$.value}
+              .citationTitle=${title$.value.value}
+              .citationIdentifier=${footnoteIdentifier ?? ''}
+              .onClickCallback=${handleClick}
+              .onDoubleClickCallback=${handleDoubleClick}
+              .active=${selected$.value}
+            ></affine-citation-card>
+          </div> `;
+        },
+        () => content
+      );
+    }
+  );

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-spec.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-spec.ts
@@ -6,6 +6,7 @@ import { literal } from 'lit/static-html.js';
 import { LinkedDocSlashMenuConfigExtension } from './configs/slash-menu';
 import { createBuiltinToolbarConfigExtension } from './configs/toolbar';
 import { EmbedLinkedDocInteraction } from './embed-edgeless-linked-doc-block';
+import { EmbedLinkedDocCitationRendererExtension } from './embed-linked-doc-citation-renderer';
 
 const flavour = EmbedLinkedDocBlockSchema.model.flavour;
 
@@ -18,4 +19,5 @@ export const EmbedLinkedDocViewExtensions: ExtensionType[] = [
   createBuiltinToolbarConfigExtension(flavour),
   EmbedLinkedDocInteraction,
   LinkedDocSlashMenuConfigExtension,
+  EmbedLinkedDocCitationRendererExtension,
 ].flat();

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -335,7 +335,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
     store.deleteBlock(this.model);
   };
 
-  protected override embedContainerStyle: StyleInfo = {
+  override embedContainerStyle: StyleInfo = {
     height: 'unset',
   };
 

--- a/blocksuite/affine/blocks/embed/src/common/embed-block-element.ts
+++ b/blocksuite/affine/blocks/embed/src/common/embed-block-element.ts
@@ -57,7 +57,7 @@ export class EmbedBlockComponent<
    * You can use this to change the height and width of the card.
    * By default, the height and width are set to `_cardHeight` and `_cardWidth` respectively.
    */
-  protected embedContainerStyle: StyleInfo = {};
+  embedContainerStyle: StyleInfo = {};
 
   renderEmbed = (content: () => TemplateResult) => {
     if (

--- a/blocksuite/affine/blocks/embed/src/common/to-edgeless-embed-block.ts
+++ b/blocksuite/affine/blocks/embed/src/common/to-edgeless-embed-block.ts
@@ -28,7 +28,7 @@ export function toEdgelessEmbedBlock<
 
     override blockDraggable = false;
 
-    protected override embedContainerStyle: StyleInfo = {};
+    override embedContainerStyle: StyleInfo = {};
 
     override [GfxElementSymbol] = true;
 

--- a/blocksuite/affine/blocks/paragraph/src/paragraph-block.ts
+++ b/blocksuite/affine/blocks/paragraph/src/paragraph-block.ts
@@ -7,7 +7,10 @@ import {
   BLOCK_CHILDREN_CONTAINER_PADDING_LEFT,
   EDGELESS_TOP_CONTENTEDITABLE_SELECTOR,
 } from '@blocksuite/affine-shared/consts';
-import { DocModeProvider } from '@blocksuite/affine-shared/services';
+import {
+  CitationProvider,
+  DocModeProvider,
+} from '@blocksuite/affine-shared/services';
 import {
   calculateCollapsedSiblings,
   getNearestHeadingBefore,
@@ -63,6 +66,10 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
       ?.getPlaceholder(this.model);
   }
 
+  get citationService() {
+    return this.std.get(CitationProvider);
+  }
+
   get attributeRenderer() {
     return this.inlineManager.getRenderer();
   }
@@ -73,6 +80,12 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
 
   get collapsedSiblings() {
     return calculateCollapsedSiblings(this.model);
+  }
+
+  get hasCitationSiblings() {
+    return this.collapsedSiblings.some(sibling =>
+      this.citationService.isCitationModel(sibling)
+    );
   }
 
   get embedChecker() {
@@ -284,6 +297,13 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
                       this.store.captureSync();
                       this.store.updateBlock(this.model, {
                         collapsed: value,
+                      });
+                    }
+
+                    if (this.hasCitationSiblings) {
+                      this.citationService.trackEvent('Expand', {
+                        control: 'Source Button',
+                        type: value ? 'Hide' : 'Show',
                       });
                     }
                   }}

--- a/blocksuite/affine/components/src/caption/captioned-block-component.ts
+++ b/blocksuite/affine/components/src/caption/captioned-block-component.ts
@@ -30,8 +30,8 @@ export class CaptionedBlockComponent<
     return this._captionEditorRef.value;
   }
 
-  constructor() {
-    super();
+  override connectedCallback() {
+    super.connectedCallback();
     this.addRenderer(this._renderWithWidget);
   }
 

--- a/blocksuite/affine/foundation/src/view.ts
+++ b/blocksuite/affine/foundation/src/view.ts
@@ -9,6 +9,7 @@ import {
 } from '@blocksuite/affine-ext-loader';
 import {
   AutoClearSelectionService,
+  CitationService,
   DefaultOpenDocExtension,
   DNDAPIExtension,
   DocDisplayMetaService,
@@ -76,6 +77,7 @@ export class FoundationViewExtension extends ViewExtensionProvider<FoundationVie
       FileSizeLimitService,
       LinkPreviewCache,
       LinkPreviewService,
+      CitationService,
     ]);
     context.register(clipboardConfigs);
     if (this.isEdgeless(context.scope)) {

--- a/blocksuite/affine/inlines/footnote/src/footnote-node/footnote-node.ts
+++ b/blocksuite/affine/inlines/footnote/src/footnote-node/footnote-node.ts
@@ -1,6 +1,7 @@
 import { HoverController } from '@blocksuite/affine-components/hover';
 import { PeekViewProvider } from '@blocksuite/affine-components/peek';
 import type { FootNote } from '@blocksuite/affine-model';
+import { CitationProvider } from '@blocksuite/affine-shared/services';
 import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
 import type { AffineTextAttributes } from '@blocksuite/affine-shared/types';
 import { WithDisposable } from '@blocksuite/global/lit';
@@ -117,6 +118,10 @@ export class AffineFootnoteNode extends WithDisposable(ShadowlessElement) {
     return this.std.store.readonly;
   }
 
+  get citationService() {
+    return this.std.get(CitationProvider);
+  }
+
   onFootnoteClick = () => {
     if (!this.footnote) {
       return;
@@ -214,6 +219,10 @@ export class AffineFootnoteNode extends WithDisposable(ShadowlessElement) {
       if (blockSelections.length) {
         return null;
       }
+
+      this.citationService.trackEvent('Hover', {
+        control: 'Source Footnote',
+      });
 
       return {
         template: this._FootNotePopup(footnote, abortController),

--- a/blocksuite/affine/shared/src/services/citation-service/citation-renderer-extension.ts
+++ b/blocksuite/affine/shared/src/services/citation-service/citation-renderer-extension.ts
@@ -1,0 +1,51 @@
+import { DisposableGroup } from '@blocksuite/global/disposable';
+import { type BlockComponent, LifeCycleWatcher } from '@blocksuite/std';
+import type { ExtensionType } from '@blocksuite/store';
+import { filter } from 'rxjs/operators';
+
+type CitationRenderer<T extends BlockComponent> = (
+  block: T,
+  content: unknown
+) => unknown;
+
+/**
+ * Creates an extension for registering a CitationRenderer for a specific block flavour.
+ *
+ * @param flavour The flavour of the block that the renderer is for
+ * @param renderer The renderer function that handles rendering for this block type
+ * @returns An ExtensionType object that can be used to set up the renderer in the DI container
+ */
+export const CitationRendererExtension = <T extends BlockComponent>(
+  flavour: string,
+  renderer: CitationRenderer<T>
+): ExtensionType => {
+  const name = flavour.split(':').pop();
+  return class CitationRenderer extends LifeCycleWatcher {
+    static override key = `${name}-citation-renderer-extension`;
+
+    private readonly _disposables = new DisposableGroup();
+
+    override mounted() {
+      const subscription = this.std.view.viewUpdated
+        .pipe(
+          filter(payload => {
+            const { type, method, view } = payload;
+            return (
+              type === 'block' &&
+              view.model.flavour === flavour &&
+              method === 'add'
+            );
+          })
+        )
+        .subscribe(({ view }) => {
+          const blockView = view as T;
+          blockView.addRenderer(content => renderer(blockView, content));
+        });
+      this._disposables.add(subscription);
+    }
+
+    override unmounted() {
+      this._disposables.dispose();
+    }
+  };
+};

--- a/blocksuite/affine/shared/src/services/citation-service/citation-service.ts
+++ b/blocksuite/affine/shared/src/services/citation-service/citation-service.ts
@@ -1,0 +1,84 @@
+import { type Container, createIdentifier } from '@blocksuite/global/di';
+import { type BlockStdScope, StdIdentifier } from '@blocksuite/std';
+import { type BlockModel, Extension } from '@blocksuite/store';
+
+import { DocModeProvider } from '../doc-mode-service';
+import type {
+  CitationEvents,
+  CitationEventType,
+} from '../telemetry-service/citation';
+import { TelemetryProvider } from '../telemetry-service/telemetry-service';
+
+const CitationEventTypeMap = {
+  Hover: 'AICitationHoverSource',
+  Expand: 'AICitationExpandSource',
+  Delete: 'AICitationDelete',
+  Edit: 'AICitationEdit',
+} as const;
+
+type EventType = keyof typeof CitationEventTypeMap;
+
+type EventTypeMapping = {
+  [K in EventType]: CitationEventType;
+};
+
+export interface CitationViewService {
+  /**
+   * Tracks citation-related events
+   * @param type - The type of citation event to track
+   * @param properties - The properties of the event
+   */
+  trackEvent<T extends EventType>(
+    type: T,
+    properties?: CitationEvents[EventTypeMapping[T]]
+  ): void;
+  /**
+   * Checks if the model is a citation model
+   * @param model - The model to check
+   * @returns True if the model is a citation model, false otherwise
+   */
+  isCitationModel(model: BlockModel): boolean;
+}
+
+export const CitationProvider =
+  createIdentifier<CitationViewService>('CitationService');
+
+export class CitationService extends Extension implements CitationViewService {
+  constructor(private readonly std: BlockStdScope) {
+    super();
+  }
+
+  static override setup(di: Container) {
+    di.addImpl(CitationProvider, CitationService, [StdIdentifier]);
+  }
+
+  get docModeService() {
+    return this.std.getOptional(DocModeProvider);
+  }
+
+  get telemetryService() {
+    return this.std.getOptional(TelemetryProvider);
+  }
+
+  isCitationModel = (model: BlockModel) => {
+    return (
+      'footnoteIdentifier' in model.props &&
+      !!model.props.footnoteIdentifier &&
+      'style' in model.props &&
+      model.props.style === 'citation'
+    );
+  };
+
+  trackEvent<T extends EventType>(
+    type: T,
+    properties?: CitationEvents[EventTypeMapping[T]]
+  ) {
+    const editorMode = this.docModeService?.getEditorMode() ?? 'page';
+    this.telemetryService?.track(CitationEventTypeMap[type], {
+      page: editorMode === 'page' ? 'doc editor' : 'whiteboard editor',
+      module: 'AI Result',
+      control: 'Source',
+      ...properties,
+    });
+  }
+}

--- a/blocksuite/affine/shared/src/services/citation-service/index.ts
+++ b/blocksuite/affine/shared/src/services/citation-service/index.ts
@@ -1,0 +1,2 @@
+export * from './citation-renderer-extension';
+export * from './citation-service';

--- a/blocksuite/affine/shared/src/services/index.ts
+++ b/blocksuite/affine/shared/src/services/index.ts
@@ -1,5 +1,6 @@
 export * from './auto-clear-selection-service';
 export * from './block-meta-service';
+export * from './citation-service';
 export * from './doc-display-meta-service';
 export * from './doc-mode-service';
 export * from './drag-handle-config';

--- a/blocksuite/affine/shared/src/services/telemetry-service/citation.ts
+++ b/blocksuite/affine/shared/src/services/telemetry-service/citation.ts
@@ -1,0 +1,9 @@
+import type { TelemetryEvent } from './types';
+
+export type CitationEventType =
+  | 'AICitationHoverSource'
+  | 'AICitationExpandSource'
+  | 'AICitationDelete'
+  | 'AICitationEdit';
+
+export type CitationEvents = Record<CitationEventType, TelemetryEvent>;

--- a/blocksuite/affine/shared/src/services/telemetry-service/index.ts
+++ b/blocksuite/affine/shared/src/services/telemetry-service/index.ts
@@ -1,3 +1,4 @@
+export * from './citation.js';
 export * from './database.js';
 export * from './link.js';
 export * from './telemetry-service.js';

--- a/blocksuite/affine/shared/src/services/telemetry-service/telemetry-service.ts
+++ b/blocksuite/affine/shared/src/services/telemetry-service/telemetry-service.ts
@@ -1,6 +1,7 @@
 import { createIdentifier } from '@blocksuite/global/di';
 import type { ExtensionType } from '@blocksuite/store';
 
+import type { CitationEvents } from './citation.js';
 import type { CodeBlockEvents } from './code-block.js';
 import type { OutDatabaseAllEvents } from './database.js';
 import type { LinkToolbarEvents } from './link.js';
@@ -28,7 +29,8 @@ export type TelemetryEventMap = OutDatabaseAllEvents &
   LinkToolbarEvents &
   SlashMenuEvents &
   CodeBlockEvents &
-  NoteEvents & {
+  NoteEvents &
+  CitationEvents & {
     DocCreated: DocCreatedEvent;
     Link: TelemetryEvent;
     LinkedDocCreated: LinkedDocCreatedEvent;

--- a/packages/frontend/core/src/blocksuite/view-extensions/editor-config/toolbar/index.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/editor-config/toolbar/index.ts
@@ -51,6 +51,7 @@ import { getSelectedModelsCommand } from '@blocksuite/affine/shared/commands';
 import { ImageSelection } from '@blocksuite/affine/shared/selection';
 import {
   ActionPlacement,
+  CitationProvider,
   GenerateDocUrlProvider,
   isRemovedUserInfo,
   OpenDocExtensionIdentifier,
@@ -461,6 +462,10 @@ function createExternalLinkableToolbarConfig(
                 undefined,
                 (_std, _component, props) => {
                   ctx.store.updateBlock(model, props);
+                  const citationService = ctx.std.get(CitationProvider);
+                  if (citationService.isCitationModel(model)) {
+                    citationService.trackEvent('Edit');
+                  }
                   block.requestUpdate();
                 },
                 abortController
@@ -804,6 +809,7 @@ const embedLinkedDocToolbarConfig = {
               },
               (_std, _component, props) => {
                 ctx.store.updateBlock(model, props);
+                ctx.std.get(CitationProvider).trackEvent('Edit');
                 block.requestUpdate();
               },
               abortController


### PR DESCRIPTION
Closes: [BS-3370](https://linear.app/affine-design/issue/BS-3370/插件化-citation)
Closes: [BS-3551](https://linear.app/affine-design/issue/BS-3551/citation埋点)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced citation tracking and rendering across attachment, bookmark, and embedded document blocks with interactive citation cards.
  - Added a centralized citation service for consistent citation detection and telemetry event tracking (hover, expand, delete, edit) throughout the editor.

- **Enhancements**
  - Enhanced toolbar and block interactions to trigger citation telemetry events during editing and user interactions.
  - Updated block rendering to conditionally display citation cards or hide content for citation models.

- **Refactor**
  - Standardized citation detection and event handling across multiple block types for improved consistency.
  - Adjusted method visibility and naming conventions for clearer code structure and lifecycle management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->