### PR TITLE
fix(server): allow fork empty session in playground

### DIFF
--- a/packages/backend/server/src/models/copilot-session.ts
+++ b/packages/backend/server/src/models/copilot-session.ts
@@ -188,11 +188,6 @@ export class CopilotSessionModel extends BaseModel {
 
   @Transactional()
   async fork(options: ForkSessionOptions): Promise<string> {
-    if (!options.messages?.length) {
-      throw new CopilotSessionInvalidInput(
-        'Cannot fork session without messages'
-      );
-    }
     if (options.pinned) {
       await this.unpin(options.workspaceId, options.userId);
     }
@@ -203,12 +198,15 @@ export class CopilotSessionModel extends BaseModel {
       ...forkedState,
       messages: [],
     });
-    // save message
-    await this.models.copilotSession.updateMessages({
-      ...forkedState,
-      sessionId,
-      messages,
-    });
+    if (options.messages.length) {
+      // save message
+      await this.models.copilotSession.updateMessages({
+        ...forkedState,
+        sessionId,
+        messages,
+      });
+    }
+
     return sessionId;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session forking by allowing sessions to be forked even when no messages are provided, preventing unnecessary errors.
  * Reduced unnecessary database operations by only updating messages when there are messages to update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->