### PR TITLE
fix(editor): centerize iframe modal in mobile

### DIFF
--- a/blocksuite/affine/blocks/latex/src/latex-block.ts
+++ b/blocksuite/affine/blocks/latex/src/latex-block.ts
@@ -116,7 +116,7 @@ export class LatexBlockComponent extends CaptionedBlockComponent<LatexBlockModel
 
     this.selection.setGroup('note', []);
 
-    const portal = createLitPortal({
+    const { portal } = createLitPortal({
       template: html`<latex-editor-menu
         .std=${this.std}
         .latexSignal=${this.model.props.latex$}

--- a/blocksuite/affine/components/src/hover/controller.ts
+++ b/blocksuite/affine/components/src/hover/controller.ts
@@ -179,7 +179,7 @@ export class HoverController implements ReactiveController {
       this._portal = createLitPortal({
         ...portalOptions,
         abortController: this._abortController,
-      });
+      }).portal;
 
       const transition = this._hoverOptions.transition;
       if (transition) {

--- a/blocksuite/affine/components/src/portal/helper.ts
+++ b/blocksuite/affine/components/src/portal/helper.ts
@@ -161,7 +161,7 @@ export function createLitPortal({
   }
 
   if (!positionConfigOrFn) {
-    return portalRoot;
+    return { portal: portalRoot, update: () => {} };
   }
 
   const visibility = portalRoot.style.visibility;
@@ -221,5 +221,5 @@ export function createLitPortal({
     });
   }
 
-  return portalRoot;
+  return { portal: portalRoot, update };
 }

--- a/blocksuite/affine/data-view/src/property-presets/date/cell-renderer.ts
+++ b/blocksuite/affine/data-view/src/property-presets/date/cell-renderer.ts
@@ -78,7 +78,7 @@ export class DateCell extends BaseCellRenderer<number, number> {
         },
       });
     } else {
-      const root = createLitPortal({
+      const { portal } = createLitPortal({
         abortController,
         closeOnClickAway: true,
         computePosition: {
@@ -107,7 +107,7 @@ export class DateCell extends BaseCellRenderer<number, number> {
       //       for now the slide-layout-modal's z-index is `1001`
       //       the z-index of popover should be higher than it
       // root.style.zIndex = 'var(--affine-z-index-popover)';
-      root.style.zIndex = '1002';
+      portal.style.zIndex = '1002';
     }
   };
 

--- a/blocksuite/affine/inlines/latex/src/latex-node/latex-node.ts
+++ b/blocksuite/affine/inlines/latex/src/latex-node/latex-node.ts
@@ -190,7 +190,7 @@ export class AffineLatexNode extends SignalWatcher(
 
     blockComponent.selection.setGroup('note', []);
 
-    const portal = createLitPortal({
+    const { portal } = createLitPortal({
       template: html`<latex-editor-menu
         .std=${this.std}
         .latexSignal=${this.latexEditorSignal}

--- a/blocksuite/affine/widgets/slash-menu/src/slash-menu-popover.ts
+++ b/blocksuite/affine/widgets/slash-menu/src/slash-menu-popover.ts
@@ -378,7 +378,7 @@ export class InnerSlashMenu extends WithDisposable(LitElement) {
       this._closeSubMenu();
     });
 
-    const subMenuElement = createLitPortal({
+    const { portal: subMenuElement } = createLitPortal({
       shadowDom: false,
       template: html`<inner-slash-menu
         .context=${this.context}

--- a/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/doc-handler.ts
@@ -305,6 +305,6 @@ export function handleInlineAskAIAction(
       },
       abortController: abortController,
       closeOnClickAway: true,
-    });
+    }).portal;
   }, 0);
 }

--- a/packages/frontend/core/src/blocksuite/ai/components/ask-ai-toolbar.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ask-ai-toolbar.ts
@@ -65,7 +65,7 @@ export class AskAIToolbarButton extends WithDisposable(LitElement) {
       },
       abortController: this._abortController,
       closeOnClickAway: true,
-    });
+    }).portal;
   };
 
   private readonly _generateAnswer: AffineAIPanelWidgetConfig['generateAnswer'] =


### PR DESCRIPTION
Close [BS-3160](https://linear.app/affine-design/issue/BS-3160/新的-embed-输入的-sheet-没有弹起来)

#### PR Dependency Tree


* **PR #13073** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup positioning and responsiveness when using virtual keyboards, ensuring popups remain visible and correctly placed above the keyboard.
  * Standardized how popups and overlays are created and referenced throughout the app, reducing inconsistencies and potential display issues.
  * Enhanced stability of date picker, AI panels, and slash menu popovers by refining how their elements are managed and updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->