### PR TITLE
fix(server): should check doc public attribute when snapshot not exists

### DIFF
--- a/packages/backend/server/src/core/workspaces/resolvers/doc.ts
+++ b/packages/backend/server/src/core/workspaces/resolvers/doc.ts
@@ -304,11 +304,13 @@ export class WorkspaceDocResolver {
 
     await this.tryFixDocOwner(workspace.id, docId);
 
+    const isPublic = await this.models.doc.isPublic(workspace.id, docId);
+
     return {
       docId,
       workspaceId: workspace.id,
       mode: PublicDocMode.Page,
-      public: false,
+      public: isPublic,
       defaultRole: DocRole.Manager,
     };
   }


### PR DESCRIPTION
close CLOUD-232



#### PR Dependency Tree


* **PR #12913** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The visibility status of documents now accurately reflects their public status instead of always showing as private.
- **Tests**
  - Added an end-to-end test to verify correct handling of the public attribute for documents without snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->