### PR TITLE
chore(editor): remove feature flag of embed doc with alias

### DIFF
--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/configs/toolbar.ts
@@ -13,7 +13,6 @@ import {
   ActionPlacement,
   DocDisplayMetaProvider,
   EditorSettingProvider,
-  FeatureFlagService,
   type LinkEventType,
   type OpenDocMode,
   type ToolbarAction,
@@ -216,12 +215,7 @@ const conversionsActionGroup = {
       run(ctx) {
         const block = ctx.getCurrentBlockByType(EmbedLinkedDocBlockComponent);
 
-        if (
-          ctx.std
-            .get(FeatureFlagService)
-            .getFlag('enable_embed_doc_with_alias') &&
-          isGfxBlockComponent(block)
-        ) {
+        if (isGfxBlockComponent(block)) {
           const editorSetting = ctx.std.getOptional(EditorSettingProvider);
           editorSetting?.set?.(
             'docCanvasPreferView',

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/configs/toolbar.ts
@@ -17,7 +17,6 @@ import { REFERENCE_NODE } from '@blocksuite/affine-shared/consts';
 import {
   ActionPlacement,
   EditorSettingProvider,
-  FeatureFlagService,
   type LinkEventType,
   type OpenDocMode,
   type ToolbarAction,
@@ -163,12 +162,7 @@ const conversionsActionGroup = {
       label: 'Card view',
       run(ctx) {
         const block = ctx.getCurrentBlockByType(EmbedSyncedDocBlockComponent);
-        if (
-          ctx.std
-            .get(FeatureFlagService)
-            .getFlag('enable_embed_doc_with_alias') &&
-          isGfxBlockComponent(block)
-        ) {
+        if (isGfxBlockComponent(block)) {
           const editorSetting = ctx.std.getOptional(EditorSettingProvider);
           editorSetting?.set?.(
             'docCanvasPreferView',
@@ -296,8 +290,6 @@ const builtinSurfaceToolbarConfig = {
       label: 'Insert to page',
       tooltip: 'Insert to page',
       icon: InsertIntoPageIcon(),
-      when: ({ std }) =>
-        std.get(FeatureFlagService).getFlag('enable_embed_doc_with_alias'),
       run: ctx => {
         const model = ctx.getCurrentModelByType(EmbedSyncedDocModel);
         if (!model) return;
@@ -334,8 +326,6 @@ const builtinSurfaceToolbarConfig = {
       tooltip:
         'Duplicate as note to create an editable copy, the original remains unchanged.',
       icon: DuplicateIcon(),
-      when: ({ std }) =>
-        std.get(FeatureFlagService).getFlag('enable_embed_doc_with_alias'),
       run: ctx => {
         const { gfx } = ctx;
 

--- a/blocksuite/affine/shared/src/services/feature-flag-service.ts
+++ b/blocksuite/affine/shared/src/services/feature-flag-service.ts
@@ -19,7 +19,6 @@ export interface BlockSuiteFlags {
   enable_callout: boolean;
   enable_edgeless_scribbled_style: boolean;
   enable_table_virtual_scroll: boolean;
-  enable_embed_doc_with_alias: boolean;
   enable_turbo_renderer: boolean;
   enable_dom_renderer: boolean;
 }
@@ -45,7 +44,6 @@ export class FeatureFlagService extends StoreExtension {
     enable_callout: false,
     enable_edgeless_scribbled_style: false,
     enable_table_virtual_scroll: false,
-    enable_embed_doc_with_alias: false,
     enable_turbo_renderer: false,
     enable_dom_renderer: false,
   });

--- a/packages/frontend/core/src/modules/dnd/index.ts
+++ b/packages/frontend/core/src/modules/dnd/index.ts
@@ -2,17 +2,11 @@ import { type Framework } from '@toeverything/infra';
 
 import { DocsService } from '../doc';
 import { EditorSettingService } from '../editor-setting';
-import { FeatureFlagService } from '../feature-flag';
 import { WorkspaceScope, WorkspaceService } from '../workspace';
 import { DndService } from './services';
 
 export function configureDndModule(framework: Framework) {
   framework
     .scope(WorkspaceScope)
-    .service(DndService, [
-      DocsService,
-      WorkspaceService,
-      EditorSettingService,
-      FeatureFlagService,
-    ]);
+    .service(DndService, [DocsService, WorkspaceService, EditorSettingService]);
 }

--- a/packages/frontend/core/src/modules/dnd/services/index.ts
+++ b/packages/frontend/core/src/modules/dnd/services/index.ts
@@ -18,7 +18,6 @@ import { Service } from '@toeverything/infra';
 
 import type { DocsService } from '../../doc';
 import type { EditorSettingService } from '../../editor-setting';
-import type { FeatureFlagService } from '../../feature-flag';
 import { resolveLinkToDoc } from '../../navigation';
 import type { WorkspaceService } from '../../workspace';
 
@@ -35,8 +34,7 @@ export class DndService extends Service {
   constructor(
     private readonly docsService: DocsService,
     private readonly workspaceService: WorkspaceService,
-    private readonly editorSettingService: EditorSettingService,
-    private readonly featureFlagService: FeatureFlagService
+    private readonly editorSettingService: EditorSettingService
   ) {
     super();
 
@@ -186,9 +184,7 @@ export class DndService extends Service {
           return false;
         },
         onDropTargetChange: (args: MonitorDragEvent<MixedDNDData>) => {
-          if (this.featureFlagService.flags.enable_embed_doc_with_alias.value) {
-            changeDocCardView(args);
-          }
+          changeDocCardView(args);
         },
       })
     );

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -259,15 +259,6 @@ export const AFFINE_FLAGS = {
     configurable: isCanaryBuild,
     defaultState: false,
   },
-  // TODO(@L-Sun): remove this flag after the feature is released
-  enable_embed_doc_with_alias: {
-    category: 'blocksuite',
-    bsFlag: 'enable_embed_doc_with_alias',
-    displayName: 'Embed doc with alias',
-    description: 'Embed doc with alias',
-    configurable: isCanaryBuild,
-    defaultState: isCanaryBuild,
-  },
   enable_setting_subpage_animation: {
     category: 'affine',
     displayName: 'Enable Setting Subpage Animation',

--- a/tests/blocksuite/e2e/embed-synced-doc/edgeless.spec.ts
+++ b/tests/blocksuite/e2e/embed-synced-doc/edgeless.spec.ts
@@ -142,14 +142,6 @@ test.describe('Embed synced doc in edgeless mode', () => {
         { title: 'Page 1', content: 'hello page 1', inEdgeless: true },
       ]);
 
-      // TODO(@L-Sun): remove this after this feature is released
-      await page.evaluate(() => {
-        const { FeatureFlagService } = window.$blocksuite.services;
-        window.editor.std
-          .get(FeatureFlagService)
-          .setFlag('enable_embed_doc_with_alias', true);
-      });
-
       await switchEditorMode(page);
 
       const edgelessEmbedSyncedBlock = page.locator(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Toolbar actions for embedding and duplicating documents are now always accessible without restrictions.

- **Chores**
  - Removed the feature flag for embed document alias features to streamline functionality.

- **Tests**
  - Cleaned up test setup by removing dependency on the deprecated feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->