### PR TITLE
feat(core): save all docs options by mode

### DIFF
--- a/packages/frontend/core/src/desktop/pages/workspace/all-page/all-page-header.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/all-page/all-page-header.tsx
@@ -28,11 +28,15 @@ const menuProps: Partial<MenuProps> = {
 export const AllDocsHeader = ({
   displayPreference,
   onDisplayPreferenceChange,
+  view,
+  onViewChange,
 }: {
   displayPreference: ExplorerDisplayPreference;
   onDisplayPreferenceChange: (
     displayPreference: ExplorerDisplayPreference
   ) => void;
+  view: DocListItemView;
+  onViewChange: (view: DocListItemView) => void;
 }) => {
   const t = useI18n();
   const workspaceService = useService(WorkspaceService);
@@ -77,22 +81,12 @@ export const AllDocsHeader = ({
     });
   }, [workspaceDialogService, handleOpenDocs]);
 
-  const handleViewChange = useCallback(
-    (view: DocListItemView) => {
-      onDisplayPreferenceChange({ ...displayPreference, view });
-    },
-    [displayPreference, onDisplayPreferenceChange]
-  );
-
   return (
     <div className={styles.header}>
       <ExplorerNavigation active="docs" />
 
       <div className={styles.actions}>
-        <ViewToggle
-          view={displayPreference.view ?? 'list'}
-          onViewChange={handleViewChange}
-        />
+        <ViewToggle view={view} onViewChange={onViewChange} />
         <ExplorerDisplayMenuButton
           menuProps={menuProps}
           displayPreference={displayPreference}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved state management for display preferences, view mode, and selected collection in the "All Docs" page, making the experience more modular and consistent, especially when using multiple views.
  - Updated the header component to handle view changes more directly, allowing smoother toggling between different document views.

- **New Features**
  - Enhanced support for independent display settings in split view or multiple "All Docs" instances.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->