### PR TITLE
feat: add config for mail server name

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -195,6 +195,11 @@
       "type": "object",
       "description": "Configuration for mailer module",
       "properties": {
+        "SMTP.name": {
+          "type": "string",
+          "description": "Name of the email server (e.g. your domain name)\n@default \"AFFiNE Server\"\n@environment `MAILER_SERVERNAME`",
+          "default": "AFFiNE Server"
+        },
         "SMTP.host": {
           "type": "string",
           "description": "Host of the email server (e.g. smtp.gmail.com)\n@default \"\"\n@environment `MAILER_HOST`",
@@ -229,6 +234,11 @@
           "type": "array",
           "description": "The emails from these domains are always sent using the fallback SMTP server.\n@default []",
           "default": []
+        },
+        "fallbackSMTP.name": {
+          "type": "string",
+          "description": "Name of the fallback email server (e.g. your domain name)\n@default \"AFFiNE Server\"",
+          "default": "AFFiNE Server"
         },
         "fallbackSMTP.host": {
           "type": "string",

--- a/packages/backend/server/src/core/mail/config.ts
+++ b/packages/backend/server/src/core/mail/config.ts
@@ -6,6 +6,7 @@ declare global {
   interface AppConfigSchema {
     mailer: {
       SMTP: {
+        name: string;
         host: string;
         port: number;
         username: string;
@@ -16,6 +17,7 @@ declare global {
 
       fallbackDomains: ConfigItem<string[]>;
       fallbackSMTP: {
+        name: string;
         host: string;
         port: number;
         username: string;
@@ -28,6 +30,11 @@ declare global {
 }
 
 defineModuleConfig('mailer', {
+  'SMTP.name': {
+    desc: 'Name of the email server (e.g. your domain name)',
+    default: 'AFFiNE Server',
+    env: 'MAILER_SERVERNAME',
+  },
   'SMTP.host': {
     desc: 'Host of the email server (e.g. smtp.gmail.com)',
     default: '',
@@ -63,6 +70,10 @@ defineModuleConfig('mailer', {
     desc: 'The emails from these domains are always sent using the fallback SMTP server.',
     default: [],
     shape: z.array(z.string()),
+  },
+  'fallbackSMTP.name': {
+    desc: 'Name of the fallback email server (e.g. your domain name)',
+    default: 'AFFiNE Server',
   },
   'fallbackSMTP.host': {
     desc: 'Host of the email server (e.g. smtp.gmail.com)',

--- a/packages/backend/server/src/core/mail/sender.ts
+++ b/packages/backend/server/src/core/mail/sender.ts
@@ -20,6 +20,7 @@ function configToSMTPOptions(
   config: AppConfig['mailer']['SMTP']
 ): SMTPTransport.Options {
   return {
+    name: config.name,
     host: config.host,
     port: config.port,
     tls: {

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -89,6 +89,11 @@
     }
   },
   "mailer": {
+    "SMTP.name": {
+      "type": "String",
+      "desc": "Name of the email server (e.g. your domain name)",
+      "env": "MAILER_SERVERNAME"
+    },
     "SMTP.host": {
       "type": "String",
       "desc": "Host of the email server (e.g. smtp.gmail.com)",
@@ -122,6 +127,10 @@
     "fallbackDomains": {
       "type": "Array",
       "desc": "The emails from these domains are always sent using the fallback SMTP server."
+    },
+    "fallbackSMTP.name": {
+      "type": "String",
+      "desc": "Name of the fallback email server (e.g. your domain name)"
     },
     "fallbackSMTP.host": {
       "type": "String",


### PR DESCRIPTION
fix #13627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable display names for primary and fallback SMTP servers, improving email sender identification.
  * Defaults to “AFFiNE Server,” with support for MAILER_SERVERNAME environment variable for the primary SMTP.
  * Exposed in admin settings for easy setup alongside existing SMTP options.
  * Names are now passed through to mail transport options for consistent use across emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->