### PR TITLE
fix(core): loading spinner color issue

### DIFF
--- a/blocksuite/affine/components/src/icons/loading.ts
+++ b/blocksuite/affine/components/src/icons/loading.ts
@@ -18,6 +18,7 @@ export const LoadingIcon = ({
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
+    style="fill: none;"
   >
     <style>
       .spinner {


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13192** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the loading icon to ensure consistent appearance by explicitly setting the fill property to none using an inline style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->