### PR TITLE
fix(core): prevent emoji being clipped and adjust icon-picker default color

### DIFF
--- a/packages/frontend/component/src/ui/icon-name-editor/icon-name-editor.css.ts
+++ b/packages/frontend/component/src/ui/icon-name-editor/icon-name-editor.css.ts
@@ -16,6 +16,7 @@ export const contentRoot = style({
 export const iconPicker = style({
   padding: 0,
   lineHeight: 1,
+  color: cssVarV2.icon.primary,
 });
 globalStyle(`${iconPicker} span:has(svg)`, {
   lineHeight: 0,

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.css.ts
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.css.ts
@@ -10,6 +10,9 @@ export const docIconPickerTrigger = style({
       fontSize: 60,
       lineHeight: 1,
     },
+    '&[data-icon-type="emoji"]': {
+      fontFamily: 'emoji',
+    },
   },
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated icon picker to use the primary icon color, improving visual consistency (including SVG icons).
  - Improved emoji rendering in the document icon picker by applying an emoji-specific font for elements marked as emoji, matching existing size and line-height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->