### PR TITLE
chore(editor): disable html preview due to security issues

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -280,7 +280,8 @@ export const AFFINE_FLAGS = {
     description:
       'com.affine.settings.workspace.experimental-features.enable-code-block-html-preview.description',
     configurable: isCanaryBuild,
-    defaultState: true,
+    // Disabled due to security issues
+    defaultState: false,
   },
   enable_adapter_panel: {
     category: 'affine',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the default setting for the code block HTML preview feature flag to be disabled by default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->