### PR TITLE
fix(core): comment action button bg color

### DIFF
--- a/packages/frontend/core/src/components/comment/comment-editor/index.tsx
+++ b/packages/frontend/core/src/components/comment/comment-editor/index.tsx
@@ -514,7 +514,7 @@ export const CommentEditor = forwardRef<CommentEditorRef, CommentEditorProps>(
       return;
     }, [doc, onChange, snapshotHelper]);
 
-    // Add keydown handler to commit on CMD/CTRL + Enter key
+    // Add keydown handler to commit on Enter key
     const handleKeyDown = useCallback(
       (e: React.KeyboardEvent) => {
         if (readonly) return;
@@ -523,8 +523,8 @@ export const CommentEditor = forwardRef<CommentEditorRef, CommentEditorProps>(
         const activeElement = document.activeElement;
         if (!editorRef.current?.contains(activeElement)) return;
 
-        // If Enter is pressed with CMD/CTRL key, commit the comment
-        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        // If Enter is pressed without CMD/CTRL key, commit the comment
+        if (e.key === 'Enter' && !(e.metaKey || e.ctrlKey)) {
           e.preventDefault();
           e.stopPropagation();
           handleCommit();

--- a/packages/frontend/core/src/components/comment/sidebar/index.tsx
+++ b/packages/frontend/core/src/components/comment/sidebar/index.tsx
@@ -157,6 +157,7 @@ const ActionMenu = ({
       }
     >
       <IconButton
+        className={styles.actionButton}
         variant="solid"
         icon={<MoreHorizontalIcon />}
         disabled={disabled}
@@ -491,6 +492,7 @@ const CommentItem = ({
       >
         {canResolveComment && (
           <IconButton
+            className={styles.actionButton}
             variant="solid"
             onClick={handleResolve}
             icon={<DoneIcon />}

--- a/packages/frontend/core/src/components/comment/sidebar/style.css.ts
+++ b/packages/frontend/core/src/components/comment/sidebar/style.css.ts
@@ -163,6 +163,10 @@ export const commentActions = style({
   },
 });
 
+export const actionButton = style({
+  backgroundColor: cssVarV2('button/buttonOverHover'),
+});
+
 export const readonlyCommentContainer = style({
   display: 'flex',
   flexDirection: 'column',


### PR DESCRIPTION
fix BS-3623

Also use enter instead of enter+CMD/CTRL to commit comment/reply

#### PR Dependency Tree


* **PR #13250** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated comment editor so comments are now submitted by pressing Enter (without CMD or CTRL).
* **Style**
  * Improved visual styling for action buttons in the comment sidebar for a more consistent appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->