### PR TITLE
fix(server): don't use global AFFiNELogger

### DIFF
--- a/packages/backend/server/src/plugins/copilot/embedding/job.ts
+++ b/packages/backend/server/src/plugins/copilot/embedding/job.ts
@@ -1,8 +1,7 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 
 import {
-  AFFiNELogger,
   BlobNotFound,
   CallMetric,
   CopilotContextFileNotSupported,
@@ -22,6 +21,7 @@ import { EMBEDDING_DIMENSIONS, EmbeddingClient } from './types';
 
 @Injectable()
 export class CopilotEmbeddingJob {
+  private readonly logger = new Logger(CopilotEmbeddingJob.name);
   private readonly workspaceJobAbortController: Map<string, AbortController> =
     new Map();
 
@@ -32,13 +32,10 @@ export class CopilotEmbeddingJob {
     private readonly moduleRef: ModuleRef,
     private readonly doc: DocReader,
     private readonly event: EventBus,
-    private readonly logger: AFFiNELogger,
     private readonly models: Models,
     private readonly queue: JobQueue,
     private readonly storage: CopilotStorage
-  ) {
-    this.logger.setContext(CopilotEmbeddingJob.name);
-  }
+  ) {}
 
   @OnEvent('config.init')
   async onConfigInit() {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0e5d313f-e72b-436b-9f13-9f0a1cff8685)

#### PR Dependency Tree


* **PR #12871** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal logging mechanism to use a standard logger, resulting in a simplified and more consistent logging approach. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


#### PR Dependency Tree


* **PR #12871** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)