### PR TITLE
chore(server): disable version check for oauth callback

### DIFF
--- a/packages/backend/server/src/plugins/oauth/controller.ts
+++ b/packages/backend/server/src/plugins/oauth/controller.ts
@@ -80,8 +80,10 @@ export class OAuthController {
     };
   }
 
+  // the prerequest `/oauth/prelight` request already checked client version,
+  // let's simply ignore it for callback which will block apple oauth post_form mode
+  // @UseNamedGuard('version')
   @Public()
-  @UseNamedGuard('version')
   @Post('/callback')
   @HttpCode(HttpStatus.OK)
   async callback(

--- a/packages/backend/server/src/plugins/oauth/providers/def.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/def.ts
@@ -7,6 +7,7 @@ import { OAuthProviderFactory } from '../factory';
 export interface OAuthAccount {
   id: string;
   email: string;
+  name?: string;
   avatarUrl?: string;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Apple OAuth login reliability by ensuring client version checks do not block the callback process.

- **New Features**
  - Enhanced OAuth account information by including an optional display name field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->