### PR TITLE
chore(ios): disable dom renderer

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -227,7 +227,7 @@ export const AFFINE_FLAGS = {
     displayName: 'Enable DOM Renderer',
     description: 'Enable DOM renderer for graphics elements',
     configurable: true,
-    defaultState: isIOS,
+    defaultState: false,
   },
   enable_edgeless_scribbled_style: {
     category: 'blocksuite',


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #13462** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default configuration: The DOM-based renderer is now disabled by default on all platforms. Previously, it was enabled by default on iOS. This change standardizes the out-of-the-box experience across devices. If you rely on the DOM renderer, you can still enable it via feature flags in your environment or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->