### PR TITLE
fix(server): only send comment mention notification when comment author is doc owner

### DIFF
--- a/packages/backend/server/src/__tests__/e2e/comment/resolver.spec.ts
+++ b/packages/backend/server/src/__tests__/e2e/comment/resolver.spec.ts
@@ -744,6 +744,62 @@ e2e(
   }
 );
 
+e2e(
+  'should create reply and send comment mention notification to comment author only when author is doc owner',
+  async t => {
+    const docId = randomUUID();
+    await app.create(Mockers.DocUser, {
+      workspaceId: teamWorkspace.id,
+      docId,
+      userId: member.id,
+      type: DocRole.Owner,
+    });
+
+    await app.login(member);
+    const createResult = await app.gql({
+      query: createCommentMutation,
+      variables: {
+        input: {
+          workspaceId: teamWorkspace.id,
+          docId,
+          docMode: DocMode.page,
+          docTitle: 'test',
+          content: {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'test' }],
+          },
+        },
+      },
+    });
+
+    await app.login(owner);
+    const count = app.queue.count('notification.sendComment');
+    const result = await app.gql({
+      query: createReplyMutation,
+      variables: {
+        input: {
+          commentId: createResult.createComment.id,
+          docMode: DocMode.page,
+          docTitle: 'test',
+          content: {
+            type: 'paragraph',
+            content: [{ type: 'text', text: 'test' }],
+          },
+        },
+      },
+    });
+
+    t.truthy(result.createReply.id);
+    t.is(result.createReply.commentId, createResult.createComment.id);
+    t.is(app.queue.count('notification.sendComment'), count + 1);
+    const notification = app.queue.last('notification.sendComment');
+    t.is(notification.name, 'notification.sendComment');
+    t.is(notification.payload.userId, member.id);
+    t.is(notification.payload.body.replyId, result.createReply.id);
+    t.is(notification.payload.isMention, true);
+  }
+);
+
 e2e('should create reply work when user is Commenter', async t => {
   const docId = randomUUID();
   await app.create(Mockers.DocUser, {


### PR DESCRIPTION
close AF-2711



#### PR Dependency Tree


* **PR #13033** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test to verify that mention notifications are correctly sent when replying to a comment authored by the document owner.

* **Refactor**
  * Improved the notification logic to streamline how mention and owner notifications are sent, reducing redundancy and ensuring correct recipients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->