### PR TITLE
fix(electron): web dev server ws does not work for electron renderer

### DIFF
--- a/tools/cli/src/bundle.ts
+++ b/tools/cli/src/bundle.ts
@@ -111,7 +111,7 @@ const defaultDevServerConfig: DevServerConfiguration = {
     overlay: process.env.DISABLE_DEV_OVERLAY === 'true' ? false : undefined,
     logging: process.env.CI ? 'none' : 'error',
     // see: https://webpack.js.org/configuration/dev-server/#websocketurl
-    webSocketURL: 'auto://0.0.0.0:0/ws',
+    webSocketURL: 'auto://0.0.0.0:8080/ws',
   },
   historyApiFallback: {
     rewrites: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default WebSocket connection settings for the development server to use port 8080.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->