### PR TITLE
fix(server): send comment mention to comment author by default

### DIFF
--- a/packages/backend/server/src/core/comment/resolver.ts
+++ b/packages/backend/server/src/core/comment/resolver.ts
@@ -396,11 +396,34 @@ export class CommentResolver {
       });
     }
 
+    // send comment mention notification to comment author on reply
+    if (reply && comment.userId !== sender.id) {
+      await this.queue.add('notification.sendComment', {
+        isMention: true,
+        userId: comment.userId,
+        body: {
+          workspaceId: comment.workspaceId,
+          createdByUserId: sender.id,
+          commentId: comment.id,
+          replyId: reply.id,
+          doc: {
+            id: comment.docId,
+            title: docTitle,
+            mode: docMode,
+          },
+        },
+      });
+    }
+
     // send comment mention notification to mentioned users
     if (mentions) {
       for (const mentionUserId of mentions) {
-        // skip if the mention user is the doc owner
-        if (mentionUserId === owner?.userId || mentionUserId === sender.id) {
+        // skip if the mention user is the doc owner or the comment author
+        if (
+          mentionUserId === owner?.userId ||
+          mentionUserId === sender.id ||
+          mentionUserId === comment.userId
+        ) {
           continue;
         }
 


### PR DESCRIPTION
close AF-2708



#### PR Dependency Tree


* **PR #13018** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notifications for users when their comment receives a reply, marking them with a mention.
* **Tests**
  * Introduced an end-to-end test to verify that replying to a comment sends a mention notification to the original comment author.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->