### PR TITLE
fix(core): border color for embed-linked-doc-block and others

### DIFF
--- a/blocksuite/affine/blocks/bookmark/src/styles.ts
+++ b/blocksuite/affine/blocks/bookmark/src/styles.ts
@@ -19,7 +19,7 @@ export const styles = css`
     border-radius: 8px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
   }
 

--- a/blocksuite/affine/blocks/bookmark/src/styles.ts
+++ b/blocksuite/affine/blocks/bookmark/src/styles.ts
@@ -17,7 +17,7 @@ export const styles = css`
     width: 100%;
 
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
     background: var(--affine-background-primary-color);
     user-select: none;

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/styles.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/styles.ts
@@ -9,7 +9,7 @@ export const styles = css`
     width: 100%;
     height: 100%;
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
     background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
     position: relative;

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/styles.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/styles.ts
@@ -198,7 +198,7 @@ export const cardStyles = css`
     height: ${EMBED_CARD_HEIGHT.horizontal}px;
     border-radius: 8px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
   }
 

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/styles.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/styles.ts
@@ -197,7 +197,7 @@ export const cardStyles = css`
     width: 100%;
     height: ${EMBED_CARD_HEIGHT.horizontal}px;
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
     background: var(--affine-background-primary-color);
     user-select: none;
   }

--- a/blocksuite/affine/blocks/embed/src/embed-figma-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-figma-block/styles.ts
@@ -11,7 +11,7 @@ export const styles = css`
     height: 100%;
 
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
     background: var(--affine-background-primary-color);
     user-select: none;

--- a/blocksuite/affine/blocks/embed/src/embed-figma-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-figma-block/styles.ts
@@ -13,7 +13,7 @@ export const styles = css`
     border-radius: 8px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
   }
 

--- a/blocksuite/affine/blocks/embed/src/embed-github-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-github-block/styles.ts
@@ -1,3 +1,4 @@
+import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
 import { css, html } from 'lit';
 
 export const styles = css`
@@ -9,7 +10,7 @@ export const styles = css`
     height: 100%;
 
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
     background: var(--affine-background-primary-color);
     user-select: none;

--- a/blocksuite/affine/blocks/embed/src/embed-github-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-github-block/styles.ts
@@ -12,7 +12,7 @@ export const styles = css`
     border-radius: 8px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
     overflow: hidden;
   }

--- a/blocksuite/affine/blocks/embed/src/embed-html-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-html-block/styles.ts
@@ -1,3 +1,4 @@
+import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
 import { css, html } from 'lit';
 
 export const EMBED_HTML_MIN_WIDTH = 370;
@@ -15,7 +16,7 @@ export const styles = css`
     gap: 20px;
 
     border-radius: 12px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
     background: var(--affine-background-primary-color);
     user-select: none;

--- a/blocksuite/affine/blocks/embed/src/embed-html-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-html-block/styles.ts
@@ -18,7 +18,7 @@ export const styles = css`
     border-radius: 12px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
   }
 

--- a/blocksuite/affine/blocks/embed/src/embed-loom-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-loom-block/styles.ts
@@ -1,3 +1,4 @@
+import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
 import { css, html } from 'lit';
 
 export const styles = css`
@@ -12,7 +13,7 @@ export const styles = css`
     height: 100%;
 
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
     background: var(--affine-background-primary-color);
     user-select: none;

--- a/blocksuite/affine/blocks/embed/src/embed-loom-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-loom-block/styles.ts
@@ -15,7 +15,7 @@ export const styles = css`
     border-radius: 8px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
   }
 

--- a/blocksuite/affine/blocks/embed/src/embed-youtube-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-youtube-block/styles.ts
@@ -13,7 +13,7 @@ export const styles = css`
     padding: 12px;
 
     border-radius: 8px;
-    border: 1px solid var(--affine-background-tertiary-color);
+    border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
     background: var(--affine-background-primary-color);
     user-select: none;

--- a/blocksuite/affine/blocks/embed/src/embed-youtube-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-youtube-block/styles.ts
@@ -15,7 +15,7 @@ export const styles = css`
     border-radius: 8px;
     border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
 
-    background: var(--affine-background-primary-color);
+    background: ${unsafeCSSVarV2('layer/background/primary')};
     user-select: none;
   }
 

--- a/blocksuite/affine/blocks/image/src/preview-image/edgeless.ts
+++ b/blocksuite/affine/blocks/image/src/preview-image/edgeless.ts
@@ -1,3 +1,4 @@
+import { unsafeCSSVarV2 } from '@blocksuite/affine-shared/theme';
 import { toGfxBlockComponent } from '@blocksuite/std';
 import { css } from 'lit';
 
@@ -9,7 +10,7 @@ export class ImageEdgelessPlaceholderBlockComponent extends toGfxBlockComponent(
   static override styles = css`
     affine-edgeless-placeholder-preview-image
       .affine-placeholder-preview-container {
-      border: 1px solid var(--affine-background-tertiary-color);
+      border: 1px solid ${unsafeCSSVarV2('layer/background/tertiary')};
     }
   `;
 


### PR DESCRIPTION
fixes https://github.com/toeverything/AFFiNE/issues/12972

border: `#eee` -> `#f3f3f3`

background: `#fff` -> `#fff` (no-op)

This change is based on [@fundon 's PR from 2 month ago](https://github.com/toeverything/AFFiNE/pull/11763/files#diff-cc768d5886dd743d8a7ad97df05added2710c0487d281f2b33b02ab1a9c78e4c) which I assume has the most up-to-date design

I am also curious to know the current state of CSSVarV2 function. Should it replace all previous usage of css variables? I can do a find-replace globally (not just embed blocks) if that's important enough.

<!--
https://github.com/toeverything/design/blob/main/packages/theme/src/v2/variables.ts#L296
-->