### PR TITLE
fix(core): the down arrow may show when showLinkedDoc not configured

### DIFF
--- a/packages/frontend/core/src/desktop/components/navigation-panel/nodes/doc/index.tsx
+++ b/packages/frontend/core/src/desktop/components/navigation-panel/nodes/doc/index.tsx
@@ -252,7 +252,7 @@ export const NavigationPanelDocNode = ({
       extractEmojiAsIcon={enableEmojiIcon}
       collapsed={isCollapsed}
       setCollapsed={setCollapsed}
-      collapsible={appSettings.showLinkedDocInSidebar}
+      collapsible={!!appSettings.showLinkedDocInSidebar}
       canDrop={handleCanDrop}
       to={`/${docId}`}
       onClick={() => {

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/appearance/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/appearance/index.tsx
@@ -181,7 +181,7 @@ export const AppearanceSettings = () => {
           ]()}
         >
           <Switch
-            checked={appSettings.showLinkedDocInSidebar}
+            checked={!!appSettings.showLinkedDocInSidebar}
             onChange={checked =>
               updateSettings('showLinkedDocInSidebar', checked)
             }


### PR DESCRIPTION
The original setting object on user's device not defined, so the default value `true` won't work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of sidebar and appearance settings by ensuring toggle switches consistently reflect the correct on/off state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->