### PR TITLE
feat(core): do not show AI actions in history

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-content/ai-chat-content.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-content/ai-chat-content.ts
@@ -219,14 +219,7 @@ export class AIChatContent extends SignalWatcher(
   }
 
   get showActions() {
-    if (this.docId) {
-      if (!this.session) {
-        return true;
-      }
-      return this.session.docId === this.docId;
-    } else {
-      return false;
-    }
+    return false;
   }
 
   private readonly updateHistory = async () => {
@@ -269,7 +262,7 @@ export class AIChatContent extends SignalWatcher(
   };
 
   private readonly updateActions = async () => {
-    if (!this.docId || !AIProvider.histories) {
+    if (!this.docId || !AIProvider.histories || !this.showActions) {
       return;
     }
     const actions = await AIProvider.histories.actions(

--- a/tests/affine-cloud-copilot/e2e/ai-action/change-tone.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/change-tone.spec.ts
@@ -59,7 +59,7 @@ test.describe('AIAction/ChangeTone', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/check-code-error.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/check-code-error.spec.ts
@@ -24,7 +24,7 @@ test.describe('AIAction/CheckCodeError', () => {
     );
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/continue-writing.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/continue-writing.spec.ts
@@ -60,7 +60,7 @@ test.describe('AIAction/ContinueWriting', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/explain-code.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/explain-code.spec.ts
@@ -18,7 +18,7 @@ test.describe('AIAction/ExplainCode', () => {
     await expect(answer).toHaveText(/console.log/);
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/explain-image.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/explain-image.spec.ts
@@ -27,7 +27,7 @@ test.describe('AIAction/ExplainImage', () => {
     expect(responses).toEqual(new Set(['insert-below', 'replace-selection']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/explain-selection.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/explain-selection.spec.ts
@@ -53,7 +53,7 @@ test.describe('AIAction/ExplainSelection', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/find-actions.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/find-actions.spec.ts
@@ -102,7 +102,7 @@ Compare and Select Flights`
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/fix-grammar.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/fix-grammar.spec.ts
@@ -53,7 +53,7 @@ test.describe('AIAction/FixGrammar', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/fix-spelling.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/fix-spelling.spec.ts
@@ -50,7 +50,7 @@ test.describe('AIAction/FixSpelling', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/generate-an-image-with-image.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/generate-an-image-with-image.spec.ts
@@ -27,7 +27,7 @@ test.describe('AIAction/GenerateAnImageWithImage', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/generate-an-image-with-text.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/generate-an-image-with-text.spec.ts
@@ -63,7 +63,7 @@ test.describe('AIAction/GenerateAnImageWithText', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/generate-headings.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/generate-headings.spec.ts
@@ -74,7 +74,7 @@ test.describe('AIAction/GenerateHeadings', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/generate-image-caption.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/generate-image-caption.spec.ts
@@ -29,7 +29,7 @@ test.describe('AIAction/GenerateImageCaption', () => {
     );
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/generate-outline.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/generate-outline.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/GenerateOutline', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/image-processing.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/image-processing.spec.ts
@@ -27,7 +27,7 @@ test.describe('AIAction/ImageProcessing', () => {
     await expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/improve-writing.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/improve-writing.spec.ts
@@ -51,7 +51,7 @@ test.describe('AIAction/ImproveWriting', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/make-it-longer.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/make-it-longer.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/MakeItLonger', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/make-it-real.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/make-it-real.spec.ts
@@ -64,7 +64,7 @@ test.describe('AIAction/MakeItReal', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/make-it-shorter.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/make-it-shorter.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/MakeItShorter', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/summarize.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/summarize.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/Summarize', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/translate.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/translate.spec.ts
@@ -48,7 +48,7 @@ test.describe('AIAction/Translate', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('support show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/write-an-article.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/write-an-article.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/WriteAnArticleAboutThis', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/write-an-blog.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/write-an-blog.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/WriteAnBlogPostAboutThis', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/write-an-poem.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/write-an-poem.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/WriteAnPoemAboutThis', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {

--- a/tests/affine-cloud-copilot/e2e/ai-action/write-an-tweet.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/write-an-tweet.spec.ts
@@ -57,7 +57,7 @@ test.describe('AIAction/WriteAnTweetAboutThis', () => {
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
-  test('should show chat history in chat panel', async ({
+  test.skip('should show chat history in chat panel', async ({
     loggedInPage: page,
     utils,
   }) => {


### PR DESCRIPTION
Close [AI-351](https://linear.app/affine-design/issue/AI-351)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled action updates related to document IDs and sessions in the AI chat content panel.

* **Tests**
  * Skipped all end-to-end tests for the "should show chat history in chat panel" scenario across various AI action test suites. These tests will no longer run during automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->