### PR TITLE
chore: replaces the MailHog Docker container with Mailpit

### DIFF
--- a/.docker/dev/compose.yml.example
+++ b/.docker/dev/compose.yml.example
@@ -18,11 +18,19 @@ services:
     ports:
       - 6379:6379
 
-  mailhog:
-    image: mailhog/mailhog:latest
+  # https://mailpit.axllent.org/docs/install/docker/
+  mailpit:
+    image: axllent/mailpit:latest
     ports:
       - 1025:1025
       - 8025:8025
+    environment:
+      MP_MAX_MESSAGES: 5000
+      MP_DATABASE: /data/mailpit.db
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+    volumes:
+      - mailpit_data:/data
 
   # https://manual.manticoresearch.com/Starting_the_server/Docker
   manticoresearch:
@@ -87,4 +95,5 @@ networks:
 volumes:
   postgres_data:
   manticoresearch_data:
+  mailpit_data:
   elasticsearch_data:


### PR DESCRIPTION
This PR replaces the MailHog Docker container with Mailpit.

Reasons for this change:

- MailHog is no longer maintained.
- Mailpit is an actively developed, open-source alternative.
- Fully compatible as a drop-in replacement.
- Lightweight and Fast: Built with Go, the official Docker image is only 12.5MB.

This change improves performance and ensures we are using a maintained tool for local email testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced the email testing service with a new one that offers a similar web interface and SMTP port.
  * Updated configuration to enhance message storage and persistence for email testing in development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->