### PR TITLE
feat(ios): create paywall api

### DIFF
--- a/packages/frontend/apps/ios/App/App.xcodeproj/project.pbxproj
+++ b/packages/frontend/apps/ios/App/App.xcodeproj/project.pbxproj
@@ -16,10 +16,6 @@
 		50FF428A2D2E757E0050AA83 /* ApplicationBridgedWindowScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF42892D2E757E0050AA83 /* ApplicationBridgedWindowScript.swift */; };
 		50FF428C2D2E77CC0050AA83 /* AffineViewController+AIButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50FF428B2D2E77CC0050AA83 /* AffineViewController+AIButton.swift */; };
 		9D52FC432D26CDBF00105D0A /* JSValueContainerExt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D52FC422D26CDB600105D0A /* JSValueContainerExt.swift */; };
-		9D5622962D64A6A5009F1BE4 /* AuthPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5622952D64A6A4009F1BE4 /* AuthPlugin.swift */; };
-		9D6A85332CCF6DA700DAB35F /* HashcashPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6A85322CCF6DA700DAB35F /* HashcashPlugin.swift */; };
-		9D90BE252CCB9876006677DB /* CookieManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D90BE172CCB9876006677DB /* CookieManager.swift */; };
-		9D90BE262CCB9876006677DB /* CookiePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D90BE182CCB9876006677DB /* CookiePlugin.swift */; };
 		9D90BE272CCB9876006677DB /* AffineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D90BE1B2CCB9876006677DB /* AffineViewController.swift */; };
 		9D90BE282CCB9876006677DB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D90BE1C2CCB9876006677DB /* AppDelegate.swift */; };
 		9D90BE292CCB9876006677DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9D90BE1D2CCB9876006677DB /* Assets.xcassets */; };
@@ -33,7 +29,6 @@
 		C4C97C7C2D030BE000BC2AD1 /* affine_mobile_native.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4C97C6F2D0307B700BC2AD1 /* affine_mobile_native.swift */; };
 		C4C97C7D2D030BE000BC2AD1 /* affine_mobile_nativeFFI.h in Sources */ = {isa = PBXBuildFile; fileRef = C4C97C702D0307B700BC2AD1 /* affine_mobile_nativeFFI.h */; };
 		C4C97C7E2D030BE000BC2AD1 /* affine_mobile_nativeFFI.modulemap in Sources */ = {isa = PBXBuildFile; fileRef = C4C97C712D0307B700BC2AD1 /* affine_mobile_nativeFFI.modulemap */; };
-		E93B276C2CED92B1001409B8 /* NavigationGesturePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E93B276B2CED92B1001409B8 /* NavigationGesturePlugin.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -61,10 +56,6 @@
 		50FF42892D2E757E0050AA83 /* ApplicationBridgedWindowScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationBridgedWindowScript.swift; sourceTree = "<group>"; };
 		50FF428B2D2E77CC0050AA83 /* AffineViewController+AIButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AffineViewController+AIButton.swift"; sourceTree = "<group>"; };
 		9D52FC422D26CDB600105D0A /* JSValueContainerExt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSValueContainerExt.swift; sourceTree = "<group>"; };
-		9D5622952D64A6A4009F1BE4 /* AuthPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthPlugin.swift; sourceTree = "<group>"; };
-		9D6A85322CCF6DA700DAB35F /* HashcashPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashcashPlugin.swift; sourceTree = "<group>"; };
-		9D90BE172CCB9876006677DB /* CookieManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieManager.swift; sourceTree = "<group>"; };
-		9D90BE182CCB9876006677DB /* CookiePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookiePlugin.swift; sourceTree = "<group>"; };
 		9D90BE1B2CCB9876006677DB /* AffineViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffineViewController.swift; sourceTree = "<group>"; };
 		9D90BE1C2CCB9876006677DB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9D90BE1D2CCB9876006677DB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -83,16 +74,15 @@
 		C4C97C702D0307B700BC2AD1 /* affine_mobile_nativeFFI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = affine_mobile_nativeFFI.h; sourceTree = "<group>"; };
 		C4C97C712D0307B700BC2AD1 /* affine_mobile_nativeFFI.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = affine_mobile_nativeFFI.modulemap; sourceTree = "<group>"; };
 		E5E5070D1CA1200D4964D91F /* Pods-AFFiNE.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AFFiNE.release.xcconfig"; path = "Pods/Target Support Files/Pods-AFFiNE/Pods-AFFiNE.release.xcconfig"; sourceTree = "<group>"; };
-		E93B276B2CED92B1001409B8 /* NavigationGesturePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationGesturePlugin.swift; sourceTree = "<group>"; };
 		FC68EB0AF532CFC21C3344DD /* Pods-App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-App.debug.xcconfig"; path = "Pods/Target Support Files/Pods-App/Pods-App.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		C45499AB2D140B5000E21978 /* NBStore */ = {
+		9DAE85B72E7BAC3B00DB9F1D /* Plugins */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 			);
-			path = NBStore;
+			path = Plugins;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -163,42 +153,13 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
-		9D5622942D64A69C009F1BE4 /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-				9D5622952D64A6A4009F1BE4 /* AuthPlugin.swift */,
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
-		9D90BE192CCB9876006677DB /* Cookie */ = {
-			isa = PBXGroup;
-			children = (
-				9D90BE172CCB9876006677DB /* CookieManager.swift */,
-				9D90BE182CCB9876006677DB /* CookiePlugin.swift */,
-				9D6A85322CCF6DA700DAB35F /* HashcashPlugin.swift */,
-			);
-			path = Cookie;
-			sourceTree = "<group>";
-		};
-		9D90BE1A2CCB9876006677DB /* Plugins */ = {
-			isa = PBXGroup;
-			children = (
-				9D5622942D64A69C009F1BE4 /* Auth */,
-				C45499AB2D140B5000E21978 /* NBStore */,
-				E93B276A2CED9298001409B8 /* NavigationGesture */,
-				9D90BE192CCB9876006677DB /* Cookie */,
-			);
-			path = Plugins;
-			sourceTree = "<group>";
-		};
 		9D90BE242CCB9876006677DB /* App */ = {
 			isa = PBXGroup;
 			children = (
 				9DAE9BD82D8D1AA9000C1D5A /* AppConfigManager.swift */,
 				9DEC59422D323EE00027CEBD /* Mutex.swift */,
 				9D52FC422D26CDB600105D0A /* JSValueContainerExt.swift */,
-				9D90BE1A2CCB9876006677DB /* Plugins */,
+				9DAE85B72E7BAC3B00DB9F1D /* Plugins */,
 				9D90BE1C2CCB9876006677DB /* AppDelegate.swift */,
 				507513692D1924C600AD60C0 /* RootViewController.swift */,
 				9D90BE1B2CCB9876006677DB /* AffineViewController.swift */,
@@ -227,14 +188,6 @@
 			path = App/uniffi;
 			sourceTree = "<group>";
 		};
-		E93B276A2CED9298001409B8 /* NavigationGesture */ = {
-			isa = PBXGroup;
-			children = (
-				E93B276B2CED92B1001409B8 /* NavigationGesturePlugin.swift */,
-			);
-			path = NavigationGesture;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -255,7 +208,7 @@
 			dependencies = (
 			);
 			fileSystemSynchronizedGroups = (
-				C45499AB2D140B5000E21978 /* NBStore */,
+				9DAE85B72E7BAC3B00DB9F1D /* Plugins */,
 			);
 			name = AFFiNE;
 			productName = App;
@@ -378,14 +331,9 @@
 				9DAE9BD92D8D1AB0000C1D5A /* AppConfigManager.swift in Sources */,
 				50FF428A2D2E757E0050AA83 /* ApplicationBridgedWindowScript.swift in Sources */,
 				C4C97C7D2D030BE000BC2AD1 /* affine_mobile_nativeFFI.h in Sources */,
-				9D5622962D64A6A5009F1BE4 /* AuthPlugin.swift in Sources */,
 				C4C97C7E2D030BE000BC2AD1 /* affine_mobile_nativeFFI.modulemap in Sources */,
-				E93B276C2CED92B1001409B8 /* NavigationGesturePlugin.swift in Sources */,
 				9DEC59432D323EE40027CEBD /* Mutex.swift in Sources */,
-				9D90BE252CCB9876006677DB /* CookieManager.swift in Sources */,
 				50FF428C2D2E77CC0050AA83 /* AffineViewController+AIButton.swift in Sources */,
-				9D90BE262CCB9876006677DB /* CookiePlugin.swift in Sources */,
-				9D6A85332CCF6DA700DAB35F /* HashcashPlugin.swift in Sources */,
 				9D90BE272CCB9876006677DB /* AffineViewController.swift in Sources */,
 				9D90BE282CCB9876006677DB /* AppDelegate.swift in Sources */,
 			);

--- a/packages/frontend/apps/ios/App/App/Plugins/PayWall/PayWallPlugin.swift
+++ b/packages/frontend/apps/ios/App/App/Plugins/PayWall/PayWallPlugin.swift
@@ -1,0 +1,25 @@
+import Capacitor
+import Foundation
+
+@objc(PayWallPlugin)
+public class PayWallPlugin: CAPPlugin, CAPBridgedPlugin {
+  public let identifier = "PayWallPlugin"
+  public let jsName = "PayWall"
+  public let pluginMethods: [CAPPluginMethod] = [
+    CAPPluginMethod(name: "showPayWall", returnType: CAPPluginReturnPromise),
+  ]
+
+  @objc func showPayWall(_ call: CAPPluginCall) {
+    do {
+      let type = try call.getStringEnsure("type")
+
+      // TODO: Implement actual paywall logic here
+      // For now, just log the type and resolve
+      print("PayWall: Showing paywall of type: \(type)")
+
+      call.resolve(["success": true, "type": type])
+    } catch {
+      call.reject("Failed to show paywall", nil, error)
+    }
+  }
+}

--- a/packages/frontend/apps/ios/App/Podfile.lock
+++ b/packages/frontend/apps/ios/App/Podfile.lock
@@ -45,13 +45,13 @@ EXTERNAL SOURCES:
     :path: "../../../../../node_modules/capacitor-plugin-app-tracking-transparency"
 
 SPEC CHECKSUMS:
-  Capacitor: 03bc7cbdde6a629a8b910a9d7d78c3cc7ed09ea7
-  CapacitorApp: febecbb9582cb353aed037e18ec765141f880fe9
-  CapacitorBrowser: 6299776d496e968505464884d565992faa20444a
+  Capacitor: 106e7a4205f4618d582b886a975657c61179138d
+  CapacitorApp: d63334c052278caf5d81585d80b21905c6f93f39
+  CapacitorBrowser: 081852cf532acf77b9d2953f3a88fe5b9711fb06
   CapacitorCordova: 5967b9ba03915ef1d585469d6e31f31dc49be96f
-  CapacitorHaptics: 1f1e17041f435d8ead9ff2a34edd592c6aa6a8d6
-  CapacitorKeyboard: 09fd91dcde4f8a37313e7f11bde553ad1ed52036
-  CapacitorPluginAppTrackingTransparency: 92ae9c1cfb5cf477753db9269689332a686f675a
+  CapacitorHaptics: 70e47470fa1a6bd6338cd102552e3846b7f9a1b3
+  CapacitorKeyboard: 969647d0ca2e5c737d7300088e2517aa832434e2
+  CapacitorPluginAppTrackingTransparency: 2a2792623a5a72795f2e8f9ab3f1147573732fd8
   CryptoSwift: 967f37cea5a3294d9cce358f78861652155be483
 
 PODFILE CHECKSUM: 2c1e4be82121f2d9724ecf7e31dd14e165aeb082

--- a/packages/frontend/apps/ios/src/plugins/paywall/definitions.ts
+++ b/packages/frontend/apps/ios/src/plugins/paywall/definitions.ts
@@ -1,0 +1,5 @@
+export interface PayWallPlugin {
+  showPayWall(options: {
+    type: string;
+  }): Promise<{ success: boolean; type: string }>;
+}

--- a/packages/frontend/apps/ios/src/plugins/paywall/index.ts
+++ b/packages/frontend/apps/ios/src/plugins/paywall/index.ts
@@ -1,0 +1,8 @@
+import { registerPlugin } from '@capacitor/core';
+
+import type { PayWallPlugin } from './definitions';
+
+const PayWall = registerPlugin<PayWallPlugin>('PayWall');
+
+export * from './definitions';
+export { PayWall };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new iOS Paywall plugin with a simple API to display a paywall and receive a success response.
  - Added JavaScript wrapper and type definitions for easy integration.

- Refactor
  - Reorganized the iOS project structure for plugins.

- Chores
  - Removed unused legacy iOS plugins to streamline the app and reduce build complexity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->