### PR TITLE
chore(server): remove useless client allowGuestDemoWorkspace config

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -597,11 +597,6 @@
           "type": "string",
           "description": "Allowed version range of the app that allowed to access the server. Requires 'client/versionControl.enabled' to be true to take effect.\n@default \">=0.20.0\"",
           "default": ">=0.20.0"
-        },
-        "allowGuestDemoWorkspace": {
-          "type": "boolean",
-          "description": "Allow guests to access demo workspace.\n@default true",
-          "default": true
         }
       }
     },

--- a/packages/backend/server/src/core/version/config.ts
+++ b/packages/backend/server/src/core/version/config.ts
@@ -5,7 +5,6 @@ export interface VersionConfig {
     enabled: boolean;
     requiredVersion: string;
   };
-  allowGuestDemoWorkspace?: boolean;
 }
 
 declare global {
@@ -28,9 +27,5 @@ defineModuleConfig('client', {
   'versionControl.requiredVersion': {
     desc: "Allowed version range of the app that allowed to access the server. Requires 'client/versionControl.enabled' to be true to take effect.",
     default: '>=0.20.0',
-  },
-  allowGuestDemoWorkspace: {
-    desc: 'Allow guests to access demo workspace.',
-    default: true,
   },
 });

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -211,10 +211,6 @@
     "versionControl.requiredVersion": {
       "type": "String",
       "desc": "Allowed version range of the app that allowed to access the server. Requires 'client/versionControl.enabled' to be true to take effect."
-    },
-    "allowGuestDemoWorkspace": {
-      "type": "Boolean",
-      "desc": "Allow guests to access demo workspace."
     }
   },
   "captcha": {


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #12988** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed the configuration option that allowed guests to access demo workspaces. This affects related settings in the system configuration and admin interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->