### PR TITLE
fix(editor): missing block in select-all set

### DIFF
--- a/blocksuite/framework/std/src/gfx/layer.ts
+++ b/blocksuite/framework/std/src/gfx/layer.ts
@@ -825,7 +825,7 @@ export class LayerManager extends GfxExtension {
           const block = store.getModelById(payload.id);
 
           if (block instanceof GfxBlockElementModel) {
-            this.delete(block as GfxBlockElementModel);
+            this.delete(block);
           }
         }
       })
@@ -834,20 +834,29 @@ export class LayerManager extends GfxExtension {
     const watchSurface = (surface: SurfaceBlockModel) => {
       let lastChildMap = new Map(surface.childMap.peek());
       this._disposable.add(
-        surface.childMap.subscribe(val => {
-          val.forEach((_, id) => {
+        surface.childMap.subscribe(currentChildMap => {
+          currentChildMap.forEach((_, id) => {
             if (lastChildMap.has(id)) {
               lastChildMap.delete(id);
               return;
             }
           });
           lastChildMap.forEach((_, id) => {
-            const block = this._doc.getBlock(id);
-            if (block?.model) {
-              this.delete(block.model as GfxBlockElementModel);
+            const model = this._doc.getModelById(id);
+            if (model instanceof GfxBlockElementModel) {
+              this.delete(model);
             }
           });
-          lastChildMap = new Map(val);
+          currentChildMap.forEach((_, id) => {
+            const model = store.getModelById(id);
+            if (
+              model instanceof GfxBlockElementModel &&
+              !this.blocks.includes(model)
+            ) {
+              this.add(model);
+            }
+          });
+          lastChildMap = new Map(currentChildMap);
         })
       );
 


### PR DESCRIPTION
This PR fixed that the block is missing in the selecte-all set after undo a dragging from canvas to note. Related to #12473 

### Before

https://github.com/user-attachments/assets/828b4f48-689a-4975-bba6-f380f324de3c


### After

https://github.com/user-attachments/assets/9996c1ca-c3ea-415c-ab2b-359d826a1ffa



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of changes to child elements, ensuring more accurate updates when items are added or removed. This results in more reliable display and interaction with nested components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->