### PR TITLE
fix: correct backend server version in package.json to match v0.24.3

### DIFF
--- a/packages/backend/server/package.json
+++ b/packages/backend/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@affine/server",
   "private": true,
-  "version": "0.22.4",
+  "version": "0.24.3",
   "description": "Affine Node.js server",
   "type": "module",
   "bin": {


### PR DESCRIPTION
**Summary**
The backend server `package.json` still reports version 0.22.4, causing self-hosted servers to appear outdated and incompatible with v0.24.3 clients.

This PR updates the version field to 0.24.3 to match the current release tag.

### Related Issue
Fixes #13727

### Notes
No functional code changes — only metadata update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.24.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->