### PR TITLE
chore(core): hide embedding status in chat

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-composer/ai-chat-composer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-composer/ai-chat-composer.ts
@@ -198,12 +198,6 @@ export class AIChatComposer extends SignalWatcher(
         <ai-chat-composer-tip
           .tips=${[
             html`<span>AI outputs can be misleading or wrong</span>`,
-            this.embeddingCompleted
-              ? null
-              : html`<ai-chat-embedding-status-tooltip
-                  .affineWorkspaceDialogService=${this
-                    .affineWorkspaceDialogService}
-                />`,
           ].filter(Boolean)}
           .loop=${false}
         ></ai-chat-composer-tip>

--- a/tests/affine-cloud-copilot/e2e/basic/chat.spec.ts
+++ b/tests/affine-cloud-copilot/e2e/basic/chat.spec.ts
@@ -17,24 +17,24 @@ test.describe('AIBasic/Chat', () => {
     await expect(page.getByTestId('ai-onboarding')).toBeVisible();
   });
 
-  test('should open embedding settings when clicking check status button', async ({
-    loggedInPage: page,
-    utils,
-  }) => {
-    await utils.editor.createDoc(page, 'Doc 1', 'doc1');
-    await utils.editor.createDoc(page, 'Doc 2', 'doc2');
-    await utils.editor.createDoc(page, 'Doc 3', 'doc3');
-    await utils.editor.createDoc(page, 'Doc 4', 'doc4');
-    await utils.editor.createDoc(page, 'Doc 5', 'doc5');
+  // test('should open embedding settings when clicking check status button', async ({
+  //   loggedInPage: page,
+  //   utils,
+  // }) => {
+  //   await utils.editor.createDoc(page, 'Doc 1', 'doc1');
+  //   await utils.editor.createDoc(page, 'Doc 2', 'doc2');
+  //   await utils.editor.createDoc(page, 'Doc 3', 'doc3');
+  //   await utils.editor.createDoc(page, 'Doc 4', 'doc4');
+  //   await utils.editor.createDoc(page, 'Doc 5', 'doc5');
 
-    const check = await page.getByTestId(
-      'ai-chat-embedding-status-tooltip-check'
-    );
-    await expect(check).toBeVisible({ timeout: 50 * 1000 });
+  //   const check = await page.getByTestId(
+  //     'ai-chat-embedding-status-tooltip-check'
+  //   );
+  //   await expect(check).toBeVisible({ timeout: 50 * 1000 });
 
-    await check.click();
-    await expect(page.getByTestId('workspace-setting:embedding')).toBeVisible();
-  });
+  //   await check.click();
+  //   await expect(page.getByTestId('workspace-setting:embedding')).toBeVisible();
+  // });
 
   test(`should send message and receive AI response:
         - send message


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified the AI chat composer tip: removed the dynamic embedding-status tooltip so only a single static caution remains — “AI outputs can be misleading or wrong.”
* **Tests**
  * One end-to-end test related to embedding status was commented out and is no longer executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->