### PR TITLE
fix(electron): revert back electron to v35

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@vitest/coverage-istanbul": "3.1.3",
     "@vitest/ui": "3.1.3",
     "cross-env": "^7.0.3",
-    "electron": "^36.0.0",
+    "electron": "^35.0.0",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",

--- a/packages/frontend/apps/electron/package.json
+++ b/packages/frontend/apps/electron/package.json
@@ -57,7 +57,7 @@
     "builder-util-runtime": "^9.2.10",
     "cross-env": "^7.0.3",
     "debug": "^4.4.0",
-    "electron": "^36.0.0",
+    "electron": "^35.0.0",
     "electron-log": "^5.2.4",
     "electron-squirrel-startup": "1.0.1",
     "electron-window-state": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -573,7 +573,7 @@ __metadata:
     builder-util-runtime: "npm:^9.2.10"
     cross-env: "npm:^7.0.3"
     debug: "npm:^4.4.0"
-    electron: "npm:^36.0.0"
+    electron: "npm:^35.0.0"
     electron-log: "npm:^5.2.4"
     electron-squirrel-startup: "npm:1.0.1"
     electron-updater: "npm:^6.3.9"
@@ -776,7 +776,7 @@ __metadata:
     "@vitest/coverage-istanbul": "npm:3.1.3"
     "@vitest/ui": "npm:3.1.3"
     cross-env: "npm:^7.0.3"
-    electron: "npm:^36.0.0"
+    electron: "npm:^35.0.0"
     eslint: "npm:^9.16.0"
     eslint-config-prettier: "npm:^10.0.0"
     eslint-import-resolver-typescript: "npm:^4.0.0"
@@ -20595,16 +20595,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^36.0.0":
-  version: 36.2.1
-  resolution: "electron@npm:36.2.1"
+"electron@npm:^35.0.0":
+  version: 35.5.1
+  resolution: "electron@npm:35.5.1"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/2dbcac9208c6a513b75ef92a969441407e44fb11377a3d831d3e043d3c5e1bf927badc475a490b554e6007995f1a28db9d833044202d21d629bb84587745dbf7
+  checksum: 10/765752c94c3bea799f62fb0a75049a10452ff97e791a96111f36b97293ffed9240b27dbc083c01f7a2c7172e84b6b394b07c9aaf91d57783958b2adb4e570579
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
v36 breaks worker loading in Electron's renderer
this use to work by turning off "PlzDedicatedWorker"
related to https://github.com/electron/electron/issues/43556

Before we know the root cause, revert back the electron version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Downgraded the Electron version used in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->