### PR TITLE
feat(core): no-access & local for workspace embedding

### DIFF
--- a/packages/frontend/component/src/components/setting-components/wrapper.tsx
+++ b/packages/frontend/component/src/components/setting-components/wrapper.tsx
@@ -22,6 +22,7 @@ export const SettingWrapper = ({
       id={id}
       className={clsx(wrapper, disabled && wrapperDisabled)}
       data-testid={testId}
+      aria-disabled={disabled}
     >
       {title ? <div className="title">{title}</div> : null}
       {children}

--- a/packages/frontend/core/src/modules/workspace-indexer-embedding/view/attachments.tsx
+++ b/packages/frontend/core/src/modules/workspace-indexer-embedding/view/attachments.tsx
@@ -33,11 +33,13 @@ interface AttachmentsProps {
   totalCount: number;
   onPageChange: (offset: number) => void;
   onDelete: (id: string) => void;
+  disabled: boolean;
 }
 
 interface AttachmentItemProps {
   attachment: AttachmentFile;
   onDelete: (id: string) => void;
+  disabled: boolean;
 }
 
 const UploadingItem: React.FC<{ attachment: UploadingAttachmentFile }> = ({
@@ -88,6 +90,7 @@ const PersistedItem: React.FC<{ attachment: PersistedAttachmentFile }> = ({
 const AttachmentItem: React.FC<AttachmentItemProps> = ({
   attachment,
   onDelete,
+  disabled,
 }) => {
   const t = useI18n();
   const { openConfirmModal } = useConfirmModal();
@@ -131,20 +134,22 @@ const AttachmentItem: React.FC<AttachmentItemProps> = ({
       ) : isPersistedAttachment(attachment) ? (
         <PersistedItem attachment={attachment} />
       ) : null}
-      <div className={attachmentOperation}>
-        <Tooltip
-          content={t[
-            'com.affine.settings.workspace.indexer-embedding.embedding.additional-attachments.remove-attachment.tooltip'
-          ]()}
-        >
-          <CloseIcon
-            data-testid="workspace-embedding-setting-attachment-delete-button"
-            onClick={handleDelete}
-            color={cssVarV2('icon/primary')}
-            style={{ cursor: 'pointer' }}
-          />
-        </Tooltip>
-      </div>
+      {!disabled && (
+        <div className={attachmentOperation}>
+          <Tooltip
+            content={t[
+              'com.affine.settings.workspace.indexer-embedding.embedding.additional-attachments.remove-attachment.tooltip'
+            ]()}
+          >
+            <CloseIcon
+              data-testid="workspace-embedding-setting-attachment-delete-button"
+              onClick={handleDelete}
+              color={cssVarV2('icon/primary')}
+              style={{ cursor: 'pointer' }}
+            />
+          </Tooltip>
+        </div>
+      )}
     </div>
   );
 };
@@ -154,6 +159,7 @@ export const Attachments: React.FC<AttachmentsProps> = ({
   totalCount,
   onDelete,
   onPageChange,
+  disabled,
 }) => {
   const handlePageChange = useCallback(
     (offset: number) => {
@@ -172,6 +178,7 @@ export const Attachments: React.FC<AttachmentsProps> = ({
           key={getAttachmentId(attachment)}
           attachment={attachment}
           onDelete={onDelete}
+          disabled={disabled}
         />
       ))}
       <Pagination

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -6286,6 +6286,10 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.settings.workspace.indexer-embedding.embedding.description"](): string;
     /**
+      * `Only the workspace owner can enable Workspace Embedding.`
+      */
+    ["com.affine.settings.workspace.indexer-embedding.embedding.disabled-tooltip"](): string;
+    /**
       * `Select doc`
       */
     ["com.affine.settings.workspace.indexer-embedding.embedding.select-doc"](): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1575,6 +1575,7 @@
   "com.affine.settings.workspace.indexer-embedding.description": "Manage AFFiNE indexing and AFFiNE AI Embedding for local content processing",
   "com.affine.settings.workspace.indexer-embedding.embedding.title": "Embedding",
   "com.affine.settings.workspace.indexer-embedding.embedding.description": "Embedding allows AI to retrieve your content. If the indexer uses local settings, it may affect some of the results of the Embedding.",
+  "com.affine.settings.workspace.indexer-embedding.embedding.disabled-tooltip": "Only the workspace owner can enable Workspace Embedding.",
   "com.affine.settings.workspace.indexer-embedding.embedding.select-doc": "Select doc",
   "com.affine.settings.workspace.indexer-embedding.embedding.upload-file": "Upload file",
   "com.affine.settings.workspace.indexer-embedding.embedding.switch.title": "Workspace Embedding",

--- a/tests/affine-cloud-copilot/e2e/utils/settings-panel-utils.ts
+++ b/tests/affine-cloud-copilot/e2e/utils/settings-panel-utils.ts
@@ -7,7 +7,7 @@ export class SettingsPanelUtils {
     if (await page.getByTestId('workspace-setting:embedding').isHidden()) {
       await page.getByTestId('slider-bar-workspace-setting-button').click();
       await page.getByTestId('workspace-setting:embedding').click();
-      await page.getByTestId('workspace-embedding-setting-wrapper').waitFor({
+      await page.getByTestId('workspace-embedding-setting-header').waitFor({
         state: 'visible',
       });
     }


### PR DESCRIPTION
## TL;DR

Workspace embedding settings opt:

* **local workspace**: show enable cloud panel
* **no-access workspace**: disable settings panel

![截屏2025-05-28 14.59.36.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyktQ6Qwc7H6TiRCFoYN/58e1f511-9bde-487e-a4cd-f0818c582fcb.png)

![截屏2025-05-28 15.00.19.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/MyktQ6Qwc7H6TiRCFoYN/25c3db30-bf31-4c92-a771-55ce871c9a7a.png)

> CLOSE AI-155
> CLOSE BS-3580


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Embedding settings UI now displays a tooltip indicating that only workspace owners can enable Workspace Embedding.
  - Embedding settings are modularized for local and cloud workspaces, with clear separation and appropriate enablement controls.
  - Attachments in embedding settings cannot be deleted when the settings are disabled.

- **Accessibility**
  - Settings wrapper now includes an aria-disabled attribute for improved assistive technology support.

- **Localization**
  - Added a new tooltip message: "Only the workspace owner can enable Workspace Embedding."

- **Tests**
  - Added end-to-end tests for local workspace UI and disabled state when not the workspace owner.

- **UI Improvements**
  - Updated settings panel to better reflect disabled states with tooltips and conditional controls.
  - Improved synchronization when opening the embedding settings panel for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->