### PR TITLE
fix(core): falky translate e2e

### DIFF
--- a/tests/affine-cloud-copilot/e2e/ai-action/translate.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/ai-action/translate.spec.ts
@@ -13,8 +13,8 @@ test.describe('AIAction/Translate', () => {
     utils,
   }) => {
     const { translate } = await utils.editor.askAIWithText(page, 'Apple');
-    const { answer, responses } = await translate('German');
-    await expect(answer).toHaveText(/Apfel/, { timeout: 10000 });
+    const { answer, responses } = await translate('Simplified Chinese');
+    await expect(answer).toHaveText(/苹果/, { timeout: 10000 });
     expect(responses).toEqual(new Set(['insert-below', 'replace-selection']));
   });
 
@@ -28,8 +28,8 @@ test.describe('AIAction/Translate', () => {
         await utils.editor.createEdgelessText(page, 'Apple');
       }
     );
-    const { answer, responses } = await translate('German');
-    await expect(answer).toHaveText(/Apfel/, { timeout: 10000 });
+    const { answer, responses } = await translate('Simplified Chinese');
+    await expect(answer).toHaveText(/苹果/, { timeout: 10000 });
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
@@ -43,8 +43,8 @@ test.describe('AIAction/Translate', () => {
         await utils.editor.createEdgelessNote(page, 'Apple');
       }
     );
-    const { answer, responses } = await translate('German');
-    await expect(answer).toHaveText(/Apfel/, { timeout: 10000 });
+    const { answer, responses } = await translate('Simplified Chinese');
+    await expect(answer).toHaveText(/苹果/, { timeout: 10000 });
     expect(responses).toEqual(new Set(['insert-below']));
   });
 
@@ -53,8 +53,8 @@ test.describe('AIAction/Translate', () => {
     utils,
   }) => {
     const { translate } = await utils.editor.askAIWithText(page, 'Apple');
-    const { answer } = await translate('German');
-    await expect(answer).toHaveText(/Apfel/, { timeout: 10000 });
+    const { answer } = await translate('Simplified Chinese');
+    await expect(answer).toHaveText(/苹果/, { timeout: 10000 });
     const replace = answer.getByTestId('answer-replace');
     await replace.click();
     await utils.chatPanel.waitForHistory(page, [
@@ -67,7 +67,7 @@ test.describe('AIAction/Translate', () => {
       prompt,
       actionName,
     } = await utils.chatPanel.getLatestAIActionMessage(page);
-    await expect(panelAnswer).toHaveText(/Apfel/);
+    await expect(panelAnswer).toHaveText(/苹果/);
     await expect(prompt).toHaveText(/Translate/);
     await expect(actionName).toHaveText(/Translate/);
   });

--- a/tests/affine-cloud-copilot/e2e/chat-with/edgeless-note-block.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/chat-with/edgeless-note-block.spec.ts
@@ -18,12 +18,12 @@ test.describe('AIChatWith/EdgelessNoteBlock', () => {
         await utils.editor.createEdgelessNote(page, 'Apple');
       }
     );
-    const { answer } = await translate('German');
-    await expect(answer).toHaveText(/Apfel/, { timeout: 10000 });
+    const { answer } = await translate('Simplified Chinese');
+    await expect(answer).toHaveText(/苹果/, { timeout: 10000 });
     const insertBelow = answer.getByTestId('answer-insert-below');
     await insertBelow.click();
     await expect(page.locator('affine-edgeless-note').nth(1)).toHaveText(
-      /Apfel/
+      /苹果/
     );
   });
 });

--- a/tests/affine-cloud-copilot/e2e/chat-with/edgeless-text-block.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/chat-with/edgeless-text-block.spec.ts
@@ -18,12 +18,12 @@ test.describe('AIChatWith/EdgelessTextBlock', () => {
         await utils.editor.createEdgelessText(page, 'Apple');
       }
     );
-    const { answer } = await translate('German');
-    await expect(answer).toHaveText(/Apfel/, { timeout: 10000 });
+    const { answer } = await translate('Simplified Chinese');
+    await expect(answer).toHaveText(/苹果/, { timeout: 10000 });
     const insertBelow = answer.getByTestId('answer-insert-below');
     await insertBelow.click();
     await expect(page.locator('affine-edgeless-text')).toHaveText(
-      /Apple[\s\S]*Apfel/
+      /Apple[\s\S]*苹果/
     );
   });
 });


### PR DESCRIPTION
> CLOSE AF-2774

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated translation tests to use Simplified Chinese instead of German as the target language.
  * Adjusted expected results in assertions to match Chinese characters "苹果" instead of the German word "Apfel" across relevant test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->