### PR TITLE
fix(native): opt out napi-derive noop feature

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -151,7 +151,8 @@ jobs:
       - name: Clippy
         run: |
           rustup component add clippy
-          cargo clippy --all-targets --all-features -- -D warnings
+          cargo clippy --workspace --exclude affine_server_native --all-targets --all-features -- -D warnings
+          cargo clippy -p affine_server_native --all-targets --all-features -- -D warnings
 
   check-git-status:
     name: Check Git Status
@@ -923,7 +924,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Run tests
-        run: cargo nextest run --release --no-fail-fast
+        run: cargo nextest run --workspace --exclude affine_server_native --features use-as-lib --release --no-fail-fast
 
   copilot-api-test:
     name: Server Copilot Api Test

--- a/packages/backend/native/index.d.ts
+++ b/packages/backend/native/index.d.ts
@@ -8,6 +8,11 @@ export const AFFINE_PRO_LICENSE_AES_KEY: string | undefined | null
 
 export const AFFINE_PRO_PUBLIC_KEY: string | undefined | null
 
+export interface Chunk {
+  index: number
+  content: string
+}
+
 export declare function fromModelName(modelName: string): Tokenizer | null
 
 export declare function getMime(input: Uint8Array): string
@@ -22,6 +27,11 @@ export declare function mergeUpdatesInApplyWay(updates: Array<Buffer>): Buffer
 
 export declare function mintChallengeResponse(resource: string, bits?: number | undefined | null): Promise<string>
 
-export declare function parseDoc(filePath: string, doc: Buffer): Promise<{ name: string, chunks: Array<{index: number, content: string}> }>
+export interface ParsedDoc {
+  name: string
+  chunks: Array<Chunk>
+}
+
+export declare function parseDoc(filePath: string, doc: Buffer): Promise<ParsedDoc>
 
 export declare function verifyChallengeResponse(response: string, bits: number, resource: string): Promise<boolean>

--- a/packages/frontend/apps/android/App/app/build.gradle
+++ b/packages/frontend/apps/android/App/app/build.gradle
@@ -136,6 +136,9 @@ dependencies {
 cargo {
     module = "../../../../mobile-native"
     libname = "affine_mobile_native"
+    features {
+        defaultAnd("use-as-lib")
+    }
     targets = ["arm64"]
     pythonCommand = "python3"
     targetDirectory = "../../../../../../target"

--- a/packages/frontend/apps/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/frontend/apps/ios/App/App.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios",
       "state" : {
-        "revision" : "51e535dcf5439c01396d668a9598748ea86c7c1a",
-        "version" : "1.20.0"
+        "revision" : "39fea7617346c0731be25f61afd537e7032fb562",
+        "version" : "1.22.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/ChidoriMenu",
       "state" : {
-        "revision" : "ccd37f01cd4dcf4fb0889f263573d90d5c16e59b",
-        "version" : "2.4.3"
+        "revision" : "3bb4323fe0f7f8f435d15656c3eeffcbb7c9c605",
+        "version" : "3.0.0"
       }
     },
     {
@@ -25,15 +25,6 @@
       "state" : {
         "revision" : "7f4df436eb78fe64fe2c32c58006e9949fa28ad8",
         "version" : "0.16.0"
-      }
-    },
-    {
-      "identity" : "sqlite.swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephencelis/SQLite.swift.git",
-      "state" : {
-        "revision" : "a95fc6df17d108bd99210db5e8a9bac90fe984b8",
-        "version" : "0.15.3"
       }
     },
     {
@@ -50,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {

--- a/packages/frontend/apps/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/packages/frontend/apps/ios/App/App.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "6ecc75281dab2fa231cb0d5fed3a3713826fecae",
-        "version" : "1.21.0"
+        "revision" : "39fea7617346c0731be25f61afd537e7032fb562",
+        "version" : "1.22.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Lakr233/ChidoriMenu",
       "state" : {
-        "revision" : "ccd37f01cd4dcf4fb0889f263573d90d5c16e59b",
-        "version" : "2.4.3"
+        "revision" : "3bb4323fe0f7f8f435d15656c3eeffcbb7c9c605",
+        "version" : "3.0.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
-        "version" : "1.1.4"
+        "revision" : "c1805596154bb3a265fd91b8ac0c4433b4348fb0",
+        "version" : "1.2.0"
       }
     },
     {

--- a/packages/frontend/apps/ios/App/Podfile.lock
+++ b/packages/frontend/apps/ios/App/Podfile.lock
@@ -45,13 +45,13 @@ EXTERNAL SOURCES:
     :path: "../../../../../node_modules/capacitor-plugin-app-tracking-transparency"
 
 SPEC CHECKSUMS:
-  Capacitor: 106e7a4205f4618d582b886a975657c61179138d
-  CapacitorApp: d63334c052278caf5d81585d80b21905c6f93f39
-  CapacitorBrowser: 081852cf532acf77b9d2953f3a88fe5b9711fb06
+  Capacitor: 03bc7cbdde6a629a8b910a9d7d78c3cc7ed09ea7
+  CapacitorApp: febecbb9582cb353aed037e18ec765141f880fe9
+  CapacitorBrowser: 6299776d496e968505464884d565992faa20444a
   CapacitorCordova: 5967b9ba03915ef1d585469d6e31f31dc49be96f
-  CapacitorHaptics: 70e47470fa1a6bd6338cd102552e3846b7f9a1b3
-  CapacitorKeyboard: 969647d0ca2e5c737d7300088e2517aa832434e2
-  CapacitorPluginAppTrackingTransparency: 2a2792623a5a72795f2e8f9ab3f1147573732fd8
+  CapacitorHaptics: 1f1e17041f435d8ead9ff2a34edd592c6aa6a8d6
+  CapacitorKeyboard: 09fd91dcde4f8a37313e7f11bde553ad1ed52036
+  CapacitorPluginAppTrackingTransparency: 92ae9c1cfb5cf477753db9269689332a686f675a
   CryptoSwift: 967f37cea5a3294d9cce358f78861652155be483
 
 PODFILE CHECKSUM: 2c1e4be82121f2d9724ecf7e31dd14e165aeb082

--- a/packages/frontend/apps/ios/App/xc-universal-binary.sh
+++ b/packages/frontend/apps/ios/App/xc-universal-binary.sh
@@ -47,20 +47,20 @@ for arch in $ARCHS; do
 
       # Intel iOS simulator
       export CFLAGS_x86_64_apple_ios="-target x86_64-apple-ios"
-      $HOME/.cargo/bin/cargo rustc -p "${FFI_TARGET}" --lib --crate-type staticlib --$RELFLAG --target x86_64-apple-ios
+      $HOME/.cargo/bin/cargo rustc -p "${FFI_TARGET}" --lib --crate-type staticlib --$RELFLAG --target x86_64-apple-ios --features use-as-lib
       ;;
 
     arm64)
       if [ $IS_SIMULATOR -eq 0 ]; then
         # Hardware iOS targets
-        $HOME/.cargo/bin/cargo rustc -p "${FFI_TARGET}" --lib --crate-type staticlib --$RELFLAG --target aarch64-apple-ios
+        $HOME/.cargo/bin/cargo rustc -p "${FFI_TARGET}" --lib --crate-type staticlib --$RELFLAG --target aarch64-apple-ios --features use-as-lib
         cp $SRC_ROOT/../../../target/aarch64-apple-ios/${RELFLAG}/lib${FFI_TARGET}.a $SRCROOT/lib${FFI_TARGET}.a
       else
         # M1 iOS simulator
-        $HOME/.cargo/bin/cargo rustc -p "${FFI_TARGET}" --lib --crate-type staticlib --$RELFLAG --target aarch64-apple-ios-sim
+        $HOME/.cargo/bin/cargo rustc -p "${FFI_TARGET}" --lib --crate-type staticlib --$RELFLAG --target aarch64-apple-ios-sim --features use-as-lib
         cp $SRC_ROOT/../../../target/aarch64-apple-ios-sim/${RELFLAG}/lib${FFI_TARGET}.a $SRCROOT/lib${FFI_TARGET}.a
       fi
   esac
 done
 
-$HOME/.cargo/bin/cargo run -p affine_mobile_native --bin uniffi-bindgen generate --library $SRCROOT/lib${FFI_TARGET}.a --language swift --out-dir $SRCROOT/../../ios/App/App/uniffi
+$HOME/.cargo/bin/cargo run -p affine_mobile_native --features use-as-lib --bin uniffi-bindgen generate --library $SRCROOT/lib${FFI_TARGET}.a --language swift --out-dir $SRCROOT/../../ios/App/App/uniffi

--- a/packages/frontend/apps/ios/codegen.ts
+++ b/packages/frontend/apps/ios/codegen.ts
@@ -17,14 +17,14 @@ execSync(
 
 console.log('[*] rust...');
 execSync(
-  'cargo build -p affine_mobile_native --lib --release --target aarch64-apple-ios',
+  'cargo build -p affine_mobile_native --features use-as-lib --lib --release --target aarch64-apple-ios',
   {
     stdio: 'inherit',
   }
 );
 
 execSync(
-  `cargo run -p affine_mobile_native --bin uniffi-bindgen generate \
+  `cargo run -p affine_mobile_native --features use-as-lib --bin uniffi-bindgen generate \
   --library ${ProjectRoot}/target/aarch64-apple-ios/release/libaffine_mobile_native.a \
   --language swift --out-dir ${PackageRoot}/App/App/uniffi`,
   { stdio: 'inherit' }

--- a/packages/frontend/mobile-native/Cargo.toml
+++ b/packages/frontend/mobile-native/Cargo.toml
@@ -11,9 +11,12 @@ crate-type = ["cdylib", "staticlib"]
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
+[features]
+use-as-lib = ["affine_nbstore/use-as-lib"]
+
 [dependencies]
 affine_common  = { workspace = true }
-affine_nbstore = { workspace = true, features = ["use-as-lib"] }
+affine_nbstore = { workspace = true }
 anyhow         = { workspace = true }
 base64-simd    = { workspace = true }
 chrono         = { workspace = true }


### PR DESCRIPTION
It would cause the napi-derive not work as expect in workspace level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling and type definitions for document parsing, resulting in clearer and more maintainable data structures.
- **Chores**
  - Introduced a new feature flag for mobile native builds, enabling conditional compilation for enhanced flexibility across Android and iOS.
  - Updated build scripts to support the new feature flag for both Android and iOS platforms.
  - Updated iOS app dependencies to newer versions, including Apollo iOS, ChidoriMenu, and swift-collections, and removed SQLite.swift.
- **Tests**
  - Enhanced Rust linting and testing workflows to run selectively across workspace packages with the new feature flag enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->