### PR TITLE
fix(core): show actions only if docId equals session.docId

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-content/ai-chat-content.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-content/ai-chat-content.ts
@@ -197,6 +197,17 @@ export class AIChatContent extends SignalWatcher(
     });
   }
 
+  get showActions() {
+    if (this.docId) {
+      if (!this.session) {
+        return true;
+      }
+      return this.session.docId === this.docId;
+    } else {
+      return false;
+    }
+  }
+
   private readonly updateHistory = async () => {
     const currentRequest = ++this.updateHistoryCounter;
     if (!AIProvider.histories) {
@@ -208,7 +219,7 @@ export class AIChatContent extends SignalWatcher(
       sessionId
         ? AIProvider.histories.chats(this.workspaceId, sessionId)
         : Promise.resolve([]),
-      this.docId
+      this.docId && this.showActions
         ? AIProvider.histories.actions(this.workspaceId, this.docId)
         : Promise.resolve([]),
     ]);


### PR DESCRIPTION
Close [AI-240](https://linear.app/affine-design/issue/AI-240)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved logic for displaying actions in AI chat content, ensuring actions are shown only when appropriate based on session and document context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->