### PR TITLE
fix(core): avoid shared page to fetch workspace info

### DIFF
--- a/packages/frontend/core/src/modules/permissions/entities/permission.ts
+++ b/packages/frontend/core/src/modules/permissions/entities/permission.ts
@@ -37,7 +37,10 @@ export class WorkspacePermission extends Entity {
   revalidate = effect(
     exhaustMapWithTrailing(() => {
       return fromPromise(async signal => {
-        if (this.workspaceService.workspace.flavour !== 'local') {
+        if (
+          this.workspaceService.workspace.flavour !== 'local' &&
+          !this.workspaceService.workspace.openOptions.isSharedMode
+        ) {
           const info = await this.store.fetchWorkspaceInfo(
             this.workspaceService.workspace.id,
             signal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission handling to correctly identify user roles when the workspace is in shared mode or has a local flavour, ensuring accurate permissions are assigned in these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->