### PR TITLE
fix(mobile): change mobile docs display config and prevent opening doc when close menu

### DIFF
--- a/packages/frontend/core/src/mobile/pages/workspace/all.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/all.tsx
@@ -15,8 +15,13 @@ import { AllDocsHeader } from '../../views';
 const AllDocs = () => {
   const [explorerContextValue] = useState(() =>
     createDocExplorerContext({
-      quickFavorite: true,
-      displayProperties: ['createdAt', 'updatedAt', 'tags'],
+      quickFavorite: false,
+      showDocIcon: false,
+      displayProperties: [
+        'system:createdAt',
+        'system:updatedAt',
+        'system:tags',
+      ],
       view: 'masonry',
       showDragHandle: false,
       groupBy: undefined,

--- a/packages/frontend/core/src/modules/workbench/view/workbench-link.tsx
+++ b/packages/frontend/core/src/modules/workbench/view/workbench-link.tsx
@@ -61,6 +61,11 @@ export const WorkbenchLink = forwardRef<HTMLAnchorElement, WorkbenchLinkProps>(
     const link = basename + stringTo;
     const handleClick = useAsyncCallback(
       async (event: React.MouseEvent<HTMLAnchorElement>) => {
+        // a trick to prevent click from modal overlay propagation
+        if (!event.currentTarget.contains(event.target as Node)) {
+          return;
+        }
+
         onClick?.(event);
         if (event.defaultPrevented) {
           return;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated document explorer to hide quick favorite and document icons, and display more detailed system properties for each document.
  - Enhanced link behavior in the workbench to prevent unintended clicks from triggering navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->