### PR TITLE
feat(editor): can highlight resolved comment

### DIFF
--- a/blocksuite/affine/inlines/comment/src/inline-comment.ts
+++ b/blocksuite/affine/inlines/comment/src/inline-comment.ts
@@ -22,7 +22,7 @@ import { isEqual } from 'lodash-es';
 })
 export class InlineComment extends WithDisposable(ShadowlessElement) {
   static override styles = css`
-    inline-comment {
+    inline-comment.unresolved {
       display: inline-block;
       background-color: ${unsafeCSSVarV2('block/comment/highlightDefault')};
       border-bottom: 2px solid
@@ -41,6 +41,9 @@ export class InlineComment extends WithDisposable(ShadowlessElement) {
   })
   accessor commentIds!: string[];
 
+  @property({ attribute: false })
+  accessor unresolved = false;
+
   private _index: number = 0;
 
   @consume({ context: stdContext })
@@ -54,8 +57,10 @@ export class InlineComment extends WithDisposable(ShadowlessElement) {
   }
 
   private readonly _handleClick = () => {
-    this._provider?.highlightComment(this.commentIds[this._index]);
-    this._index = (this._index + 1) % this.commentIds.length;
+    if (this.unresolved) {
+      this._provider?.highlightComment(this.commentIds[this._index]);
+      this._index = (this._index + 1) % this.commentIds.length;
+    }
   };
 
   private readonly _handleHighlight = (id: CommentId | null) => {
@@ -87,6 +92,13 @@ export class InlineComment extends WithDisposable(ShadowlessElement) {
         this.classList.add('highlighted');
       } else {
         this.classList.remove('highlighted');
+      }
+    }
+    if (_changedProperties.has('unresolved')) {
+      if (this.unresolved) {
+        this.classList.add('unresolved');
+      } else {
+        this.classList.remove('unresolved');
       }
     }
   }

--- a/blocksuite/affine/inlines/comment/src/inline-spec.ts
+++ b/blocksuite/affine/inlines/comment/src/inline-spec.ts
@@ -21,19 +21,25 @@ export const CommentInlineSpecExtension =
     ),
     match: delta => {
       if (!delta.attributes) return false;
-      const comments = Object.entries(delta.attributes).filter(
-        ([key, value]) => isInlineCommendId(key) && value === true
-      );
+      const comments = Object.keys(delta.attributes).filter(isInlineCommendId);
       return comments.length > 0;
     },
-    renderer: ({ delta, children }) =>
-      html`<inline-comment .commentIds=${extractCommentIdFromDelta(delta)}
+    renderer: ({ delta, children }) => {
+      if (!delta.attributes) return html`${nothing}`;
+
+      const unresolved = Object.entries(delta.attributes).some(
+        ([key, value]) => isInlineCommendId(key) && value === true
+      );
+      return html`<inline-comment
+        .unresolved=${unresolved}
+        .commentIds=${extractCommentIdFromDelta(delta)}
         >${when(
           children,
           () => html`${children}`,
           () => nothing
         )}</inline-comment
-      >`,
+      >`;
+    },
     wrapper: true,
   });
 

--- a/blocksuite/affine/shared/src/services/comment-service/block-element-comment-manager.ts
+++ b/blocksuite/affine/shared/src/services/comment-service/block-element-comment-manager.ts
@@ -57,10 +57,12 @@ export class BlockElementCommentManager extends LifeCycleWatcher {
 
     this._disposables.add(provider.onCommentAdded(this._handleAddComment));
     this._disposables.add(
-      provider.onCommentDeleted(this.handleDeleteAndResolve)
+      provider.onCommentDeleted(id => this.handleDeleteAndResolve(id, 'delete'))
     );
     this._disposables.add(
-      provider.onCommentResolved(this.handleDeleteAndResolve)
+      provider.onCommentResolved(id =>
+        this.handleDeleteAndResolve(id, 'resolve')
+      )
     );
     this._disposables.add(
       provider.onCommentHighlighted(this._handleHighlightComment)
@@ -147,18 +149,29 @@ export class BlockElementCommentManager extends LifeCycleWatcher {
     }
   };
 
-  readonly handleDeleteAndResolve = (id: CommentId) => {
+  readonly handleDeleteAndResolve = (
+    id: CommentId,
+    type: 'delete' | 'resolve'
+  ) => {
     const commentedBlocks = findCommentedBlocks(this.std.store, id);
     this.std.store.withoutTransact(() => {
       commentedBlocks.forEach(block => {
-        delete block.props.comments[id];
+        if (type === 'delete') {
+          delete block.props.comments[id];
+        } else {
+          block.props.comments[id] = false;
+        }
       });
     });
 
     const commentedElements = findCommentedElements(this.std.store, id);
     this.std.store.withoutTransact(() => {
       commentedElements.forEach(element => {
-        delete element.comments[id];
+        if (type === 'delete') {
+          delete element.comments[id];
+        } else {
+          element.comments[id] = false;
+        }
       });
     });
   };


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13122** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inline comments now visually distinguish between unresolved, resolved, and deleted states.
  * Only unresolved inline comments are interactive and highlighted in the editor.

* **Bug Fixes**
  * Improved accuracy in fetching and displaying all comments, including resolved ones, during initialization.

* **Refactor**
  * Enhanced handling of comment resolution and deletion to provide clearer differentiation in both behavior and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->