### PR TITLE
chore: adjust general access button styles

### DIFF
--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/general-access/styles.css.ts
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/general-access/styles.css.ts
@@ -21,6 +21,9 @@ export const menuTriggerStyle = style({
 });
 export const menuTriggerText = style({
   margin: '0px 4px',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '4px',
 });
 export const suffixClassName = style({
   width: '20px',


### PR DESCRIPTION
close AF-2685

When the button is disabled, the frontmost icon is not positioned correctly. This commit is to fix the icon position.

![CleanShot 2025-06-05 at 12 38 55@2x](https://github.com/user-attachments/assets/af2f80bc-69a0-4e33-bc8f-e5e169f769fc)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **Style**
  - Improved the layout of the share menu trigger text by aligning its content vertically and adding spacing between elements for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->