### PR TITLE
feat(core): hide linked doc by default

### DIFF
--- a/packages/common/infra/src/atom/settings.ts
+++ b/packages/common/infra/src/atom/settings.ts
@@ -34,7 +34,7 @@ const appSettingBaseAtom = atomWithStorage<AppSetting>(
     autoCheckUpdate: true,
     autoDownloadUpdate: true,
     enableTelemetry: true,
-    showLinkedDocInSidebar: true,
+    showLinkedDocInSidebar: false,
   },
   undefined,
   {

--- a/packages/frontend/core/src/modules/app-sidebar/views/index.tsx
+++ b/packages/frontend/core/src/modules/app-sidebar/views/index.tsx
@@ -36,7 +36,7 @@ export type History = {
 };
 
 const MAX_WIDTH = 480;
-const MIN_WIDTH = 248;
+const MIN_WIDTH = 180;
 const isMacosDesktop = BUILD_CONFIG.isElectron && environment.isMacOs;
 
 export function AppSidebar({ children }: PropsWithChildren) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sidebar can now be resized to a narrower minimum width, allowing for more flexible layout options.

* **Chores**
  * Linked documents are now hidden by default in the sidebar for new users or fresh installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->