### PR TITLE
Fix emoji icon overlap

### DIFF
--- a/packages/frontend/component/src/ui/button/button.css.ts
+++ b/packages/frontend/component/src/ui/button/button.css.ts
@@ -193,7 +193,6 @@ export const content = style({
   // in case that width is specified by parent and text is too long
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  overflow: 'hidden',
 });
 
 export const icon = style({


### PR DESCRIPTION
Fix icon on doc editor:

<img width="901" height="450" alt="изображение" src="https://github.com/user-attachments/assets/99108379-8a18-4da8-9767-a0d0be924d1b" />


<img width="1003" height="635" alt="изображение" src="https://github.com/user-attachments/assets/4cd685ef-cffb-43fd-87cb-a22a18e070ef" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated button component text overflow handling to allow alternative clipping behavior based on layout context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->