### PR TITLE
chore(server): add comment attachment storage metrics

### DIFF
--- a/packages/backend/server/src/base/metrics/metrics.ts
+++ b/packages/backend/server/src/base/metrics/metrics.ts
@@ -59,7 +59,8 @@ export type KnownMetricScopes =
   | 'mail'
   | 'ai'
   | 'event'
-  | 'queue';
+  | 'queue'
+  | 'storage';
 
 const metricCreators: MetricCreators = {
   counter(meter: Meter, name: string, opts?: MetricOptions) {


### PR DESCRIPTION
close AF-2728



#### PR Dependency Tree


* **PR #13143** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics tracking for comment attachment uploads, including recording attachment size and total uploads by MIME type.
  * Enhanced logging for attachment uploads with detailed information such as workspace ID, document ID, file size, and user ID.

* **Chores**
  * Expanded internal metric categories to include storage-related metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->