### PR TITLE
fix(ios): enable horizontal scroll for database

### DIFF
--- a/blocksuite/affine/data-view/src/view-presets/table/mobile/table-view-style.ts
+++ b/blocksuite/affine/data-view/src/view-presets/table/mobile/table-view-style.ts
@@ -1,4 +1,3 @@
-import { IS_IOS } from '@blocksuite/global/env';
 import { css } from '@emotion/css';
 import { cssVarV2 } from '@toeverything/theme/v2';
 
@@ -6,12 +5,6 @@ export const mobileTableViewWrapper = css({
   position: 'relative',
   width: '100%',
   paddingBottom: '4px',
-  /**
-   * Disable horizontal scrolling to prevent crashes on iOS Safari
-   * See https://github.com/toeverything/AFFiNE/pull/12203
-   * and https://github.com/toeverything/blocksuite/pull/8784
-   */
-  overflowX: IS_IOS ? 'hidden' : undefined,
   overflowY: 'hidden',
 });
 


### PR DESCRIPTION
Close [BS-3625](https://linear.app/affine-design/issue/BS-3625/移动端database-table-view无法横向滚动)

#### PR Dependency Tree


* **PR #13494** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS mobile table view scrolling: horizontal overflow is no longer forcibly hidden, preventing clipped content and enabling smoother horizontal navigation.
  * Users can now access columns that previously appeared truncated on narrow screens.
  * Vertical scrolling behavior remains unchanged.
  * No impact on non‑iOS devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->