### PR TITLE
chore: disable code block html preview

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -280,7 +280,7 @@ export const AFFINE_FLAGS = {
     description:
       'com.affine.settings.workspace.experimental-features.enable-code-block-html-preview.description',
     configurable: isCanaryBuild,
-    defaultState: false,
+    defaultState: isCanaryBuild,
   },
   enable_adapter_panel: {
     category: 'affine',

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -280,7 +280,7 @@ export const AFFINE_FLAGS = {
     description:
       'com.affine.settings.workspace.experimental-features.enable-code-block-html-preview.description',
     configurable: isCanaryBuild,
-    defaultState: true,
+    defaultState: false,
   },
   enable_adapter_panel: {
     category: 'affine',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default setting for the code block HTML preview feature flag; it is now enabled only in experimental (canary) builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->