### PR TITLE
fix(core): adjust workspace selector style in import page

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/import-template/dialog.css.ts
+++ b/packages/frontend/core/src/desktop/dialogs/import-template/dialog.css.ts
@@ -44,5 +44,5 @@ export const workspaceSelector = style({
   margin: '0 -16px',
   width: 'calc(100% + 32px)',
   border: `1px solid ${cssVarV2('layer/insideBorder/border')}`,
-  padding: '0 16px',
+  padding: '6px',
 });

--- a/packages/frontend/core/src/desktop/pages/import-clipper/style.css.ts
+++ b/packages/frontend/core/src/desktop/pages/import-clipper/style.css.ts
@@ -10,6 +10,7 @@ export const container = style({
   margin: '0 auto',
   color: cssVarV2('text/primary'),
   padding: '16px',
+  height: 'calc(100% - 48px)',
 });
 
 export const authHeader = style({
@@ -47,8 +48,7 @@ export const mainButton = style({
 });
 
 export const workspaceSelector = style({
-  margin: '0 -16px',
-  width: 'calc(100% + 32px)',
+  width: '100%',
   border: `1px solid ${cssVarV2('layer/insideBorder/border')}`,
-  padding: '0 16px',
+  padding: 6,
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated padding for workspace selector elements to provide a more uniform appearance.
  - Adjusted container height and workspace selector width for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->