### PR TITLE
fix(editor): remove patch of key-binding in andriod

### DIFF
--- a/blocksuite/framework/std/src/event/control/keyboard.ts
+++ b/blocksuite/framework/std/src/event/control/keyboard.ts
@@ -1,5 +1,4 @@
-import { DisposableGroup } from '@blocksuite/global/disposable';
-import { IS_ANDROID, IS_MAC } from '@blocksuite/global/env';
+import { IS_MAC } from '@blocksuite/global/env';
 
 import {
   type UIEventHandler,
@@ -7,7 +6,7 @@ import {
   UIEventStateContext,
 } from '../base.js';
 import type { EventOptions, UIEventDispatcher } from '../dispatcher.js';
-import { androidBindKeymapPatch, bindKeymap } from '../keymap.js';
+import { bindKeymap } from '../keymap.js';
 import { KeyboardEventState } from '../state/index.js';
 import { EventScopeSourceType, EventSourceState } from '../state/source.js';
 
@@ -88,33 +87,15 @@ export class KeyboardControl {
   }
 
   bindHotkey(keymap: Record<string, UIEventHandler>, options?: EventOptions) {
-    const disposables = new DisposableGroup();
-    if (IS_ANDROID) {
-      disposables.add(
-        this._dispatcher.add(
-          'beforeInput',
-          ctx => {
-            if (this.composition) return false;
-            const binding = androidBindKeymapPatch(keymap);
-            return binding(ctx);
-          },
-          options
-        )
-      );
-    }
-
-    disposables.add(
-      this._dispatcher.add(
-        'keyDown',
-        ctx => {
-          if (this.composition) return false;
-          const binding = bindKeymap(keymap);
-          return binding(ctx);
-        },
-        options
-      )
+    return this._dispatcher.add(
+      'keyDown',
+      ctx => {
+        if (this.composition) return false;
+        const binding = bindKeymap(keymap);
+        return binding(ctx);
+      },
+      options
     );
-    return () => disposables.dispose();
   }
 
   listen() {

--- a/blocksuite/framework/std/src/event/keymap.ts
+++ b/blocksuite/framework/std/src/event/keymap.ts
@@ -103,25 +103,3 @@ export function bindKeymap(
     return false;
   };
 }
-
-// In Android, the keypress event  dose not contain
-// the information about what key is pressed. See
-// https://stackoverflow.com/a/68188679
-// https://stackoverflow.com/a/66724830
-export function androidBindKeymapPatch(
-  bindings: Record<string, UIEventHandler>
-): UIEventHandler {
-  return ctx => {
-    const event = ctx.get('defaultState').event;
-    if (!(event instanceof InputEvent)) return;
-
-    if (
-      event.inputType === 'deleteContentBackward' &&
-      'Backspace' in bindings
-    ) {
-      return bindings['Backspace'](ctx);
-    }
-
-    return false;
-  };
-}


### PR DESCRIPTION
In recent versions of Android (or maybe webview), the `KeyboardEvent.key` for the backspace key now has the correct value. This PR remove the patch since it will trigger two delete actions when press backspace at the first character of paragraph"

Related PR https://github.com/toeverything/AFFiNE/issues/10523

#### PR Dependency Tree


* **PR #13483** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined keyboard shortcut handling for greater consistency across platforms.
  * Reduced overhead by consolidating event bindings; no change to expected shortcut behavior for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->