### PR TITLE
fix(core): prevent navigating when clicking doc title in ai chat

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-keyword-search-result.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-keyword-search-result.ts
@@ -3,7 +3,7 @@ import { WithDisposable } from '@blocksuite/global/lit';
 import { PageIcon, SearchIcon } from '@blocksuite/icons/lit';
 import { ShadowlessElement } from '@blocksuite/std';
 import type { Signal } from '@preact/signals-core';
-import { css, html, nothing } from 'lit';
+import { html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import type { ToolResult } from './tool-result-card';
@@ -27,12 +27,6 @@ interface DocKeywordSearchToolResult {
 }
 
 export class DocKeywordSearchResult extends WithDisposable(ShadowlessElement) {
-  static override styles = css`
-    .doc-keyword-search-result-title {
-      cursor: pointer;
-    }
-  `;
-
   @property({ attribute: false })
   accessor data!: DocKeywordSearchToolCall | DocKeywordSearchToolResult;
 
@@ -60,12 +54,7 @@ export class DocKeywordSearchResult extends WithDisposable(ShadowlessElement) {
     let results: ToolResult[] = [];
     try {
       results = this.data.result.map(item => ({
-        title: html`<span
-          class="doc-keyword-search-result-title"
-          @click=${() => this.onOpenDoc(item.docId)}
-        >
-          ${item.title}
-        </span>`,
+        title: item.title,
         icon: PageIcon(),
         onClick: () => {
           this.peekViewService.peekView

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-semantic-search-result.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-semantic-search-result.ts
@@ -3,7 +3,7 @@ import { WithDisposable } from '@blocksuite/global/lit';
 import { AiEmbeddingIcon, PageIcon } from '@blocksuite/icons/lit';
 import { ShadowlessElement } from '@blocksuite/std';
 import type { Signal } from '@preact/signals-core';
-import { css, html, nothing } from 'lit';
+import { html, nothing } from 'lit';
 import { property } from 'lit/decorators.js';
 
 import type { DocDisplayConfig } from '../ai-chat-chips';
@@ -55,12 +55,6 @@ function parseResultContent(content: string) {
 }
 
 export class DocSemanticSearchResult extends WithDisposable(ShadowlessElement) {
-  static override styles = css`
-    .doc-semantic-search-result-title {
-      cursor: pointer;
-    }
-  `;
-
   @property({ attribute: false })
   accessor data!: DocSemanticSearchToolCall | DocSemanticSearchToolResult;
 
@@ -95,12 +89,7 @@ export class DocSemanticSearchResult extends WithDisposable(ShadowlessElement) {
       .results=${this.data.result
         .map(result => ({
           ...parseResultContent(result.content),
-          title: html`<span
-            class="doc-semantic-search-result-title"
-            @click=${() => this.onOpenDoc(result.docId)}
-          >
-            ${this.docDisplayService.getTitle(result.docId)}
-          </span>`,
+          title: this.docDisplayService.getTitle(result.docId),
           onClick: () => {
             this.peekViewService.peekView
               .open({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated search result titles to remove special styling and clickable highlighting.

* **Bug Fixes**
  * Improved consistency of click behavior by making entire search result items clickable, rather than just the title text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->