### PR TITLE
chore(server): use localhost sub domain

### DIFF
--- a/.docker/dev/README.md
+++ b/.docker/dev/README.md
@@ -15,13 +15,7 @@ yarn affine cert --install
 
 ```bash
 # certificates will be located at `./.docker/dev/certs/${domain}`
-yarn affine cert --domain dev.affine.fail
+yarn affine cert --domain affine.localhost
 ```
 
-### 3. Enable dns and nginx service in compose.yml
-
-### 4. Add custom dns server
-
-```bash
-echo "nameserver 127.0.0.1" | sudo tee /etc/resolver/dev.affine.fail
-```
+### 3. Enable nginx service in compose.yml

--- a/.docker/dev/compose.yml.example
+++ b/.docker/dev/compose.yml.example
@@ -73,17 +73,6 @@ services:
   #     timeout: 10s
   #     retries: 120
 
-  # dns:
-  #   image: strm/dnsmasq
-  #   volumes:
-  #     - ./dnsmasq.conf:/etc/dnsmasq.d/local.conf
-  #   ports:
-  #     - "53:53/udp"
-  #   cap_add:
-  #     - NET_ADMIN
-  #   depends_on:
-  #     - nginx
-
   # nginx:
   #   image: nginx:alpine
   #   volumes:

--- a/.docker/dev/dnsmasq.conf
+++ b/.docker/dev/dnsmasq.conf
@@ -1,2 +1,0 @@
-log-queries
-address=/dev.affine.fail/127.0.0.1

--- a/tools/cli/src/cert.ts
+++ b/tools/cli/src/cert.ts
@@ -21,7 +21,7 @@ export class CertCommand extends Command {
 
   domain = Option.String('--domain', {
     description:
-      'Generate certificates for given domain. e.g. "dev.affine.fail"',
+      'Generate certificates for given domain. e.g. "affine.localhost"',
   });
 
   uninstall = Option.Boolean('--uninstall', {


### PR DESCRIPTION
reduce dnsmasq service



#### PR Dependency Tree


* **PR #13012** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instructions to use the domain `affine.localhost` instead of `dev.affine.fail`.
  * Simplified setup steps by removing references to DNS service configuration and custom DNS server entries.

* **Chores**
  * Removed DNS server configuration and related files from the development environment setup.
  * Updated example descriptions to reflect the new domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->