### PR TITLE
fix(core): correct doc icon padding in editor header

### DIFF
--- a/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.tsx
@@ -11,8 +11,7 @@ const TitleContainer = ({ children }: { children: React.ReactNode }) => {
     <div
       className="doc-icon-container"
       style={{
-        paddingTop: 0,
-        paddingBottom: 0,
+        paddingBottom: 8,
       }}
     >
       {children}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical spacing in the document icon picker header, reducing excess top padding and setting a consistent bottom padding for a cleaner, tighter layout.
  * Improves visual alignment and readability without altering functionality—interactions and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->