### PR TITLE
feat(ios): hidden version variant

### DIFF
--- a/packages/frontend/core/src/mobile/dialogs/setting/about/index.tsx
+++ b/packages/frontend/core/src/mobile/dialogs/setting/about/index.tsx
@@ -9,12 +9,21 @@ export const AboutGroup = () => {
   return (
     <SettingGroup title={t['com.affine.mobile.setting.about.title']()}>
       <RowLayout label={t['com.affine.mobile.setting.about.appVersion']()}>
-        {BUILD_CONFIG.appVersion}
+        {BUILD_CONFIG.isIOS
+          ? hiddenVersionVariant(BUILD_CONFIG.appVersion)
+          : BUILD_CONFIG.appVersion}
       </RowLayout>
 
       <RowLayout label={t['com.affine.mobile.setting.about.editorVersion']()}>
-        {BUILD_CONFIG.editorVersion}
+        {BUILD_CONFIG.isIOS
+          ? hiddenVersionVariant(BUILD_CONFIG.editorVersion)
+          : BUILD_CONFIG.editorVersion}
       </RowLayout>
     </SettingGroup>
   );
 };
+
+// 0.23.0-beta.1 -> 0.23.0
+function hiddenVersionVariant(version: string) {
+  return version.replace(/(\d+\.\d+\.\d+)(.*)/, '$1');
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On iOS devices, the app and editor version numbers in the About section now display only the main version (e.g., "0.23.0"), hiding any additional suffixes.
* **Other**
  * No visible changes for users on non-iOS platforms; full version strings remain displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->