### PR TITLE
fix(core): show toolbar when quick select doc explorer

### DIFF
--- a/packages/frontend/core/src/components/explorer/docs-view/quick-actions.tsx
+++ b/packages/frontend/core/src/components/explorer/docs-view/quick-actions.tsx
@@ -213,6 +213,7 @@ export const QuickSelect = memo(function QuickSelect({
       onClick?.(e);
       e.stopPropagation();
       e.preventDefault();
+      contextValue.selectMode$?.next(true);
       contextValue.selectedDocIds$?.next(
         selected
           ? selectedDocIds.filter(id => id !== doc.id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Selection mode is now automatically activated when a document is selected or deselected in the quick actions view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->