### PR TITLE
chore(server): down scale service

### DIFF
--- a/.github/actions/deploy/deploy.mjs
+++ b/.github/actions/deploy/deploy.mjs
@@ -29,25 +29,25 @@ const isInternal = buildType === 'internal';
 
 const replicaConfig = {
   stable: {
-    web: 3,
-    graphql: Number(process.env.PRODUCTION_GRAPHQL_REPLICA) || 3,
-    sync: Number(process.env.PRODUCTION_SYNC_REPLICA) || 3,
-    renderer: Number(process.env.PRODUCTION_RENDERER_REPLICA) || 3,
-    doc: Number(process.env.PRODUCTION_DOC_REPLICA) || 3,
+    web: 2,
+    graphql: Number(process.env.PRODUCTION_GRAPHQL_REPLICA) || 2,
+    sync: Number(process.env.PRODUCTION_SYNC_REPLICA) || 2,
+    renderer: Number(process.env.PRODUCTION_RENDERER_REPLICA) || 2,
+    doc: Number(process.env.PRODUCTION_DOC_REPLICA) || 2,
   },
   beta: {
-    web: 2,
-    graphql: Number(process.env.BETA_GRAPHQL_REPLICA) || 2,
-    sync: Number(process.env.BETA_SYNC_REPLICA) || 2,
-    renderer: Number(process.env.BETA_RENDERER_REPLICA) || 2,
-    doc: Number(process.env.BETA_DOC_REPLICA) || 2,
+    web: 1,
+    graphql: Number(process.env.BETA_GRAPHQL_REPLICA) || 1,
+    sync: Number(process.env.BETA_SYNC_REPLICA) || 1,
+    renderer: Number(process.env.BETA_RENDERER_REPLICA) || 1,
+    doc: Number(process.env.BETA_DOC_REPLICA) || 1,
   },
   canary: {
-    web: 2,
-    graphql: 2,
-    sync: 2,
-    renderer: 2,
-    doc: 2,
+    web: 1,
+    graphql: 1,
+    sync: 1,
+    renderer: 1,
+    doc: 1,
   },
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the number of deployment replicas for web, graphql, sync, renderer, and doc components across all build types (stable, beta, canary).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->