### PR TITLE
fix(web): adjust sign-in panel height

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/sign-in/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/sign-in/index.tsx
@@ -25,10 +25,13 @@ export const SignInDialog = ({
       persistent
       onOpenChange={() => close()}
       width={400}
-      height={550}
       contentOptions={{
         ['data-testid' as string]: 'auth-modal',
-        style: { padding: '44px 40px 20px' },
+        style: {
+          padding: '44px 40px 20px',
+          minHeight: 550,
+          maxHeight: 650,
+        },
       }}
     >
       <SignInPanel


### PR DESCRIPTION
before:

![image](https://github.com/user-attachments/assets/dde283fb-65af-413f-8610-a297da8968d6)


after:

![Electron 2025-07-01 15 02 53](https://github.com/user-attachments/assets/cf1b58d2-612c-4fc3-9e7e-56685b6668c3)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the sign-in dialog to have a flexible height, allowing it to adjust between 550 and 650 pixels for improved display across different content sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->