### PR TITLE
fix(editor): improve status display of attachments and images

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/styles.ts
+++ b/blocksuite/affine/blocks/attachment/src/styles.ts
@@ -91,6 +91,7 @@ export const styles = css`
     font-size: var(--affine-font-xs);
     font-style: normal;
     font-weight: 500;
+    text-transform: capitalize;
     line-height: 20px;
 
     svg {

--- a/blocksuite/affine/blocks/image/src/components/page-image-block.ts
+++ b/blocksuite/affine/blocks/image/src/components/page-image-block.ts
@@ -359,7 +359,9 @@ export class ImageBlockPageComponent extends SignalWatcher(
       ? ImageSelectedRect(this._doc.readonly)
       : null;
 
-    const { loading, error, icon, description } = this.state;
+    const blobUrl = this.block.blobUrl;
+    const caption = this.block.model.props.caption$.value ?? 'Image';
+    const { loading, error, icon, description, needUpload } = this.state;
 
     return html`
       <div class="resizable-img" style=${styleMap(imageSize)}>
@@ -367,8 +369,8 @@ export class ImageBlockPageComponent extends SignalWatcher(
           class="drag-target"
           draggable="false"
           loading="lazy"
-          src=${this.block.blobUrl}
-          alt=${this.block.model.props.caption$.value ?? 'Image'}
+          src=${blobUrl}
+          alt=${caption}
           @error=${this._handleError}
         />
 
@@ -377,12 +379,16 @@ export class ImageBlockPageComponent extends SignalWatcher(
 
       ${when(loading, () => html`<div class="loading">${icon}</div>`)}
       ${when(
-        error && description,
+        Boolean(error && description),
         () =>
           html`<affine-resource-status
             class="affine-image-status"
             .message=${description}
-            .reload=${() => this.block.refreshData()}
+            .needUpload=${needUpload}
+            .action=${() =>
+              needUpload
+                ? this.block.resourceController.upload()
+                : this.block.refreshData()}
           ></affine-resource-status>`
       )}
     `;

--- a/blocksuite/affine/blocks/image/src/image-edgeless-block.ts
+++ b/blocksuite/affine/blocks/image/src/image-edgeless-block.ts
@@ -137,6 +137,8 @@ export class ImageEdgelessBlockComponent extends GfxBlockComponent<ImageBlockMod
       description: formatSize(size),
     });
 
+    const { loading, icon, description, error, needUpload } = resovledState;
+
     return html`
       <div class="affine-image-container" style=${containerStyleMap}>
         ${when(
@@ -152,17 +154,18 @@ export class ImageEdgelessBlockComponent extends GfxBlockComponent<ImageBlockMod
                 @error=${this._handleError}
               />
             </div>
+            ${when(loading, () => html`<div class="loading">${icon}</div>`)}
             ${when(
-              resovledState.loading,
-              () => html`<div class="loading">${resovledState.icon}</div>`
-            )}
-            ${when(
-              resovledState.error && resovledState.description,
+              Boolean(error && description),
               () =>
                 html`<affine-resource-status
                   class="affine-image-status"
-                  .message=${resovledState.description}
-                  .reload=${() => this.refreshData()}
+                  .message=${description}
+                  .needUpload=${needUpload}
+                  .action=${() =>
+                    needUpload
+                      ? this.resourceController.upload()
+                      : this.refreshData()}
                 ></affine-resource-status>`
             )}
           `,

--- a/blocksuite/affine/shared/src/services/telemetry-service/types.ts
+++ b/blocksuite/affine/shared/src/services/telemetry-service/types.ts
@@ -65,7 +65,7 @@ export interface AttachmentReloadedEvent extends TelemetryEvent {
   page: 'doc editor' | 'whiteboard editor';
   segment: 'doc' | 'whiteboard';
   module: 'attachment';
-  control: 'reload';
+  control: 'reload' | 'retry';
   category: 'card' | 'embed';
   type: string; // file type
 }

--- a/blocksuite/framework/sync/src/blob/engine.ts
+++ b/blocksuite/framework/sync/src/blob/engine.ts
@@ -108,6 +108,10 @@ export class BlobEngine {
     return this.main.blobState$?.(key) ?? null;
   }
 
+  upload(key: string) {
+    return this.main.upload?.(key) ?? null;
+  }
+
   start() {
     if (this._abort) {
       return;

--- a/blocksuite/framework/sync/src/blob/source.ts
+++ b/blocksuite/framework/sync/src/blob/source.ts
@@ -5,6 +5,8 @@ export interface BlobState {
   downloading: boolean;
   errorMessage?: string | null;
   overSize: boolean;
+  needUpload: boolean;
+  needDownload: boolean;
 }
 
 export interface BlobSource {
@@ -16,4 +18,6 @@ export interface BlobSource {
   list: () => Promise<string[]>;
   // This state is only available when uploading to the server or downloading from the server.
   blobState$?: (key: string) => Observable<BlobState> | null;
+  // Re-upload to the server.
+  upload?: (key: string) => Promise<boolean>;
 }

--- a/blocksuite/playground/apps/_common/sync/blob/mock-server.ts
+++ b/blocksuite/playground/apps/_common/sync/blob/mock-server.ts
@@ -112,7 +112,13 @@ export class MockServerBlobSource implements BlobSource {
 }
 
 function defaultState(): BlobState {
-  return { uploading: false, downloading: false, overSize: false };
+  return {
+    uploading: false,
+    downloading: false,
+    overSize: false,
+    needDownload: false,
+    needUpload: false,
+  };
 }
 
 function nextState(

--- a/packages/frontend/core/src/modules/workspace/entities/workspace.ts
+++ b/packages/frontend/core/src/modules/workspace/entities/workspace.ts
@@ -58,6 +58,7 @@ export class Workspace extends Entity {
           },
           /* eslint-disable rxjs/finnish */
           blobState$: key => this.engine.blob.blobState$(key),
+          upload: key => this.engine.blob.upload(key),
           name: 'blob',
           readonly: false,
         },


### PR DESCRIPTION
Closes: [BS-3564](https://linear.app/affine-design/issue/BS-3564/ui-embed-view-报错-ui-加-title)
Closes: [BS-3454](https://linear.app/affine-design/issue/BS-3454/点击-reload-后应该隐藏-attachment-embed-view-左下角-status（待新状态）)

<img width="807" alt="Screenshot 2025-05-28 at 17 23 26" src="https://github.com/user-attachments/assets/9ecc29f8-73c6-4441-bc38-dfe9bd876542" />

<img width="820" alt="Screenshot 2025-05-28 at 17 45 37" src="https://github.com/user-attachments/assets/68e6db17-a814-4df4-a9fa-067ca03dec30" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrying failed uploads of attachments and images, enabling users to re-upload files directly from the error status interface.
  - The error status dialog now dynamically displays "Retry" for upload failures and "Reload" for download failures, with context-sensitive actions.
- **Enhancements**
  - Improved clarity and consistency in file type extraction, display, and icon usage for attachments and citations.
  - Button labels in the attachment interface now have capitalized text for better readability.
  - Unified error and loading state handling across attachment and image components, reducing redundant UI elements.
- **Bug Fixes**
  - Refined error handling and status updates for attachment and image uploads/downloads to improve reliability and user feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->