### PR TITLE
fix(core): copy & paste ai message failed

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/content/pure-text.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/content/pure-text.ts
@@ -40,9 +40,14 @@ export class ChatContentPureText extends ShadowlessElement {
   @property({ attribute: 'data-testid', reflect: true })
   accessor testId = 'chat-content-pure-text';
 
+  stopPropagation(event: Event) {
+    event.stopPropagation();
+  }
+
   protected override render() {
     return this.text.length > 0
-      ? html`<div class="chat-content-pure-text">${this.text}</div>`
+      ? // prettier-ignore
+        html`<div class="chat-content-pure-text" @copy=${this.stopPropagation}>${this.text}</div>`
       : nothing;
   }
 }

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
@@ -492,6 +492,7 @@ export class AIChatInput extends SignalWatcher(
   };
 
   private readonly _handlePaste = (event: ClipboardEvent) => {
+    event.stopPropagation();
     const items = event.clipboardData?.items;
     if (!items) return;
 


### PR DESCRIPTION
### TL;DR
* fix: ai message copy bug
  * Select a section of content in the Page
  * Choose the user's question from the AI chat conversation history and copy it
  * The copied (pasted) content will be the selected section from the Page

* fix: ai message paste bug
  * Select a section of content in the Page
  * Choose the user's question from the AI chat conversation history and copy it
  * Paste it into the AI Input, and the content will be pasted back into the original Page text

> CLOSE AF-2683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved event handling to prevent unintended propagation of copy and paste actions within chat components, ensuring smoother user interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->