### PR TITLE
fix(core): should be able to unresolve a resolved comment

### DIFF
--- a/blocksuite/affine/inlines/comment/src/inline-comment-manager.ts
+++ b/blocksuite/affine/inlines/comment/src/inline-comment-manager.ts
@@ -74,12 +74,6 @@ export class InlineCommentManager extends LifeCycleWatcher {
       ...new Set([...inlineComments, ...blockComments]),
     ];
 
-    // resolve comments that are in provider but not in editor
-    // which means the commented content may be deleted
-    difference(commentsInProvider, commentsInEditor).forEach(comment => {
-      provider.resolveComment(comment);
-    });
-
     // remove comments that are in editor but not in provider
     // which means the comment may be removed or resolved in provider side
     difference(commentsInEditor, commentsInProvider).forEach(comment => {

--- a/packages/frontend/core/src/components/comment/sidebar/index.tsx
+++ b/packages/frontend/core/src/components/comment/sidebar/index.tsx
@@ -362,7 +362,7 @@ const CommentItem = ({
         data-menu-open={menuOpen}
         data-editing={isEditing}
       >
-        {!comment.resolved && canResolveComment && (
+        {canResolveComment && (
           <IconButton
             variant="solid"
             onClick={handleResolve}


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13078** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The resolve comment button is now always visible to users with permission to resolve comments, regardless of the comment's current status.

* **Refactor**
  * Adjusted internal comment resolution logic to streamline how missing comments are handled between the provider and the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->