### PR TITLE
fix(editor): keyboard can not open after closing input modal

### DIFF
--- a/blocksuite/affine/widgets/keyboard-toolbar/src/widget.ts
+++ b/blocksuite/affine/widgets/keyboard-toolbar/src/widget.ts
@@ -42,6 +42,7 @@ export class AffineKeyboardToolbarWidget extends WidgetComponent<RootBlockModel>
 
     return {
       // fallback keyboard actions
+      fallback: true,
       show: () => {
         const rootComponent = this.block?.rootComponent;
         if (rootComponent && rootComponent === document.activeElement) {


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13041** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of keyboard provider fallbacks to ensure more reliable keyboard behavior when certain features are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->