### PR TITLE
feat(core): render session title in ai session history

### DIFF
--- a/packages/common/graphql/src/graphql/copilot-session-list-recent.gql
+++ b/packages/common/graphql/src/graphql/copilot-session-list-recent.gql
@@ -11,7 +11,7 @@ query getCopilotRecentSessions(
         options: {
           fork: false
           sessionOrder: desc
-          withMessages: true
+          withMessages: false
         }
       ) {
         ...PaginatedCopilotChats

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -1073,7 +1073,7 @@ export const getCopilotRecentSessionsQuery = {
     copilot(workspaceId: $workspaceId) {
       chats(
         pagination: {first: $limit}
-        options: {fork: false, sessionOrder: desc, withMessages: true}
+        options: {fork: false, sessionOrder: desc, withMessages: false}
       ) {
         ...PaginatedCopilotChats
       }

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-toolbar/ai-session-history.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-toolbar/ai-session-history.ts
@@ -225,7 +225,7 @@ export class AISessionHistory extends WithDisposable(ShadowlessElement) {
               }}
             >
               <div class="ai-session-title">
-                ${session.sessionId}
+                ${session.title || 'New chat'}
                 <affine-tooltip .offsetX=${60}>
                   Click to open this chat
                 </affine-tooltip>


### PR DESCRIPTION
Close [AI-331](https://linear.app/affine-design/issue/AI-331)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session history now displays the session title (or "New chat" if unavailable) instead of the session ID for a clearer user experience.

* **Performance**
  * Recent copilot chat session lists now load faster by excluding message details from the initial query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->