### PR TITLE
fix(core): share page should have basename correctly set

### DIFF
--- a/packages/frontend/core/src/desktop/pages/workspace/share/share-page.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/share/share-page.tsx
@@ -14,7 +14,11 @@ import {
   EditorsService,
 } from '@affine/core/modules/editor';
 import { PeekViewManagerModal } from '@affine/core/modules/peek-view';
-import { ViewIcon, ViewTitle } from '@affine/core/modules/workbench';
+import {
+  ViewIcon,
+  ViewTitle,
+  WorkbenchService,
+} from '@affine/core/modules/workbench';
 import {
   type Workspace,
   WorkspacesService,
@@ -33,6 +37,17 @@ import { PageNotFound } from '../../404';
 import { ShareFooter } from './share-footer';
 import { ShareHeader } from './share-header';
 import * as styles from './share-page.css';
+
+const useUpdateBasename = (workspace: Workspace | null) => {
+  const location = useLocation();
+  const basename = location.pathname.match(/\/workspace\/[^/]+/g)?.[0] ?? '/';
+  useEffect(() => {
+    if (workspace) {
+      const workbench = workspace.scope.get(WorkbenchService).workbench;
+      workbench.updateBasename(basename);
+    }
+  }, [basename, workspace]);
+};
 
 export const SharePage = ({
   workspaceId,
@@ -187,6 +202,7 @@ const SharePageInner = ({
   const t = useI18n();
   const pageTitle = useLiveData(page?.title$);
   const { jumpToPageBlock, openPage } = useNavigateHelper();
+  useUpdateBasename(workspace);
 
   const onEditorLoad = useCallback(
     (editorContainer: AffineEditorContainer) => {


### PR DESCRIPTION
fix AF-2760

#### PR Dependency Tree


* **PR #13256** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved synchronization of workspace information with the URL path, ensuring the displayed workspace name stays up-to-date when navigating within the workspace share page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->