### PR TITLE
fix(server): increase doc-service liveness probe timeout from 1s to 5s

### DIFF
--- a/.github/helm/affine/charts/doc/templates/deployment.yaml
+++ b/.github/helm/affine/charts/doc/templates/deployment.yaml
@@ -95,11 +95,13 @@ spec:
               path: /info
               port: http
             initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.probe.timeoutSeconds }}
           readinessProbe:
             httpGet:
               path: /info
               port: http
             initialDelaySeconds: {{ .Values.probe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.probe.timeoutSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/.github/helm/affine/charts/doc/values.yaml
+++ b/.github/helm/affine/charts/doc/values.yaml
@@ -36,6 +36,7 @@ resources:
 
 probe:
   initialDelaySeconds: 20
+  timeoutSeconds: 5
 
 nodeSelector: {}
 tolerations: []


### PR DESCRIPTION
yjs operations may take more than 1 second

before
![image](https://github.com/user-attachments/assets/feb7e375-ea73-4f5f-84f2-d85934f94844)

after
![image](https://github.com/user-attachments/assets/e760ee1f-a1c6-4f9d-8dbc-a4796efbd77a)


#### PR Dependency Tree


* **PR #12804** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable timeout settings for liveness and readiness probes in Helm chart deployments, allowing users to specify probe timeout duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->