### PR TITLE
chore(server): disable indexer by default

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -886,8 +886,8 @@
       "properties": {
         "enabled": {
           "type": "boolean",
-          "description": "Enable indexer plugin\n@default true\n@environment `AFFINE_INDEXER_ENABLED`",
-          "default": true
+          "description": "Enable indexer plugin\n@default false\n@environment `AFFINE_INDEXER_ENABLED`",
+          "default": false
         },
         "provider.type": {
           "type": "string",

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,6 +20,7 @@ env:
   COVERAGE: true
   MACOSX_DEPLOYMENT_TARGET: '10.13'
   DEPLOYMENT_TYPE: affine
+  AFFINE_INDEXER_ENABLED: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/packages/backend/server/.env.example
+++ b/packages/backend/server/.env.example
@@ -10,3 +10,5 @@
 # MAILER_USER="noreply@toeverything.info"
 # MAILER_PASSWORD="affine"
 # MAILER_SECURE=false
+
+# AFFINE_INDEXER_ENABLED=true

--- a/packages/backend/server/src/plugins/indexer/__tests__/event.spec.ts
+++ b/packages/backend/server/src/plugins/indexer/__tests__/event.spec.ts
@@ -3,11 +3,19 @@ import Sinon from 'sinon';
 
 import { createModule } from '../../../__tests__/create-module';
 import { Config } from '../../../base';
+import { ConfigModule } from '../../../base/config';
 import { IndexerModule } from '..';
 import { IndexerEvent } from '../event';
 
 const module = await createModule({
-  imports: [IndexerModule],
+  imports: [
+    IndexerModule,
+    ConfigModule.override({
+      indexer: {
+        enabled: true,
+      },
+    }),
+  ],
 });
 const indexerEvent = module.get(IndexerEvent);
 const config = module.get(Config);

--- a/packages/backend/server/src/plugins/indexer/__tests__/job.spec.ts
+++ b/packages/backend/server/src/plugins/indexer/__tests__/job.spec.ts
@@ -7,6 +7,7 @@ import Sinon from 'sinon';
 import { createModule } from '../../../__tests__/create-module';
 import { Mockers } from '../../../__tests__/mocks';
 import { JOB_SIGNAL } from '../../../base';
+import { ConfigModule } from '../../../base/config';
 import { ServerConfigModule } from '../../../core/config';
 import { Models } from '../../../models';
 import { IndexerModule, IndexerService } from '..';
@@ -15,7 +16,15 @@ import { IndexerJob } from '../job';
 import { ManticoresearchProvider } from '../providers';
 
 const module = await createModule({
-  imports: [IndexerModule, ServerConfigModule],
+  imports: [
+    IndexerModule,
+    ServerConfigModule,
+    ConfigModule.override({
+      indexer: {
+        enabled: true,
+      },
+    }),
+  ],
   providers: [IndexerService],
 });
 const indexerService = module.get(IndexerService);

--- a/packages/backend/server/src/plugins/indexer/__tests__/providers/elasticsearch.spec.ts
+++ b/packages/backend/server/src/plugins/indexer/__tests__/providers/elasticsearch.spec.ts
@@ -33,6 +33,7 @@ _test.before(async () => {
       IndexerModule,
       ConfigModule.override({
         indexer: {
+          enabled: true,
           provider: {
             type: SearchProviderType.Elasticsearch,
             endpoint: 'http://localhost:9200',

--- a/packages/backend/server/src/plugins/indexer/__tests__/providers/manticoresearch.spec.ts
+++ b/packages/backend/server/src/plugins/indexer/__tests__/providers/manticoresearch.spec.ts
@@ -18,6 +18,7 @@ const module = await createModule({
     IndexerModule,
     ConfigModule.override({
       indexer: {
+        enabled: true,
         provider: {
           type: SearchProviderType.Manticoresearch,
           endpoint: 'http://localhost:9308',

--- a/packages/backend/server/src/plugins/indexer/__tests__/service.spec.ts
+++ b/packages/backend/server/src/plugins/indexer/__tests__/service.spec.ts
@@ -6,6 +6,7 @@ import { omit, pick } from 'lodash-es';
 
 import { createModule } from '../../../__tests__/create-module';
 import { Mockers } from '../../../__tests__/mocks';
+import { ConfigModule } from '../../../base/config';
 import { ServerConfigModule } from '../../../core/config';
 import { IndexerModule, IndexerService } from '..';
 import { SearchProviderFactory } from '../factory';
@@ -20,7 +21,15 @@ import {
 } from '../types';
 
 const module = await createModule({
-  imports: [IndexerModule, ServerConfigModule],
+  imports: [
+    IndexerModule,
+    ServerConfigModule,
+    ConfigModule.override({
+      indexer: {
+        enabled: true,
+      },
+    }),
+  ],
   providers: [IndexerService],
 });
 const indexerService = module.get(IndexerService);

--- a/packages/backend/server/src/plugins/indexer/config.ts
+++ b/packages/backend/server/src/plugins/indexer/config.ts
@@ -30,7 +30,7 @@ declare global {
 defineModuleConfig('indexer', {
   enabled: {
     desc: 'Enable indexer plugin',
-    default: true,
+    default: false,
     env: ['AFFINE_INDEXER_ENABLED', 'boolean'],
   },
   'provider.type': {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the default setting for the indexer feature to be disabled by default.
	- Added a sample environment variable for enabling the indexer in the example configuration file.
	- Introduced a new environment variable for the indexer in the CI workflow configuration.
- **Tests**
	- Adjusted test configurations to explicitly enable the indexer feature during test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->