### PR TITLE
feat(server): refresh subscription

### DIFF
--- a/packages/backend/server/src/plugins/payment/resolver.ts
+++ b/packages/backend/server/src/plugins/payment/resolver.ts
@@ -567,10 +567,21 @@ export class UserSubscriptionResolver {
       },
     });
 
+    const subscriptions = current.reduce(
+      (r, s) => {
+        if (s.plan in SubscriptionPlan) {
+          r[s.plan as SubscriptionPlan] = s.provider;
+        }
+        return r;
+      },
+      {} as Record<SubscriptionPlan, Provider>
+    );
+
     // has revenuecat subscription or no subscription at all
     const shouldSync =
       current.length === 0 ||
-      current.some(s => s.provider === Provider.revenuecat);
+      subscriptions.pro === Provider.revenuecat ||
+      subscriptions.ai === Provider.revenuecat;
 
     if (shouldSync) {
       try {

--- a/packages/backend/server/src/plugins/payment/resolver.ts
+++ b/packages/backend/server/src/plugins/payment/resolver.ts
@@ -12,8 +12,7 @@ import {
   ResolveField,
   Resolver,
 } from '@nestjs/graphql';
-import type { User } from '@prisma/client';
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Provider, type User } from '@prisma/client';
 import { GraphQLJSONObject } from 'graphql-scalars';
 import { groupBy } from 'lodash-es';
 import Stripe from 'stripe';
@@ -31,6 +30,7 @@ import { AccessController } from '../../core/permission';
 import { UserType } from '../../core/user';
 import { WorkspaceType } from '../../core/workspaces';
 import { Invoice, Subscription, WorkspaceSubscriptionManager } from './manager';
+import { RevenueCatWebhookHandler } from './revenuecat';
 import { CheckoutParams, SubscriptionService } from './service';
 import {
   InvoiceStatus,
@@ -463,7 +463,10 @@ export class SubscriptionResolver {
 
 @Resolver(() => UserType)
 export class UserSubscriptionResolver {
-  constructor(private readonly db: PrismaClient) {}
+  constructor(
+    private readonly db: PrismaClient,
+    private readonly rcHandler: RevenueCatWebhookHandler
+  ) {}
 
   @ResolveField(() => [SubscriptionType])
   async subscriptions(
@@ -533,6 +536,68 @@ export class UserSubscriptionResolver {
         createdAt: 'desc',
       },
     });
+  }
+
+  @Throttle('strict')
+  @Mutation(() => [SubscriptionType], {
+    description: 'Refresh current user subscriptions and return latest.',
+  })
+  async refreshUserSubscriptions(
+    @CurrentUser() user: CurrentUser
+  ): Promise<Subscription[]> {
+    if (!user) {
+      throw new AuthenticationRequired();
+    }
+
+    let current = await this.db.subscription.findMany({
+      where: {
+        targetId: user.id,
+        status: {
+          in: [
+            SubscriptionStatus.Active,
+            SubscriptionStatus.Trialing,
+            SubscriptionStatus.PastDue,
+          ],
+        },
+      },
+    });
+
+    // has revenuecat subscription or no subscription at all
+    const shouldSync =
+      current.length === 0 ||
+      current.some(s => s.provider === Provider.revenuecat);
+
+    if (shouldSync) {
+      try {
+        await this.rcHandler.syncAppUser(user.id);
+        current = await this.db.subscription.findMany({
+          where: {
+            targetId: user.id,
+            status: {
+              in: [
+                SubscriptionStatus.Active,
+                SubscriptionStatus.Trialing,
+                SubscriptionStatus.PastDue,
+              ],
+            },
+          },
+        });
+        // ignore errors
+      } catch {}
+    }
+
+    current.forEach(subscription => {
+      if (
+        subscription.variant &&
+        ![SubscriptionVariant.EA, SubscriptionVariant.Onetime].includes(
+          subscription.variant as SubscriptionVariant
+        )
+      ) {
+        subscription.variant = null;
+      }
+    });
+
+    return current;
   }
 }
 

--- a/packages/backend/server/src/plugins/payment/resolver.ts
+++ b/packages/backend/server/src/plugins/payment/resolver.ts
@@ -567,9 +567,10 @@ export class UserSubscriptionResolver {
       },
     });
 
+    const existsPlans = Object.values(SubscriptionPlan);
     const subscriptions = current.reduce(
       (r, s) => {
-        if (s.plan in SubscriptionPlan) {
+        if (existsPlans.includes(s.plan as SubscriptionPlan)) {
           r[s.plan as SubscriptionPlan] = s.provider;
         }
         return r;

--- a/packages/backend/server/src/plugins/payment/resolver.ts
+++ b/packages/backend/server/src/plugins/payment/resolver.ts
@@ -468,6 +468,18 @@ export class UserSubscriptionResolver {
     private readonly rcHandler: RevenueCatWebhookHandler
   ) {}
 
+  private normalizeSubscription(s: Subscription) {
+    if (
+      s.variant &&
+      ![SubscriptionVariant.EA, SubscriptionVariant.Onetime].includes(
+        s.variant as SubscriptionVariant
+      )
+    ) {
+      s.variant = null;
+    }
+    return s;
+  }
+
   @ResolveField(() => [SubscriptionType])
   async subscriptions(
     @CurrentUser() me: User,
@@ -490,16 +502,9 @@ export class UserSubscriptionResolver {
       },
     });
 
-    subscriptions.forEach(subscription => {
-      if (
-        subscription.variant &&
-        ![SubscriptionVariant.EA, SubscriptionVariant.Onetime].includes(
-          subscription.variant as SubscriptionVariant
-        )
-      ) {
-        subscription.variant = null;
-      }
-    });
+    subscriptions.forEach(subscription =>
+      this.normalizeSubscription(subscription)
+    );
 
     return subscriptions;
   }
@@ -586,16 +591,7 @@ export class UserSubscriptionResolver {
       } catch {}
     }
 
-    current.forEach(subscription => {
-      if (
-        subscription.variant &&
-        ![SubscriptionVariant.EA, SubscriptionVariant.Onetime].includes(
-          subscription.variant as SubscriptionVariant
-        )
-      ) {
-        subscription.variant = null;
-      }
-    });
+    current.forEach(subscription => this.normalizeSubscription(subscription));
 
     return current;
   }

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1299,6 +1299,9 @@ type Mutation {
   """mark notification as read"""
   readNotification(id: String!): Boolean!
   recoverDoc(guid: String!, timestamp: DateTime!, workspaceId: String!): DateTime!
+
+  """Refresh current user subscriptions and return latest."""
+  refreshUserSubscriptions: [SubscriptionType!]!
   releaseDeletedBlobs(workspaceId: String!): Boolean!
 
   """Remove user avatar"""

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -2218,6 +2218,25 @@ export const setWorkspacePublicByIdMutation = {
 }`,
 };
 
+export const refreshSubscriptionMutation = {
+  id: 'refreshSubscriptionMutation' as const,
+  op: 'refreshSubscription',
+  query: `mutation refreshSubscription {
+  refreshUserSubscriptions {
+    id
+    status
+    plan
+    recurring
+    start
+    end
+    nextBillAt
+    canceledAt
+    variant
+  }
+}`,
+  deprecations: ["'id' is deprecated: removed"],
+};
+
 export const subscriptionQuery = {
   id: 'subscriptionQuery' as const,
   op: 'subscription',

--- a/packages/common/graphql/src/graphql/subscription-refresh.gql
+++ b/packages/common/graphql/src/graphql/subscription-refresh.gql
@@ -1,0 +1,13 @@
+mutation refreshSubscription {
+  refreshUserSubscriptions {
+    id
+    status
+    plan
+    recurring
+    start
+    end
+    nextBillAt
+    canceledAt
+    variant
+  }
+}

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -1451,6 +1451,8 @@ export interface Mutation {
   /** mark notification as read */
   readNotification: Scalars['Boolean']['output'];
   recoverDoc: Scalars['DateTime']['output'];
+  /** Refresh current user subscriptions and return latest. */
+  refreshUserSubscriptions: Array<SubscriptionType>;
   releaseDeletedBlobs: Scalars['Boolean']['output'];
   /** Remove user avatar */
   removeAvatar: RemoveAvatar;
@@ -5996,6 +5998,26 @@ export type SetWorkspacePublicByIdMutation = {
   updateWorkspace: { __typename?: 'WorkspaceType'; id: string };
 };
 
+export type RefreshSubscriptionMutationVariables = Exact<{
+  [key: string]: never;
+}>;
+
+export type RefreshSubscriptionMutation = {
+  __typename?: 'Mutation';
+  refreshUserSubscriptions: Array<{
+    __typename?: 'SubscriptionType';
+    id: string | null;
+    status: SubscriptionStatus;
+    plan: SubscriptionPlan;
+    recurring: SubscriptionRecurring;
+    start: string;
+    end: string | null;
+    nextBillAt: string | null;
+    canceledAt: string | null;
+    variant: SubscriptionVariant | null;
+  }>;
+};
+
 export type SubscriptionQueryVariables = Exact<{ [key: string]: never }>;
 
 export type SubscriptionQuery = {
@@ -7080,6 +7102,11 @@ export type Mutations =
       name: 'setWorkspacePublicByIdMutation';
       variables: SetWorkspacePublicByIdMutationVariables;
       response: SetWorkspacePublicByIdMutation;
+    }
+  | {
+      name: 'refreshSubscriptionMutation';
+      variables: RefreshSubscriptionMutationVariables;
+      response: RefreshSubscriptionMutation;
     }
   | {
       name: 'updateDocDefaultRoleMutation';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-demand mutation to refresh the current user's subscriptions, syncing with RevenueCat when applicable and handling Stripe-only cases.
  * Subscription variant normalization for clearer plan information and consistent results.

* **Tests**
  * Added tests for refresh behavior: empty state, RevenueCat-backed multi-step sync, and Stripe-only scenarios.

* **Client**
  * New client operation to invoke the refresh mutation and retrieve updated subscription fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->