### PR TITLE
fix(editor): add trash state for linked-doc and synced-doc appearance

### DIFF
--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/embed-linked-doc-block.ts
@@ -323,7 +323,8 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
 
   private readonly _renderEmbedView = () => {
     const linkedDoc = this.linkedDoc;
-    const isDeleted = !linkedDoc;
+    const trash = linkedDoc?.meta?.trash;
+    const isDeleted = trash || !linkedDoc;
     const isLoading = this._loading;
     const isError = this.isError;
     const isEmpty = this._isDocEmpty() && this.isBannerEmpty;
@@ -521,11 +522,6 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
       );
 
       this._setDocUpdatedAt();
-      this.disposables.add(
-        this.store.workspace.slots.docListUpdated.subscribe(() => {
-          this._setDocUpdatedAt();
-        })
-      );
 
       if (this._referenceToNode) {
         this._linkedDocMode = this.model.props.params?.mode ?? 'page';
@@ -551,6 +547,13 @@ export class EmbedLinkedDocBlockComponent extends EmbedBlockComponent<EmbedLinke
             this.isError = true;
           });
         }
+      })
+    );
+
+    this.disposables.add(
+      this.store.workspace.slots.docListUpdated.subscribe(() => {
+        this._setDocUpdatedAt();
+        this.refreshData();
       })
     );
 

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-block.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-synced-doc-block.ts
@@ -357,10 +357,14 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
   };
 
   refreshData = () => {
-    this._load().catch(e => {
-      console.error(e);
-      this._error = true;
-    });
+    this._load()
+      .then(() => {
+        this._isEmptySyncedDoc = isEmptyDoc(this.syncedDoc, this.editorMode);
+      })
+      .catch(e => {
+        console.error(e);
+        this._error = true;
+      });
   };
 
   title$ = computed(() => {
@@ -445,7 +449,8 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
     this._cycle = false;
 
     const syncedDoc = this.syncedDoc;
-    if (!syncedDoc) {
+    const trash = syncedDoc?.meta?.trash;
+    if (trash || !syncedDoc) {
       this._deleted = true;
       this._loading = false;
       return;
@@ -521,6 +526,7 @@ export class EmbedSyncedDocBlockComponent extends EmbedBlockComponent<EmbedSynce
     this.disposables.add(
       this.store.workspace.slots.docListUpdated.subscribe(() => {
         this._setDocUpdatedAt();
+        this.refreshData();
       })
     );
 

--- a/blocksuite/framework/store/src/extension/workspace/workspace-meta.ts
+++ b/blocksuite/framework/store/src/extension/workspace/workspace-meta.ts
@@ -17,6 +17,7 @@ export interface DocMeta {
   createDate: number;
   updatedDate?: number;
   favorite?: boolean;
+  trash?: boolean;
 }
 
 export interface WorkspaceMeta {


### PR DESCRIPTION
This PR updates the appearance of `embed-linked-doc-block` and `embed-synced-doc-block` to reflect the trashed state of their linked documents. 
Previously, these blocks showed no visual difference whether the linked document was trashed or not, despite the existing of codes for deletion-related appearance. 
This change ensures that the deletion appearance is properly displayed.

![after](https://github.com/user-attachments/assets/fe2d66d9-6685-4d15-95aa-0680111bc190)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documents now support trash state tracking for improved deletion management

* **Bug Fixes**
  * Improved synchronization and refresh of embedded documents when document states change
  * Enhanced handling of trashed documents in embedded content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->