### PR TITLE
fix(core): remove attachment chip failed

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/utils.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-chips/utils.ts
@@ -108,7 +108,10 @@ export function omitChip(chips: ChatChip[], chip: ChatChip) {
       return !isCollectionChip(item) || item.collectionId !== chip.collectionId;
     }
     if (isSelectedContextChip(chip)) {
-      return !isSelectedContextChip(chip);
+      return !isSelectedContextChip(item) || item.uuid !== chip.uuid;
+    }
+    if (isAttachmentChip(chip)) {
+      return !isAttachmentChip(item) || item.sourceId !== chip.sourceId;
     }
     return true;
   });


### PR DESCRIPTION
> CLOSE PD-2697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removing an attachment chip now also removes duplicate attachments with the same source, preventing duplicate attachments in the AI chat chip list.
  * Removing a selected context chip now also removes duplicate selected contexts with the same identifier, preventing duplicate context chips.
  * Attachments from different sources and chips of other types (document, file, tag, collection) remain unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->