### PR TITLE
fix(core): some ux enhancements on comments

### DIFF
--- a/blocksuite/affine/blocks/root/src/page/page-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/page/page-root-block.ts
@@ -305,7 +305,10 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
       );
 
       // make sure there is a block can be focused
-      if (notes.length === 0 || notes[notes.length - 1].children.length === 0) {
+      if (
+        !this.store.readonly$.value &&
+        (notes.length === 0 || notes[notes.length - 1].children.length === 0)
+      ) {
         this.std.command.exec(appendParagraphCommand);
         return;
       }
@@ -322,7 +325,7 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
         parseFloat(paddingLeft),
         parseFloat(paddingRight)
       );
-      if (!isClickOnBlankArea) {
+      if (!isClickOnBlankArea && !this.store.readonly$.value) {
         const lastBlock = notes[notes.length - 1].lastChild();
         if (
           !lastBlock ||

--- a/blocksuite/affine/inlines/comment/src/index.ts
+++ b/blocksuite/affine/inlines/comment/src/index.ts
@@ -1,2 +1,4 @@
+export { InlineCommentManager } from './inline-comment-manager';
 export * from './inline-spec';
 export * from './utils';
+export * from './view';

--- a/blocksuite/affine/inlines/comment/src/inline-spec.ts
+++ b/blocksuite/affine/inlines/comment/src/inline-spec.ts
@@ -36,3 +36,14 @@ export const CommentInlineSpecExtension =
       >`,
     wrapper: true,
   });
+
+export const NullCommentInlineSpecExtension =
+  InlineSpecExtension<AffineTextAttributes>({
+    name: 'comment',
+    schema: dynamicSchema(
+      isInlineCommendId,
+      z.boolean().optional().nullable().catch(undefined)
+    ),
+    match: () => false,
+    renderer: () => html``,
+  });

--- a/blocksuite/affine/inlines/comment/src/view.ts
+++ b/blocksuite/affine/inlines/comment/src/view.ts
@@ -2,21 +2,41 @@ import {
   type ViewExtensionContext,
   ViewExtensionProvider,
 } from '@blocksuite/affine-ext-loader';
+import z from 'zod';
 
 import { effects } from './effects';
 import { InlineCommentManager } from './inline-comment-manager';
-import { CommentInlineSpecExtension } from './inline-spec';
+import {
+  CommentInlineSpecExtension,
+  NullCommentInlineSpecExtension,
+} from './inline-spec';
 
-export class InlineCommentViewExtension extends ViewExtensionProvider {
+const optionsSchema = z.object({
+  enabled: z.boolean().optional().default(true),
+});
+
+export class InlineCommentViewExtension extends ViewExtensionProvider<
+  z.infer<typeof optionsSchema>
+> {
   override name = 'affine-inline-comment';
+
+  override schema = optionsSchema;
 
   override effect(): void {
     super.effect();
     effects();
   }
 
-  override setup(context: ViewExtensionContext) {
-    super.setup(context);
-    context.register([CommentInlineSpecExtension, InlineCommentManager]);
+  override setup(
+    context: ViewExtensionContext,
+    options?: z.infer<typeof optionsSchema>
+  ) {
+    super.setup(context, options);
+    context.register([
+      options?.enabled
+        ? CommentInlineSpecExtension
+        : NullCommentInlineSpecExtension,
+      InlineCommentManager,
+    ]);
   }
 }

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/lit-adaper.tsx
@@ -59,7 +59,7 @@ interface BlocksuiteEditorProps {
   defaultOpenProperty?: DefaultOpenProperty;
 }
 
-const usePatchSpecs = (mode: DocMode) => {
+const usePatchSpecs = (mode: DocMode, shared?: boolean) => {
   const [reactToLit, portals] = useLitPortalFactory();
   const { workspaceService, featureFlagService } = useServices({
     WorkspaceService,
@@ -86,7 +86,8 @@ const usePatchSpecs = (mode: DocMode) => {
   const serverConfig = useLiveData(serverService.server.config$);
 
   // comment may not be supported by the server
-  const enableComment = serverConfig.features.includes(ServerFeature.Comment);
+  const enableComment =
+    serverConfig.features.includes(ServerFeature.Comment) && !shared;
 
   const patchedSpecs = useMemo(() => {
     const manager = getViewManager()
@@ -206,7 +207,7 @@ export const BlocksuiteDocEditor = forwardRef<
     [externalTitleRef]
   );
 
-  const [specs, portals] = usePatchSpecs('page');
+  const [specs, portals] = usePatchSpecs('page', shared);
 
   const displayBiDirectionalLink = useLiveData(
     editorSettingService.editorSetting.settings$.selector(

--- a/packages/frontend/core/src/blocksuite/manager/view.ts
+++ b/packages/frontend/core/src/blocksuite/manager/view.ts
@@ -33,6 +33,7 @@ import type {
 import { ViewExtensionManager } from '@blocksuite/affine/ext-loader';
 import { getInternalViewExtensions } from '@blocksuite/affine/extensions/view';
 import { FoundationViewExtension } from '@blocksuite/affine/foundation/view';
+import { InlineCommentViewExtension } from '@blocksuite/affine/inlines/comment';
 import { AffineCanvasTextFonts } from '@blocksuite/affine/shared/services';
 import { LinkedDocViewExtension } from '@blocksuite/affine/widgets/linked-doc/view';
 import type { FrameworkProvider } from '@toeverything/infra';
@@ -340,6 +341,11 @@ class ViewProvider {
       enableComment,
       framework,
     });
+
+    this._manager.configure(InlineCommentViewExtension, {
+      enabled: enableComment,
+    });
+
     return this.config;
   };
 }

--- a/packages/frontend/core/src/blocksuite/view-extensions/comment/comment-provider.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/comment/comment-provider.ts
@@ -128,6 +128,7 @@ class AffineCommentService implements CommentProvider {
     private readonly framework: FrameworkProvider
   ) {
     this.docCommentManager = framework.get(DocCommentManagerService);
+    this.docCommentManager.std = std;
   }
 
   private get currentDocId(): string {

--- a/packages/frontend/core/src/components/comment/comment-editor/specs.ts
+++ b/packages/frontend/core/src/components/comment/comment-editor/specs.ts
@@ -1,6 +1,7 @@
 import { CloudViewExtension } from '@affine/core/blocksuite/view-extensions/cloud';
 import { AffineEditorViewExtension } from '@affine/core/blocksuite/view-extensions/editor-view/editor-view';
 import { AffineThemeViewExtension } from '@affine/core/blocksuite/view-extensions/theme';
+import { I18n } from '@affine/i18n';
 import { CodeBlockViewExtension } from '@blocksuite/affine/blocks/code/view';
 import { DividerViewExtension } from '@blocksuite/affine/blocks/divider/view';
 import { LatexViewExtension as LatexBlockViewExtension } from '@blocksuite/affine/blocks/latex/view';
@@ -154,7 +155,7 @@ export function getCommentEditorViewManager(framework: FrameworkProvider) {
 
     manager.configure(ParagraphViewExtension, {
       getPlaceholder: () => {
-        return '';
+        return I18n.t('com.affine.notification.comment-prompt');
       },
     });
 

--- a/packages/frontend/core/src/components/comment/sidebar/index.tsx
+++ b/packages/frontend/core/src/components/comment/sidebar/index.tsx
@@ -377,7 +377,7 @@ const CommentItem = ({
     entity.dismissDraftReply();
   }, [entity, pendingReply]);
 
-  const handleClickPreview = useCallback(() => {
+  const handleClick = useCallback(() => {
     workbench.workbench.openDoc(
       {
         docId: entity.props.docId,
@@ -470,6 +470,10 @@ const CommentItem = ({
   const canDelete =
     (isMyComment && canCreateComment) || (!isMyComment && canDeleteComment);
 
+  const isCommentInEditor = useLiveData(entity.commentsInEditor$).includes(
+    comment.id
+  );
+
   // invalid comment, should not happen
   if (!comment.content) {
     return null;
@@ -477,7 +481,7 @@ const CommentItem = ({
 
   return (
     <div
-      onClick={handleClickPreview}
+      onClick={handleClick}
       data-comment-id={comment.id}
       data-resolved={comment.resolved}
       data-highlighting={highlighting || menuOpen}
@@ -512,7 +516,12 @@ const CommentItem = ({
           onDelete={handleDelete}
         />
       </div>
-      <div className={styles.previewContainer}>{comment.content?.preview}</div>
+      <div
+        data-deleted={!isCommentInEditor}
+        className={styles.previewContainer}
+      >
+        {comment.content?.preview}
+      </div>
 
       <div className={styles.repliesContainer}>
         {isEditing && editingDoc ? (

--- a/packages/frontend/core/src/components/comment/sidebar/style.css.ts
+++ b/packages/frontend/core/src/components/comment/sidebar/style.css.ts
@@ -130,6 +130,9 @@ export const previewContainer = style({
       top: '0',
       backgroundColor: cssVarV2('block/comment/highlightUnderline'),
     },
+    '&[data-deleted="true"]': {
+      textDecoration: 'line-through',
+    },
   },
 });
 

--- a/packages/frontend/core/src/modules/comment/entities/doc-comment-store.ts
+++ b/packages/frontend/core/src/modules/comment/entities/doc-comment-store.ts
@@ -179,13 +179,14 @@ export class DocCommentStore extends Entity<{
 
   async createComment(commentInput: {
     content: DocCommentContent;
+    mentions?: string[];
   }): Promise<DocComment> {
     const graphql = this.graphqlService;
     if (!graphql) {
       throw new Error('GraphQL service not found');
     }
 
-    const mentions = findMentions(commentInput.content.snapshot.blocks);
+    const mentions = commentInput.mentions;
 
     const response = await graphql.gql({
       query: createCommentMutation,
@@ -265,14 +266,13 @@ export class DocCommentStore extends Entity<{
     commentId: string,
     replyInput: {
       content: DocCommentContent;
+      mentions?: string[];
     }
   ): Promise<DocCommentReply> {
     const graphql = this.graphqlService;
     if (!graphql) {
       throw new Error('GraphQL service not found');
     }
-
-    const mentions = findMentions(replyInput.content.snapshot.blocks);
 
     const response = await graphql.gql({
       query: createReplyMutation,
@@ -282,7 +282,7 @@ export class DocCommentStore extends Entity<{
           content: replyInput.content,
           docMode: this.props.getDocMode(),
           docTitle: this.props.getDocTitle(),
-          mentions: mentions,
+          mentions: replyInput.mentions,
         },
       },
     });

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -7755,6 +7755,10 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.notification.unsupported"](): string;
     /**
+      * `What are your thoughts?`
+      */
+    ["com.affine.notification.comment-prompt"](): string;
+    /**
       * `No new notifications`
       */
     ["com.affine.notification.empty"](): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1936,6 +1936,7 @@
   "com.affine.notification.mention": "<1>{{username}}</1> mentioned you in <2>{{docTitle}}</2>",
   "com.affine.notification.comment": "<1>{{username}}</1> commented in <2>{{docTitle}}</2>",
   "com.affine.notification.comment-mention": "<1>{{username}}</1> mentioned you in a comment in <2>{{docTitle}}</2>",
+  "com.affine.notification.comment-prompt": "What are your thoughts?",
   "com.affine.notification.empty": "No new notifications",
   "com.affine.notification.loading-more": "Loading more...",
   "com.affine.notification.empty.description": "You'll be notified here for @mentions and workspace invites.",

--- a/packages/frontend/track/src/events.ts
+++ b/packages/frontend/track/src/events.ts
@@ -198,6 +198,15 @@ type WorkspaceEmbeddingEvents =
   | 'addIgnoredDocs';
 // END SECTION
 
+// SECTION: comment events
+// Add events for comment actions
+type CommentEvents =
+  | 'createComment'
+  | 'editComment'
+  | 'deleteComment'
+  | 'resolveComment';
+// END SECTION
+
 type UserEvents =
   | GeneralEvents
   | AppEvents
@@ -215,6 +224,7 @@ type UserEvents =
   | PaymentEvents
   | DNDEvents
   | AIEvents
+  | CommentEvents
   | AttachmentEvents
   | TemplateEvents
   | NotificationEvents
@@ -420,6 +430,9 @@ interface PageEvents extends PageDivision {
     };
     chatPanel: {
       chatPanelInput: ['addEmbeddingDoc'];
+    };
+    commentPanel: {
+      $: ['createComment', 'editComment', 'deleteComment', 'resolveComment'];
     };
     attachment: {
       $: [
@@ -807,6 +820,15 @@ export type EventArgs = {
   navigatePinedCollectionRouter: {
     control: 'all' | 'user-custom-collection';
   };
+  resolveComment: { type: 'on' | 'off' };
+  createComment: {
+    type: 'root' | 'node';
+    withAttachment: boolean;
+    withMention: boolean;
+    category: string;
+  };
+  editComment: { type: 'root' | 'node' };
+  deleteComment: { type: 'root' | 'node' };
 };
 
 // for type checking


### PR DESCRIPTION
fix PD-2688

#### PR Dependency Tree


* **PR #13105** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added configurable support for enabling or disabling inline comments.
  * Introduced visual indication (strikethrough) for deleted comments in the comment sidebar.
  * Sidebar now shows when a comment is no longer present in the editor.
  * Added a localized placeholder prompt ("What are your thoughts?") in the comment editor.
  * Integrated detailed event tracking for comment actions: create, edit, delete, and resolve.

* **Improvements**
  * Inline comments are now disabled in shared mode.
  * Enhanced synchronization between editor comments and provider state to remove stale comments.
  * Inline comment features now respect the document’s read-only state.
  * Improved mention handling and tracking in comment creation and editing.
  * Comment manager and entities now dynamically track comments present in the editor.
  * Comment configuration updated to enable or disable inline comments based on settings.

* **Bug Fixes**
  * Prevented comment block creation when in read-only mode.

* **Localization**
  * Added English localization for the comment prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


#### PR Dependency Tree


* **PR #13105** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)