### PR TITLE
fix(server): use Query instead of Args

### DIFF
--- a/packages/backend/server/src/core/doc-service/__tests__/controller.spec.ts
+++ b/packages/backend/server/src/core/doc-service/__tests__/controller.spec.ts
@@ -36,6 +36,10 @@ test.beforeEach(async t => {
   workspace = await t.context.models.workspace.create(user.id);
 });
 
+test.afterEach.always(async () => {
+  mock.reset();
+});
+
 test.after.always(async t => {
   await t.context.app.close();
 });
@@ -176,6 +180,15 @@ test('should get doc content in json format', async t => {
       summary: 'test summary',
     })
     .expect(200);
+
+  await app
+    .GET(`/rpc/workspaces/${workspace.id}/docs/${docId}/content?full=false`)
+    .set('x-access-token', t.context.crypto.sign(docId))
+    .expect({
+      title: 'test title',
+      summary: 'test summary',
+    })
+    .expect(200);
   t.pass();
 });
 
@@ -184,7 +197,7 @@ test('should get full doc content in json format', async t => {
   mock.method(t.context.databaseDocReader, 'getFullDocContent', async () => {
     return {
       title: 'test title',
-      summary: 'test summary',
+      summary: 'test summary full',
     };
   });
 
@@ -194,7 +207,7 @@ test('should get full doc content in json format', async t => {
     .set('x-access-token', t.context.crypto.sign(docId))
     .expect({
       title: 'test title',
-      summary: 'test summary',
+      summary: 'test summary full',
     })
     .expect(200);
   t.pass();

--- a/packages/backend/server/src/core/doc-service/controller.ts
+++ b/packages/backend/server/src/core/doc-service/controller.ts
@@ -4,10 +4,10 @@ import {
   Logger,
   Param,
   Post,
+  Query,
   RawBody,
   Res,
 } from '@nestjs/common';
-import { Args } from '@nestjs/graphql';
 import type { Response } from 'express';
 
 import { NotFound, SkipThrottle } from '../../base';
@@ -78,11 +78,12 @@ export class DocRpcController {
   async getDocContent(
     @Param('workspaceId') workspaceId: string,
     @Param('docId') docId: string,
-    @Args('full', { nullable: true }) fullContent?: boolean
+    @Query('full') fullContent?: string
   ) {
-    const content = fullContent
-      ? await this.docReader.getFullDocContent(workspaceId, docId)
-      : await this.docReader.getDocContent(workspaceId, docId);
+    const content =
+      fullContent === 'true'
+        ? await this.docReader.getFullDocContent(workspaceId, docId)
+        : await this.docReader.getDocContent(workspaceId, docId);
     if (!content) {
       throw new NotFound('Doc not found');
     }


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #12813** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of the "full" query parameter when retrieving document content, ensuring correct responses based on the parameter value.

- **Tests**
  - Enhanced test coverage for document content retrieval, including scenarios with and without the "full" query parameter to ensure consistent and accurate responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->