### PR TITLE
feat(server): skip cleanup for stale workspace

### DIFF
--- a/packages/backend/server/migrations/20250805074035_workspace_last_check_embeddings/migration.sql
+++ b/packages/backend/server/migrations/20250805074035_workspace_last_check_embeddings/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workspaces" ADD COLUMN     "last_check_embedding" TIMESTAMPTZ(3) NOT NULL DEFAULT '1970-01-01 00:00:00 +00:00';

--- a/packages/backend/server/migrations/20250805074035_workspace_last_check_embeddings/migration.sql
+++ b/packages/backend/server/migrations/20250805074035_workspace_last_check_embeddings/migration.sql
@@ -1,2 +1,5 @@
 -- AlterTable
 ALTER TABLE "workspaces" ADD COLUMN     "last_check_embeddings" TIMESTAMPTZ(3) NOT NULL DEFAULT '1970-01-01 00:00:00 +00:00';
+
+-- CreateIndex
+CREATE INDEX "workspaces_last_check_embeddings_idx" ON "workspaces"("last_check_embeddings");

--- a/packages/backend/server/migrations/20250805074035_workspace_last_check_embeddings/migration.sql
+++ b/packages/backend/server/migrations/20250805074035_workspace_last_check_embeddings/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "workspaces" ADD COLUMN     "last_check_embedding" TIMESTAMPTZ(3) NOT NULL DEFAULT '1970-01-01 00:00:00 +00:00';
+ALTER TABLE "workspaces" ADD COLUMN     "last_check_embeddings" TIMESTAMPTZ(3) NOT NULL DEFAULT '1970-01-01 00:00:00 +00:00';

--- a/packages/backend/server/schema.prisma
+++ b/packages/backend/server/schema.prisma
@@ -111,17 +111,18 @@ model VerificationToken {
 
 model Workspace {
   // NOTE: manually set this column type to identity in migration file
-  sid                Int      @unique @default(autoincrement())
-  id                 String   @id @default(uuid()) @db.VarChar
-  public             Boolean
-  createdAt          DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
+  sid                 Int      @unique @default(autoincrement())
+  id                  String   @id @default(uuid()) @db.VarChar
+  public              Boolean
+  createdAt           DateTime @default(now()) @map("created_at") @db.Timestamptz(3)
   // workspace level feature flags
-  enableAi           Boolean  @default(true) @map("enable_ai")
-  enableUrlPreview   Boolean  @default(false) @map("enable_url_preview")
-  enableDocEmbedding Boolean  @default(true) @map("enable_doc_embedding")
-  name               String?  @db.VarChar
-  avatarKey          String?  @map("avatar_key") @db.VarChar
-  indexed            Boolean  @default(false)
+  enableAi            Boolean  @default(true) @map("enable_ai")
+  enableUrlPreview    Boolean  @default(false) @map("enable_url_preview")
+  enableDocEmbedding  Boolean  @default(true) @map("enable_doc_embedding")
+  name                String?  @db.VarChar
+  avatarKey           String?  @map("avatar_key") @db.VarChar
+  indexed             Boolean  @default(false)
+  lastCheckEmbeddings DateTime @default("1970-01-01T00:00:00-00:00") @map("last_check_embeddings") @db.Timestamptz(3)
 
   features           WorkspaceFeature[]
   docs               WorkspaceDoc[]

--- a/packages/backend/server/schema.prisma
+++ b/packages/backend/server/schema.prisma
@@ -134,6 +134,7 @@ model Workspace {
   comments           Comment[]
   commentAttachments CommentAttachment[]
 
+  @@index([lastCheckEmbeddings])
   @@map("workspaces")
 }
 

--- a/packages/backend/server/src/models/workspace.ts
+++ b/packages/backend/server/src/models/workspace.ts
@@ -24,6 +24,7 @@ export type UpdateWorkspaceInput = Pick<
   | 'name'
   | 'avatarKey'
   | 'indexed'
+  | 'lastCheckEmbedding'
 >;
 
 @Injectable()
@@ -81,25 +82,15 @@ export class WorkspaceModel extends BaseModel {
     });
   }
 
-  async listAfterSid(sid: number, limit: number) {
-    return await this.db.workspace.findMany({
-      where: {
-        sid: { gt: sid },
-      },
-      take: limit,
-      orderBy: {
-        sid: 'asc',
-      },
-    });
-  }
-
   async list<S extends Prisma.WorkspaceSelect>(
     where: Prisma.WorkspaceWhereInput = {},
-    select?: S
+    select?: S,
+    limit?: number
   ) {
     return (await this.db.workspace.findMany({
       where,
       select,
+      take: limit,
       orderBy: {
         sid: 'asc',
       },

--- a/packages/backend/server/src/models/workspace.ts
+++ b/packages/backend/server/src/models/workspace.ts
@@ -50,7 +50,11 @@ export class WorkspaceModel extends BaseModel {
   /**
    * Update the workspace with the given data.
    */
-  async update(workspaceId: string, data: UpdateWorkspaceInput) {
+  async update(
+    workspaceId: string,
+    data: UpdateWorkspaceInput,
+    notifyUpdate = true
+  ) {
     const workspace = await this.db.workspace.update({
       where: {
         id: workspaceId,
@@ -61,7 +65,9 @@ export class WorkspaceModel extends BaseModel {
       `Updated workspace ${workspaceId} with data ${JSON.stringify(data)}`
     );
 
-    this.event.emit('workspace.updated', workspace);
+    if (notifyUpdate) {
+      this.event.emit('workspace.updated', workspace);
+    }
 
     return workspace;
   }

--- a/packages/backend/server/src/models/workspace.ts
+++ b/packages/backend/server/src/models/workspace.ts
@@ -24,7 +24,7 @@ export type UpdateWorkspaceInput = Pick<
   | 'name'
   | 'avatarKey'
   | 'indexed'
-  | 'lastCheckEmbedding'
+  | 'lastCheckEmbeddings'
 >;
 
 @Injectable()

--- a/packages/backend/server/src/plugins/copilot/cron.ts
+++ b/packages/backend/server/src/plugins/copilot/cron.ts
@@ -93,8 +93,11 @@ export class CopilotCronJobs {
     params: Jobs['copilot.workspace.cleanupTrashedDocEmbeddings']
   ) {
     const nextSid = params.nextSid ?? 0;
-    let workspaces = await this.models.workspace.listAfterSid(
-      nextSid,
+    // only consider workspaces that cleared their embeddings more than 24 hours ago
+    const oneDayAgo = new Date(Date.now() - OneDay);
+    const workspaces = await this.models.workspace.list(
+      { sid: { gt: nextSid }, lastCheckEmbedding: { lt: oneDayAgo } },
+      { id: true, sid: true },
       CLEANUP_EMBEDDING_JOB_BATCH_SIZE
     );
     if (!workspaces.length) {

--- a/packages/backend/server/src/plugins/copilot/cron.ts
+++ b/packages/backend/server/src/plugins/copilot/cron.ts
@@ -96,7 +96,7 @@ export class CopilotCronJobs {
     // only consider workspaces that cleared their embeddings more than 24 hours ago
     const oneDayAgo = new Date(Date.now() - OneDay);
     const workspaces = await this.models.workspace.list(
-      { sid: { gt: nextSid }, lastCheckEmbedding: { lt: oneDayAgo } },
+      { sid: { gt: nextSid }, lastCheckEmbeddings: { lt: oneDayAgo } },
       { id: true, sid: true },
       CLEANUP_EMBEDDING_JOB_BATCH_SIZE
     );

--- a/packages/backend/server/src/plugins/copilot/embedding/job.ts
+++ b/packages/backend/server/src/plugins/copilot/embedding/job.ts
@@ -521,6 +521,7 @@ export class CopilotEmbeddingJob {
       this.logger.warn(`workspace snapshot ${workspaceId} not found`);
       return;
     } else if (
+      // always check if never cleared
       workspace.lastCheckEmbedding > new Date(0) &&
       snapshot.updatedAt < oneMonthAgo
     ) {

--- a/packages/backend/server/src/plugins/copilot/embedding/job.ts
+++ b/packages/backend/server/src/plugins/copilot/embedding/job.ts
@@ -528,9 +528,11 @@ export class CopilotEmbeddingJob {
       this.logger.verbose(
         `workspace ${workspaceId} is too old, skipping embeddings cleanup`
       );
-      await this.models.workspace.update(workspaceId, {
-        lastCheckEmbeddings: new Date(),
-      });
+      await this.models.workspace.update(
+        workspaceId,
+        { lastCheckEmbeddings: new Date() },
+        false
+      );
       return;
     }
 
@@ -540,9 +542,11 @@ export class CopilotEmbeddingJob {
       this.logger.verbose(
         `No doc embeddings found in workspace ${workspaceId}, skipping cleanup`
       );
-      await this.models.workspace.update(workspaceId, {
-        lastCheckEmbeddings: new Date(),
-      });
+      await this.models.workspace.update(
+        workspaceId,
+        { lastCheckEmbeddings: new Date() },
+        false
+      );
       return;
     }
 
@@ -559,9 +563,11 @@ export class CopilotEmbeddingJob {
       );
     }
 
-    await this.models.workspace.update(workspaceId, {
-      lastCheckEmbeddings: new Date(),
-    });
+    await this.models.workspace.update(
+      workspaceId,
+      { lastCheckEmbeddings: new Date() },
+      false
+    );
   }
 
   @OnEvent('workspace.updated')

--- a/packages/backend/server/src/plugins/copilot/embedding/job.ts
+++ b/packages/backend/server/src/plugins/copilot/embedding/job.ts
@@ -8,6 +8,7 @@ import {
   EventBus,
   JobQueue,
   mapAnyError,
+  OneDay,
   OnEvent,
   OnJob,
 } from '../../../base';
@@ -511,6 +512,7 @@ export class CopilotEmbeddingJob {
       return;
     }
 
+    const oneMonthAgo = new Date(Date.now() - OneDay * 30);
     const snapshot = await this.models.doc.getSnapshot(
       workspaceId,
       workspaceId
@@ -518,11 +520,26 @@ export class CopilotEmbeddingJob {
     if (!snapshot) {
       this.logger.warn(`workspace snapshot ${workspaceId} not found`);
       return;
+    } else if (
+      workspace.lastCheckEmbedding > new Date(0) &&
+      snapshot.updatedAt < oneMonthAgo
+    ) {
+      this.logger.verbose(
+        `workspace ${workspaceId} is too old, skipping embeddings cleanup`
+      );
+      return;
+    }
+
+    const docIdsInEmbedding =
+      await this.models.copilotContext.listWorkspaceDocEmbedding(workspaceId);
+    if (!docIdsInEmbedding.length) {
+      this.logger.verbose(
+        `No doc embeddings found in workspace ${workspaceId}, skipping cleanup`
+      );
+      return;
     }
 
     const docIdsInWorkspace = readAllDocIdsFromWorkspaceSnapshot(snapshot.blob);
-    const docIdsInEmbedding =
-      await this.models.copilotContext.listWorkspaceDocEmbedding(workspaceId);
     const docIdsInWorkspaceSet = new Set(docIdsInWorkspace);
 
     const deletedDocIds = docIdsInEmbedding.filter(
@@ -534,5 +551,18 @@ export class CopilotEmbeddingJob {
         docId
       );
     }
+
+    await this.models.workspace.update(workspaceId, {
+      lastCheckEmbedding: new Date(),
+    });
+  }
+
+  @OnEvent('workspace.updated')
+  async onWorkspaceUpdated({ id }: Events['workspace.updated']) {
+    if (!this.supportEmbedding) return;
+
+    await this.queue.add('copilot.embedding.cleanupTrashedDocEmbeddings', {
+      workspaceId: id,
+    });
   }
 }

--- a/packages/backend/server/src/plugins/copilot/embedding/job.ts
+++ b/packages/backend/server/src/plugins/copilot/embedding/job.ts
@@ -528,6 +528,9 @@ export class CopilotEmbeddingJob {
       this.logger.verbose(
         `workspace ${workspaceId} is too old, skipping embeddings cleanup`
       );
+      await this.models.workspace.update(workspaceId, {
+        lastCheckEmbedding: new Date(),
+      });
       return;
     }
 
@@ -537,6 +540,9 @@ export class CopilotEmbeddingJob {
       this.logger.verbose(
         `No doc embeddings found in workspace ${workspaceId}, skipping cleanup`
       );
+      await this.models.workspace.update(workspaceId, {
+        lastCheckEmbedding: new Date(),
+      });
       return;
     }
 

--- a/packages/backend/server/src/plugins/copilot/embedding/job.ts
+++ b/packages/backend/server/src/plugins/copilot/embedding/job.ts
@@ -522,14 +522,14 @@ export class CopilotEmbeddingJob {
       return;
     } else if (
       // always check if never cleared
-      workspace.lastCheckEmbedding > new Date(0) &&
+      workspace.lastCheckEmbeddings > new Date(0) &&
       snapshot.updatedAt < oneMonthAgo
     ) {
       this.logger.verbose(
         `workspace ${workspaceId} is too old, skipping embeddings cleanup`
       );
       await this.models.workspace.update(workspaceId, {
-        lastCheckEmbedding: new Date(),
+        lastCheckEmbeddings: new Date(),
       });
       return;
     }
@@ -541,7 +541,7 @@ export class CopilotEmbeddingJob {
         `No doc embeddings found in workspace ${workspaceId}, skipping cleanup`
       );
       await this.models.workspace.update(workspaceId, {
-        lastCheckEmbedding: new Date(),
+        lastCheckEmbeddings: new Date(),
       });
       return;
     }
@@ -560,7 +560,7 @@ export class CopilotEmbeddingJob {
     }
 
     await this.models.workspace.update(workspaceId, {
-      lastCheckEmbedding: new Date(),
+      lastCheckEmbeddings: new Date(),
     });
   }
 

--- a/packages/backend/server/src/plugins/indexer/job.ts
+++ b/packages/backend/server/src/plugins/indexer/job.ts
@@ -157,10 +157,12 @@ export class IndexerJob {
     }
 
     const startSid = payload.lastIndexedWorkspaceSid ?? 0;
-    const workspaces = await this.models.workspace.listAfterSid(
-      startSid,
+    const workspaces = await this.models.workspace.list(
+      { sid: { gt: startSid } },
+      { id: true, indexed: true, sid: true },
       this.config.indexer.autoIndex.batchSize
     );
+
     if (workspaces.length === 0) {
       // Keep the current sid value when repeating
       return JOB_SIGNAL.Repeat;


### PR DESCRIPTION
fix AI-408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new field to workspaces to track the last time embeddings were checked.
  * Cleanup jobs for workspace embeddings now skip workspaces that haven't changed in over 30 days or have no embeddings, improving efficiency.
  * Cleanup jobs are now automatically triggered when a workspace is updated.

* **Improvements**
  * Enhanced workspace selection for cleanup and indexing tasks to use more precise filters and batching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->