### PR TITLE
fix(core): insert diff not displayed after the expected block​

### DIFF
--- a/packages/frontend/core/src/__tests__/ai/utils/apply-model/generate-render-diff.spec.ts
+++ b/packages/frontend/core/src/__tests__/ai/utils/apply-model/generate-render-diff.spec.ts
@@ -334,4 +334,58 @@ Inserted at tail.
       updates: {},
     });
   });
+
+  test('should handle interval insertions & deletions', () => {
+    const oldMd = `
+<!-- block_id=block-001 flavour=title -->
+# 1
+
+<!-- block_id=block-002 flavour=paragraph -->
+2
+
+<!-- block_id=block-003 flavour=paragraph -->
+3
+
+<!-- block_id=block-004 flavour=paragraph -->
+4
+
+<!-- block_id=block-005 flavour=paragraph -->
+5
+`;
+    const newMd = `
+<!-- block_id=block-001 flavour=title -->
+# 1
+
+<!-- block_id=block-002 flavour=paragraph -->
+2
+
+<!-- block_id=block-004 flavour=paragraph -->
+4
+
+<!-- block_id=block-006 flavour=paragraph -->
+6
+
+<!-- block_id=block-007 flavour=paragraph -->
+7
+`;
+    const diff = generateRenderDiff(oldMd, newMd);
+    expect(diff).toEqual({
+      deletes: ['block-003', 'block-005'],
+      inserts: {
+        'block-004': [
+          {
+            id: 'block-006',
+            type: 'paragraph',
+            content: '6',
+          },
+          {
+            id: 'block-007',
+            type: 'paragraph',
+            content: '7',
+          },
+        ],
+      },
+      updates: {},
+    });
+  });
 });

--- a/packages/frontend/core/src/__tests__/ai/utils/apply-model/markdown-diff.spec.ts
+++ b/packages/frontend/core/src/__tests__/ai/utils/apply-model/markdown-diff.spec.ts
@@ -21,6 +21,7 @@ This is a new paragraph.
       {
         op: 'insert',
         index: 1,
+        after: 'block-001',
         block: {
           id: 'block-002',
           type: 'paragraph',
@@ -104,6 +105,7 @@ New paragraph.
       {
         op: 'insert',
         index: 2,
+        after: 'block-002',
         block: {
           id: 'block-004',
           type: 'paragraph',
@@ -138,6 +140,7 @@ Second inserted paragraph.
       {
         op: 'insert',
         index: 1,
+        after: 'block-001',
         block: {
           id: 'block-002',
           type: 'paragraph',
@@ -147,6 +150,7 @@ Second inserted paragraph.
       {
         op: 'insert',
         index: 2,
+        after: 'block-002',
         block: {
           id: 'block-003',
           type: 'paragraph',
@@ -213,11 +217,141 @@ This is a new paragraph inserted after deletion.
       {
         op: 'insert',
         index: 2,
+        after: 'block-003',
         block: {
           id: 'block-004',
           type: 'paragraph',
           content: 'This is a new paragraph inserted after deletion.',
         },
+      },
+      {
+        op: 'delete',
+        id: 'block-002',
+      },
+    ]);
+  });
+
+  test('should diff interval insertions & deletions', () => {
+    const oldMd = `
+<!-- block_id=block-001 flavour=title -->
+# 1
+
+<!-- block_id=block-002 flavour=paragraph -->
+2
+
+<!-- block_id=block-003 flavour=paragraph -->
+3
+
+<!-- block_id=block-004 flavour=paragraph -->
+4
+
+<!-- block_id=block-005 flavour=paragraph -->
+5
+`;
+
+    const newMd = `
+<!-- block_id=block-001 flavour=title -->
+# 1
+
+<!-- block_id=block-002 flavour=paragraph -->
+2
+
+<!-- block_id=block-004 flavour=paragraph -->
+4
+
+<!-- block_id=block-006 flavour=paragraph -->
+6
+
+<!-- block_id=block-007 flavour=paragraph -->
+7
+`;
+    const { patches } = diffMarkdown(oldMd, newMd);
+    expect(patches).toEqual([
+      {
+        op: 'insert',
+        index: 3,
+        after: 'block-004',
+        block: {
+          id: 'block-006',
+          type: 'paragraph',
+          content: '6',
+        },
+      },
+      {
+        op: 'insert',
+        index: 4,
+        after: 'block-006',
+        block: {
+          id: 'block-007',
+          type: 'paragraph',
+          content: '7',
+        },
+      },
+      {
+        op: 'delete',
+        id: 'block-003',
+      },
+      {
+        op: 'delete',
+        id: 'block-005',
+      },
+    ]);
+  });
+
+  test('should diff insertions after remove all', () => {
+    const oldMd = `
+<!-- block_id=block-001 flavour=title -->
+# 1
+
+<!-- block_id=block-002 flavour=paragraph -->
+2
+`;
+
+    const newMd = `
+<!-- block_id=block-003 flavour=paragraph -->
+3
+
+<!-- block_id=block-004 flavour=paragraph -->
+4
+
+<!-- block_id=block-005 flavour=paragraph -->
+5
+`;
+    const { patches } = diffMarkdown(oldMd, newMd);
+    expect(patches).toEqual([
+      {
+        op: 'insert',
+        index: 0,
+        after: 'HEAD',
+        block: {
+          id: 'block-003',
+          type: 'paragraph',
+          content: '3',
+        },
+      },
+      {
+        op: 'insert',
+        index: 1,
+        after: 'block-003',
+        block: {
+          id: 'block-004',
+          type: 'paragraph',
+          content: '4',
+        },
+      },
+      {
+        op: 'insert',
+        index: 2,
+        after: 'block-004',
+        block: {
+          id: 'block-005',
+          type: 'paragraph',
+          content: '5',
+        },
+      },
+      {
+        op: 'delete',
+        id: 'block-001',
       },
       {
         op: 'delete',

--- a/packages/frontend/core/src/blocksuite/ai/utils/apply-model/markdown-diff.ts
+++ b/packages/frontend/core/src/blocksuite/ai/utils/apply-model/markdown-diff.ts
@@ -7,7 +7,7 @@ export type Block = {
 export type PatchOp =
   | { op: 'replace'; id: string; content: string }
   | { op: 'delete'; id: string }
-  | { op: 'insert'; index: number; block: Block };
+  | { op: 'insert'; index: number; after: string; block: Block };
 
 const BLOCK_MATCH_REGEXP = /^\s*<!--\s*block_id=(.*?)\s+flavour=(.*?)\s*-->/;
 
@@ -61,7 +61,6 @@ function diffBlockLists(oldBlocks: Block[], newBlocks: Block[]): PatchOp[] {
   // Mark old blocks that have been handled
   const handledOld = new Set<string>();
 
-  // First process newBlocks in order
   newBlocks.forEach((newBlock, newIdx) => {
     const old = oldMap.get(newBlock.id);
     if (old) {
@@ -74,9 +73,11 @@ function diffBlockLists(oldBlocks: Block[], newBlocks: Block[]): PatchOp[] {
         });
       }
     } else {
+      const after = newIdx > 0 ? newBlocks[newIdx - 1].id : 'HEAD';
       patch.push({
         op: 'insert',
         index: newIdx,
+        after,
         block: {
           id: newBlock.id,
           type: newBlock.type,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of insertions and deletions in markdown block sequences, allowing new blocks to be inserted after specific existing blocks.

* **Bug Fixes**
  * Enhanced accuracy of patch operations for block insertions by specifying the correct insertion point.

* **Tests**
  * Added and updated test cases to verify correct behavior for interval insertions and deletions, and to ensure insertions use the new positioning logic.

* **Documentation**
  * Updated example documentation to reflect the new insert operation format and improved usage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

> CLOSE AI-319