### PR TITLE
fix(editor): font weight of label on open doc menu

### DIFF
--- a/blocksuite/affine/components/src/open-doc-dropdown-menu/dropdown-menu.ts
+++ b/blocksuite/affine/components/src/open-doc-dropdown-menu/dropdown-menu.ts
@@ -29,12 +29,6 @@ export class OpenDocDropdownMenu extends SignalWatcher(
       gap: unset !important;
     }
 
-    editor-icon-button {
-      .label {
-        font-weight: 400;
-      }
-    }
-
     div[data-orientation] {
       width: 264px;
       gap: 4px;


### PR DESCRIPTION
Closes: [BS-3496](https://linear.app/affine-design/issue/BS-3496/toolbar-菜单字重)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated dropdown menu appearance by removing bold styling from button labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->