### PR TITLE
fix(editor): unexpectedly update edgeless note in readonly mode

### DIFF
--- a/blocksuite/affine/blocks/note/src/components/edgeless-note-mask.ts
+++ b/blocksuite/affine/blocks/note/src/components/edgeless-note-mask.ts
@@ -14,6 +14,7 @@ export class EdgelessNoteMask extends SignalWatcher(
   protected override firstUpdated() {
     const maskDOM = this.renderRoot!.querySelector('.affine-note-mask');
     const observer = new ResizeObserver(entries => {
+      if (this.model.store.readonly) return;
       for (const entry of entries) {
         if (!this.model.props.edgeless.collapse) {
           const bound = Bound.deserialize(this.model.xywh);


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #12839** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Prevented updates to note sizing during resize events when in readonly mode, ensuring consistent behavior for read-only notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->