### PR TITLE
fix(editor): commented heading style

### DIFF
--- a/blocksuite/framework/std/src/inline/utils/attribute-renderer.ts
+++ b/blocksuite/framework/std/src/inline/utils/attribute-renderer.ts
@@ -30,9 +30,9 @@ function inlineTextStyles(
   }
 
   return styleMap({
-    'font-weight': props.bold ? 'bold' : 'normal',
-    'font-style': props.italic ? 'italic' : 'normal',
-    'text-decoration': textDecorations.length > 0 ? textDecorations : 'none',
+    'font-weight': props.bold ? 'bold' : 'inherit',
+    'font-style': props.italic ? 'italic' : 'inherit',
+    'text-decoration': textDecorations.length > 0 ? textDecorations : 'inherit',
     ...inlineCodeStyle,
   });
 }


### PR DESCRIPTION
Close BS-3613

#### PR Dependency Tree


* **PR #13140** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated default text styling to inherit font weight, style, and decoration from parent elements when bold, italic, underline, or strike attributes are not set. This may result in text more closely matching its surrounding context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->