### PR TITLE
fix(editor): deactivate editor when selection out of editor

### DIFF
--- a/blocksuite/framework/std/src/event/dispatcher.ts
+++ b/blocksuite/framework/std/src/event/dispatcher.ts
@@ -228,8 +228,13 @@ export class UIEventDispatcher extends LifeCycleWatcher {
     });
     // When the selection is outside the host, the event dispatcher should be inactive
     this.disposables.addFromEvent(document, 'selectionchange', () => {
-      const domSelection = document.getSelection();
-      if (domSelection && !this.host.contains(domSelection.anchorNode)) {
+      const sel = document.getSelection();
+      if (!sel || sel.rangeCount === 0) return;
+      const { anchorNode, focusNode } = sel;
+      if (
+        (anchorNode && !this.host.contains(anchorNode)) ||
+        (focusNode && !this.host.contains(focusNode))
+      ) {
         this._setActive(false);
       }
     });

--- a/blocksuite/framework/std/src/event/dispatcher.ts
+++ b/blocksuite/framework/std/src/event/dispatcher.ts
@@ -226,6 +226,13 @@ export class UIEventDispatcher extends LifeCycleWatcher {
         this._setActive(false);
       }
     });
+    // When the selection is outside the host, the event dispatcher should be inactive
+    this.disposables.addFromEvent(document, 'selectionchange', () => {
+      const domSelection = document.getSelection();
+      if (domSelection && !this.host.contains(domSelection.anchorNode)) {
+        this._setActive(false);
+      }
+    });
   }
 
   private _buildEventScopeBySelection(name: EventName) {

--- a/tests/blocksuite/e2e/link.spec.ts
+++ b/tests/blocksuite/e2e/link.spec.ts
@@ -241,6 +241,7 @@ test('should keyboard work in link popover', async ({ page }) => {
   const toolbar = page.locator('affine-toolbar-widget editor-toolbar');
   const linkLocator = page.locator(`text="${linkText}"`);
 
+  await focusRichText(page);
   // hover link
   await linkLocator.hover();
   // wait for popover delay open
@@ -294,6 +295,7 @@ test('link bar should not be appear when the range is collapsed', async ({
   // create auto line-break in span element
   await type(page, 'd'.repeat(67));
   await page.mouse.click(1, 1);
+  await focusRichText(page);
   await waitNextFrame(page);
   await dragBetweenIndices(page, [1, 1], [1, 66]);
   await pressCreateLinkShortCut(page);


### PR DESCRIPTION
Close [AI-415](https://linear.app/affine-design/issue/AI-415/code-artifact-复制更好的支持code-block和插入正文)

#### PR Dependency Tree


* **PR #13490** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editor now deactivates when text selection moves outside the app, preventing unintended interactions.
  * Better handling when selection changes to external content, reducing cases where the editor stayed active incorrectly.

* **Stability**
  * Improved reliability around selection, focus, and visibility changes to avoid accidental edits or actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


#### PR Dependency Tree


* **PR #13490** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)