### PR TITLE
chore(server): add new darkskygit to stable image approvers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         name: Wait for approval
         with:
           secret: ${{ secrets.GITHUB_TOKEN }}
-          approvers: forehalo,fengmk2
+          approvers: forehalo,fengmk2,darkskygit
           minimum-approvals: 1
           fail-on-denial: true
           issue-title: Please confirm to release docker image
@@ -84,7 +84,7 @@ jobs:
             Tag: ghcr.io/toeverything/affine:${{ needs.prepare.outputs.BUILD_TYPE }}
 
             > comment with "approve", "approved", "lgtm", "yes" to approve
-            > comment with "deny", "deny", "no" to deny
+            > comment with "deny", "denied", "no" to deny
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13449** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded the list of approvers for the manual approval step in the release workflow.
  * Added more keywords that can be used to deny approval during the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->