### PR TITLE
fix(server): should save end date of subscription in db

### DIFF
--- a/packages/backend/server/src/plugins/payment/manager/selfhost.ts
+++ b/packages/backend/server/src/plugins/payment/manager/selfhost.ts
@@ -158,6 +158,7 @@ export class SelfhostTeamSubscriptionManager extends SubscriptionManager {
           'stripeScheduleId',
           'nextBillAt',
           'canceledAt',
+          'end',
         ]),
       });
     }

--- a/packages/backend/server/src/plugins/payment/manager/user.ts
+++ b/packages/backend/server/src/plugins/payment/manager/user.ts
@@ -243,6 +243,7 @@ export class UserSubscriptionManager extends SubscriptionManager {
         'stripeScheduleId',
         'nextBillAt',
         'canceledAt',
+        'end',
       ]),
       create: {
         targetId: userId,

--- a/packages/backend/server/src/plugins/payment/manager/workspace.ts
+++ b/packages/backend/server/src/plugins/payment/manager/workspace.ts
@@ -166,6 +166,7 @@ export class WorkspaceSubscriptionManager extends SubscriptionManager {
           'nextBillAt',
           'canceledAt',
           'quantity',
+          'end',
         ]),
       },
       create: {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Subscription end dates are now correctly saved and updated for Stripe subscriptions, ensuring accurate display and management of subscription periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->