### PR TITLE
feat(core): hide model switch menu

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/preference-popup.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/preference-popup.ts
@@ -6,7 +6,6 @@ import {
 } from '@blocksuite/affine/components/context-menu';
 import { SignalWatcher, WithDisposable } from '@blocksuite/affine/global/lit';
 import {
-  AiOutlineIcon,
   ArrowDownSmallIcon,
   ThinkingIcon,
   WebIcon,
@@ -82,9 +81,9 @@ export class ChatInputPreference extends SignalWatcher(
     | undefined;
   // --------- search props end ---------
 
-  private readonly _onModelChange = (modelId: string) => {
-    this.onModelChange?.(modelId);
-  };
+  // private readonly _onModelChange = (modelId: string) => {
+  //   this.onModelChange?.(modelId);
+  // };
 
   openPreference(e: Event) {
     const element = e.currentTarget;
@@ -93,20 +92,20 @@ export class ChatInputPreference extends SignalWatcher(
     const searchItems = [];
 
     // model switch
-    modelItems.push(
-      menu.subMenu({
-        name: 'Model',
-        prefix: AiOutlineIcon(),
-        options: {
-          items: (this.session?.optionalModels ?? []).map(modelId => {
-            return menu.action({
-              name: modelId,
-              select: () => this._onModelChange(modelId),
-            });
-          }),
-        },
-      })
-    );
+    // modelItems.push(
+    //   menu.subMenu({
+    //     name: 'Model',
+    //     prefix: AiOutlineIcon(),
+    //     options: {
+    //       items: (this.session?.optionalModels ?? []).map(modelId => {
+    //         return menu.action({
+    //           name: modelId,
+    //           select: () => this._onModelChange(modelId),
+    //         });
+    //       }),
+    //     },
+    //   })
+    // );
 
     modelItems.push(
       menu.toggleSwitch({
@@ -152,9 +151,7 @@ export class ChatInputPreference extends SignalWatcher(
       data-testid="chat-input-preference-trigger"
       class="chat-input-preference-trigger"
     >
-      <span class="chat-input-preference-trigger-label">
-        ${this.modelId || this.session?.model}
-      </span>
+      <span class="chat-input-preference-trigger-label"> Claude </span>
       <span class="chat-input-preference-trigger-icon">
         ${ArrowDownSmallIcon()}
       </span>


### PR DESCRIPTION
Close [AI-307](https://linear.app/affine-design/issue/AI-307)

![image](https://github.com/user-attachments/assets/35ff1261-561c-43d6-91ed-d57cef0a8a41)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the preference popup by removing the model selection submenu and displaying a static model label ("Claude").
  * Only the "Extended Thinking" and "Web Search" toggle options remain in the popup menu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->