### PR TITLE
fix(core): comment mention filters

### DIFF
--- a/packages/frontend/core/src/components/comment/comment-editor/index.tsx
+++ b/packages/frontend/core/src/components/comment/comment-editor/index.tsx
@@ -106,6 +106,15 @@ export const CommentEditor = forwardRef<CommentEditorRef, CommentEditorProps>(
       [doc, snapshotHelper]
     );
 
+    const focusEditor = useCallback(() => {
+      if (editorRef.current) {
+        const lastChild = editorRef.current.std.store.root?.lastChild();
+        if (lastChild) {
+          focusTextModel(editorRef.current.std, lastChild.id);
+        }
+      }
+    }, [editorRef]);
+
     useEffect(() => {
       let cancel = false;
       if (autoFocus && editorRef.current && doc) {
@@ -117,25 +126,20 @@ export const CommentEditor = forwardRef<CommentEditorRef, CommentEditorProps>(
               'rich-text'
             ) as unknown as RichText;
             if (!richText) return;
-
-            // Finally focus the inline editor
-            const inlineEditor = richText.inlineEditor;
-            richText.focus();
-
             richText.scrollIntoView({
               behavior: 'smooth',
               block: 'center',
             });
-
-            // fixme: the following does not work
-            inlineEditor?.focusEnd();
+            // Finally focus the inline editor
+            richText.focus();
+            focusEditor();
           })
           .catch(console.error);
       }
       return () => {
         cancel = true;
       };
-    }, [autoFocus, doc]);
+    }, [autoFocus, doc, focusEditor]);
 
     useEffect(() => {
       if (doc && onChange) {
@@ -174,14 +178,9 @@ export const CommentEditor = forwardRef<CommentEditorRef, CommentEditorProps>(
     const handleClickEditor = useCallback(
       (e: React.MouseEvent) => {
         e.stopPropagation();
-        if (editorRef.current) {
-          const lastChild = editorRef.current.std.store.root?.lastChild();
-          if (lastChild) {
-            focusTextModel(editorRef.current.std, lastChild.id);
-          }
-        }
+        focusEditor();
       },
-      [editorRef]
+      [focusEditor]
     );
 
     return (

--- a/packages/frontend/core/src/components/comment/comment-editor/style.css.ts
+++ b/packages/frontend/core/src/components/comment/comment-editor/style.css.ts
@@ -12,7 +12,7 @@ export const container = style({
       borderRadius: 16,
       padding: '0 8px',
     },
-    '&[data-readonly="false"]:focus-within': {
+    '&[data-readonly="false"]:is(:focus-within, :active)': {
       borderColor: cssVarV2('layer/insideBorder/primaryBorder'),
       boxShadow: cssVar('activeShadow'),
     },

--- a/packages/frontend/core/src/components/comment/sidebar/style.css.ts
+++ b/packages/frontend/core/src/components/comment/sidebar/style.css.ts
@@ -189,3 +189,24 @@ export const time = style({
   color: cssVarV2('text/secondary'),
   fontWeight: '500',
 });
+
+export const collapsedReplies = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-start',
+  cursor: 'pointer',
+  height: '28px',
+  paddingLeft: '42px',
+  borderRadius: 8,
+  selectors: {
+    '&:hover': {
+      backgroundColor: cssVarV2('layer/background/hoverOverlay'),
+    },
+  },
+});
+
+export const collapsedRepliesTitle = style({
+  color: cssVarV2('text/emphasis'),
+  fontSize: cssVar('fontXs'),
+  fontWeight: '500',
+});

--- a/packages/frontend/core/src/modules/comment/entities/utils.ts
+++ b/packages/frontend/core/src/modules/comment/entities/utils.ts
@@ -1,0 +1,37 @@
+import type {
+  BaseTextAttributes,
+  BlockSnapshot,
+  DeltaInsert,
+} from '@blocksuite/affine/store';
+
+const MentionAttribute = 'mention';
+type ExtendedTextAttributes = BaseTextAttributes & {
+  [MentionAttribute]: {
+    member: string;
+  };
+};
+
+export function findMentions(snapshot: BlockSnapshot): string[] {
+  const mentionedUserIds = new Set<string>();
+  if (
+    snapshot.props.type === 'text' &&
+    snapshot.props.text &&
+    'delta' in (snapshot.props.text as any)
+  ) {
+    const delta = (snapshot.props.text as any)
+      .delta as DeltaInsert<ExtendedTextAttributes>[];
+    for (const op of delta) {
+      if (op.attributes?.[MentionAttribute]) {
+        mentionedUserIds.add(op.attributes[MentionAttribute].member);
+      }
+    }
+  }
+
+  for (const block of snapshot.children) {
+    findMentions(block).forEach(userId => {
+      mentionedUserIds.add(userId);
+    });
+  }
+
+  return Array.from(mentionedUserIds);
+}

--- a/packages/frontend/core/src/modules/comment/types.ts
+++ b/packages/frontend/core/src/modules/comment/types.ts
@@ -18,6 +18,7 @@ export interface BaseComment {
 
 export interface DocComment extends BaseComment {
   resolved: boolean;
+  mentions: string[];
   replies?: DocCommentReply[];
 }
 
@@ -29,7 +30,10 @@ export type PendingComment = {
   commentId?: CommentId; // only for replies, points to the parent comment
 };
 
-export type DocCommentReply = BaseComment;
+export interface DocCommentReply extends BaseComment {
+  commentId: CommentId;
+  mentions: string[];
+}
 
 export type DocCommentContent = {
   snapshot: DocSnapshot; // blocksuite snapshot

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -8255,6 +8255,12 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.comment.reply.delete.confirm.description"](): string;
     /**
+      * `Show {{count}} more replies`
+      */
+    ["com.affine.comment.reply.show-more"](options: {
+        readonly count: string;
+    }): string;
+    /**
       * `Show resolved comments`
       */
     ["com.affine.comment.filter.show-resolved"](): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -2071,6 +2071,7 @@
   "com.affine.comment.delete.confirm.description": "All comments will also be deleted, and this action cannot be undone.",
   "com.affine.comment.reply.delete.confirm.title": "Delete this reply?",
   "com.affine.comment.reply.delete.confirm.description": "Delete this reply? This action cannot be undone.",
+  "com.affine.comment.reply.show-more": "Show {{count}} more replies",
   "com.affine.comment.filter.show-resolved": "Show resolved comments",
   "com.affine.comment.filter.only-my-replies": "Only my replies and mentions",
   "com.affine.comment.filter.only-current-mode": "Only current mode",


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13062** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replies in comment threads are now collapsed when there are more than four, with an option to expand and view all replies.
  * Mentions within comments and replies are automatically detected and tracked.
  * "Show more replies" indicator is now localized for English users.

* **Improvements**
  * Filtering for "only my replies" now includes replies where you are mentioned.
  * Enhanced focus behavior in the comment editor for improved usability.
  * Updated styling for active and collapsed reply states in comment threads.

* **Bug Fixes**
  * Ensured consistent handling of mentions and reply associations in comment data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->