### PR TITLE
fix(core): allow mobile connect selfhost without https

### DIFF
--- a/packages/frontend/apps/android/App/app/src/main/AndroidManifest.xml
+++ b/packages/frontend/apps/android/App/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
 
         <activity

--- a/packages/frontend/apps/ios/App/App/Info.plist
+++ b/packages/frontend/apps/ios/App/App/Info.plist
@@ -69,5 +69,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+  </dict>
 </dict>
 </plist>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android and iOS app configurations to allow non-HTTPS (cleartext) network traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->