### PR TITLE
fix(core): show actions only if docId equals session.docId

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-content/ai-chat-content.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-content/ai-chat-content.ts
@@ -208,7 +208,7 @@ export class AIChatContent extends SignalWatcher(
       sessionId
         ? AIProvider.histories.chats(this.workspaceId, sessionId)
         : Promise.resolve([]),
-      this.docId
+      this.docId && this.session?.docId === this.docId
         ? AIProvider.histories.actions(this.workspaceId, this.docId)
         : Promise.resolve([]),
     ]);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of action history retrieval in AI chat by ensuring histories are only fetched when the session's document matches the current document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->