### PR TITLE
feat(core): add comment notification settings

### DIFF
--- a/packages/backend/server/src/__tests__/utils/user-settings.ts
+++ b/packages/backend/server/src/__tests__/utils/user-settings.ts
@@ -14,6 +14,7 @@ export async function getUserSettings(
         settings {
           receiveInvitationEmail
           receiveMentionEmail
+          receiveCommentEmail
         }
       }
     }

--- a/packages/backend/server/src/core/user/__tests__/resolver.e2e.ts
+++ b/packages/backend/server/src/core/user/__tests__/resolver.e2e.ts
@@ -23,6 +23,7 @@ test('should get user settings', async t => {
   t.deepEqual(settings, {
     receiveInvitationEmail: true,
     receiveMentionEmail: true,
+    receiveCommentEmail: true,
   });
 });
 
@@ -31,11 +32,13 @@ test('should update user settings', async t => {
   await updateUserSettings(app, {
     receiveInvitationEmail: false,
     receiveMentionEmail: false,
+    receiveCommentEmail: false,
   });
   const settings = await getUserSettings(app);
   t.deepEqual(settings, {
     receiveInvitationEmail: false,
     receiveMentionEmail: false,
+    receiveCommentEmail: false,
   });
 
   await updateUserSettings(app, {
@@ -45,6 +48,7 @@ test('should update user settings', async t => {
   t.deepEqual(settings2, {
     receiveInvitationEmail: false,
     receiveMentionEmail: true,
+    receiveCommentEmail: false,
   });
 
   await updateUserSettings(app, {
@@ -54,6 +58,33 @@ test('should update user settings', async t => {
   const settings3 = await getUserSettings(app);
   t.deepEqual(settings3, {
     receiveInvitationEmail: false,
+    receiveMentionEmail: true,
+    receiveCommentEmail: false,
+  });
+});
+
+test('should update user settings with comment email', async t => {
+  await app.signup();
+
+  await updateUserSettings(app, {
+    receiveCommentEmail: true,
+  });
+
+  const settings = await getUserSettings(app);
+  t.deepEqual(settings, {
+    receiveCommentEmail: true,
+    receiveInvitationEmail: true,
+    receiveMentionEmail: true,
+  });
+
+  await updateUserSettings(app, {
+    receiveCommentEmail: false,
+  });
+
+  const settings2 = await getUserSettings(app);
+  t.deepEqual(settings2, {
+    receiveCommentEmail: false,
+    receiveInvitationEmail: true,
     receiveMentionEmail: true,
   });
 });

--- a/packages/common/graphql/src/graphql/get-user-settings.gql
+++ b/packages/common/graphql/src/graphql/get-user-settings.gql
@@ -3,6 +3,7 @@ query getUserSettings {
     settings {
       receiveInvitationEmail
       receiveMentionEmail
+      receiveCommentEmail
     }
   }
 }

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1558,6 +1558,7 @@ export const getUserSettingsQuery = {
     settings {
       receiveInvitationEmail
       receiveMentionEmail
+      receiveCommentEmail
     }
   }
 }`,

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -4714,6 +4714,7 @@ export type GetUserSettingsQuery = {
       __typename?: 'UserSettingsType';
       receiveInvitationEmail: boolean;
       receiveMentionEmail: boolean;
+      receiveCommentEmail: boolean;
     };
   } | null;
 };

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/notifications/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/notifications/index.tsx
@@ -95,6 +95,17 @@ export const NotificationSettings = () => {
             }
           />
         </SettingRow>
+        <SettingRow
+          name={t['com.affine.setting.notifications.email.comments.title']()}
+          desc={t['com.affine.setting.notifications.email.comments.subtitle']()}
+        >
+          <Switch
+            data-testid="notification-email-comments-trigger"
+            checked={userSettings?.receiveCommentEmail ?? false}
+            disabled={disable}
+            onChange={checked => handleUpdate('receiveCommentEmail', checked)}
+          />
+        </SettingRow>
       </SettingWrapper>
     </>
   );

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -4826,6 +4826,14 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.setting.notifications.email.invites.subtitle"](): string;
     /**
+      * `Comments`
+      */
+    ["com.affine.setting.notifications.email.comments.title"](): string;
+    /**
+      * `You will be notified through email when other members of the workspace comment on your docs.`
+      */
+    ["com.affine.setting.notifications.email.comments.subtitle"](): string;
+    /**
       * `Account settings`
       */
     ["com.affine.setting.account"](): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1199,6 +1199,8 @@
   "com.affine.setting.notifications.email.mention.subtitle": "You will be notified through email when other members of the workspace @ you.",
   "com.affine.setting.notifications.email.invites.title": "Invites",
   "com.affine.setting.notifications.email.invites.subtitle": "Invitation related messages will be sent through emails.",
+  "com.affine.setting.notifications.email.comments.title": "Comments",
+  "com.affine.setting.notifications.email.comments.subtitle": "You will be notified through email when other members of the workspace comment on your docs.",
   "com.affine.setting.account": "Account settings",
   "com.affine.setting.account.delete": "Delete your account",
   "com.affine.setting.account.delete.message": "Once deleted, your account will no longer be accessible, and all data in your personal cloud space will be permanently deleted.",


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/1b239592-1c0d-4575-ad3b-bfb3d0c873c8)





#### PR Dependency Tree


* **PR #13029** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option in user settings to enable or disable email notifications for comments on your documents.
  * Updated the user interface to include a toggle for comment email notifications.
  * Extended GraphQL queries and schema to support the new comment email notification setting.

* **Localization**
  * Added new English translations for comment email notification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->