### PR TITLE
fix(editor): support copying single image from edgeless and pasting to page

### DIFF
--- a/blocksuite/affine/blocks/embed/src/embed-html-block/components/fullscreen-toolbar.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-html-block/components/fullscreen-toolbar.ts
@@ -107,10 +107,10 @@ export class EmbedHtmlFullscreenToolbar extends LitElement {
     if (this._copied) return;
 
     this.embedHtml.std.clipboard
-      .writeToClipboard(items => {
-        items['text/plain'] = this.embedHtml.model.props.html ?? '';
-        return items;
-      })
+      .writeToClipboard(items => ({
+        ...items,
+        'text/plain': this.embedHtml.model.props.html ?? '',
+      }))
       .then(() => {
         this._copied = true;
         setTimeout(() => (this._copied = false), 1500);

--- a/blocksuite/affine/blocks/image/src/utils.ts
+++ b/blocksuite/affine/blocks/image/src/utils.ts
@@ -11,6 +11,7 @@ import {
   NativeClipboardProvider,
 } from '@blocksuite/affine-shared/services';
 import {
+  convertToPng,
   formatSize,
   getBlockProps,
   isInsidePageEditor,
@@ -109,28 +110,6 @@ export async function resetImageSize(
   const props: Partial<ImageBlockProps> = { ...imageSize, xywh };
 
   block.store.updateBlock(model, props);
-}
-
-function convertToPng(blob: Blob): Promise<Blob | null> {
-  return new Promise(resolve => {
-    const reader = new FileReader();
-    reader.addEventListener('load', _ => {
-      const img = new Image();
-      img.onload = () => {
-        const c = document.createElement('canvas');
-        c.width = img.width;
-        c.height = img.height;
-        const ctx = c.getContext('2d');
-        if (!ctx) return;
-        ctx.drawImage(img, 0, 0);
-        c.toBlob(resolve, 'image/png');
-      };
-      img.onerror = () => resolve(null);
-      img.src = reader.result as string;
-    });
-    reader.addEventListener('error', () => resolve(null));
-    reader.readAsDataURL(blob);
-  });
 }
 
 export async function copyImageBlob(

--- a/blocksuite/affine/shared/src/utils/image.ts
+++ b/blocksuite/affine/shared/src/utils/image.ts
@@ -26,3 +26,34 @@ export function readImageSize(file: File | Blob) {
     img.src = sanitizedURL;
   });
 }
+
+export function convertToPng(blob: Blob): Promise<Blob | null> {
+  return new Promise(resolve => {
+    const reader = new FileReader();
+
+    reader.addEventListener('load', _ => {
+      const img = new Image();
+
+      img.onload = () => {
+        const c = document.createElement('canvas');
+        c.width = img.width;
+        c.height = img.height;
+        const ctx = c.getContext('2d');
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(img, 0, 0);
+        c.toBlob(resolve, 'image/png');
+      };
+
+      img.onerror = () => resolve(null);
+
+      img.src = reader.result as string;
+    });
+
+    reader.addEventListener('error', () => resolve(null));
+
+    reader.readAsDataURL(blob);
+  });
+}

--- a/packages/frontend/core/src/utils/clipboard/index.ts
+++ b/packages/frontend/core/src/utils/clipboard/index.ts
@@ -34,12 +34,12 @@ export const copyLinkToBlockStdScopeClipboard = async (
 
   if (clipboardWriteIsSupported) {
     try {
-      await clipboard.writeToClipboard(items => {
-        items['text/plain'] = text;
+      await clipboard.writeToClipboard(items => ({
+        ...items,
+        'text/plain': text,
         // wrap a link
-        items['text/html'] = `<a href="${text}">${text}</a>`;
-        return items;
-      });
+        'text/html': `<a href="${text}">${text}</a>`,
+      }));
       success = true;
     } catch (error) {
       console.error(error);


### PR DESCRIPTION
Closes: [BS-3586](https://linear.app/affine-design/issue/BS-3586/复制白板图片，然后粘贴到-page，图片失败)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Copying a single selected image in edgeless mode now places the image directly onto the system clipboard as a native image blob for smoother pasting.

- **Bug Fixes**
  - Enhanced clipboard handling to better manage image and text data inclusion, with improved fallback for snapshot HTML.

- **Tests**
  - Added an end-to-end test verifying image copy-paste functionality between edgeless and page editor modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->