### PR TITLE
feat(server): export title and summary on doc resolver

### DIFF
--- a/packages/backend/server/src/__tests__/e2e/doc/resolver.spec.ts
+++ b/packages/backend/server/src/__tests__/e2e/doc/resolver.spec.ts
@@ -99,3 +99,56 @@ e2e(
     t.is(result2.workspace.doc.public, true);
   }
 );
+
+e2e('should get doc with title and summary', async t => {
+  const owner = await app.signup();
+
+  const workspace = await app.create(Mockers.Workspace, {
+    owner: { id: owner.id },
+  });
+
+  const docSnapshot = await app.create(Mockers.DocSnapshot, {
+    workspaceId: workspace.id,
+    user: owner,
+  });
+  const doc = await app.create(Mockers.DocMeta, {
+    workspaceId: workspace.id,
+    docId: docSnapshot.id,
+    title: 'doc1',
+    summary: 'summary1',
+  });
+
+  const result = await app.gql({
+    query: getWorkspacePageByIdQuery,
+    variables: { workspaceId: workspace.id, pageId: doc.docId },
+  });
+
+  t.is(result.workspace.doc.title, doc.title);
+  t.is(result.workspace.doc.summary, doc.summary);
+});
+
+e2e('should get doc with title and null summary', async t => {
+  const owner = await app.signup();
+
+  const workspace = await app.create(Mockers.Workspace, {
+    owner: { id: owner.id },
+  });
+
+  const docSnapshot = await app.create(Mockers.DocSnapshot, {
+    workspaceId: workspace.id,
+    user: owner,
+  });
+  const doc = await app.create(Mockers.DocMeta, {
+    workspaceId: workspace.id,
+    docId: docSnapshot.id,
+    title: 'doc1',
+  });
+
+  const result = await app.gql({
+    query: getWorkspacePageByIdQuery,
+    variables: { workspaceId: workspace.id, pageId: doc.docId },
+  });
+
+  t.is(result.workspace.doc.title, doc.title);
+  t.is(result.workspace.doc.summary, null);
+});

--- a/packages/backend/server/src/__tests__/models/doc.spec.ts
+++ b/packages/backend/server/src/__tests__/models/doc.spec.ts
@@ -669,7 +669,10 @@ test('should get doc info', async t => {
   };
 
   await t.context.doc.upsert(snapshot);
-  await t.context.doc.upsertMeta(workspace.id, docId);
+  await t.context.doc.upsertMeta(workspace.id, docId, {
+    title: 'test title',
+    summary: 'test summary',
+  });
 
   const docInfo = await t.context.doc.getDocInfo(workspace.id, docId);
 
@@ -679,6 +682,8 @@ test('should get doc info', async t => {
     updatedAt: new Date(snapshot.timestamp),
     creatorId: user.id,
     lastUpdaterId: user.id,
+    title: 'test title',
+    summary: 'test summary',
   });
 });
 

--- a/packages/backend/server/src/models/doc.ts
+++ b/packages/backend/server/src/models/doc.ts
@@ -558,6 +558,8 @@ export class DocModel extends BaseModel {
         mode: PublicDocMode;
         public: boolean;
         defaultRole: DocRole;
+        title: string | null;
+        summary: string | null;
         createdAt: Date;
         updatedAt: Date;
         creatorId?: string;
@@ -570,6 +572,8 @@ export class DocModel extends BaseModel {
      "workspace_pages"."mode" as "mode",
      "workspace_pages"."public" as "public",
      "workspace_pages"."defaultRole" as "defaultRole",
+     "workspace_pages"."title" as "title",
+     "workspace_pages"."summary" as "summary",
      "snapshots"."created_at" as "createdAt",
      "snapshots"."updated_at" as "updatedAt",
      "snapshots"."created_by" as "creatorId",

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -595,6 +595,7 @@ type DocType {
   mode: PublicDocMode!
   permissions: DocPermissions!
   public: Boolean!
+  summary: String
   title: String
   updatedAt: DateTime
   workspaceId: String!

--- a/packages/common/graphql/src/graphql/get-workspace-page-by-id.gql
+++ b/packages/common/graphql/src/graphql/get-workspace-page-by-id.gql
@@ -5,6 +5,8 @@ query getWorkspacePageById($workspaceId: String!, $pageId: String!) {
       mode
       defaultRole
       public
+      title
+      summary
     }
   }
 }

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1584,6 +1584,8 @@ export const getWorkspacePageByIdQuery = {
       mode
       defaultRole
       public
+      title
+      summary
     }
   }
 }`,

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -703,6 +703,7 @@ export interface DocType {
   mode: PublicDocMode;
   permissions: DocPermissions;
   public: Scalars['Boolean']['output'];
+  summary: Maybe<Scalars['String']['output']>;
   title: Maybe<Scalars['String']['output']>;
   updatedAt: Maybe<Scalars['DateTime']['output']>;
   workspaceId: Scalars['String']['output'];
@@ -5147,6 +5148,8 @@ export type GetWorkspacePageByIdQuery = {
       mode: PublicDocMode;
       defaultRole: DocRole;
       public: boolean;
+      title: string | null;
+      summary: string | null;
     };
   };
 };


### PR DESCRIPTION
close AF-2732






#### PR Dependency Tree


* **PR #13139** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a document summary field, allowing documents to include and display an optional summary alongside the title.

* **Bug Fixes**
  * Improved access control when retrieving documents, ensuring proper permission checks are enforced.

* **Tests**
  * Expanded test coverage to verify correct handling of document title and summary fields, including cases where the summary is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->