### PR TITLE
feat(server): support read all notifications

### DIFF
--- a/packages/backend/server/src/core/notification/resolver.ts
+++ b/packages/backend/server/src/core/notification/resolver.ts
@@ -100,6 +100,14 @@ export class UserNotificationResolver {
     await this.service.markAsRead(me.id, notificationId);
     return true;
   }
+
+  @Mutation(() => Boolean, {
+    description: 'mark all notifications as read',
+  })
+  async readAllNotifications(@CurrentUser() me: UserType) {
+    await this.service.markAllAsRead(me.id);
+    return true;
+  }
 }
 
 @Resolver(() => NotificationObjectType)

--- a/packages/backend/server/src/core/notification/service.ts
+++ b/packages/backend/server/src/core/notification/service.ts
@@ -399,6 +399,10 @@ export class NotificationService {
     }
   }
 
+  async markAllAsRead(userId: string) {
+    await this.models.notification.markAllAsRead(userId);
+  }
+
   /**
    * Find notifications by user id, order by createdAt desc
    */

--- a/packages/backend/server/src/models/__tests__/notification.spec.ts
+++ b/packages/backend/server/src/models/__tests__/notification.spec.ts
@@ -430,3 +430,32 @@ test('should create a comment mention notification', async t => {
   t.is(notification.body.commentId, commentId);
   t.is(notification.body.replyId, replyId);
 });
+
+test('should mark all notifications as read', async t => {
+  await models.notification.createMention({
+    userId: user.id,
+    body: {
+      workspaceId: workspace.id,
+      doc: {
+        id: docId,
+        title: 'doc-title',
+        blockId: 'blockId',
+        mode: DocMode.page,
+      },
+      createdByUserId: createdBy.id,
+    },
+  });
+  await models.notification.createInvitation({
+    userId: user.id,
+    body: {
+      workspaceId: workspace.id,
+      createdByUserId: createdBy.id,
+      inviteId: randomUUID(),
+    },
+  });
+
+  await models.notification.markAllAsRead(user.id);
+
+  const notifications = await models.notification.findManyByUserId(user.id);
+  t.is(notifications.length, 0);
+});

--- a/packages/backend/server/src/models/notification.ts
+++ b/packages/backend/server/src/models/notification.ts
@@ -261,6 +261,18 @@ export class NotificationModel extends BaseModel {
     });
   }
 
+  async markAllAsRead(userId: string) {
+    const { count } = await this.db.notification.updateMany({
+      where: { userId },
+      data: {
+        read: true,
+      },
+    });
+    this.logger.log(
+      `Marked all notifications as read for user ${userId}, count: ${count}`
+    );
+  }
+
   /**
    * Find many notifications by user id, exclude read notifications by default
    */

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1236,6 +1236,9 @@ type Mutation {
   """queue workspace doc embedding"""
   queueWorkspaceEmbedding(docId: [String!]!, workspaceId: String!): Boolean!
 
+  """mark all notifications as read"""
+  readAllNotifications: Boolean!
+
   """mark notification as read"""
   readNotification(id: String!): Boolean!
   recoverDoc(guid: String!, timestamp: DateTime!, workspaceId: String!): DateTime!

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1989,6 +1989,14 @@ export const quotaQuery = {
   deprecations: ["'storageQuota' is deprecated: use `UserQuotaType['usedStorageQuota']` instead"],
 };
 
+export const readAllNotificationsMutation = {
+  id: 'readAllNotificationsMutation' as const,
+  op: 'readAllNotifications',
+  query: `mutation readAllNotifications {
+  readAllNotifications
+}`,
+};
+
 export const readNotificationMutation = {
   id: 'readNotificationMutation' as const,
   op: 'readNotification',

--- a/packages/common/graphql/src/graphql/read-all-notifications.gql
+++ b/packages/common/graphql/src/graphql/read-all-notifications.gql
@@ -1,0 +1,3 @@
+mutation readAllNotifications {
+  readAllNotifications
+}

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -1371,6 +1371,8 @@ export interface Mutation {
   publishPage: DocType;
   /** queue workspace doc embedding */
   queueWorkspaceEmbedding: Scalars['Boolean']['output'];
+  /** mark all notifications as read */
+  readAllNotifications: Scalars['Boolean']['output'];
   /** mark notification as read */
   readNotification: Scalars['Boolean']['output'];
   recoverDoc: Scalars['DateTime']['output'];
@@ -5218,6 +5220,15 @@ export type QuotaQuery = {
   } | null;
 };
 
+export type ReadAllNotificationsMutationVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type ReadAllNotificationsMutation = {
+  __typename?: 'Mutation';
+  readAllNotifications: boolean;
+};
+
 export type ReadNotificationMutationVariables = Exact<{
   id: Scalars['String']['input'];
 }>;
@@ -6351,6 +6362,11 @@ export type Mutations =
       name: 'publishPageMutation';
       variables: PublishPageMutationVariables;
       response: PublishPageMutation;
+    }
+  | {
+      name: 'readAllNotificationsMutation';
+      variables: ReadAllNotificationsMutationVariables;
+      response: ReadAllNotificationsMutation;
     }
   | {
       name: 'readNotificationMutation';


### PR DESCRIPTION
close AF-2719



#### PR Dependency Tree


* **PR #13083** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to mark all notifications as read with a single action.
  
* **Bug Fixes**
  * Ensured notifications marked as read are no longer shown as unread.

* **Tests**
  * Introduced new tests to verify the functionality of marking all notifications as read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->