### PR TITLE
feat(core): add flag for two-step journal conformation

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -264,6 +264,14 @@ export const AFFINE_FLAGS = {
     configurable: isCanaryBuild,
     defaultState: false,
   },
+  enable_two_step_journal_confirmation: {
+    category: 'affine',
+    displayName: 'Enable Two Step Journal Confirmation',
+    description:
+      'When enabled, you must confirm the journal before you can create a new journal.',
+    configurable: isCanaryBuild,
+    defaultState: isCanaryBuild,
+  },
 } satisfies { [key in string]: FlagInfo };
 
 // oxlint-disable-next-line no-redeclare


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a feature flag to control a two-step journal confirmation process.
  * Users may now experience either an immediate journal opening or a confirmation step before journal creation, depending on the feature flag status.

* **Chores**
  * Added a new feature flag for two-step journal confirmation, configurable in canary builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->