### PR TITLE
fix(core): can not scroll all page list in MacOS 26

### DIFF
--- a/packages/frontend/core/src/desktop/pages/workspace/all-page/all-page.css.ts
+++ b/packages/frontend/core/src/desktop/pages/workspace/all-page/all-page.css.ts
@@ -25,7 +25,6 @@ export const body = style({
   display: 'flex',
   flexDirection: 'column',
   flex: 1,
-  height: '100%',
   width: '100%',
   containerName: 'docs-body',
   containerType: 'size',


### PR DESCRIPTION
Close https://github.com/toeverything/AFFiNE/issues/13754

#### PR Dependency Tree


* **PR #13763** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated page layout sizing to no longer force full-height on the docs body, allowing height to adapt to content.
  * Improves natural scrolling and reduces layout constraints in the workspace “All” page.
  * Enhances responsiveness across varying screen sizes by relying on content and container sizing rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->