### PR TITLE
feat(ios): enable ai button

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -209,8 +209,8 @@ export const AFFINE_FLAGS = {
     category: 'affine',
     displayName: 'Enable AI Button',
     description: 'Enable AI Button on mobile',
-    configurable: BUILD_CONFIG.isMobileEdition && isCanaryBuild,
-    defaultState: false,
+    configurable: BUILD_CONFIG.isMobileEdition && BUILD_CONFIG.isIOS,
+    defaultState: BUILD_CONFIG.isMobileEdition && BUILD_CONFIG.isIOS,
   },
   enable_turbo_renderer: {
     category: 'blocksuite',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The AI button feature on mobile is now enabled by default only on iOS devices, instead of being limited to canary builds.
  
* **Chores**
  * Updated internal configuration for mobile feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->