### PR TITLE
chore(ios): fix ios version

### DIFF
--- a/.github/actions/setup-version/action.yml
+++ b/.github/actions/setup-version/action.yml
@@ -4,9 +4,15 @@ inputs:
   app-version:
     description: 'App Version'
     required: true
+  ios-app-version:
+    description: 'iOS App Store Version (Optional, use App version if empty)'
+    required: false
+    type: string
 runs:
   using: 'composite'
   steps:
     - name: 'Write Version'
       shell: bash
+      env:
+        IOS_APP_VERSION: ${{ inputs.ios-app-version }}
       run: ./scripts/set-version.sh ${{ inputs.app-version }}

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -12,6 +12,9 @@ on:
       build-type:
         type: string
         required: true
+      ios-app-version:
+        type: string
+        required: false
 
 env:
   BUILD_TYPE: ${{ inputs.build-type }}
@@ -78,7 +81,7 @@ jobs:
           path: packages/frontend/apps/android/dist
 
   ios:
-    runs-on: ${{ github.ref_name == 'canary' && 'macos-latest' || 'blaze/macos-14' }}
+    runs-on: 'macos-15'
     needs:
       - build-ios-web
     steps:
@@ -87,6 +90,7 @@ jobs:
         uses: ./.github/actions/setup-version
         with:
           app-version: ${{ inputs.app-version }}
+          ios-app-version: ${{ inputs.ios-app-version }}
       - name: 'Update Code Sign Identity'
         shell: bash
         run: ./packages/frontend/apps/ios/update_code_sign_identity.sh
@@ -106,7 +110,7 @@ jobs:
           enableScripts: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: 16.2
+          xcode-version: 16.4
       - name: Install Swiftformat
         run: brew install swiftformat
       - name: Cap sync

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
         required: true
         type: boolean
         default: false
+      ios-app-version:
+        description: 'iOS App Store Version (Optional, use tag version if empty)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -117,3 +121,4 @@ jobs:
       build-type: ${{ needs.prepare.outputs.BUILD_TYPE }}
       app-version: ${{ needs.prepare.outputs.APP_VERSION }}
       git-short-hash: ${{ needs.prepare.outputs.GIT_SHORT_HASH }}
+      ios-app-version: ${{ inputs.ios-app-version }}

--- a/packages/frontend/apps/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/frontend/apps/ios/App/App.xcodeproj/project.pbxproj
@@ -541,7 +541,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				MARKETING_VERSION = 0.22.2;
+				MARKETING_VERSION = 0.23.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = app.affine.pro;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -577,7 +577,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				MARKETING_VERSION = 0.22.2;
+				MARKETING_VERSION = 0.23.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = app.affine.pro;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/scripts/set-version.sh
+++ b/scripts/set-version.sh
@@ -99,6 +99,7 @@ update_ios_marketing_version() {
 }
 
 new_version=$1
+ios_new_version=${IOS_APP_VERSION:-$new_version}
 
 update_app_version_in_helm_charts ".github/helm/affine/Chart.yaml" "$new_version"
 update_app_version_in_helm_charts ".github/helm/affine/charts/graphql/Chart.yaml" "$new_version"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a custom iOS App Store version during release workflows.

* **Chores**
  * Updated the iOS app's marketing version to 0.23.1.
  * Upgraded the iOS workflow runner to macOS 15 and Xcode 16.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->