### PR TITLE
fix(editor): invoke subscriber.unsubscribe() during cleanup

### DIFF
--- a/blocksuite/framework/sync/src/doc/engine.ts
+++ b/blocksuite/framework/sync/src/doc/engine.ts
@@ -132,12 +132,13 @@ export class DocEngine {
         this.logger
       );
 
-      cleanUp.push(
-        state.mainPeer.onStatusChange.subscribe(() => {
-          if (!signal.aborted)
-            this.updateSyncingState(state.mainPeer, state.shadowPeers);
-        }).unsubscribe
-      );
+      const subscriber = state.mainPeer.onStatusChange.subscribe(() => {
+        if (!signal.aborted)
+          this.updateSyncingState(state.mainPeer, state.shadowPeers);
+      });
+      cleanUp.push(() => {
+        subscriber.unsubscribe();
+      });
 
       this.updateSyncingState(state.mainPeer, state.shadowPeers);
 
@@ -152,12 +153,15 @@ export class DocEngine {
           this.priorityTarget,
           this.logger
         );
-        cleanUp.push(
-          peer.onStatusChange.subscribe(() => {
-            if (!signal.aborted)
-              this.updateSyncingState(state.mainPeer, state.shadowPeers);
-          }).unsubscribe
-        );
+
+        const subscriber = peer.onStatusChange.subscribe(() => {
+          if (!signal.aborted)
+            this.updateSyncingState(state.mainPeer, state.shadowPeers);
+        });
+        cleanUp.push(() => {
+          subscriber.unsubscribe();
+        });
+
         return peer;
       });
 


### PR DESCRIPTION
Hello, this PR is for doc-synchronizing in the blocksuite project.

https://github.com/toeverything/blocksuite/pull/9130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the reliability of subscription cleanup processes for syncing status updates to ensure proper resource management. No visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->