### PR TITLE
feat: add dedicated sign-up config for oauth

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -148,6 +148,11 @@
           "description": "Whether allow new registrations.\n@default true",
           "default": true
         },
+        "allowSignupForOauth": {
+          "type": "boolean",
+          "description": "Whether allow new registrations via configured oauth.\n@default true",
+          "default": true
+        },
         "requireEmailDomainVerification": {
           "type": "boolean",
           "description": "Whether require email domain record verification before accessing restricted resources.\n@default false",

--- a/packages/backend/server/src/core/auth/config.ts
+++ b/packages/backend/server/src/core/auth/config.ts
@@ -8,6 +8,7 @@ export interface AuthConfig {
     ttr: number;
   };
   allowSignup: boolean;
+  allowSignupForOauth: boolean;
   requireEmailDomainVerification: boolean;
   requireEmailVerification: boolean;
   passwordRequirements: ConfigItem<{
@@ -25,6 +26,10 @@ declare global {
 defineModuleConfig('auth', {
   allowSignup: {
     desc: 'Whether allow new registrations.',
+    default: true,
+  },
+  allowSignupForOauth: {
+    desc: 'Whether allow new registrations via configured oauth.',
     default: true,
   },
   requireEmailDomainVerification: {

--- a/packages/backend/server/src/plugins/oauth/controller.ts
+++ b/packages/backend/server/src/plugins/oauth/controller.ts
@@ -224,7 +224,7 @@ export class OAuthController {
       return connectedAccount.user;
     }
 
-    if (!this.config.auth.allowSignup) {
+    if (!this.config.auth.allowSignupForOauth) {
       throw new SignUpForbidden();
     }
 

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -63,6 +63,10 @@
       "type": "Boolean",
       "desc": "Whether allow new registrations."
     },
+    "allowSignupForOauth": {
+      "type": "Boolean",
+      "desc": "Whether allow new registrations via configured oauth."
+    },
     "requireEmailDomainVerification": {
       "type": "Boolean",
       "desc": "Whether require email domain record verification before accessing restricted resources."

--- a/packages/frontend/admin/src/modules/settings/config.ts
+++ b/packages/frontend/admin/src/modules/settings/config.ts
@@ -55,6 +55,7 @@ export const KNOWN_CONFIG_GROUPS = [
     module: 'auth',
     fields: [
       'allowSignup',
+      'allowSignupForOauth',
       // nested json object
       {
         key: 'passwordRequirements',


### PR DESCRIPTION
Currently, it is only possible to disable all registrations. However, it would be helpful if you could disable normal registration but enable OAuth registration. 