### PR TITLE
fix(server): use config.server.host to be consistent with port

### DIFF
--- a/packages/backend/server/src/core/config/config.ts
+++ b/packages/backend/server/src/core/config/config.ts
@@ -51,7 +51,7 @@ Default to be \`[server.protocol]://[server.host][:server.port]\` if not specifi
   },
   host: {
     desc: 'Where the server get deployed(FQDN).',
-    default: 'localhost',
+    default: '0.0.0.0',
     env: 'AFFINE_SERVER_HOST',
   },
   hosts: {

--- a/packages/backend/server/src/server.ts
+++ b/packages/backend/server/src/server.ts
@@ -60,11 +60,10 @@ export async function run() {
   app.useWebSocketAdapter(adapter);
 
   const url = app.get(URLHelper);
-  const listeningHost = '0.0.0.0';
 
-  await app.listen(config.server.port, listeningHost);
+  await app.listen(config.server.port, config.server.host);
 
   logger.log(`AFFiNE Server is running in [${env.DEPLOYMENT_TYPE}] mode`);
-  logger.log(`Listening on http://${listeningHost}:${config.server.port}`);
+  logger.log(`Listening on http://${config.server.host}:${config.server.port}`);
   logger.log(`And the public server should be recognized as ${url.baseUrl}`);
 }


### PR DESCRIPTION
fixes #12882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated server to use a configurable host address based on settings, improving flexibility for deployment environments.
  * Changed default server host to listen on all network interfaces by default, enhancing accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->