### PR TITLE
feat(core): enable two step journal by default

### DIFF
--- a/packages/frontend/core/src/blocksuite/block-suite-header/journal/date-picker.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-header/journal/date-picker.tsx
@@ -1,6 +1,5 @@
 import type { WeekDatePickerHandle } from '@affine/component';
 import { WeekDatePicker } from '@affine/component';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import {
   JOURNAL_DATE_FORMAT,
   JournalService,
@@ -26,11 +25,6 @@ export const JournalWeekDatePicker = ({ page }: JournalWeekDatePickerProps) => {
   );
   const workbench = useService(WorkbenchService).workbench;
 
-  const featureFlagService = useService(FeatureFlagService);
-  const isTwoStepJournalConfirmationEnabled = useLiveData(
-    featureFlagService.flags.enable_two_step_journal_confirmation.$
-  );
-
   useEffect(() => {
     if (!journalDate) return;
     setDate(journalDate.format(JOURNAL_DATE_FORMAT));
@@ -39,19 +33,14 @@ export const JournalWeekDatePicker = ({ page }: JournalWeekDatePickerProps) => {
 
   const openJournal = useCallback(
     (date: string) => {
-      if (isTwoStepJournalConfirmationEnabled) {
-        const docs = journalService.journalsByDate$(date).value;
-        if (docs.length > 0) {
-          workbench.openDoc(docs[0].id, { at: 'active' });
-        } else {
-          workbench.open(`/journals?date=${date}`, { at: 'active' });
-        }
+      const docs = journalService.journalsByDate$(date).value;
+      if (docs.length > 0) {
+        workbench.openDoc(docs[0].id, { at: 'active' });
       } else {
-        const doc = journalService.ensureJournalByDate(date);
-        workbench.openDoc(doc.id, { at: 'active' });
+        workbench.open(`/journals?date=${date}`, { at: 'active' });
       }
     },
-    [isTwoStepJournalConfirmationEnabled, journalService, workbench]
+    [journalService, workbench]
   );
 
   return (

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/journal/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/tabs/journal/index.tsx
@@ -16,7 +16,6 @@ import {
   DocsService,
 } from '@affine/core/modules/doc';
 import { DocDisplayMetaService } from '@affine/core/modules/doc-display-meta';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { JournalService } from '@affine/core/modules/journal';
 import {
   WorkbenchLink,
@@ -114,26 +113,16 @@ export const EditorJournalPanel = () => {
   const journalDate = journalDateStr ? dayjs(journalDateStr) : null;
   const isJournal = !!journalDate;
 
-  const featureFlagService = useService(FeatureFlagService);
-  const isTwoStepJournalConfirmationEnabled = useLiveData(
-    featureFlagService.flags.enable_two_step_journal_confirmation.$
-  );
-
   const openJournal = useCallback(
     (date: string) => {
-      if (isTwoStepJournalConfirmationEnabled) {
-        const docs = journalService.journalsByDate$(date).value;
-        if (docs.length > 0) {
-          workbench.openDoc(docs[0].id, { at: 'active' });
-        } else {
-          workbench.open(`/journals?date=${date}`, { at: 'active' });
-        }
+      const docs = journalService.journalsByDate$(date).value;
+      if (docs.length > 0) {
+        workbench.openDoc(docs[0].id, { at: 'active' });
       } else {
-        const doc = journalService.ensureJournalByDate(date);
-        workbench.openDoc(doc.id, { at: 'active' });
+        workbench.open(`/journals?date=${date}`, { at: 'active' });
       }
     },
-    [isTwoStepJournalConfirmationEnabled, journalService, workbench]
+    [journalService, workbench]
   );
 
   const onDateSelect = useCallback(

--- a/packages/frontend/core/src/desktop/pages/workspace/journals/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/journals/index.tsx
@@ -4,7 +4,6 @@ import {
   type WeekDatePickerHandle,
 } from '@affine/component';
 import { BlocksuiteEditorJournalDocTitleUI } from '@affine/core/blocksuite/block-suite-editor/journal-doc-title';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import {
   JOURNAL_DATE_FORMAT,
   JournalService,
@@ -22,13 +21,7 @@ import { TodayIcon } from '@blocksuite/icons/rc';
 import { useLiveData, useService } from '@toeverything/infra';
 import dayjs from 'dayjs';
 import type { Location } from 'history';
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useLayoutEffect, useRef, useState } from 'react';
 
 import { AllDocSidebarTabs } from '../layouts/all-doc-sidebar-tabs';
 import * as styles from './index.css';
@@ -157,31 +150,6 @@ export const JournalsPageWithConfirmation = () => {
   );
 };
 
-export const JournalsPageWithoutConfirmation = () => {
-  const journalService = useService(JournalService);
-  const workbench = useService(WorkbenchService).workbench;
-
-  useEffect(() => {
-    const today = dayjs().format(JOURNAL_DATE_FORMAT);
-    const doc = journalService.ensureJournalByDate(today);
-    workbench.openDoc(doc.id, {
-      replaceHistory: true,
-      at: 'active',
-    });
-  }, [journalService, workbench]);
-
-  return null;
-};
-
 export const Component = () => {
-  const featureFlagService = useService(FeatureFlagService);
-  const isTwoStepJournalConfirmationEnabled = useLiveData(
-    featureFlagService.flags.enable_two_step_journal_confirmation.$
-  );
-
-  if (isTwoStepJournalConfirmationEnabled) {
-    return <JournalsPageWithConfirmation />;
-  }
-
-  return <JournalsPageWithoutConfirmation />;
+  return <JournalsPageWithConfirmation />;
 };

--- a/packages/frontend/core/src/mobile/components/app-tabs/journal.tsx
+++ b/packages/frontend/core/src/mobile/components/app-tabs/journal.tsx
@@ -1,5 +1,4 @@
 import { DocDisplayMetaService } from '@affine/core/modules/doc-display-meta';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { JournalService } from '@affine/core/modules/journal';
 import { WorkbenchService } from '@affine/core/modules/workbench';
 import { TodayIcon } from '@blocksuite/icons/rc';
@@ -14,23 +13,14 @@ export const AppTabJournal = ({ tab }: AppTabCustomFCProps) => {
   const location = useLiveData(workbench.location$);
   const journalService = useService(JournalService);
   const docDisplayMetaService = useService(DocDisplayMetaService);
-  const featureFlagService = useService(FeatureFlagService);
-  const isTwoStepJournalConfirmationEnabled = useLiveData(
-    featureFlagService.flags.enable_two_step_journal_confirmation.$
-  );
 
   const maybeDocId = location.pathname.split('/')[1];
   const journalDate = useLiveData(journalService.journalDate$(maybeDocId));
   const JournalIcon = useLiveData(docDisplayMetaService.icon$(maybeDocId));
 
   const handleOpenToday = useCallback(() => {
-    if (isTwoStepJournalConfirmationEnabled) {
-      workbench.open('/journals', { at: 'active' });
-    } else {
-      const docId = journalService.ensureJournalByDate(new Date()).id;
-      workbench.openDoc({ docId, fromTab: 'true' }, { at: 'active' });
-    }
-  }, [workbench, journalService, isTwoStepJournalConfirmationEnabled]);
+    workbench.open('/journals', { at: 'active' });
+  }, [workbench]);
 
   const Icon = journalDate ? JournalIcon : TodayIcon;
 

--- a/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/detail/mobile-detail-page.tsx
@@ -242,10 +242,6 @@ const MobileDetailPage = ({
   const workbench = useService(WorkbenchService).workbench;
   const [showTitle, setShowTitle] = useState(checkShowTitle);
   const title = useLiveData(docDisplayMetaService.title$(pageId));
-  const featureFlagService = useService(FeatureFlagService);
-  const isTwoStepJournalConfirmationEnabled = useLiveData(
-    featureFlagService.flags.enable_two_step_journal_confirmation.$
-  );
 
   const canAccess = useGuard('Doc_Read', pageId);
 
@@ -256,25 +252,17 @@ const MobileDetailPage = ({
 
   const handleDateChange = useCallback(
     (date: string) => {
-      if (isTwoStepJournalConfirmationEnabled) {
-        const docs = journalService.journalsByDate$(date).value;
-        if (docs.length > 0) {
-          workbench.openDoc(
-            { docId: docs[0].id, fromTab: fromTab ? 'true' : undefined },
-            { replaceHistory: true }
-          );
-        } else {
-          workbench.open(`/journals?date=${date}`);
-        }
-      } else {
-        const docId = journalService.ensureJournalByDate(date).id;
+      const docs = journalService.journalsByDate$(date).value;
+      if (docs.length > 0) {
         workbench.openDoc(
-          { docId, fromTab: fromTab ? 'true' : undefined },
+          { docId: docs[0].id, fromTab: fromTab ? 'true' : undefined },
           { replaceHistory: true }
         );
+      } else {
+        workbench.open(`/journals?date=${date}`);
       }
     },
-    [fromTab, isTwoStepJournalConfirmationEnabled, journalService, workbench]
+    [fromTab, journalService, workbench]
   );
 
   useGlobalEvent(

--- a/packages/frontend/core/src/mobile/pages/workspace/journals.tsx
+++ b/packages/frontend/core/src/mobile/pages/workspace/journals.tsx
@@ -2,17 +2,13 @@ import {
   getDateFromUrl,
   JournalPlaceholder,
 } from '@affine/core/desktop/pages/workspace/journals';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
-import {
-  JOURNAL_DATE_FORMAT,
-  JournalService,
-} from '@affine/core/modules/journal';
+import { JournalService } from '@affine/core/modules/journal';
 import { ViewService, WorkbenchService } from '@affine/core/modules/workbench';
 import { i18nTime } from '@affine/i18n';
 import { useLiveData, useService } from '@toeverything/infra';
 import { cssVarV2 } from '@toeverything/theme/v2';
 import dayjs from 'dayjs';
-import { useCallback, useEffect, useLayoutEffect, useState } from 'react';
+import { useCallback, useLayoutEffect, useState } from 'react';
 
 import { AppTabs, PageHeader } from '../../components';
 import { JournalDatePicker } from './detail/journal-date-picker';
@@ -77,31 +73,6 @@ export const JournalsPageWithConfirmation = () => {
   );
 };
 
-export const JournalsPageWithoutConfirmation = () => {
-  const journalService = useService(JournalService);
-  const workbench = useService(WorkbenchService).workbench;
-
-  useEffect(() => {
-    const today = dayjs().format(JOURNAL_DATE_FORMAT);
-    const doc = journalService.ensureJournalByDate(today);
-    workbench.openDoc(doc.id, {
-      replaceHistory: true,
-      at: 'active',
-    });
-  }, [journalService, workbench]);
-
-  return null;
-};
-
 export const Component = () => {
-  const featureFlagService = useService(FeatureFlagService);
-  const isTwoStepJournalConfirmationEnabled = useLiveData(
-    featureFlagService.flags.enable_two_step_journal_confirmation.$
-  );
-
-  if (isTwoStepJournalConfirmationEnabled) {
-    return <JournalsPageWithConfirmation />;
-  }
-
-  return <JournalsPageWithoutConfirmation />;
+  return <JournalsPageWithConfirmation />;
 };

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -264,14 +264,6 @@ export const AFFINE_FLAGS = {
     configurable: isCanaryBuild,
     defaultState: false,
   },
-  enable_two_step_journal_confirmation: {
-    category: 'affine',
-    displayName: 'Enable Two Step Journal Confirmation',
-    description:
-      'When enabled, you must confirm the journal before you can create a new journal.',
-    configurable: isCanaryBuild,
-    defaultState: isCanaryBuild,
-  },
 } satisfies { [key in string]: FlagInfo };
 
 // oxlint-disable-next-line no-redeclare


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The journal confirmation flow is now always enabled when creating or opening journals across all platforms.

* **Refactor**
  * Removed the two-step journal confirmation feature flag and all related conditional logic.
  * Simplified journal navigation and creation flows for a more consistent user experience.

* **Chores**
  * Cleaned up unused components and imports related to the removed feature flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->