### PR TITLE
feat(server): refresh subscription if event is from anonymous account

### DIFF
--- a/packages/backend/server/src/plugins/payment/revenuecat/controller.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/controller.ts
@@ -82,11 +82,12 @@ export class RevenueCatWebhookController {
                 appUserId,
                 familyShare: event.is_family_share,
                 environment: event.environment,
+                transactionId: event.transaction_id,
               };
               this.logger.log(
                 `[${id}] RevenueCat Webhook {${type}} received for appUserId=${appUserId}.`
               );
-              if (appUserId) {
+              if (appUserId && !appUserId.startsWith('$RCAnonymousID:')) {
                 const user = await this.models.user.get(appUserId);
                 if (user) {
                   if (
@@ -112,6 +113,19 @@ export class RevenueCatWebhookController {
                     );
                   }
                 }
+              } else if (event.transaction_id) {
+                this.event
+                  .emitAsync('revenuecat.subscription.refresh.anonymous', {
+                    externalRef: event.transaction_id,
+                    startTime: Date.now(),
+                  })
+                  .catch((e: Error) => {
+                    this.logger.error(
+                      'Failed to handle RevenueCat Webhook event.',
+                      e
+                    );
+                  });
+                return;
               }
               this.logger.warn(
                 `RevenueCat Webhook received for unknown user`,

--- a/packages/backend/server/src/plugins/payment/revenuecat/controller.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/controller.ts
@@ -1,7 +1,7 @@
 import { Body, Controller, Headers, Logger, Post } from '@nestjs/common';
 import { z } from 'zod';
 
-import { Config, EventBus } from '../../../base';
+import { Config, EventBus, JobQueue } from '../../../base';
 import { Public } from '../../../core/auth';
 import { FeatureService } from '../../../core/features';
 import { Models } from '../../../models';
@@ -55,6 +55,7 @@ export class RevenueCatWebhookController {
   constructor(
     private readonly config: Config,
     private readonly event: EventBus,
+    private readonly queue: JobQueue,
     private readonly models: Models,
     private readonly feature: FeatureService
   ) {}
@@ -114,8 +115,8 @@ export class RevenueCatWebhookController {
                   }
                 }
               } else if (event.transaction_id) {
-                this.event
-                  .emitAsync('revenuecat.subscription.refresh.anonymous', {
+                await this.queue
+                  .add('nightly.revenuecat.subscription.refresh.anonymous', {
                     externalRef: event.transaction_id,
                     startTime: Date.now(),
                   })

--- a/packages/backend/server/src/plugins/payment/revenuecat/service.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/service.ts
@@ -48,6 +48,7 @@ const zRcV2RawSubscription = z
   .object({
     object: z.enum(['subscription']),
     id: z.string().nonempty(),
+    customer_id: z.string().nonempty(),
     product_id: z.string().nonempty().nullable(),
     entitlements: zRcV2RawEntitlements,
     starts_at: z.number(),
@@ -75,11 +76,25 @@ const zRcV2RawSubscription = z
   })
   .passthrough();
 
-const zRcV2RawEnvelope = z
+const zRcV2RawSubscriptionEnvelope = z
   .object({
     app_user_id: z.string().optional(),
     id: z.string().optional(),
     items: z.array(zRcV2RawSubscription).default([]),
+  })
+  .passthrough();
+
+const zRcV2RawCustomerAlias = z
+  .object({
+    object: z.literal('customer.alias'),
+    id: z.string().nonempty(),
+    created_at: z.number(),
+  })
+  .passthrough();
+
+const zRcV2RawCustomerAliasEnvelope = z
+  .object({
+    items: z.array(zRcV2RawCustomerAlias).default([]),
   })
   .passthrough();
 
@@ -90,6 +105,7 @@ export const Subscription = z.object({
   isActive: z.boolean(),
   latestPurchaseDate: z.date().nullable(),
   expirationDate: z.date().nullable(),
+  customerId: z.string(),
   productId: z.string(),
   store: Store,
   willRenew: z.boolean(),
@@ -166,6 +182,40 @@ export class RevenueCatService {
     return null;
   }
 
+  async getCustomerAlias(customerId: string): Promise<string[] | null> {
+    const res = await fetch(
+      `https://api.revenuecat.com/v2/projects/${this.projectId}/customers/${customerId}/aliases`,
+      {
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `RevenueCat getCustomerAlias failed: ${res.status} ${res.statusText} - ${text}`
+      );
+    }
+
+    const json = await res.json();
+    const customerParsed = zRcV2RawCustomerAliasEnvelope.safeParse(json);
+
+    if (customerParsed.success) {
+      return customerParsed.data.items
+        .map(alias => alias.id)
+        .filter(id => !id.startsWith('$RCAnonymousID:'));
+    }
+    this.logger.error(
+      `RevenueCat customer ${customerId} parse failed: ${JSON.stringify(
+        customerParsed.error.format()
+      )}`
+    );
+    return null;
+  }
+
   async getSubscriptionByExternalRef(
     externalRef: string
   ): Promise<Subscription[] | null> {
@@ -182,12 +232,12 @@ export class RevenueCatService {
     if (!res.ok) {
       const text = await res.text();
       throw new Error(
-        `RevenueCat getSubscriber failed: ${res.status} ${res.statusText} - ${text}`
+        `RevenueCat getSubscriptionByExternalRef failed: ${res.status} ${res.statusText} - ${text}`
       );
     }
 
     const json = await res.json();
-    const envParsed = zRcV2RawEnvelope.safeParse(json);
+    const envParsed = zRcV2RawSubscriptionEnvelope.safeParse(json);
 
     if (envParsed.success) {
       const parsedSubs = await Promise.all(
@@ -222,7 +272,7 @@ export class RevenueCatService {
     }
 
     const json = await res.json();
-    const envParsed = zRcV2RawEnvelope.safeParse(json);
+    const envParsed = zRcV2RawSubscriptionEnvelope.safeParse(json);
 
     if (envParsed.success) {
       const parsedSubs = await Promise.all(
@@ -248,7 +298,8 @@ export class RevenueCatService {
     const product = products.find(p => p.id === sub.product_id);
     if (!product) {
       this.logger.warn(
-        `RevenueCat subscription ${sub.id} missing product for product_id=${sub.product_id}`
+        `RevenueCat subscription ${sub.id} missing product for product_id=${sub.product_id}`,
+        products
       );
       return null;
     }
@@ -264,6 +315,7 @@ export class RevenueCatService {
       expirationDate: sub.current_period_ends_at
         ? new Date(sub.current_period_ends_at)
         : null,
+      customerId: sub.customer_id,
       productId: product.store_identifier,
       store: sub.store ?? product.app?.type,
       willRenew: sub.auto_renewal_status === 'will_renew',

--- a/packages/backend/server/src/plugins/payment/revenuecat/service.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/service.ts
@@ -48,7 +48,7 @@ const zRcV2RawSubscription = z
   .object({
     object: z.enum(['subscription']),
     id: z.string().nonempty(),
-    customer_id: z.string().nonempty(),
+    customer_id: z.string().nonempty().nullish(),
     product_id: z.string().nonempty().nullable(),
     entitlements: zRcV2RawEntitlements,
     starts_at: z.number(),
@@ -105,7 +105,7 @@ export const Subscription = z.object({
   isActive: z.boolean(),
   latestPurchaseDate: z.date().nullable(),
   expirationDate: z.date().nullable(),
-  customerId: z.string(),
+  customerId: z.string().optional(),
   productId: z.string(),
   store: Store,
   willRenew: z.boolean(),
@@ -315,7 +315,7 @@ export class RevenueCatService {
       expirationDate: sub.current_period_ends_at
         ? new Date(sub.current_period_ends_at)
         : null,
-      customerId: sub.customer_id,
+      customerId: sub.customer_id || undefined,
       productId: product.store_identifier,
       store: sub.store ?? product.app?.type,
       willRenew: sub.auto_renewal_status === 'will_renew',

--- a/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
@@ -5,8 +5,10 @@ import {
   Config,
   EventBus,
   JOB_SIGNAL,
+  JobQueue,
   OneMinute,
   OnEvent,
+  OnJob,
   sleep,
 } from '../../../base';
 import { SubscriptionStatus } from '../types';
@@ -25,7 +27,8 @@ export class RevenueCatWebhookHandler {
     private readonly rc: RevenueCatService,
     private readonly db: PrismaClient,
     private readonly config: Config,
-    private readonly event: EventBus
+    private readonly event: EventBus,
+    private readonly queue: JobQueue
   ) {}
 
   @OnEvent('revenuecat.webhook')
@@ -67,7 +70,7 @@ export class RevenueCatWebhookHandler {
       externalRef,
       new Date(Date.now() + 10 * OneMinute) // expire after 10 minutes
     );
-    this.event.emit('revenuecat.subscription.refresh', {
+    await this.queue.add('nightly.revenuecat.subscription.refresh', {
       userId: appUserId,
       startTime: Date.now(),
     });
@@ -301,7 +304,7 @@ export class RevenueCatWebhookHandler {
     };
   }
 
-  @OnEvent('revenuecat.subscription.refresh.anonymous')
+  @OnJob('nightly.revenuecat.subscription.refresh.anonymous')
   async onSubscriptionRefreshAnonymousUser(evt: {
     externalRef: string;
     startTime: number;
@@ -357,7 +360,7 @@ export class RevenueCatWebhookHandler {
     return JOB_SIGNAL.Retry;
   }
 
-  @OnEvent('revenuecat.subscription.refresh')
+  @OnJob('nightly.revenuecat.subscription.refresh')
   async onSubscriptionRefresh(evt: { userId: string; startTime: number }) {
     if (!this.config.payment.revenuecat?.enabled) return;
     if (Date.now() - evt.startTime > REFRESH_MAX_TIMES) {

--- a/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
@@ -1,11 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { IapStore, PrismaClient, Provider } from '@prisma/client';
 
-import { Config, EventBus, OneMinute, OnEvent } from '../../../base';
+import {
+  Config,
+  EventBus,
+  JOB_SIGNAL,
+  OneMinute,
+  OnEvent,
+  sleep,
+} from '../../../base';
 import { SubscriptionStatus } from '../types';
 import { RcEvent } from './controller';
 import { resolveProductMapping } from './map';
 import { RevenueCatService, Subscription } from './service';
+
+const REFRESH_INTERVAL = 5 * 1000; // 5 seconds
+const REFRESH_MAX_TIMES = 10 * OneMinute;
 
 @Injectable()
 export class RevenueCatWebhookHandler {
@@ -39,39 +49,47 @@ export class RevenueCatWebhookHandler {
     >;
     try {
       subscriptions = await this.rc.getSubscriptionByExternalRef(externalRef);
-      if (!subscriptions) return;
+      if (!subscriptions) {
+        throw new Error(`No transaction found: ${externalRef}`);
+      }
     } catch (e) {
       this.logger.error(
         `Failed to fetch RC subscriptions for ${appUserId} by ${externalRef}`,
         e
       );
-      return;
+      return false;
     }
 
-    await this.syncSubscription(
+    const success = await this.syncSubscription(
       appUserId,
       subscriptions,
       undefined,
       externalRef,
       new Date(Date.now() + 10 * OneMinute) // expire after 10 minutes
     );
+    this.event.emit('revenuecat.subscription.refresh', {
+      userId: appUserId,
+      startTime: Date.now(),
+    });
+
+    return success;
   }
 
   // Exposed for reuse by reconcile job
-  async syncAppUser(appUserId: string, event?: RcEvent) {
+  async syncAppUser(appUserId: string, event?: RcEvent): Promise<boolean> {
     // Pull latest state to be resilient to reorder/duplicate events
     let subscriptions: Awaited<
       ReturnType<RevenueCatService['getSubscriptions']>
     >;
     try {
       subscriptions = await this.rc.getSubscriptions(appUserId);
-      if (!subscriptions) return;
+      if (!subscriptions) return false;
     } catch (e) {
       this.logger.error(`Failed to fetch RC subscription for ${appUserId}`, e);
-      return;
+      return false;
     }
 
-    await this.syncSubscription(appUserId, subscriptions, event);
+    return await this.syncSubscription(appUserId, subscriptions, event);
   }
 
   private async syncSubscription(
@@ -80,9 +98,10 @@ export class RevenueCatWebhookHandler {
     event?: RcEvent,
     externalRef?: string,
     overrideExpirationDate?: Date
-  ) {
+  ): Promise<boolean> {
     const productOverride = this.config.payment.revenuecat?.productMap;
 
+    let success = 0;
     for (const sub of subscriptions) {
       const mapping = resolveProductMapping(sub, productOverride);
       // ignore non-whitelisted and non-fallbackable products
@@ -197,6 +216,7 @@ export class RevenueCatWebhookHandler {
           plan: mapping.plan,
           recurring: mapping.recurring,
         });
+        success += 1;
       } else if (status !== SubscriptionStatus.PastDue) {
         // Do not emit canceled for PastDue (still within retry/grace window)
         this.event.emit('user.subscription.canceled', {
@@ -206,6 +226,7 @@ export class RevenueCatWebhookHandler {
         });
       }
     }
+    return success > 0;
   }
 
   private pickExternalRef(e?: RcEvent): string | null {
@@ -269,5 +290,25 @@ export class RevenueCatWebhookHandler {
       status: SubscriptionStatus.Canceled,
       deleteInstead: true,
     };
+  }
+
+  @OnEvent('revenuecat.subscription.refresh')
+  async onSubscriptionRefresh(evt: { userId: string; startTime: number }) {
+    if (!this.config.payment.revenuecat?.enabled) return;
+    if (Date.now() - evt.startTime > REFRESH_MAX_TIMES) {
+      this.logger.warn(
+        `RevenueCat subscription refresh timed out for user ${evt.userId}`
+      );
+      return;
+    }
+    const startTime = Date.now();
+    const success = await this.syncAppUser(evt.userId);
+    if (success) return;
+
+    const elapsed = Date.now() - startTime;
+    if (elapsed < REFRESH_INTERVAL) {
+      await sleep(REFRESH_INTERVAL - elapsed);
+    }
+    return JOB_SIGNAL.Retry;
   }
 }

--- a/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
@@ -106,6 +106,12 @@ export class RevenueCatWebhookHandler {
 
     let success = 0;
     for (const sub of subscriptions) {
+      if (!sub.customerId) {
+        this.logger.warn(`RevenueCat subscription missing customerId`, {
+          subscription: sub,
+        });
+        continue;
+      }
       const customerAlias = await this.rc.getCustomerAlias(sub.customerId);
       if (customerAlias && !customerAlias.includes(appUserId)) {
         this.logger.warn(`RevenueCat subscription customer alias mismatch`, {
@@ -324,9 +330,19 @@ export class RevenueCatWebhookHandler {
       let success = 0;
       if (subscriptions) {
         for (const sub of subscriptions) {
+          if (!sub.customerId) {
+            this.logger.warn(`RevenueCat subscription missing customerId`, {
+              subscription: sub,
+            });
+            continue;
+          }
           const customerAlias = await this.rc.getCustomerAlias(sub.customerId);
           if (customerAlias) {
-            if (customerAlias.length === 0 || customerAlias.length > 1) {
+            if (
+              customerAlias.length === 0 ||
+              customerAlias.length > 1 ||
+              !customerAlias[0]
+            ) {
               this.logger.warn(
                 `RevenueCat anonymous subscription has invalid customer alias`,
                 { customerId: sub.customerId, customerAlias }

--- a/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/webhook.ts
@@ -103,6 +103,15 @@ export class RevenueCatWebhookHandler {
 
     let success = 0;
     for (const sub of subscriptions) {
+      const customerAlias = await this.rc.getCustomerAlias(sub.customerId);
+      if (customerAlias && !customerAlias.includes(appUserId)) {
+        this.logger.warn(`RevenueCat subscription customer alias mismatch`, {
+          customerId: sub.customerId,
+          customerAlias,
+          appUserId,
+        });
+        continue;
+      }
       const mapping = resolveProductMapping(sub, productOverride);
       // ignore non-whitelisted and non-fallbackable products
       if (!mapping) continue;
@@ -290,6 +299,62 @@ export class RevenueCatWebhookHandler {
       status: SubscriptionStatus.Canceled,
       deleteInstead: true,
     };
+  }
+
+  @OnEvent('revenuecat.subscription.refresh.anonymous')
+  async onSubscriptionRefreshAnonymousUser(evt: {
+    externalRef: string;
+    startTime: number;
+  }) {
+    if (!this.config.payment.revenuecat?.enabled) return;
+    if (Date.now() - evt.startTime > REFRESH_MAX_TIMES) {
+      this.logger.warn(
+        `RevenueCat subscription refresh timed out for externalRef ${evt.externalRef}`
+      );
+      return;
+    }
+    const startTime = Date.now();
+    try {
+      const subscriptions = await this.rc.getSubscriptionByExternalRef(
+        evt.externalRef
+      );
+      let success = 0;
+      if (subscriptions) {
+        for (const sub of subscriptions) {
+          const customerAlias = await this.rc.getCustomerAlias(sub.customerId);
+          if (customerAlias) {
+            if (customerAlias.length === 0 || customerAlias.length > 1) {
+              this.logger.warn(
+                `RevenueCat anonymous subscription has invalid customer alias`,
+                { customerId: sub.customerId, customerAlias }
+              );
+              continue;
+            }
+            const appUserId = customerAlias[0];
+            const saved = await this.syncSubscription(
+              appUserId,
+              [sub],
+              undefined,
+              evt.externalRef
+            );
+            if (saved) success += 1;
+          }
+        }
+      }
+      if (success > 0) return;
+    } catch (e) {
+      this.logger.error(
+        `Failed to fetch RC anonymous subscriptions by ${evt.externalRef}`,
+        e
+      );
+      return;
+    }
+
+    const elapsed = Date.now() - startTime;
+    if (elapsed < REFRESH_INTERVAL) {
+      await sleep(REFRESH_INTERVAL - elapsed);
+    }
+    return JOB_SIGNAL.Retry;
   }
 
   @OnEvent('revenuecat.subscription.refresh')

--- a/packages/backend/server/src/plugins/payment/types.ts
+++ b/packages/backend/server/src/plugins/payment/types.ts
@@ -99,6 +99,10 @@ declare global {
       userId: User['id'];
       startTime: number;
     };
+    'revenuecat.subscription.refresh.anonymous': {
+      externalRef: string;
+      startTime: number;
+    };
   }
 }
 

--- a/packages/backend/server/src/plugins/payment/types.ts
+++ b/packages/backend/server/src/plugins/payment/types.ts
@@ -94,12 +94,14 @@ declare global {
       appUserId?: string;
       event: RcEvent;
     };
+  }
 
-    'revenuecat.subscription.refresh': {
+  interface Jobs {
+    'nightly.revenuecat.subscription.refresh': {
       userId: User['id'];
       startTime: number;
     };
-    'revenuecat.subscription.refresh.anonymous': {
+    'nightly.revenuecat.subscription.refresh.anonymous': {
       externalRef: string;
       startTime: number;
     };

--- a/packages/backend/server/src/plugins/payment/types.ts
+++ b/packages/backend/server/src/plugins/payment/types.ts
@@ -94,6 +94,11 @@ declare global {
       appUserId?: string;
       event: RcEvent;
     };
+
+    'revenuecat.subscription.refresh': {
+      userId: User['id'];
+      startTime: number;
+    };
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nightly and on-demand subscription refresh jobs (including anonymous transaction support) with retry/backoff and public refresh events.
  * Customer-alias resolution to better associate external subscription records with users.
  * Webhook now schedules subscription refreshes after processing.

* **Bug Fixes**
  * More reliable subscription sync: emits activation/cancellation events consistently.
  * Improved error handling, explicit retry signaling, and safer upsert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->