### PR TITLE
chore: display join button text based on invitation type

### DIFF
--- a/packages/frontend/component/src/components/member-components/request-to-join-page.tsx
+++ b/packages/frontend/component/src/components/member-components/request-to-join-page.tsx
@@ -2,7 +2,10 @@ import {
   AuthPageContainer,
   type User,
 } from '@affine/component/auth-components';
-import type { GetInviteInfoQuery } from '@affine/graphql';
+import {
+  type GetInviteInfoQuery,
+  WorkspaceMemberStatus,
+} from '@affine/graphql';
 import { useI18n } from '@affine/i18n';
 import { SignOutIcon } from '@blocksuite/icons/rc';
 
@@ -51,7 +54,9 @@ export const RequestToJoinPage = ({
       }
     >
       <Button variant="primary" size="large" onClick={requestToJoin}>
-        {t['com.affine.request-to-join-workspace.button']()}
+        {inviteInfo?.status === WorkspaceMemberStatus.Pending
+          ? t['com.affine.notification.invitation.accept']()
+          : t['com.affine.request-to-join-workspace.button']()}
       </Button>
       {user ? (
         <div className={styles.userInfoWrapper}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The button on the Request to Join page now dynamically updates its label to show "accept invitation" when an invitation is pending, improving clarity for users responding to workspace invites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->