### PR TITLE
fix(core): code-edit param maybe json string

### DIFF
--- a/packages/backend/server/src/plugins/copilot/tools/doc-edit.ts
+++ b/packages/backend/server/src/plugins/copilot/tools/doc-edit.ts
@@ -142,24 +142,33 @@ You should specify the following arguments before the others: [doc_id], [origin_
           'A short, first-person description of the intended edit, clearly summarizing what I will change. For example: "I will translate the steps into English and delete the paragraph explaining the delay." This helps the downstream system understand the purpose of the changes.'
         ),
 
-      code_edit: z
-        .array(
-          z.object({
-            op: z
-              .string()
-              .describe(
-                'A short description of the change, such as "Bold intro name"'
-              ),
-            updates: z
-              .string()
-              .describe(
-                'Markdown block fragments that represent the change, including the block_id and type'
-              ),
-          })
-        )
-        .describe(
-          'An array of independent semantic changes to apply to the document.'
-        ),
+      code_edit: z.preprocess(
+        val => {
+          // BACKGROUND: LLM sometimes returns a JSON string instead of an array.
+          if (typeof val === 'string') {
+            return JSON.parse(val);
+          }
+          return val;
+        },
+        z
+          .array(
+            z.object({
+              op: z
+                .string()
+                .describe(
+                  'A short description of the change, such as "Bold intro name"'
+                ),
+              updates: z
+                .string()
+                .describe(
+                  'Markdown block fragments that represent the change, including the block_id and type'
+                ),
+            })
+          )
+          .describe(
+            'An array of independent semantic changes to apply to the document.'
+          )
+      ),
     }),
     execute: async ({ doc_id, origin_content, code_edit }) => {
       try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved input handling for code editing by allowing the tool to accept both arrays and JSON string representations for the `code_edit` parameter, ensuring more robust and flexible input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->