### PR TITLE
chore(ios): revert upgrade ci xcode version

### DIFF
--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -106,7 +106,7 @@ jobs:
           enableScripts: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.4
+          xcode-version: 16.2
       - name: Install Swiftformat
         run: brew install swiftformat
       - name: Cap sync


### PR DESCRIPTION
Reverts toeverything/AFFiNE#12977

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS build environment to use Xcode version 16.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->