### PR TITLE
feat(core): allow importing affine file within import dialog

### DIFF
--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -2412,6 +2412,14 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.import.snapshot.tooltip"](): string;
     /**
+      * `.affine file`
+      */
+    ["com.affine.import.dotaffinefile"](): string;
+    /**
+      * `Import your AFFiNE db file (.affine)`
+      */
+    ["com.affine.import.dotaffinefile.tooltip"](): string;
+    /**
       * `Import failed, please try again.`
       */
     ["com.affine.import.status.failed.message"](): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -602,6 +602,8 @@
   "com.affine.import.notion.tooltip": "Import your Notion data. Supported import formats: HTML with subpages.",
   "com.affine.import.snapshot": "Snapshot",
   "com.affine.import.snapshot.tooltip": "Import your AFFiNE workspace and page snapshot file.",
+  "com.affine.import.dotaffinefile": ".affine file",
+  "com.affine.import.dotaffinefile.tooltip": "Import your AFFiNE db file (.affine)",
   "com.affine.import.status.failed.message": "Import failed, please try again.",
   "com.affine.import.status.failed.message.no-file-selected": "No file selected",
   "com.affine.import.status.failed.title": "Import failure",


### PR DESCRIPTION
fix AF-2693

#### PR Dependency Tree


* **PR #12850** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for importing AFFiNE database files (.affine) through a new import option in the import dialog (Electron only).
  - Introduced a dedicated workflow and dialog for importing workspace files, with smooth navigation to the imported workspace.

- **Localization**
  - Added new English language entries and tooltips for the AFFiNE file import option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->