### PR TITLE
fix(editor): viewportElement is undefined in edgeless root block

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
@@ -129,7 +129,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
     ) as SurfaceBlockModel;
   }
 
-  private get _viewportElement(): HTMLElement {
+  get viewportElement(): HTMLElement {
     return this.std.get(ViewportElementProvider).viewportElement;
   }
 
@@ -267,7 +267,7 @@ export class EdgelessRootBlockComponent extends BlockComponent<
       this.gfx.viewport.onResize();
     });
 
-    resizeObserver.observe(this._viewportElement);
+    resizeObserver.observe(this.viewportElement);
     this._resizeObserver = resizeObserver;
   }
 


### PR DESCRIPTION
This PR fixed that `rootComponent.viewportElement` is undefeined in edgeless mode, which leads that toast can not be render in playground.

https://github.com/toeverything/AFFiNE/blob/388641bc89caf37451c2d57ae5e538d432bf1518/blocksuite/affine/components/src/toast/create.ts#L23-L35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal code organization for better maintainability. No changes to visible features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->