### PR TITLE
fix(editor): connector not added as frame child

### DIFF
--- a/blocksuite/integration-test/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/blocksuite/integration-test/src/__tests__/edgeless/surface-ref.spec.ts
@@ -40,6 +40,7 @@ describe('basic', () => {
       xywh: '[100, 0, 100, 100]',
       index: service.generateIndex(),
     })!;
+    await wait(0); // wait next frame
     frameId = service.crud.addBlock(
       'affine:frame',
       {
@@ -97,9 +98,9 @@ describe('basic', () => {
 
     expect(refBlocks.length).toBe(2);
     expect(stackingCanvas.length).toBe(2);
-    expect(stackingCanvas[0].style.zIndex > refBlocks[0].style.zIndex).toBe(
-      true
-    );
+    // expect(stackingCanvas[0].style.zIndex > refBlocks[0].style.zIndex).toBe(
+    // true
+    // );
   });
 
   test('content in group should be rendered in the correct order', async () => {

--- a/blocksuite/integration-test/src/__tests__/edgeless/surface-ref.spec.ts
+++ b/blocksuite/integration-test/src/__tests__/edgeless/surface-ref.spec.ts
@@ -98,9 +98,9 @@ describe('basic', () => {
 
     expect(refBlocks.length).toBe(2);
     expect(stackingCanvas.length).toBe(2);
-    // expect(stackingCanvas[0].style.zIndex > refBlocks[0].style.zIndex).toBe(
-    // true
-    // );
+    expect(stackingCanvas[0].style.zIndex > refBlocks[0].style.zIndex).toBe(
+      true
+    );
   });
 
   test('content in group should be rendered in the correct order', async () => {


### PR DESCRIPTION
Fix: #12428 

Connectors had invalid bounds: When elementAdded fires, connectors have bounds of [0,0,0,0] because their path/bounds are calculated in a separate microtask by the connector-watcher. Frame detection waits for connector bounds calculation update to complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when adding connectors and shapes to frames by deferring frame detection to ensure elements are fully initialized before grouping.
  - Ensured all elements within a frame move together correctly when the frame is moved.

- **Tests**
  - Added an end-to-end test verifying connectors and shapes created simultaneously inside a frame are properly contained and move together.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->