### PR TITLE
feat(core): hide search locally button when battery save enabled

### DIFF
--- a/packages/frontend/core/src/modules/quicksearch/index.ts
+++ b/packages/frontend/core/src/modules/quicksearch/index.ts
@@ -6,6 +6,7 @@ import { WorkspaceDialogService } from '../dialogs';
 import { DocsService } from '../doc';
 import { DocDisplayMetaService } from '../doc-display-meta';
 import { DocsSearchService } from '../docs-search';
+import { FeatureFlagService } from '../feature-flag';
 import { GlobalContextService } from '../global-context';
 import { JournalService } from '../journal';
 import { TagService } from '../tag';
@@ -61,6 +62,7 @@ export function configureQuickSearchModule(framework: Framework) {
       DocsSearchService,
       DocsService,
       DocDisplayMetaService,
+      FeatureFlagService,
     ])
     .entity(LinksQuickSearchSession, [
       WorkspaceService,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated a feature flag to control "battery save mode" within quick search for documentation.

* **Behavior Changes**
  * Local search is now enabled by default for non-cloud workspaces.
  * The "search locally" option is hidden when battery save mode is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->