### PR TITLE
fix: avoid unnecessary rerendering of selected-rect

### DIFF
--- a/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
@@ -400,7 +400,7 @@ export const EdgelessNoteInteraction =
 
           onResizeMove(context): void {
             const { originalBound, newBound, lockRatio, constraint } = context;
-            const { minWidth, minHeight } = constraint;
+            const { minWidth, minHeight, maxHeight, maxWidth } = constraint;
 
             let scale = initialScale;
             let edgelessProp = { ...model.props.edgeless };
@@ -411,8 +411,8 @@ export const EdgelessNoteInteraction =
               edgelessProp.scale = scale;
             }
 
-            newBound.w = clamp(newBound.w, minWidth, Number.MAX_SAFE_INTEGER);
-            newBound.h = clamp(newBound.h, minHeight, Number.MAX_SAFE_INTEGER);
+            newBound.w = clamp(newBound.w, minWidth * scale, maxWidth);
+            newBound.h = clamp(newBound.h, minHeight * scale, maxHeight);
 
             if (newBound.h > minHeight * scale) {
               edgelessProp.collapse = true;

--- a/blocksuite/affine/blocks/surface/src/renderer/overlay.ts
+++ b/blocksuite/affine/blocks/surface/src/renderer/overlay.ts
@@ -35,7 +35,9 @@ export abstract class Overlay extends Extension {
     ]);
   }
 
-  clear() {}
+  clear() {
+    this.refresh();
+  }
 
   dispose() {}
 

--- a/blocksuite/affine/widgets/edgeless-selected-rect/src/resize-handles.ts
+++ b/blocksuite/affine/widgets/edgeless-selected-rect/src/resize-handles.ts
@@ -1,6 +1,7 @@
 import type { ResizeHandle } from '@blocksuite/std/gfx';
 import { html, nothing } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 export enum HandleDirection {
   Bottom = 'bottom',
@@ -17,36 +18,28 @@ function ResizeHandleRenderer(
   handle: ResizeHandle,
   rotatable: boolean,
   onPointerDown?: (e: PointerEvent, direction: ResizeHandle) => void,
-  updateCursor?: (options?: {
+  getCursor?: (options: {
     type: 'resize' | 'rotate';
     handle: ResizeHandle;
-  }) => void
+  }) => string
 ) {
   const handlerPointerDown = (e: PointerEvent) => {
     e.stopPropagation();
     onPointerDown && onPointerDown(e, handle);
   };
 
-  const pointerEnter = (type: 'resize' | 'rotate') => (e: PointerEvent) => {
-    e.stopPropagation();
-    if (e.buttons === 1 || !updateCursor) return;
-
-    updateCursor({ type, handle });
-  };
-
-  const pointerLeave = (e: PointerEvent) => {
-    e.stopPropagation();
-    if (e.buttons === 1 || !updateCursor) return;
-
-    updateCursor();
-  };
-
   const rotationTpl =
     handle.length > 6 && rotatable
       ? html`<div
           class="rotate"
-          @pointerover=${pointerEnter('rotate')}
-          @pointerout=${pointerLeave}
+          style=${styleMap({
+            cursor: getCursor
+              ? getCursor({
+                  type: 'rotate',
+                  handle,
+                })
+              : 'default',
+          })}
         ></div>`
       : nothing;
 
@@ -58,8 +51,14 @@ function ResizeHandleRenderer(
     ${rotationTpl}
     <div
       class="resize transparent-handle"
-      @pointerover=${pointerEnter('resize')}
-      @pointerout=${pointerLeave}
+      style=${styleMap({
+        cursor: getCursor
+          ? getCursor({
+              type: 'resize',
+              handle,
+            })
+          : 'default',
+      })}
     ></div>
   </div>`;
 }
@@ -79,17 +78,17 @@ export function RenderResizeHandles(
   resizeHandles: ResizeHandle[],
   rotatable: boolean,
   onPointerDown: (e: PointerEvent, direction: ResizeHandle) => void,
-  updateCursor?: (options?: {
+  getCursor?: (options: {
     type: 'resize' | 'rotate';
     handle: ResizeHandle;
-  }) => void
+  }) => string
 ) {
   return html`
     ${repeat(
       resizeHandles,
       handle => handle,
       handle =>
-        ResizeHandleRenderer(handle, rotatable, onPointerDown, updateCursor)
+        ResizeHandleRenderer(handle, rotatable, onPointerDown, getCursor)
     )}
   `;
 }


### PR DESCRIPTION
### Changed

- Note scale issue
- Overlay should call refresh when `clear` is called
- Optimize edgeless-selected-rect to avoid unecessary rerendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Edgeless note blocks now respect both minimum and maximum size limits when resizing.

- **Improvements**
  - Enhanced performance and responsiveness of resize and rotate handles in selection overlays by caching allowed handles and optimizing cursor management.
  - Cursor styles for resize and rotate handles are now set more reliably and efficiently through declarative styling.

- **Bug Fixes**
  - Ensured overlay clearing now properly refreshes the renderer for more consistent visual updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->