### PR TITLE
feat(editor): hidden 'Add icon' label on print if icon is not set

### DIFF
--- a/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.css.ts
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.css.ts
@@ -1,5 +1,5 @@
 import { cssVarV2 } from '@toeverything/theme/v2';
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 export const docIconPickerTrigger = style({
   width: 64,
@@ -34,4 +34,12 @@ export const placeholderContentIcon = style({
 export const placeholderContentText = style({
   color: cssVarV2.text.secondary,
   fontSize: 12,
+});
+
+globalStyle('.doc-icon-container[data-has-icon="false"]', {
+  '@media': {
+    print: {
+      display: 'none',
+    },
+  },
 });

--- a/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-editor/doc-icon-picker.tsx
@@ -6,10 +6,17 @@ import { useLiveData, useService } from '@toeverything/infra';
 
 import * as styles from './doc-icon-picker.css';
 
-const TitleContainer = ({ children }: { children: React.ReactNode }) => {
+const TitleContainer = ({
+  children,
+  hasIcon,
+}: {
+  children: React.ReactNode;
+  hasIcon: boolean;
+}) => {
   return (
     <div
       className="doc-icon-container"
+      data-has-icon={hasIcon ? 'true' : 'false'}
       style={{
         paddingBottom: 8,
       }}
@@ -45,7 +52,7 @@ export const DocIconPicker = ({
   }
 
   return (
-    <TitleContainer>
+    <TitleContainer hasIcon={!isPlaceholder}>
       <IconEditor
         icon={icon?.icon}
         onIconChange={data => {


### PR DESCRIPTION
This caption (see screenshot) is added when you try to print doc, even if there is no icon.
<img width="1269" height="897" alt="изображение" src="https://github.com/user-attachments/assets/d63383e6-48a2-44fb-8f32-ae91d1e9e8c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved print layout by hiding empty document icon containers in print media, providing a cleaner printed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->