### PR TITLE
feat(core): peek doc in ai doc-read tool result

### DIFF
--- a/packages/backend/server/src/plugins/copilot/tools/doc-read.ts
+++ b/packages/backend/server/src/plugins/copilot/tools/doc-read.ts
@@ -57,6 +57,7 @@ export const buildDocContentGetter = (
     }
 
     return {
+      docId,
       title: content.title,
       markdown: content.markdown,
       createdAt: docMeta.createdAt,

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-message-content/stream-objects.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-message-content/stream-objects.ts
@@ -220,6 +220,8 @@ export class ChatContentStreamObjects extends WithDisposable(
         return html`<doc-read-result
           .data=${streamObject}
           .width=${this.width}
+          .peekViewService=${this.peekViewService}
+          .onOpenDoc=${this.onOpenDoc}
         ></doc-read-result>`;
       case 'section_edit':
         return html`

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-read-result.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-read-result.ts
@@ -1,3 +1,4 @@
+import type { PeekViewService } from '@affine/core/modules/peek-view';
 import { WithDisposable } from '@blocksuite/global/lit';
 import { PageIcon, ViewIcon } from '@blocksuite/icons/lit';
 import { ShadowlessElement } from '@blocksuite/std';
@@ -18,6 +19,8 @@ interface DocReadToolResult {
   toolName: string;
   args: { doc_id: string };
   result: {
+    /** Old result may not have docId */
+    docId?: string;
     title: string;
     markdown: string;
   };
@@ -29,6 +32,9 @@ export class DocReadResult extends WithDisposable(ShadowlessElement) {
 
   @property({ attribute: false })
   accessor width: Signal<number | undefined> | undefined;
+
+  @property({ attribute: false })
+  accessor peekViewService!: PeekViewService;
 
   renderToolCall() {
     // TODO: get document name by doc_id
@@ -53,6 +59,18 @@ export class DocReadResult extends WithDisposable(ShadowlessElement) {
           title: this.data.result.title,
           icon: PageIcon(),
           content: this.data.result.markdown,
+          onClick: () => {
+            const docId = (this.data as DocReadToolResult).result.docId;
+            if (!docId) {
+              return;
+            }
+            this.peekViewService.peekView
+              .open({
+                type: 'doc',
+                docRef: { docId },
+              })
+              .catch(console.error);
+          },
         },
       ]}
     ></tool-result-card>`;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced document read results with clickable cards that open a peek view of the referenced document.
  * Added support for displaying document identifiers in document read results.

* **Bug Fixes**
  * Improved compatibility with older document read results that may lack a document identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->