### PR TITLE
feat(server): only trigger embedding in workspace sync

### DIFF
--- a/packages/backend/server/src/core/sync/gateway.ts
+++ b/packages/backend/server/src/core/sync/gateway.ts
@@ -203,7 +203,9 @@ export class SpaceSyncGateway
         await client.join(room);
       }
     } else {
-      this.event.emit('workspace.embedding', { workspaceId: spaceId });
+      if (spaceType === SpaceType.Workspace) {
+        this.event.emit('workspace.embedding', { workspaceId: spaceId });
+      }
       await this.selectAdapter(client, spaceType).join(user.id, spaceId);
     }
 

--- a/packages/backend/server/src/plugins/copilot/context/job.ts
+++ b/packages/backend/server/src/plugins/copilot/context/job.ts
@@ -129,6 +129,10 @@ export class CopilotContextDocJob {
     if (enableDocEmbedding) {
       const toBeEmbedDocIds =
         await this.models.copilotWorkspace.findDocsToEmbed(workspaceId);
+      this.logger.debug('Trigger embedding for docs', {
+        workspaceId,
+        toBeEmbedDocs: toBeEmbedDocIds.length,
+      });
       for (const docId of toBeEmbedDocIds) {
         await this.queue.add(
           'copilot.embedding.docs',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of workspace embedding events to ensure they are only triggered for workspace-type spaces.

- **Chores**
  - Added additional debug logging for document embedding jobs to aid in monitoring and troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->