### PR TITLE
fix(server): allow MS Office365 / Azure compatibility by making OIDC.preferred_username optional

### DIFF
--- a/packages/backend/server/src/plugins/oauth/providers/oidc.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/oidc.ts
@@ -21,7 +21,7 @@ const OIDCTokenSchema = z.object({
 const OIDCUserInfoSchema = z
   .object({
     sub: z.string(),
-    preferred_username: z.string(),
+    preferred_username: z.string().optional(),
     email: z.string().email(),
     name: z.string(),
     groups: z.array(z.string()).optional(),


### PR DESCRIPTION
> [!NOTE]
> **This is a reopened (already approved) PR**
> Needed to reopen https://github.com/toeverything/AFFiNE/pull/13011 because commit email was wrong and I could not sign the CLA

Make Office365 / Azure login possible by making preferred_username optional.
This is NOT send in the token of MS.

To make this work you ALSO need to set the oidc.config.args.id to "email" (there preferred_username is used as default)
Source: https://github.com/toeverything/AFFiNE/blob/canary/packages/backend/server/src/plugins/oauth/providers/oidc.ts#L152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with OIDC providers by allowing the preferred username field to be optional during user info validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->