### PR TITLE
fix(ios): fix xcode marketing version

### DIFF
--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -73,7 +73,8 @@ update_app_stream_version() {
 
 update_ios_marketing_version() {
   local file_path=$1
-  local new_version=$2
+  # Remove everything after the "-"
+  local new_version=$(echo "$2" | sed -E 's/-.*$//')
 
   # Check if file exists
   if [ ! -f "$file_path" ]; then


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version handling to ensure only the main version number is used, ignoring any suffixes after a hyphen when updating the iOS marketing version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->