### PR TITLE
feat(server): add apple-itunes-app meta tag on shage page

### DIFF
--- a/packages/backend/server/src/__tests__/e2e/doc-renderer/controller.spec.ts
+++ b/packages/backend/server/src/__tests__/e2e/doc-renderer/controller.spec.ts
@@ -1,0 +1,64 @@
+import { app, createApp, e2e, Mockers } from '../test';
+
+e2e('should render doc share page with apple-itunes-app meta tag', async t => {
+  const owner = await app.signup();
+  const workspace = await app.create(Mockers.Workspace, {
+    owner,
+  });
+
+  const docSnapshot = await app.create(Mockers.DocSnapshot, {
+    workspaceId: workspace.id,
+    user: owner,
+  });
+  // set public to true
+  await app.create(Mockers.DocMeta, {
+    workspaceId: workspace.id,
+    docId: docSnapshot.id,
+    public: true,
+  });
+
+  const res = await app
+    .GET(`/workspace/${workspace.id}/${docSnapshot.id}`)
+    .expect(200)
+    .expect('Content-Type', 'text/html; charset=utf-8');
+
+  t.regex(
+    res.text,
+    /<meta name="apple-itunes-app" content="app-id=6736937980" \/>/
+  );
+});
+
+e2e(
+  'should render doc share page without apple-itunes-app meta tag when selfhosted',
+  async t => {
+    // @ts-expect-error override
+    globalThis.env.DEPLOYMENT_TYPE = 'selfhosted';
+    await using app = await createApp();
+
+    const owner = await app.signup();
+    const workspace = await app.create(Mockers.Workspace, {
+      owner,
+    });
+
+    const docSnapshot = await app.create(Mockers.DocSnapshot, {
+      workspaceId: workspace.id,
+      user: owner,
+    });
+    // set public to true
+    await app.create(Mockers.DocMeta, {
+      workspaceId: workspace.id,
+      docId: docSnapshot.id,
+      public: true,
+    });
+
+    const res = await app
+      .GET(`/workspace/${workspace.id}/${docSnapshot.id}`)
+      .expect(200)
+      .expect('Content-Type', 'text/html; charset=utf-8');
+
+    t.notRegex(
+      res.text,
+      /<meta name="apple-itunes-app" content="app-id=6736937980" \/>/
+    );
+  }
+);

--- a/packages/backend/server/src/core/doc-renderer/controller.ts
+++ b/packages/backend/server/src/core/doc-renderer/controller.ts
@@ -171,6 +171,7 @@ export class DocRendererController {
       name="apple-mobile-web-app-status-bar-style"
       content="black-translucent"
     />
+    ${env.selfhosted ? '' : '<meta name="apple-itunes-app" content="app-id=6736937980" />'}
 
     <title>${title}</title>
     <meta name="theme-color" content="#fafafa" />


### PR DESCRIPTION
disable on selfhosted

close AF-2715
![IMG_1232](https://github.com/user-attachments/assets/21fdd066-3f67-411e-9407-7349e221c23e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Apple iTunes app association meta tag to the document share page for improved app integration, shown only in non-self-hosted environments.

* **Tests**
  * Introduced end-to-end tests to verify the conditional presence of the Apple iTunes app meta tag based on the deployment environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


#### PR Dependency Tree


* **PR #13065** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)