### PR TITLE
fix(editor): focus comment editor after click its bottom area

### DIFF
--- a/packages/frontend/core/src/components/comment/comment-editor/index.tsx
+++ b/packages/frontend/core/src/components/comment/comment-editor/index.tsx
@@ -1,6 +1,6 @@
 import { LitDocEditor, type PageEditor } from '@affine/core/blocksuite/editors';
 import { SnapshotHelper } from '@affine/core/modules/comment/services/snapshot-helper';
-import type { RichText } from '@blocksuite/affine/rich-text';
+import { focusTextModel, type RichText } from '@blocksuite/affine/rich-text';
 import { ViewportElementExtension } from '@blocksuite/affine/shared/services';
 import { type DocSnapshot, Store } from '@blocksuite/affine/store';
 import { ArrowUpBigIcon } from '@blocksuite/icons/rc';
@@ -175,7 +175,10 @@ export const CommentEditor = forwardRef<CommentEditorRef, CommentEditorProps>(
       (e: React.MouseEvent) => {
         e.stopPropagation();
         if (editorRef.current) {
-          editorRef.current.focus();
+          const lastChild = editorRef.current.std.store.root?.lastChild();
+          if (lastChild) {
+            focusTextModel(editorRef.current.std, lastChild.id);
+          }
         }
       },
       [editorRef]


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13060** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the comment editor's focus behavior to place the cursor at the end of the content when clicking inside the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->