### PR TITLE
chore(server): set log level to debug on canary

### DIFF
--- a/packages/backend/server/src/plugins/gcloud/logging/service.ts
+++ b/packages/backend/server/src/plugins/gcloud/logging/service.ts
@@ -13,7 +13,7 @@ export const LoggerProvider: Provider<LoggerService> = {
   provide: LoggerProvide,
   useFactory: () => {
     const instance = createLogger({
-      level: 'info',
+      level: env.namespaces.canary ? 'debug' : 'info',
       transports: [new transports.Console()],
       format: format.combine(moreMetadata(), format.json()),
     });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted logging verbosity to be more detailed in the 'canary' environment, providing debug-level logs, while maintaining info-level logs elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->