### PR TITLE
feat(server): support multiple hosts in one deployment

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -540,6 +540,11 @@
           "description": "Where the server get deployed(FQDN).\n@default \"localhost\"\n@environment `AFFINE_SERVER_HOST`",
           "default": "localhost"
         },
+        "hosts": {
+          "type": "array",
+          "description": "Multiple hosts the server will accept requests from.\n@default []",
+          "default": []
+        },
         "port": {
           "type": "number",
           "description": "Which port the server will listen on.\n@default 3010\n@environment `AFFINE_SERVER_PORT`",

--- a/.github/helm/affine/templates/ingress.yaml
+++ b/.github/helm/affine/templates/ingress.yaml
@@ -36,7 +36,8 @@ spec:
     {{- end }}
   {{- end }}
   rules:
-    - host: "{{ .Values.global.ingress.host }}"
+    {{- range .Values.global.ingress.hosts }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: /socket.io
@@ -45,33 +46,34 @@ spec:
               service:
                 name: affine-sync
                 port:
-                  number: {{ .Values.sync.service.port }}
+                  number: {{ $.Values.sync.service.port }}
           - path: /graphql
             pathType: Prefix
             backend:
               service:
                 name: affine-graphql
                 port:
-                  number: {{ .Values.graphql.service.port }}
+                  number: {{ $.Values.graphql.service.port }}
           - path: /api
             pathType: Prefix
             backend:
               service:
                 name: affine-graphql
                 port:
-                  number: {{ .Values.graphql.service.port }}
+                  number: {{ $.Values.graphql.service.port }}
           - path: /workspace
             pathType: Prefix
             backend:
               service:
                 name: affine-renderer
                 port:
-                  number: {{ .Values.renderer.service.port }}
+                  number: {{ $.Values.renderer.service.port }}
           - path: /
             pathType: Prefix
             backend:
               service:
                 name: affine-web
                 port:
-                  number: {{ .Values.web.service.port }}
+                  number: {{ $.Values.web.service.port }}
+    {{- end }}
 {{- end }}

--- a/.github/helm/affine/values.yaml
+++ b/.github/helm/affine/values.yaml
@@ -4,7 +4,13 @@ global:
   ingress:
     enabled: false
     className: ''
-    host: affine.pro
+    # hosts for ingress rules
+    # e.g.
+    # hosts:
+    #  - affine.pro
+    #  - www.affine.pro
+    hosts:
+      - affine.pro
     tls: []
   secret:
     secretName: 'server-private-key'

--- a/blocksuite/affine/blocks/embed/src/embed-iframe-block/configs/providers/generic.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-iframe-block/configs/providers/generic.ts
@@ -15,6 +15,7 @@ const AFFINE_DOMAINS = [
   'insider.affine.pro', // Beta/internal cloud domain
   'affine.fail', // Canary cloud domain
   'toeverything.app', // Safety measure for potential future use
+  'apple.getaffineapp.com', // Cloud domain for Apple app
 ];
 
 /**

--- a/packages/backend/server/src/app.module.ts
+++ b/packages/backend/server/src/app.module.ts
@@ -8,6 +8,7 @@ import { ClsModule } from 'nestjs-cls';
 
 import { AppController } from './app.controller';
 import {
+  getRequestFromHost,
   getRequestIdFromHost,
   getRequestIdFromRequest,
   ScannerModule,
@@ -66,8 +67,9 @@ export const FunctionalityModules = [
         // make every request has a unique id to tracing
         return getRequestIdFromRequest(req, 'http');
       },
-      setup(cls, _req, res: Response) {
+      setup(cls, req: Request, res: Response) {
         res.setHeader('X-Request-Id', cls.getId());
+        cls.set(CLS_REQUEST_HOST, req.hostname);
       },
     },
     // for websocket connection
@@ -78,6 +80,10 @@ export const FunctionalityModules = [
       idGenerator(context: ExecutionContext) {
         // make every request has a unique id to tracing
         return getRequestIdFromHost(context);
+      },
+      setup(cls, context: ExecutionContext) {
+        const req = getRequestFromHost(context);
+        cls.set(CLS_REQUEST_HOST, req.hostname);
       },
     },
     plugins: [

--- a/packages/backend/server/src/base/helpers/__tests__/url.spec.ts
+++ b/packages/backend/server/src/base/helpers/__tests__/url.spec.ts
@@ -12,6 +12,7 @@ test.beforeEach(async t => {
     server: {
       externalUrl: '',
       host: 'app.affine.local',
+      hosts: [],
       port: 3010,
       https: true,
       path: '',
@@ -28,6 +29,7 @@ test('can factor base url correctly with specified external url', t => {
     server: {
       externalUrl: 'https://external.domain.com',
       host: 'app.affine.local',
+      hosts: [],
       port: 3010,
       https: true,
       path: '/ignored',
@@ -42,6 +44,7 @@ test('can factor base url correctly with specified external url and path', t => 
     server: {
       externalUrl: 'https://external.domain.com/anything',
       host: 'app.affine.local',
+      hosts: [],
       port: 3010,
       https: true,
       path: '/ignored',
@@ -56,6 +59,7 @@ test('can factor base url correctly with specified external url with port', t =>
     server: {
       externalUrl: 'https://external.domain.com:123',
       host: 'app.affine.local',
+      hosts: [],
       port: 3010,
       https: true,
     },
@@ -95,7 +99,7 @@ test('can safe redirect', t => {
 
   function deny(to: string) {
     t.context.url.safeRedirect(res, to);
-    t.true(spy.calledOnceWith(t.context.url.home));
+    t.true(spy.calledOnceWith(t.context.url.baseUrl));
     spy.resetHistory();
   }
 
@@ -105,4 +109,39 @@ test('can safe redirect', t => {
     'https://app.affine.local/path?query=1',
   ].forEach(allow);
   ['https://other.domain.com', 'a://invalid.uri'].forEach(deny);
+});
+
+test('can get request origin', t => {
+  t.is(t.context.url.requestOrigin, 'https://app.affine.local');
+});
+
+test('can get request base url', t => {
+  t.is(t.context.url.requestBaseUrl, 'https://app.affine.local');
+});
+
+test('can get request base url with multiple hosts', t => {
+  // mock cls
+  const cls = new Map<string, string>();
+  const url = new URLHelper(
+    {
+      server: {
+        externalUrl: '',
+        host: 'app.affine.local1',
+        hosts: ['app.affine.local1', 'app.affine.local2'],
+        port: 3010,
+        https: true,
+        path: '',
+      },
+    } as any,
+    cls as any
+  );
+
+  // no cls, use default origin
+  t.is(url.requestOrigin, 'https://app.affine.local1');
+  t.is(url.requestBaseUrl, 'https://app.affine.local1');
+
+  // set cls
+  cls.set(CLS_REQUEST_HOST, 'app.affine.local2');
+  t.is(url.requestOrigin, 'https://app.affine.local2');
+  t.is(url.requestBaseUrl, 'https://app.affine.local2');
 });

--- a/packages/backend/server/src/core/config/config.ts
+++ b/packages/backend/server/src/core/config/config.ts
@@ -12,6 +12,7 @@ declare global {
       externalUrl?: string;
       https: boolean;
       host: string;
+      hosts: ConfigItem<string[]>;
       port: number;
       path: string;
       name?: string;
@@ -51,6 +52,11 @@ Default to be \`[server.protocol]://[server.host][:server.port]\` if not specifi
     desc: 'Where the server get deployed(FQDN).',
     default: 'localhost',
     env: 'AFFINE_SERVER_HOST',
+  },
+  hosts: {
+    desc: 'Multiple hosts the server will accept requests from.',
+    default: [],
+    shape: z.array(z.string()),
   },
   port: {
     desc: 'Which port the server will listen on.',

--- a/packages/backend/server/src/core/config/resolver.ts
+++ b/packages/backend/server/src/core/config/resolver.ts
@@ -82,7 +82,7 @@ export class ServerConfigResolver {
               ? 'AFFiNE Beta Cloud'
               : 'AFFiNE Cloud'),
       version: env.version,
-      baseUrl: this.url.home,
+      baseUrl: this.url.requestBaseUrl,
       type: env.DEPLOYMENT_TYPE,
       features: this.server.features,
     };

--- a/packages/backend/server/src/env.ts
+++ b/packages/backend/server/src/env.ts
@@ -12,6 +12,8 @@ declare global {
     var readEnv: <T>(key: string, defaultValue: T, availableValues?: T[]) => T;
     // oxlint-disable-next-line no-var
     var CUSTOM_CONFIG_PATH: string;
+    // oxlint-disable-next-line no-var
+    var CLS_REQUEST_HOST: 'CLS_REQUEST_HOST';
   }
 }
 
@@ -53,6 +55,7 @@ export type AppEnv = {
   version: string;
 };
 
+globalThis.CLS_REQUEST_HOST = 'CLS_REQUEST_HOST';
 globalThis.CUSTOM_CONFIG_PATH = join(homedir(), '.affine/config');
 globalThis.readEnv = function readEnv<T>(
   env: string,

--- a/packages/backend/server/src/plugins/oauth/controller.ts
+++ b/packages/backend/server/src/plugins/oauth/controller.ts
@@ -142,7 +142,7 @@ export class OAuthController {
           provider: rawState.provider,
         })
       );
-      clientUrl.searchParams.set('server', this.url.origin);
+      clientUrl.searchParams.set('server', this.url.requestOrigin);
 
       return res.redirect(
         this.url.link('/open-app/url?', {

--- a/packages/backend/server/src/plugins/worker/controller.ts
+++ b/packages/backend/server/src/plugins/worker/controller.ts
@@ -56,7 +56,7 @@ export class WorkerController {
       this.logger.error('Invalid Origin', 'ERROR', { origin, referer });
       throw new BadRequest('Invalid header');
     }
-    const url = new URL(req.url, this.url.baseUrl);
+    const url = new URL(req.url, this.url.requestBaseUrl);
     const imageURL = url.searchParams.get('url');
     if (!imageURL) {
       throw new BadRequest('Missing "url" parameter');

--- a/packages/backend/server/src/plugins/worker/service.ts
+++ b/packages/backend/server/src/plugins/worker/service.ts
@@ -5,7 +5,7 @@ import { fixUrl, OriginRules } from './utils';
 
 @Injectable()
 export class WorkerService {
-  allowedOrigins: OriginRules = [this.url.origin];
+  allowedOrigins: OriginRules = [...this.url.allowedOrigins];
 
   constructor(
     private readonly config: Config,
@@ -18,7 +18,7 @@ export class WorkerService {
       ...this.config.worker.allowedOrigin
         .map(u => fixUrl(u)?.origin as string)
         .filter(v => !!v),
-      this.url.origin,
+      ...this.url.allowedOrigins,
     ];
   }
 

--- a/packages/backend/server/src/server.ts
+++ b/packages/backend/server/src/server.ts
@@ -66,5 +66,5 @@ export async function run() {
 
   logger.log(`AFFiNE Server is running in [${env.DEPLOYMENT_TYPE}] mode`);
   logger.log(`Listening on http://${listeningHost}:${config.server.port}`);
-  logger.log(`And the public server should be recognized as ${url.home}`);
+  logger.log(`And the public server should be recognized as ${url.baseUrl}`);
 }

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -171,6 +171,10 @@
       "desc": "Where the server get deployed(FQDN).",
       "env": "AFFINE_SERVER_HOST"
     },
+    "hosts": {
+      "type": "Array",
+      "desc": "Multiple hosts the server will accept requests from."
+    },
     "port": {
       "type": "Number",
       "desc": "Which port the server will listen on.",

--- a/packages/frontend/admin/src/modules/settings/config.ts
+++ b/packages/frontend/admin/src/modules/settings/config.ts
@@ -48,7 +48,7 @@ export const KNOWN_CONFIG_GROUPS = [
   {
     name: 'Server',
     module: 'server',
-    fields: ['externalUrl', 'name'],
+    fields: ['externalUrl', 'name', 'hosts'],
   } as ConfigGroup<'server'>,
   {
     name: 'Auth',

--- a/packages/frontend/core/src/modules/cloud/constant.ts
+++ b/packages/frontend/core/src/modules/cloud/constant.ts
@@ -63,7 +63,11 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
         ? [
             {
               id: 'affine-cloud',
-              baseUrl: 'https://app.affine.pro',
+              baseUrl: BUILD_CONFIG.isNative
+                ? BUILD_CONFIG.isIOS
+                  ? 'https://apple.getaffineapp.com'
+                  : 'https://app.affine.pro'
+                : location.origin,
               config: {
                 serverName: 'Affine Cloud',
                 features: [
@@ -91,7 +95,11 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
           ? [
               {
                 id: 'affine-cloud',
-                baseUrl: 'https://insider.affine.pro',
+                baseUrl: BUILD_CONFIG.isNative
+                  ? BUILD_CONFIG.isIOS
+                    ? 'https://apple.getaffineapp.com'
+                    : 'https://insider.affine.pro'
+                  : location.origin,
                 config: {
                   serverName: 'Affine Cloud',
                   features: [
@@ -147,7 +155,9 @@ export const BUILD_IN_SERVERS: (ServerMetadata & { config: ServerConfig })[] =
               ? [
                   {
                     id: 'affine-cloud',
-                    baseUrl: 'https://affine.fail',
+                    baseUrl: BUILD_CONFIG.isNative
+                      ? 'https://affine.fail'
+                      : location.origin,
                     config: {
                       serverName: 'Affine Cloud',
                       features: [

--- a/packages/frontend/core/src/modules/navigation/utils.ts
+++ b/packages/frontend/core/src/modules/navigation/utils.ts
@@ -8,6 +8,7 @@ function maybeAffineOrigin(origin: string, baseUrl: string) {
   return (
     origin.startsWith('file://') ||
     origin.endsWith('affine.pro') || // stable/beta
+    origin.endsWith('apple.getaffineapp.com') || // stable/beta
     origin.endsWith('affine.fail') || // canary
     origin === baseUrl // localhost or self-hosted
   );


### PR DESCRIPTION
close CLOUD-233



#### PR Dependency Tree


* **PR #12950** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring multiple server hosts across backend and frontend settings.
  * Enhanced deployment and Helm chart configuration to allow specifying multiple ingress hosts.
  * Updated admin and configuration interfaces to display and manage multiple server hosts.

* **Improvements**
  * Improved URL generation, OAuth, and worker service logic to dynamically handle requests from multiple hosts.
  * Enhanced captcha verification to support multiple allowed hostnames.
  * Updated frontend logic for platform-specific server base URLs and allowed origins, including Apple app domains.
  * Expanded test coverage for multi-host scenarios.

* **Bug Fixes**
  * Corrected backend logic to consistently use dynamic base URLs and origins based on request host context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->