### PR TITLE
fix(editor): improve performence of link card render

### DIFF
--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -495,14 +495,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
 
     const linkedDoc = this.linkedDoc;
     if (linkedDoc) {
-      this.disposables.add(
-        linkedDoc.workspace.slots.docListUpdated.subscribe(() => {
-          this._load().catch(e => {
-            console.error(e);
-            this.isError = true;
-          });
-        })
-      );
       // Should throttle the blockUpdated event to avoid too many re-renders
       // Because the blockUpdated event is triggered too frequently at some cases
       this.disposables.add(


### PR DESCRIPTION
Close [BS-3097](https://linear.app/affine-design/issue/BS-3607/linkdoccard-重复渲染导致卡顿)

![CleanShot 2025-06-26 at 14 58 54](https://github.com/user-attachments/assets/2787f88b-3596-4a34-a9a8-91966b83418d)


#### PR Dependency Tree


* **PR #12937** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the handling of updates for embedded linked documents, reducing unnecessary reloads when the document list changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->