### PR TITLE
refactor(core): display selected doc & attachment chip

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/actions/types.ts
+++ b/packages/frontend/core/src/blocksuite/ai/actions/types.ts
@@ -361,12 +361,12 @@ declare global {
         op: string,
         updates: string
       ) => Promise<string>;
-      addContextBlobs: (options: {
-        blobIds: string[];
+      addContextBlob: (options: {
+        blobId: string;
         contextId: string;
-      }) => Promise<CopilotContextBlob[]>;
-      removeContextBlobs: (options: {
-        blobIds: string[];
+      }) => Promise<CopilotContextBlob>;
+      removeContextBlob: (options: {
+        blobId: string;
         contextId: string;
       }) => Promise<boolean>;
     }

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/attachment-chip.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/attachment-chip.ts
@@ -1,0 +1,40 @@
+import { getAttachmentFileIcon } from '@blocksuite/affine/components/icons';
+import { SignalWatcher, WithDisposable } from '@blocksuite/affine/global/lit';
+import { ShadowlessElement } from '@blocksuite/affine/std';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
+
+import type { AttachmentChip } from './type';
+import { getChipIcon, getChipTooltip } from './utils';
+
+export class ChatPanelAttachmentChip extends SignalWatcher(
+  WithDisposable(ShadowlessElement)
+) {
+  @property({ attribute: false })
+  accessor chip!: AttachmentChip;
+
+  @property({ attribute: false })
+  accessor removeChip!: (chip: AttachmentChip) => void;
+
+  override render() {
+    const { state, name } = this.chip;
+    const isLoading = state === 'processing';
+    const tooltip = getChipTooltip(state, name, this.chip.tooltip);
+    const fileType = name.split('.').pop() ?? '';
+    const fileIcon = getAttachmentFileIcon(fileType);
+    const icon = getChipIcon(state, fileIcon);
+
+    return html`<chat-panel-chip
+      .state=${state}
+      .name=${name}
+      .tooltip=${tooltip}
+      .icon=${icon}
+      .closeable=${!isLoading}
+      .onChipDelete=${this.onChipDelete}
+    ></chat-panel-chip>`;
+  }
+
+  private readonly onChipDelete = () => {
+    this.removeChip(this.chip);
+  };
+}

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/chat-panel-chips.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/chat-panel-chips.ts
@@ -15,6 +15,7 @@ import type { ChatChip, DocChip, DocDisplayConfig, FileChip } from './type';
 import {
   estimateTokenCount,
   getChipKey,
+  isAttachmentChip,
   isCollectionChip,
   isDocChip,
   isFileChip,
@@ -159,6 +160,12 @@ export class ChatPanelChips extends SignalWatcher(
               .chip=${chip}
               .removeChip=${this.removeChip}
             ></chat-panel-file-chip>`;
+          }
+          if (isAttachmentChip(chip)) {
+            return html`<chat-panel-attachment-chip
+              .chip=${chip}
+              .removeChip=${this.removeChip}
+            ></chat-panel-attachment-chip>`;
           }
           if (isTagChip(chip)) {
             const tag = this._tags.value.find(tag => tag.id === chip.tagId);

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/type.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/type.ts
@@ -36,10 +36,13 @@ export interface CollectionChip extends BaseChip {
   collectionId: string;
 }
 
+export interface AttachmentChip extends BaseChip {
+  sourceId: string;
+  name: string;
+}
+
 export interface SelectedContextChip extends BaseChip {
   uuid: string;
-  attachments: { sourceId: string; name: string }[];
-  docs: string[];
   snapshot: string | null;
   combinedElementsMarkdown: string | null;
   html: string | null;
@@ -50,6 +53,7 @@ export type ChatChip =
   | FileChip
   | TagChip
   | CollectionChip
+  | AttachmentChip
   | SelectedContextChip;
 
 export interface DocDisplayConfig {

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/utils.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/utils.ts
@@ -3,6 +3,7 @@ import { WarningIcon } from '@blocksuite/icons/lit';
 import { type TemplateResult } from 'lit';
 
 import type {
+  AttachmentChip,
   ChatChip,
   ChipState,
   CollectionChip,
@@ -66,11 +67,11 @@ export function isCollectionChip(chip: ChatChip): chip is CollectionChip {
 export function isSelectedContextChip(
   chip: ChatChip
 ): chip is SelectedContextChip {
-  return (
-    'attachments' in chip &&
-    'snapshot' in chip &&
-    'combinedElementsMarkdown' in chip
-  );
+  return 'snapshot' in chip && 'combinedElementsMarkdown' in chip;
+}
+
+export function isAttachmentChip(chip: ChatChip): chip is AttachmentChip {
+  return 'sourceId' in chip && 'name' in chip;
 }
 
 export function getChipKey(chip: ChatChip) {
@@ -129,6 +130,9 @@ export function findChipIndex(chips: ChatChip[], chip: ChatChip) {
     }
     if (isSelectedContextChip(chip)) {
       return isSelectedContextChip(item) && item.uuid === chip.uuid;
+    }
+    if (isAttachmentChip(chip)) {
+      return isAttachmentChip(item) && item.sourceId === chip.sourceId;
     }
     return -1;
   });

--- a/packages/frontend/core/src/blocksuite/ai/effects.ts
+++ b/packages/frontend/core/src/blocksuite/ai/effects.ts
@@ -30,6 +30,7 @@ import { ChatPanelSplitView } from './chat-panel/split-view';
 import { ArtifactSkeleton } from './components/ai-artifact-skeleton';
 import { AIChatAddContext } from './components/ai-chat-add-context';
 import { ChatPanelAddPopover } from './components/ai-chat-chips/add-popover';
+import { ChatPanelAttachmentChip } from './components/ai-chat-chips/attachment-chip';
 import { ChatPanelCandidatesPopover } from './components/ai-chat-chips/candidates-popover';
 import { ChatPanelChips } from './components/ai-chat-chips/chat-panel-chips';
 import { ChatPanelChip } from './components/ai-chat-chips/chip';
@@ -166,6 +167,7 @@ export function registerAIEffects() {
   customElements.define('chat-panel-tag-chip', ChatPanelTagChip);
   customElements.define('chat-panel-collection-chip', ChatPanelCollectionChip);
   customElements.define('chat-panel-selected-chip', ChatPanelSelectedChip);
+  customElements.define('chat-panel-attachment-chip', ChatPanelAttachmentChip);
   customElements.define('chat-panel-chip', ChatPanelChip);
   customElements.define('ai-error-wrapper', AIErrorWrapper);
   customElements.define('ai-slides-renderer', AISlidesRenderer);

--- a/packages/frontend/core/src/blocksuite/ai/entries/edgeless/index.ts
+++ b/packages/frontend/core/src/blocksuite/ai/entries/edgeless/index.ts
@@ -57,7 +57,7 @@ export function edgelessToolbarAIEntryConfig(): ToolbarModuleConfig {
                 aiPanel.hide();
                 extractSelectedContent(host)
                   .then(context => {
-                    if (context?.attachments?.length) {
+                    if (context?.attachments?.length || context?.docs?.length) {
                       AIProvider.slots.requestOpenWithChat.next({
                         input,
                         host,

--- a/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
+++ b/packages/frontend/core/src/blocksuite/ai/provider/setup-provider.tsx
@@ -748,31 +748,20 @@ Could you make a new website based on these notes and send back just the html fi
     ) => {
       return client.applyDocUpdates(workspaceId, docId, op, updates);
     },
-    addContextBlobs: async (options: {
-      blobIds: string[];
-      contextId: string;
-    }) => {
-      return Promise.all(
-        options.blobIds.map(blobId =>
-          client.addContextBlob({
-            contextId: options.contextId,
-            blobId,
-          })
-        )
-      );
+    addContextBlob: async (options: { blobId: string; contextId: string }) => {
+      return client.addContextBlob({
+        contextId: options.contextId,
+        blobId: options.blobId,
+      });
     },
-    removeContextBlobs: async (options: {
-      blobIds: string[];
+    removeContextBlob: async (options: {
+      blobId: string;
       contextId: string;
     }) => {
-      return Promise.all(
-        options.blobIds.map(blobId =>
-          client.removeContextBlob({
-            contextId: options.contextId,
-            blobId,
-          })
-        )
-      ).then(results => results.every(Boolean));
+      return client.removeContextBlob({
+        contextId: options.contextId,
+        blobId: options.blobId,
+      });
     },
   });
 


### PR DESCRIPTION
<img width="1275" height="997" alt="截屏2025-08-08 15 13 59" src="https://github.com/user-attachments/assets/b429239d-84dc-490d-ad1e-957652e3caba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced support for displaying and managing individual attachment chips in the AI chat interface.
  * Added a new visual component for attachment chips, including status indicators and removal functionality.

* **Improvements**
  * Enhanced context management in chat by handling attachments and documents as separate chips for better clarity and control.
  * Streamlined chat context updates and status tracking for attachments.

* **Bug Fixes**
  * Improved handling of chat context to ensure attachments and documents are processed and displayed correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->