### PR TITLE
fix(editor): filterableList - prevent undefined item selection in keyboard nav

### DIFF
--- a/blocksuite/affine/components/src/filterable-list/index.ts
+++ b/blocksuite/affine/components/src/filterable-list/index.ts
@@ -111,6 +111,7 @@ export class FilterableListComponent<Props = unknown> extends WithDisposable(
           if (ev.isComposing) break;
           ev.preventDefault();
           const item = filteredItems[this._curFocusIndex];
+          if (!item) return;
           this._select(item);
           break;
         }


### PR DESCRIPTION
Fixes error in FilterableList when pressing Enter on empty search results.

![image](https://github.com/user-attachments/assets/3929c7ab-b20e-40d9-bc3d-808762ada8f3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where pressing Enter could cause errors if no item was focused in filterable lists. Now, selection only occurs when a valid item is focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->