### PR TITLE
feat(server): put current user in first on the list

### DIFF
--- a/packages/backend/server/src/__tests__/e2e/workspace/member.spec.ts
+++ b/packages/backend/server/src/__tests__/e2e/workspace/member.spec.ts
@@ -226,8 +226,22 @@ e2e('should support pagination for member', async t => {
       take: 2,
     },
   });
+  t.is(result.workspace.members[0].id, owner.id);
   t.is(result.workspace.memberCount, 3);
   t.is(result.workspace.members.length, 2);
+
+  await app.login(u1);
+  result = await app.gql({
+    query: getMembersByWorkspaceIdQuery,
+    variables: {
+      workspaceId: workspace.id,
+      skip: 0,
+      take: 5,
+    },
+  });
+  t.is(result.workspace.members[0].id, u1.id);
+  t.is(result.workspace.memberCount, 3);
+  t.is(result.workspace.members.length, 3);
 
   result = await app.gql({
     query: getMembersByWorkspaceIdQuery,

--- a/packages/backend/server/src/core/workspaces/resolvers/member.ts
+++ b/packages/backend/server/src/core/workspaces/resolvers/member.ts
@@ -117,10 +117,14 @@ export class WorkspaceMemberResolver {
         status,
       }));
     } else {
-      const [list] = await this.models.workspaceUser.paginate(workspace.id, {
-        offset: skip ?? 0,
-        first: take ?? 8,
-      });
+      const [list] = await this.models.workspaceUser.paginate(
+        workspace.id,
+        {
+          offset: skip ?? 0,
+          first: take ?? 8,
+        },
+        user.id
+      );
 
       return list.map(({ id, status, type, user }) => ({
         ...user,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved workspace member pagination to prioritize displaying the current user at the top of the member list.
* **Tests**
  * Enhanced end-to-end tests to verify the updated member pagination behavior, ensuring correct ordering and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->