### PR TITLE
feat(server): add fallback smtp config

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -219,6 +219,41 @@
           "type": "boolean",
           "description": "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.\n@default false\n@environment `MAILER_IGNORE_TLS`",
           "default": false
+        },
+        "fallbackDomains": {
+          "type": "array",
+          "description": "The emails from these domains are always sent using the fallback SMTP server.\n@default []",
+          "default": []
+        },
+        "fallbackSMTP.host": {
+          "type": "string",
+          "description": "Host of the email server (e.g. smtp.gmail.com)\n@default \"\"",
+          "default": ""
+        },
+        "fallbackSMTP.port": {
+          "type": "number",
+          "description": "Port of the email server (they commonly are 25, 465 or 587)\n@default 465",
+          "default": 465
+        },
+        "fallbackSMTP.username": {
+          "type": "string",
+          "description": "Username used to authenticate the email server\n@default \"\"",
+          "default": ""
+        },
+        "fallbackSMTP.password": {
+          "type": "string",
+          "description": "Password used to authenticate the email server\n@default \"\"",
+          "default": ""
+        },
+        "fallbackSMTP.sender": {
+          "type": "string",
+          "description": "Sender of all the emails (e.g. \"AFFiNE Team <noreply@affine.pro>\")\n@default \"\"",
+          "default": ""
+        },
+        "fallbackSMTP.ignoreTLS": {
+          "type": "boolean",
+          "description": "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.\n@default false",
+          "default": false
         }
       }
     },

--- a/packages/backend/server/src/core/mail/config.ts
+++ b/packages/backend/server/src/core/mail/config.ts
@@ -1,9 +1,21 @@
+import z from 'zod';
+
 import { defineModuleConfig } from '../../base';
 
 declare global {
   interface AppConfigSchema {
     mailer: {
       SMTP: {
+        host: string;
+        port: number;
+        username: string;
+        password: string;
+        ignoreTLS: boolean;
+        sender: string;
+      };
+
+      fallbackDomains: ConfigItem<string[]>;
+      fallbackSMTP: {
         host: string;
         port: number;
         username: string;
@@ -45,5 +57,35 @@ defineModuleConfig('mailer', {
     desc: "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.",
     default: false,
     env: ['MAILER_IGNORE_TLS', 'boolean'],
+  },
+
+  fallbackDomains: {
+    desc: 'The emails from these domains are always sent using the fallback SMTP server.',
+    default: [],
+    shape: z.array(z.string()),
+  },
+  'fallbackSMTP.host': {
+    desc: 'Host of the email server (e.g. smtp.gmail.com)',
+    default: '',
+  },
+  'fallbackSMTP.port': {
+    desc: 'Port of the email server (they commonly are 25, 465 or 587)',
+    default: 465,
+  },
+  'fallbackSMTP.username': {
+    desc: 'Username used to authenticate the email server',
+    default: '',
+  },
+  'fallbackSMTP.password': {
+    desc: 'Password used to authenticate the email server',
+    default: '',
+  },
+  'fallbackSMTP.sender': {
+    desc: 'Sender of all the emails (e.g. "AFFiNE Team <noreply@affine.pro>")',
+    default: '',
+  },
+  'fallbackSMTP.ignoreTLS': {
+    desc: "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.",
+    default: false,
   },
 });

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -114,6 +114,34 @@
       "type": "Boolean",
       "desc": "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.",
       "env": "MAILER_IGNORE_TLS"
+    },
+    "fallbackDomains": {
+      "type": "Array",
+      "desc": "The emails from these domains are always sent using the fallback SMTP server."
+    },
+    "fallbackSMTP.host": {
+      "type": "String",
+      "desc": "Host of the email server (e.g. smtp.gmail.com)"
+    },
+    "fallbackSMTP.port": {
+      "type": "Number",
+      "desc": "Port of the email server (they commonly are 25, 465 or 587)"
+    },
+    "fallbackSMTP.username": {
+      "type": "String",
+      "desc": "Username used to authenticate the email server"
+    },
+    "fallbackSMTP.password": {
+      "type": "String",
+      "desc": "Password used to authenticate the email server"
+    },
+    "fallbackSMTP.sender": {
+      "type": "String",
+      "desc": "Sender of all the emails (e.g. \"AFFiNE Team <noreply@affine.pro>\")"
+    },
+    "fallbackSMTP.ignoreTLS": {
+      "type": "Boolean",
+      "desc": "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates."
     }
   },
   "doc": {


### PR DESCRIPTION
fix AF-2749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a fallback SMTP server for outgoing emails.
  * Introduced the ability to specify email domains that will always use the fallback SMTP server.
  * Enhanced email sending to automatically route messages to the appropriate SMTP server based on recipient domain.

* **Documentation**
  * Updated configuration options and descriptions in the admin interface to reflect new fallback SMTP settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->