### PR TITLE
fix(core): avoid infinite sign in with selfhost

### DIFF
--- a/packages/frontend/core/src/modules/cloud/services/servers.ts
+++ b/packages/frontend/core/src/modules/cloud/services/servers.ts
@@ -47,6 +47,17 @@ export class ServersService extends Service {
     [] as any
   );
 
+  serversWithAccount$ = this.servers$
+    .map(servers =>
+      servers.map(server =>
+        server.account$.map(account => ({
+          server,
+          account,
+        }))
+      )
+    )
+    .flat();
+
   server$(id: string) {
     return this.servers$.map(servers =>
       servers.find(server => server.id === id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The 404 page now reflects user session state across multiple servers, showing the appropriate user context when multiple accounts are logged in.

* **Improvements**
  * Enhanced user experience on the 404 page by accurately displaying information based on the first active logged-in account across all servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->