### PR TITLE
fix(core): ai tool calling explanation

### DIFF
--- a/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
+++ b/packages/backend/server/src/plugins/copilot/prompt/prompts.ts
@@ -1675,6 +1675,7 @@ This sentence contains information from the first source[^1]. This sentence refe
 
 <tool-calling-guidelines>
 Before starting Tool calling, you need to follow:
+- DO NOT explain what operation you will perform.
 - DO NOT embed a tool call mid-sentence.
 - When searching for unknown information or keyword, prioritize searching the user's workspace.
 - Depending on the complexity of the question and the information returned by the search tools, you can call different tools multiple times to search.

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/web-crawl.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/web-crawl.ts
@@ -46,7 +46,7 @@ export class WebCrawlTool extends WithDisposable(ShadowlessElement) {
   renderToolCall() {
     return html`
       <tool-call-card
-        .name=${'Reading the website'}
+        .name=${`Reading the website "${this.data.args.url}"`}
         .icon=${WebIcon()}
       ></tool-call-card>
     `;

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/web-search.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/web-search.ts
@@ -12,14 +12,14 @@ interface WebSearchToolCall {
   type: 'tool-call';
   toolCallId: string;
   toolName: string;
-  args: { url: string };
+  args: { query: string };
 }
 
 interface WebSearchToolResult {
   type: 'tool-result';
   toolCallId: string;
   toolName: string;
-  args: { url: string };
+  args: { query: string };
   result:
     | Array<{
         title: string;
@@ -46,7 +46,7 @@ export class WebSearchTool extends WithDisposable(ShadowlessElement) {
   renderToolCall() {
     return html`
       <tool-call-card
-        .name=${'Search from web'}
+        .name=${`Searching the web for "${this.data.args.query}"`}
         .icon=${WebIcon()}
       ></tool-call-card>
     `;


### PR DESCRIPTION
Close [AI-293](https://linear.app/affine-design/issue/AI-293)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool call cards for website reading now display the specific URL being accessed.
  * Tool call cards for web searches now display the search query being used.

* **Style**
  * Updated tool call instructions to prevent explanations of operations before execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->