### PR TITLE
chore(ios): enable edgeless dom renderer

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -2,7 +2,6 @@ import type { FlagInfo } from './types';
 
 // const isNotStableBuild = BUILD_CONFIG.appBuildType !== 'stable';
 const isCanaryBuild = BUILD_CONFIG.appBuildType === 'canary';
-const isBetaBuild = BUILD_CONFIG.appBuildType === 'beta';
 const isMobile = BUILD_CONFIG.isMobileEdition;
 const isIOS = BUILD_CONFIG.isIOS;
 
@@ -227,7 +226,7 @@ export const AFFINE_FLAGS = {
     bsFlag: 'enable_dom_renderer',
     displayName: 'Enable DOM Renderer',
     description: 'Enable DOM renderer for graphics elements',
-    configurable: isCanaryBuild || isBetaBuild,
+    configurable: true,
     defaultState: isIOS,
   },
   enable_edgeless_scribbled_style: {


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13460** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The DOM renderer setting is now configurable across all builds, not just beta/canary. This expands access to the feature flag for all users, enabling broader experimentation and customization.
  - Users on stable releases can now enable or disable the DOM renderer through standard configuration, ensuring consistent behavior across release channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->