### PR TITLE
fix(editor): should check url origin and ip address url

### DIFF
--- a/blocksuite/affine/shared/src/__tests__/utils/url.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/utils/url.unit.spec.ts
@@ -80,4 +80,8 @@ describe('isValidUrl: determining whether a URL is valid is very complicated', (
     // See also https://stackoverflow.com/questions/9238640/how-long-can-a-tld-possibly-be#:~:text=Longest%20TLD%20up%20to%20date,17%20when%20decoded%20%5Bverm%C3%B6gensberatung%5D.
     expect(isValidUrl('example.xn--vermgensberatung-pwb')).toEqual(false);
   });
+
+  test('should allow ip address url when origin is same', () => {
+    expect(isValidUrl('http://127.0.0.1', 'http://127.0.0.1')).toEqual(true);
+  });
 });


### PR DESCRIPTION
Closes: [BS-3578](https://linear.app/affine-design/issue/BS-3578/复制本的-url-无法识别)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved URL validation to recognize and allow IPv4 addresses when the origin matches the provided base URL.

- **Tests**
  - Added a test to ensure URLs with IP addresses (e.g., http://127.0.0.1) are considered valid when the origin matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->