### PR TITLE
fix(editor): linked doc popover close when layout is switched

### DIFF
--- a/blocksuite/affine/widgets/linked-doc/src/linked-doc-popover.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/linked-doc-popover.ts
@@ -181,6 +181,10 @@ export class LinkedDocPopover extends SignalWatcher(
       target: eventSource,
       signal: keydownObserverAbortController.signal,
       interceptor: (event, next) => {
+        if (event.key === 'GroupNext' || event.key === 'GroupPrevious') {
+          event.stopPropagation();
+          return;
+        }
         if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
           event.preventDefault();
           event.stopPropagation();


### PR DESCRIPTION
Fixing the disappearing linked doc menu called by @ when switching language using Alt+Shift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyboard event handling in the linked document popover to prevent certain key combinations from triggering unintended downstream actions during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->