### PR TITLE
fix(core): remove list view doc preview skeleton

### DIFF
--- a/packages/frontend/core/src/components/explorer/docs-view/doc-list-item.tsx
+++ b/packages/frontend/core/src/components/explorer/docs-view/doc-list-item.tsx
@@ -3,7 +3,6 @@ import {
   DragHandle as DragHandleIcon,
   Tooltip,
   useDraggable,
-  Wrapper,
 } from '@affine/component';
 import { DocsService } from '@affine/core/modules/doc';
 import { DocDisplayMetaService } from '@affine/core/modules/doc-display-meta';
@@ -331,11 +330,7 @@ export const ListViewDoc = ({ docId }: DocListItemProps) => {
           className={styles.listTitle}
           data-testid="doc-list-item-title"
         />
-        <DocPreview
-          id={docId}
-          className={styles.listPreview}
-          loading={<Wrapper height={20} width={10} />}
-        />
+        <DocPreview id={docId} className={styles.listPreview} />
       </div>
       <div className={styles.listSpace} />
       <ListViewProperties docId={docId} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the document preview in the list view to remove the loading placeholder, resulting in a simplified and cleaner display when loading previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->