### PR TITLE
fix(core): hide intelligence entrance when ai is disabled

### DIFF
--- a/packages/frontend/core/src/components/root-app-sidebar/index.tsx
+++ b/packages/frontend/core/src/components/root-app-sidebar/index.tsx
@@ -10,8 +10,9 @@ import {
   SidebarScrollableContainer,
 } from '@affine/core/modules/app-sidebar/views';
 import { ExternalMenuLinkItem } from '@affine/core/modules/app-sidebar/views/menu-item/external-menu-link-item';
-import { AuthService } from '@affine/core/modules/cloud';
+import { AuthService, ServerService } from '@affine/core/modules/cloud';
 import { WorkspaceDialogService } from '@affine/core/modules/dialogs';
+import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { CMDKQuickSearchService } from '@affine/core/modules/quicksearch/services/cmdk';
 import type { Workspace } from '@affine/core/modules/workspace';
 import { useI18n } from '@affine/i18n';
@@ -88,6 +89,11 @@ const AllDocsButton = () => {
 };
 
 const AIChatButton = () => {
+  const featureFlagService = useService(FeatureFlagService);
+  const serverService = useService(ServerService);
+  const serverFeatures = useLiveData(serverService.server.features$);
+  const enableAI = useLiveData(featureFlagService.flags.enable_ai.$);
+
   const { workbenchService } = useServices({
     WorkbenchService,
   });
@@ -95,6 +101,10 @@ const AIChatButton = () => {
   const aiChatActive = useLiveData(
     workbench.location$.selector(location => location.pathname === '/chat')
   );
+
+  if (!enableAI || !serverFeatures?.copilot) {
+    return null;
+  }
 
   return (
     <MenuLinkItem icon={<AiOutlineIcon />} active={aiChatActive} to={'/chat'}>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI Chat button is now only visible when AI features are enabled and supported by the server, ensuring users see it only when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->