### PR TITLE
chore(server): send comment notification to all repliers

### DIFF
--- a/packages/backend/server/src/models/__tests__/comment.spec.ts
+++ b/packages/backend/server/src/models/__tests__/comment.spec.ts
@@ -524,3 +524,43 @@ test('should list changes', async t => {
   });
   t.is(changes5.length, 0);
 });
+
+test('should list replies', async t => {
+  const docId = randomUUID();
+  const comment = await models.comment.create({
+    content: {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'test' }],
+    },
+    workspaceId: workspace.id,
+    docId,
+    userId: owner.id,
+  });
+
+  const reply1 = await models.comment.createReply({
+    userId: owner.id,
+    content: {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'test reply1' }],
+    },
+    commentId: comment.id,
+  });
+
+  const reply2 = await models.comment.createReply({
+    userId: owner.id,
+    content: {
+      type: 'paragraph',
+      content: [{ type: 'text', text: 'test reply2' }],
+    },
+    commentId: comment.id,
+  });
+
+  const replies = await models.comment.listReplies(
+    workspace.id,
+    docId,
+    comment.id
+  );
+  t.is(replies.length, 2);
+  t.is(replies[0].id, reply1.id);
+  t.is(replies[1].id, reply2.id);
+});

--- a/packages/backend/server/src/models/comment.ts
+++ b/packages/backend/server/src/models/comment.ts
@@ -300,6 +300,13 @@ export class CommentModel extends BaseModel {
     })) as Reply | null;
   }
 
+  async listReplies(workspaceId: string, docId: string, commentId: string) {
+    return (await this.db.reply.findMany({
+      where: { workspaceId, docId, commentId, deletedAt: null },
+      orderBy: { sid: 'asc' },
+    })) as Reply[];
+  }
+
   /**
    * Update a reply content
    * @param input - The reply update input


### PR DESCRIPTION
close AF-2714



#### PR Dependency Tree


* **PR #13063** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to list all replies for a specific comment.

* **Bug Fixes**
  * Improved notification delivery for comment replies, ensuring all relevant users (comment author, document owner, and all repliers) are notified appropriately.

* **Tests**
  * Added and updated tests to verify correct notification behavior and the new reply listing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->