### PR TITLE
fix(core): should show delete permanently for trash page multi-select

### DIFF
--- a/packages/frontend/core/src/components/explorer/docs-view/docs-list.tsx
+++ b/packages/frontend/core/src/components/explorer/docs-view/docs-list.tsx
@@ -108,7 +108,14 @@ export const DocsExplorer = ({
   masonryItemWidthMin?: number;
   onRestore?: (ids: string[]) => void;
   /** Override the default delete action */
-  onDelete?: (ids: string[]) => void;
+  onDelete?: (
+    ids: string[],
+    callbacks?: {
+      onFinished?: () => void;
+      onAbort?: () => void;
+      onError?: (error: Error) => void;
+    }
+  ) => void;
 }) => {
   const t = useI18n();
   const contextValue = useContext(DocExplorerContext);
@@ -163,8 +170,11 @@ export const DocsExplorer = ({
       return;
     }
     if (onDelete) {
-      onDelete(contextValue.selectedDocIds$.value);
-      handleCloseFloatingToolbar();
+      onDelete(contextValue.selectedDocIds$.value, {
+        onFinished: () => {
+          handleCloseFloatingToolbar();
+        },
+      });
       return;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation modal before permanently deleting pages from the trash, ensuring users must confirm before deletion.
  * Permanent deletion now displays a toast notification upon completion.

* **Improvements**
  * Enhanced deletion actions with callbacks for handling completion, cancellation, or errors.
  * Permanent delete option is now conditionally available based on user permissions (admin or owner).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->