### PR TITLE
chore(editor): add max height to the dragging preview of toc card

### DIFF
--- a/blocksuite/affine/fragments/outline/src/card/outline-card.ts
+++ b/blocksuite/affine/fragments/outline/src/card/outline-card.ts
@@ -120,6 +120,8 @@ export class OutlineNoteCard extends SignalWatcher(
           setOffset({ x: clientX - left, y: clientY - top });
 
           container.style.width = `${this.parentElement?.clientWidth ?? 0}px`;
+          container.style.maxHeight = '500px';
+          container.style.overflow = 'hidden';
           container.style.backgroundColor = cssVarV2(
             'layer/background/primary'
           );


### PR DESCRIPTION
Close [BS-3030](https://linear.app/affine-design/issue/BS-3030/侧边栏：toc-目录，这里拖动要限定一个最大高度，建议就-500-px)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Limited the drag preview container's height to 500px and hid overflow content for improved visual consistency during drag operations.

- **Bug Fixes**
  - Enhanced drag preview appearance to prevent content from spilling outside the container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->