### PR TITLE
fix(core): right click on edgeless will also damage other functions

### DIFF
--- a/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
+++ b/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
@@ -100,8 +100,8 @@ export class PanTool extends BaseTool<PanToolOption> {
       const dispose = on(document, 'pointerup', evt => {
         if (evt.button === MouseButton.MIDDLE) {
           restoreToPrevious();
-          dispose();
         }
+        dispose();
       });
 
       return false;


### PR DESCRIPTION
Close [AI-411](https://linear.app/affine-design/issue/AI-411)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Releasing the mouse now always ends panning, preventing stuck states.
  - Actions cancel correctly when you release without dragging.

- Refactor
  - More consistent Copilot activation: use right-click or Ctrl (⌘ on Mac) + left-click.
  - Smoother switching to Copilot with improved drag-state reset and cleanup.
  - Removed automatic restoration of previous selection when activating Copilot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->