### PR TITLE
chore(server): downscale  sql proxy

### DIFF
--- a/.github/helm/affine/charts/gcloud-sql-proxy/values.yaml
+++ b/.github/helm/affine/charts/gcloud-sql-proxy/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 3
+replicaCount: 2
 enabled: false
 database: 
   connectionName: ""
@@ -33,8 +33,8 @@ service:
 
 resources:
   limits:
-    memory: "4Gi"
-    cpu: "2"
+    memory: "1Gi"
+    cpu: "1"
 
 volumes: []
 volumeMounts: []

--- a/.github/helm/affine/charts/gcloud-sql-proxy/values.yaml
+++ b/.github/helm/affine/charts/gcloud-sql-proxy/values.yaml
@@ -35,6 +35,9 @@ resources:
   limits:
     memory: "1Gi"
     cpu: "1"
+  requests:
+    memory: "512Mi"
+    cpu: "100m"
 
 volumes: []
 volumeMounts: []


### PR DESCRIPTION
<img width="1199" height="190" alt="image" src="https://github.com/user-attachments/assets/e1adec4a-5a62-454a-ad0d-26f50872e10b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced the number of gcloud-sql-proxy replicas from 3 to 2.
  * Lowered memory and CPU resource limits for the gcloud-sql-proxy container.
  * Added resource requests to optimize container performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->