### PR TITLE
fix: 🚑 replace problematic attachment count

### DIFF
--- a/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/ChatManager/ChatManager+Stream.swift
+++ b/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/ChatManager/ChatManager+Stream.swift
@@ -170,7 +170,7 @@ private extension ChatManager {
     ]
     let attachmentCount = [
       editorData.fileAttachments.count,
-      editorData.documentAttachments.count,
+      editorData.imageAttachments.count,
     ].reduce(0, +)
     let attachmentFieldName = attachmentCount > 1 && attachmentCount != 0 ? "options.blobs" : "options.blob"
     let uploadableAttachments: [GraphQLFile] = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment handling in chat by updating the way attachments are counted, ensuring only files and images are included. Document attachments are no longer counted in this process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->