### PR TITLE
feat(server): add process memory usage metrics

### DIFF
--- a/packages/backend/server/src/app.module.ts
+++ b/packages/backend/server/src/app.module.ts
@@ -36,6 +36,7 @@ import { DocRendererModule } from './core/doc-renderer';
 import { DocServiceModule } from './core/doc-service';
 import { FeatureModule } from './core/features';
 import { MailModule } from './core/mail';
+import { MonitorModule } from './core/monitor';
 import { NotificationModule } from './core/notification';
 import { PermissionModule } from './core/permission';
 import { QuotaModule } from './core/quota';
@@ -112,6 +113,7 @@ export const FunctionalityModules = [
   WebSocketModule,
   JobModule.forRoot(),
   ModelsModule,
+  MonitorModule,
 ];
 
 export class AppModuleBuilder {

--- a/packages/backend/server/src/base/metrics/metrics.ts
+++ b/packages/backend/server/src/base/metrics/metrics.ts
@@ -60,7 +60,8 @@ export type KnownMetricScopes =
   | 'ai'
   | 'event'
   | 'queue'
-  | 'storage';
+  | 'storage'
+  | 'process';
 
 const metricCreators: MetricCreators = {
   counter(meter: Meter, name: string, opts?: MetricOptions) {

--- a/packages/backend/server/src/core/monitor/index.ts
+++ b/packages/backend/server/src/core/monitor/index.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+
+import { MonitorService } from './service';
+
+@Global()
+@Module({
+  providers: [MonitorService],
+})
+export class MonitorModule {}

--- a/packages/backend/server/src/core/monitor/service.ts
+++ b/packages/backend/server/src/core/monitor/service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+
+import { metrics } from '../../base';
+
+@Injectable()
+export class MonitorService {
+  protected logger = new Logger(MonitorService.name);
+
+  @Cron(CronExpression.EVERY_MINUTE)
+  async monitor() {
+    const memoryUsage = process.memoryUsage();
+    this.logger.log(
+      `memory usage: rss: ${memoryUsage.rss}, heapTotal: ${memoryUsage.heapTotal}, heapUsed: ${memoryUsage.heapUsed}, external: ${memoryUsage.external}, arrayBuffers: ${memoryUsage.arrayBuffers}`
+    );
+    metrics.process.gauge('node_process_rss').record(memoryUsage.rss);
+    metrics.process
+      .gauge('node_process_heap_total')
+      .record(memoryUsage.heapTotal);
+    metrics.process
+      .gauge('node_process_heap_used')
+      .record(memoryUsage.heapUsed);
+    metrics.process.gauge('node_process_external').record(memoryUsage.external);
+    metrics.process
+      .gauge('node_process_array_buffers')
+      .record(memoryUsage.arrayBuffers);
+  }
+}


### PR DESCRIPTION
close CLOUD-235

<img width="2104" height="1200" alt="image" src="https://github.com/user-attachments/assets/6ea0fd89-ab32-42e3-a675-f00f9e5856ad" />



#### PR Dependency Tree


* **PR #13148** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new monitoring service that automatically collects and logs process memory usage statistics every minute.
  * Enhanced system monitoring capabilities by integrating a global monitoring module.
  * Added support for a new "process" scope in metric tracking.

* **Chores**
  * Improved internal module organization by including the monitoring module in the core functionality set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->