### PR TITLE
fix(electron): adjust some command line flags

### DIFF
--- a/packages/frontend/apps/electron/src/main/index.ts
+++ b/packages/frontend/apps/electron/src/main/index.ts
@@ -30,7 +30,19 @@ if (isDev) {
   app.commandLine.appendSwitch('host-rules', 'MAP 0.0.0.0 127.0.0.1');
 }
 // https://github.com/electron/electron/issues/43556
-app.commandLine.appendSwitch('disable-features', 'PlzDedicatedWorker');
+// // `CalculateNativeWinOcclusion` - Disable native window occlusion tracker (https://groups.google.com/a/chromium.org/g/embedder-dev/c/ZF3uHHyWLKw/m/VDN2hDXMAAAJ)
+app.commandLine.appendSwitch(
+  'disable-features',
+  'PlzDedicatedWorker,CalculateNativeWinOcclusion'
+);
+
+// Following features are enabled from the runtime:
+// `DocumentPolicyIncludeJSCallStacksInCrashReports` - https://www.electronjs.org/docs/latest/api/web-frame-main#framecollectjavascriptcallstack-experimental
+// `EarlyEstablishGpuChannel` - Refs https://issues.chromium.org/issues/40208065
+// `EstablishGpuChannelAsync` - Refs https://issues.chromium.org/issues/40208065
+const featuresToEnable = `DocumentPolicyIncludeJSCallStacksInCrashReports,EarlyEstablishGpuChannel,EstablishGpuChannelAsync`;
+app.commandLine.appendSwitch('enable-features', featuresToEnable);
+app.commandLine.appendSwitch('force-color-profile', 'srgb');
 
 // use the same data for internal & beta for testing
 if (overrideSession) {


### PR DESCRIPTION
some flags are copied from vscode.
In some cases that Electron is running in HDR mode, the color toning will be over exposed. Force using srgb to workaround this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved app performance and compatibility by enabling and disabling specific Electron features.
  - Enhanced color profile handling by forcing the color profile to "srgb".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->