### PR TITLE
chore(infra): fix canary version format

### DIFF
--- a/.github/actions/prepare-release/action.yml
+++ b/.github/actions/prepare-release/action.yml
@@ -21,7 +21,7 @@ runs:
         if [ "${{ github.ref_type }}" == "tag" ]; then
           APP_VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
         else
-          APP_VERSION=$(date '+%Y.%-m.%-d-canary.%-H%-M')
+          APP_VERSION=$(date '+%Y.%-m.%-d-canary.%-H%M')
         fi
         if [[ "$APP_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
           BUILD_TYPE=stable


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #12994** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the timestamp format in canary version strings to remove the hyphen between hour and minute components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->