### PR TITLE
fix: tuning drag and resize snapping

### DIFF
--- a/blocksuite/affine/gfx/pointer/src/snap/snap-manager.ts
+++ b/blocksuite/affine/gfx/pointer/src/snap/snap-manager.ts
@@ -1,6 +1,6 @@
 import { OverlayIdentifier } from '@blocksuite/affine-block-surface';
 import { MindmapElementModel } from '@blocksuite/affine-model';
-import { Bound } from '@blocksuite/global/gfx';
+import { type Bound } from '@blocksuite/global/gfx';
 import {
   type DragExtensionInitializeContext,
   type ExtensionDragMoveContext,
@@ -74,47 +74,63 @@ export class SnapExtension extends InteractivityExtension {
         return {};
       }
 
-      let alignBound: Bound | null = null;
-
       return {
         onResizeStart(context) {
-          alignBound = snapOverlay.setMovingElements(context.elements);
+          snapOverlay.setMovingElements(context.elements);
         },
         onResizeMove(context) {
-          if (!alignBound || alignBound.w === 0 || alignBound.h === 0) {
-            return;
+          const {
+            handle,
+            originalBound,
+            scaleX,
+            scaleY,
+            handleSign,
+            currentHandlePos,
+            elements,
+          } = context;
+          const rotate = elements.length > 1 ? 0 : elements[0].rotate;
+          const alignDirection: ('vertical' | 'horizontal')[] = [];
+          let switchDirection = false;
+          let nx = handleSign.x;
+          let ny = handleSign.y;
+
+          if (handle.length > 6) {
+            alignDirection.push('vertical', 'horizontal');
+          } else if (rotate % 90 === 0) {
+            nx =
+              handleSign.x * Math.cos((rotate / 180) * Math.PI) -
+              handleSign.y * Math.sin((rotate / 180) * Math.PI);
+            ny =
+              handleSign.x * Math.sin((rotate / 180) * Math.PI) +
+              handleSign.y * Math.cos((rotate / 180) * Math.PI);
+
+            if (Math.abs(nx) > Math.abs(ny)) {
+              alignDirection.push('horizontal');
+            } else {
+              alignDirection.push('vertical');
+            }
+
+            if (rotate % 180 !== 0) {
+              switchDirection = true;
+            }
           }
 
-          const { handle, handleSign, lockRatio } = context;
-          let { dx, dy } = context;
-
-          if (lockRatio) {
-            const min = Math.min(
-              Math.abs(dx / alignBound.w),
-              Math.abs(dy / alignBound.h)
+          if (alignDirection.length > 0) {
+            const rst = snapOverlay.alignResize(
+              currentHandlePos,
+              alignDirection
             );
 
-            dx = min * Math.sign(dx) * alignBound.w;
-            dy = min * Math.sign(dy) * alignBound.h;
+            const dx = switchDirection ? ny * rst.dy : nx * rst.dx;
+            const dy = switchDirection ? nx * rst.dx : ny * rst.dy;
+
+            context.suggest({
+              scaleX: scaleX + dx / originalBound.w,
+              scaleY: scaleY + dy / originalBound.h,
+            });
           }
-
-          const currentBound = new Bound(
-            alignBound.x +
-              (handle.includes('left') ? -dx * handleSign.xSign : 0),
-            alignBound.y +
-              (handle.includes('top') ? -dy * handleSign.ySign : 0),
-            Math.abs(alignBound.w + dx * handleSign.xSign),
-            Math.abs(alignBound.h + dy * handleSign.ySign)
-          );
-          const alignRst = snapOverlay.align(currentBound);
-
-          context.suggest({
-            dx: alignRst.dx + context.dx,
-            dy: alignRst.dy + context.dy,
-          });
         },
         onResizeEnd() {
-          alignBound = null;
           snapOverlay.clear();
         },
       };

--- a/blocksuite/framework/std/src/gfx/interactivity/manager.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/manager.ts
@@ -947,23 +947,34 @@ export class InteractivityManager extends GfxExtension {
       ...options,
       lockRatio,
       elements,
-      onResizeMove: ({ dx, dy, handleSign, lockRatio }) => {
+      onResizeMove: ({
+        scaleX,
+        scaleY,
+        originalBound,
+        handleSign,
+        handlePos,
+        currentHandlePos,
+        lockRatio,
+      }) => {
         const suggested: {
-          dx: number;
-          dy: number;
+          scaleX: number;
+          scaleY: number;
           priority?: number;
         }[] = [];
-        const suggest = (distance: { dx: number; dy: number }) => {
+        const suggest = (distance: { scaleX: number; scaleY: number }) => {
           suggested.push(distance);
         };
 
         extensionHandlers.forEach(ext => {
           ext.onResizeMove?.({
-            dx,
-            dy,
+            scaleX,
+            scaleY,
             elements,
-            handleSign,
             handle,
+            handleSign,
+            handlePos,
+            originalBound,
+            currentHandlePos,
             lockRatio,
             suggest,
           });
@@ -973,9 +984,9 @@ export class InteractivityManager extends GfxExtension {
           return (a.priority ?? 0) - (b.priority ?? 0);
         });
 
-        return last(suggested) ?? { dx, dy };
+        return last(suggested) ?? { scaleX, scaleY };
       },
-      onResizeStart: ({ data }) => {
+      onResizeStart: ({ handleSign, handlePos, data }) => {
         this.activeInteraction$.value = {
           type: 'resize',
           elements,
@@ -984,6 +995,8 @@ export class InteractivityManager extends GfxExtension {
           ext.onResizeStart?.({
             elements,
             handle,
+            handlePos,
+            handleSign,
           });
         });
 
@@ -1045,13 +1058,15 @@ export class InteractivityManager extends GfxExtension {
 
         options.onResizeUpdate?.({ scaleX, scaleY, lockRatio, exceed });
       },
-      onResizeEnd: ({ data }) => {
+      onResizeEnd: ({ handleSign, handlePos, data }) => {
         this.activeInteraction$.value = null;
 
         extensionHandlers.forEach(ext => {
           ext.onResizeEnd?.({
             elements,
             handle,
+            handlePos,
+            handleSign,
           });
         });
         options.onResizeEnd?.();

--- a/blocksuite/framework/std/src/gfx/interactivity/types/resize.ts
+++ b/blocksuite/framework/std/src/gfx/interactivity/types/resize.ts
@@ -1,3 +1,5 @@
+import type { IBound, IPoint, IVec } from '@blocksuite/global/gfx';
+
 import type { GfxModel } from '../../model/model';
 import type { ResizeHandle } from '../resize/manager';
 
@@ -8,6 +10,16 @@ export type ExtensionElementResizeContext = {
 export type ExtensionElementResizeStartContext = {
   elements: GfxModel[];
 
+  /**
+   * The position of the handle in the browser coordinate space.
+   */
+  handlePos: IVec;
+
+  /**
+   * The sign (or normal vector) of the handle.
+   */
+  handleSign: IPoint;
+
   handle: ResizeHandle;
 };
 
@@ -16,15 +28,14 @@ export type ExtensionElementResizeEndContext =
 
 export type ExtensionElementResizeMoveContext =
   ExtensionElementResizeStartContext & {
-    dx: number;
-    dy: number;
+    scaleX: number;
+    scaleY: number;
+
+    originalBound: IBound;
+
+    currentHandlePos: IVec;
 
     lockRatio: boolean;
 
-    handleSign: {
-      xSign: number;
-      ySign: number;
-    };
-
-    suggest: (distance: { dx: number; dy: number }) => void;
+    suggest: (distance: { scaleX: number; scaleY: number }) => void;
   };

--- a/tests/blocksuite/e2e/edgeless/resizing.spec.ts
+++ b/tests/blocksuite/e2e/edgeless/resizing.spec.ts
@@ -37,23 +37,16 @@ test.describe('resizing shapes and aspect ratio will be maintained', () => {
 
     await addBasicRectShapeElement(
       page,
-      { x: 210, y: 110 },
-      { x: 310, y: 210 }
+      { x: 210, y: 210 },
+      { x: 310, y: 310 }
     );
-    await page.mouse.click(220, 120);
-    await assertEdgelessSelectedRect(page, [210, 110, 100, 100]);
+    await page.mouse.click(220, 220);
 
-    await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
-    await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
+    await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 220 });
+    await assertEdgelessSelectedRect(page, [98, 98, 212, 212]);
 
     await resizeElementByHandle(page, { x: 50, y: 50 });
-    await assertEdgelessSelectedRect(page, [148, 124.19, 162, 85.81]);
-
-    await page.mouse.move(160, 160);
-    await assertEdgelessSelectedRect(page, [148, 124.19, 162, 85.81]);
-
-    await page.mouse.move(260, 160);
-    await assertEdgelessSelectedRect(page, [148, 124.19, 162, 85.81]);
+    await assertEdgelessSelectedRect(page, [148, 148, 162, 162]);
   });
 
   test('negative adjustment', async ({ page }) => {
@@ -73,23 +66,16 @@ test.describe('resizing shapes and aspect ratio will be maintained', () => {
 
     await addBasicRectShapeElement(
       page,
-      { x: 210, y: 110 },
-      { x: 310, y: 210 }
+      { x: 210, y: 210 },
+      { x: 310, y: 310 }
     );
-    await page.mouse.click(220, 120);
-    await assertEdgelessSelectedRect(page, [210, 110, 100, 100]);
+    await page.mouse.click(220, 220);
 
-    await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 130 });
-    await assertEdgelessSelectedRect(page, [98, 98, 212, 112]);
+    await dragBetweenCoords(page, { x: 120, y: 90 }, { x: 220, y: 220 });
+    await assertEdgelessSelectedRect(page, [98, 98, 212, 212]);
 
-    await resizeElementByHandle(page, { x: 400, y: 300 }, 'top-left', 30);
-    await assertEdgelessSelectedRect(page, [310, 210, 356, 188]);
-
-    await page.mouse.move(450, 300);
-    await assertEdgelessSelectedRect(page, [310, 210, 356, 188]);
-
-    await page.mouse.move(320, 220);
-    await assertEdgelessSelectedRect(page, [310, 210, 356, 188]);
+    await resizeElementByHandle(page, { x: 50, y: 50 }, 'bottom-right', 30);
+    await assertEdgelessSelectedRect(page, [98, 98, 262, 262]);
   });
 });
 


### PR DESCRIPTION
### Changed
- Better snapping when resize elements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved resizing behavior with enhanced alignment and snapping during element resizing, supporting rotation and multiple element selection.
  - Alignment lines now display more accurately when resizing elements.

- **Refactor**
  - Resizing logic updated to use scale factors instead of position deltas, enabling smoother and more precise resize operations.
  - Resize event data now includes richer details about handle positions, scaling, and original bounds.
  - Coordinate transformations and scaling now account for rotation and aspect ratio locking more robustly.
  - Cursor updates are disabled during active resize or rotate interactions for a smoother user experience.

- **Tests**
  - Updated resizing tests to use square shapes, ensuring consistent verification of aspect ratio maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->