### PR TITLE
fix: memory leak due to missing unsubscribe

### DIFF
--- a/blocksuite/affine/widgets/toolbar/src/toolbar.ts
+++ b/blocksuite/affine/widgets/toolbar/src/toolbar.ts
@@ -536,9 +536,7 @@ export class AffineToolbarWidget extends WidgetComponent {
           );
         });
 
-        return () => {
-          subscription.unsubscribe();
-        };
+        disposables.add(subscription);
       })
     );
 

--- a/packages/common/infra/src/livedata/livedata.ts
+++ b/packages/common/infra/src/livedata/livedata.ts
@@ -250,6 +250,9 @@ export class LiveData<T = unknown>
   private isPoisoned = false;
   private poisonedError: PoisonedError | null = null;
 
+  private _signal: Signal<T> | undefined;
+  private _signalSubscription: Subscription | undefined;
+
   constructor(
     initialValue: T,
     upstream:
@@ -302,12 +305,10 @@ export class LiveData<T = unknown>
     this.next(v);
   }
 
-  private _signal: Signal<T> | undefined;
-
   get signal(): ReadonlySignal<T> {
     if (!this._signal) {
       this._signal = signal(this.value);
-      this.subscribe(v => {
+      this._signalSubscription = this.subscribe(v => {
         // oxlint-disable-next-line no-non-null-assertion
         this._signal!.value = v;
       });
@@ -464,6 +465,7 @@ export class LiveData<T = unknown>
     this.ops$.complete();
     this.raw$.complete();
     this.upstreamSubscription?.unsubscribe();
+    this._signalSubscription?.unsubscribe();
   }
 
   /**


### PR DESCRIPTION
- unsubscribe `Signal` not correctly
- missing un-subscription for `Livedata.signal`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource management to ensure subscriptions are properly cleaned up, reducing potential memory leaks and improving overall app stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->