### PR TITLE
chore(server): auto rollback unapplied migrations fix

### DIFF
--- a/packages/backend/server/scripts/self-host-predeploy.js
+++ b/packages/backend/server/scripts/self-host-predeploy.js
@@ -61,10 +61,13 @@ function fixFailedMigrations() {
       });
       console.log(`migration [${migration}] has been rolled back.`);
     } catch (err) {
-      if (
-        err.message.includes(
-          'cannot be rolled back because it is not in a failed state'
-        )
+      if (err.message.includes(
+            'cannot be rolled back because it is not in a failed state'
+          )
+          ||
+          err.message.includes(
+            'cannot be rolled back because it was never applied'
+          )
       ) {
         // migration has been rolled back, skip it
         continue;


### PR DESCRIPTION
This will fix an error that may happen if prisma tries to rollback a migration that wasn't applied.
Fixes #12701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for database migrations to better manage cases where rollbacks are not applicable, reducing unnecessary errors during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->