### PR TITLE
feat: add Oracle Cloud free deployment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,144 @@
+# MingNote 环境变量配置示例
+# 复制此文件为 .env 并根据实际情况修改
+
+# ================================
+# 应用基础配置
+# ================================
+
+# 环境类型：production 或 development
+NODE_ENV=production
+
+# 服务器主机和端口
+AFFINE_SERVER_HOST=0.0.0.0
+AFFINE_SERVER_PORT=3000
+
+# 是否启用 HTTPS（如果使用 Nginx 反向代理，这里设为 false）
+AFFINE_SERVER_HTTPS=false
+
+# ================================
+# 数据库配置
+# ================================
+
+# PostgreSQL 用户名
+POSTGRES_USER=affine
+
+# PostgreSQL 密码（请修改为强密码！）
+POSTGRES_PASSWORD=CHANGE_THIS_TO_SECURE_PASSWORD
+
+# PostgreSQL 数据库名
+POSTGRES_DB=affine
+
+# 完整数据库连接 URL（会自动从上面的配置生成）
+# DATABASE_URL=postgresql://affine:password@postgres:5432/affine
+
+# ================================
+# Redis 配置
+# ================================
+
+REDIS_SERVER_HOST=redis
+REDIS_SERVER_PORT=6379
+
+# Redis 密码（可选）
+# REDIS_SERVER_PASSWORD=
+
+# ================================
+# 安全配置（重要！）
+# ================================
+
+# 认证密钥（请修改！使用 openssl rand -base64 32 生成）
+AUTH_SECRET=CHANGE_THIS_TO_RANDOM_STRING_32_CHARS
+
+# JWT 密钥（请修改！使用 openssl rand -base64 32 生成）
+JWT_SECRET=CHANGE_THIS_TO_RANDOM_STRING_32_CHARS
+
+# ================================
+# 存储配置
+# ================================
+
+# 存储提供商：local | s3 | cloudflare-r2
+AFFINE_STORAGE_PROVIDER=local
+
+# 本地存储路径
+AFFINE_LOCAL_STORAGE_PATH=/app/storage
+
+# 如果使用 S3 或 R2，配置以下选项
+# AFFINE_STORAGE_BUCKET=your-bucket-name
+# AFFINE_STORAGE_REGION=us-west-1
+# AFFINE_STORAGE_ACCESS_KEY=your-access-key
+# AFFINE_STORAGE_SECRET_KEY=your-secret-key
+
+# ================================
+# 搜索引擎配置
+# ================================
+
+AFFINE_INDEXER_SEARCH_ENDPOINT=http://indexer:9308
+
+# ================================
+# 管理员账号（首次部署时设置）
+# ================================
+
+# 管理员邮箱
+AFFINE_ADMIN_EMAIL=admin@example.com
+
+# 管理员密码（首次登录后请修改）
+AFFINE_ADMIN_PASSWORD=admin123456
+
+# ================================
+# 功能开关
+# ================================
+
+# 启用注册功能
+AFFINE_ALLOW_SIGNUP=true
+
+# 启用邮件邀请
+AFFINE_ALLOW_EMAIL_INVITE=false
+
+# 启用遥测（统计使用数据，可关闭）
+TELEMETRY_ENABLE=false
+
+# ================================
+# 邮件服务配置（可选）
+# ================================
+
+# SMTP 服务器
+# MAILER_HOST=smtp.gmail.com
+# MAILER_PORT=587
+# MAILER_USER=your-email@gmail.com
+# MAILER_PASSWORD=your-app-password
+# MAILER_SENDER=noreply@yourdomain.com
+
+# ================================
+# AI 功能配置（可选）
+# ================================
+
+# OpenAI API Key（如果需要 AI 功能）
+# OPENAI_API_KEY=sk-...
+
+# AI 模型
+# OPENAI_MODEL=gpt-4
+
+# ================================
+# 其他高级配置
+# ================================
+
+# 日志级别：debug | info | warn | error
+LOG_LEVEL=info
+
+# 工作进程数（建议设为 CPU 核心数）
+# WORKER_COUNT=4
+
+# 会话超时时间（秒）
+# SESSION_TIMEOUT=86400
+
+# 上传文件大小限制（字节）
+# MAX_UPLOAD_SIZE=104857600
+
+# ================================
+# 域名配置（如果使用自定义域名）
+# ================================
+
+# 应用访问 URL
+# AFFINE_BASE_URL=https://your-domain.com
+
+# CORS 允许的域名
+# AFFINE_CORS_ORIGINS=https://your-domain.com,https://www.your-domain.com

--- a/.github/workflows/deploy-to-oracle-cloud.yml
+++ b/.github/workflows/deploy-to-oracle-cloud.yml
@@ -1,0 +1,77 @@
+name: Deploy to Oracle Cloud
+
+# 此工作流用于自动部署到 Oracle Cloud 服务器
+# 需要配置 GitHub Secrets
+
+on:
+  workflow_dispatch:  # 手动触发
+  push:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/**'
+      - '!.github/workflows/deploy-to-oracle-cloud.yml'
+
+jobs:
+  deploy:
+    name: Deploy to Server
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Oracle Cloud
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          port: ${{ secrets.DEPLOY_PORT || 22 }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH || '~/MingNote' }}
+
+            echo "📥 拉取最新代码..."
+            git pull origin main
+
+            echo "🔄 更新应用..."
+            ./deploy.sh update
+
+            echo "✅ 部署完成"
+            ./deploy.sh status
+
+      - name: Notification
+        if: always()
+        run: |
+          if [ "${{ job.status }}" == "success" ]; then
+            echo "✅ 部署成功！"
+          else
+            echo "❌ 部署失败！"
+          fi
+
+# GitHub Secrets 配置说明：
+#
+# 需要在仓库设置中添加以下 Secrets：
+# Settings → Secrets and variables → Actions → New repository secret
+#
+# 1. DEPLOY_HOST - 服务器 IP 地址或域名
+#    示例: 123.456.789.012
+#
+# 2. DEPLOY_USER - SSH 用户名
+#    示例: ubuntu
+#
+# 3. DEPLOY_SSH_KEY - SSH 私钥内容
+#    获取方式: cat ~/.ssh/id_rsa (或你的私钥文件)
+#    复制完整内容，包括 -----BEGIN 和 -----END 行
+#
+# 4. DEPLOY_PORT（可选）- SSH 端口
+#    默认: 22
+#
+# 5. DEPLOY_PATH（可选）- 项目在服务器上的路径
+#    默认: ~/MingNote
+#
+# 配置完成后，每次推送代码到 main 分支，
+# 或手动触发 workflow，都会自动部署到服务器

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ Thumbs.db
 # env
 *.env.local
 *.local.env
+.env
 .history
 
 .next
@@ -88,3 +89,13 @@ af.cmd
 
 # playwright
 storageState.json
+
+# deployment
+backups/
+storage/
+ssl/
+*.pem
+*.key
+*.crt
+*.sql
+*.tar.gz

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -1,0 +1,308 @@
+# MingNote 快速开始指南
+
+## 🚀 5 分钟快速部署到 Oracle Cloud
+
+### 前提条件
+- ✅ 已注册 Oracle Cloud 账号
+- ✅ 已创建并启动虚拟机实例
+- ✅ 已配置网络安全规则（开放 80、443、3000 端口）
+- ✅ 已通过 SSH 连接到服务器
+
+---
+
+## 步骤 1：准备服务器环境
+
+```bash
+# 更新系统
+sudo apt update && sudo apt upgrade -y
+
+# 安装 Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+sudo usermod -aG docker $USER
+
+# 安装 Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# 安装其他工具
+sudo apt install -y git vim ufw
+
+# 配置防火墙
+sudo ufw allow 22/tcp
+sudo ufw allow 80/tcp
+sudo ufw allow 443/tcp
+sudo ufw allow 3000/tcp
+sudo ufw --force enable
+
+# 退出并重新登录
+exit
+```
+
+---
+
+## 步骤 2：克隆项目
+
+```bash
+# 重新 SSH 连接到服务器
+ssh -i your-key.key ubuntu@YOUR_SERVER_IP
+
+# 克隆项目
+cd ~
+git clone https://github.com/YOUR_USERNAME/MingNote.git
+cd MingNote
+
+# 给部署脚本添加执行权限
+chmod +x deploy.sh
+```
+
+---
+
+## 步骤 3：一键部署
+
+```bash
+# 运行部署脚本
+./deploy.sh init
+```
+
+这个命令会：
+1. 自动生成 `.env` 配置文件（包含随机密钥）
+2. 拉取所有需要的 Docker 镜像
+3. 启动所有服务（数据库、Redis、后端等）
+4. 显示访问地址
+
+---
+
+## 步骤 4：配置管理员账号
+
+```bash
+# 编辑环境变量
+nano .env
+```
+
+找到并修改以下内容：
+```bash
+# 设置管理员邮箱和密码
+AFFINE_ADMIN_EMAIL=your-email@example.com
+AFFINE_ADMIN_PASSWORD=your-secure-password
+```
+
+保存退出（Ctrl+X，然后 Y，然后 Enter）
+
+```bash
+# 重启服务使配置生效
+./deploy.sh restart
+```
+
+---
+
+## 步骤 5：访问应用
+
+在浏览器中访问：
+```
+http://YOUR_SERVER_IP:3000
+```
+
+使用刚才配置的管理员邮箱和密码登录。
+
+🎉 恭喜！你的 MingNote 已经成功部署！
+
+---
+
+## 常用命令
+
+```bash
+# 查看服务状态
+./deploy.sh status
+
+# 查看日志
+./deploy.sh logs
+
+# 查看特定服务日志
+./deploy.sh logs backend
+./deploy.sh logs postgres
+
+# 重启服务
+./deploy.sh restart
+
+# 停止服务
+./deploy.sh stop
+
+# 启动服务
+./deploy.sh start
+
+# 备份数据
+./deploy.sh backup
+
+# 更新应用
+./deploy.sh update
+```
+
+---
+
+## 下一步：配置域名和 HTTPS（可选）
+
+### 方式 1：使用 Cloudflare（推荐，免费）
+
+1. **注册域名**（或使用现有域名）
+2. **添加到 Cloudflare**：
+   - 访问 https://dash.cloudflare.com/
+   - 添加站点
+   - 修改域名 DNS 为 Cloudflare 的 NS 服务器
+
+3. **配置 DNS 记录**：
+   - 类型：A
+   - 名称：@（或子域名，如 notes）
+   - 内容：你的服务器 IP
+   - 代理状态：已代理（橙色云朵）
+
+4. **配置 SSL**：
+   - SSL/TLS → 概述 → 加密模式：选择 "灵活"
+
+5. **访问你的域名**：
+   ```
+   https://your-domain.com
+   ```
+
+### 方式 2：使用 Let's Encrypt（免费 SSL）
+
+```bash
+# 安装 Certbot
+sudo apt install -y certbot python3-certbot-nginx nginx
+
+# 创建 Nginx 配置
+sudo nano /etc/nginx/sites-available/mingnote
+```
+
+添加配置：
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+启用配置：
+```bash
+sudo ln -s /etc/nginx/sites-available/mingnote /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl restart nginx
+
+# 申请 SSL 证书
+sudo certbot --nginx -d your-domain.com
+
+# 自动续期
+sudo certbot renew --dry-run
+```
+
+---
+
+## 故障排查
+
+### 问题 1：无法访问服务器
+**检查清单**：
+- ✅ Oracle Cloud 安全列表是否开放端口？
+- ✅ 服务器防火墙是否开放端口：`sudo ufw status`
+- ✅ 服务是否运行：`./deploy.sh status`
+
+### 问题 2：服务启动失败
+```bash
+# 查看详细日志
+./deploy.sh logs backend
+
+# 检查容器状态
+docker ps -a
+
+# 重新启动
+./deploy.sh restart
+```
+
+### 问题 3：数据库连接失败
+```bash
+# 检查数据库容器
+docker ps | grep postgres
+
+# 查看数据库日志
+./deploy.sh logs postgres
+
+# 检查环境变量
+cat .env | grep DATABASE
+```
+
+### 问题 4：内存不足
+```bash
+# 添加 Swap（交换空间）
+sudo fallocate -l 4G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+
+# 验证
+free -h
+```
+
+---
+
+## 性能优化建议
+
+### 1. 定期备份
+```bash
+# 添加到 crontab
+crontab -e
+
+# 添加每天凌晨 2 点自动备份
+0 2 * * * cd /home/ubuntu/MingNote && ./deploy.sh backup
+```
+
+### 2. 日志清理
+```bash
+# 添加到 crontab
+# 每周清理一次 Docker 日志
+0 3 * * 0 truncate -s 0 /var/lib/docker/containers/*/*-json.log
+```
+
+### 3. 监控资源使用
+```bash
+# 安装 htop
+sudo apt install -y htop
+
+# 实时监控
+htop
+
+# Docker 资源监控
+docker stats
+```
+
+---
+
+## 更多资源
+
+- 📖 完整部署文档：[docs/DEPLOY_ORACLE_CLOUD.md](docs/DEPLOY_ORACLE_CLOUD.md)
+- 🐛 问题反馈：GitHub Issues
+- 💬 社区讨论：GitHub Discussions
+- 📚 AFFiNE 官方文档：https://docs.affine.pro/
+
+---
+
+## 获取帮助
+
+如果遇到问题：
+1. 查看日志：`./deploy.sh logs`
+2. 检查文档：`docs/DEPLOY_ORACLE_CLOUD.md`
+3. 搜索 GitHub Issues
+4. 提交新 Issue
+
+祝你使用愉快！🎉

--- a/README.md
+++ b/README.md
@@ -193,6 +193,23 @@ We would like to express our gratitude to all the individuals who have already c
 
 Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiNE. Our team is diligently updating to the latest version. For more information on how to self-host AFFiNE, please refer to our [documentation](https://docs.affine.pro/self-host-affine).
 
+### 🚀 Free Deployment Options
+
+- **[Oracle Cloud 永久免费部署指南](docs/DEPLOY_ORACLE_CLOUD.md)** - 完整的 Oracle Cloud 免费部署教程
+- **[快速开始指南](QUICK_START.md)** - 5 分钟快速部署到任何 VPS
+
+### Quick Start
+
+```bash
+# 克隆项目
+git clone https://github.com/YOUR_USERNAME/MingNote.git
+cd MingNote
+
+# 一键部署
+chmod +x deploy.sh
+./deploy.sh init
+```
+
 [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
 
 ## Hiring

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,355 @@
+#!/bin/bash
+
+# MingNote 自动部署脚本
+# 适用于 Oracle Cloud、VPS 等 Linux 服务器
+# 支持：初始部署、更新、备份、恢复等功能
+
+set -e
+
+# 颜色输出
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# 日志函数
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# 检查是否为 root 用户
+check_root() {
+    if [ "$EUID" -eq 0 ]; then
+        log_warning "建议不要使用 root 用户运行此脚本"
+        read -p "是否继续？(y/n) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    fi
+}
+
+# 检查系统要求
+check_requirements() {
+    log_info "检查系统要求..."
+
+    # 检查 Docker
+    if ! command -v docker &> /dev/null; then
+        log_error "Docker 未安装，请先安装 Docker"
+        log_info "安装 Docker: curl -fsSL https://get.docker.com | sh"
+        exit 1
+    fi
+
+    # 检查 Docker Compose
+    if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+        log_error "Docker Compose 未安装"
+        log_info "安装 Docker Compose:"
+        log_info "sudo curl -L \"https://github.com/docker/compose/releases/latest/download/docker-compose-\$(uname -s)-\$(uname -m)\" -o /usr/local/bin/docker-compose"
+        log_info "sudo chmod +x /usr/local/bin/docker-compose"
+        exit 1
+    fi
+
+    # 检查 Git
+    if ! command -v git &> /dev/null; then
+        log_warning "Git 未安装，某些功能可能无法使用"
+    fi
+
+    log_success "系统要求检查通过"
+}
+
+# 生成随机密钥
+generate_secret() {
+    openssl rand -base64 32 | tr -d '\n'
+}
+
+# 初始化环境变量文件
+init_env() {
+    log_info "初始化环境变量..."
+
+    if [ -f .env ]; then
+        log_warning ".env 文件已存在"
+        read -p "是否覆盖？(y/n) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            log_info "保持现有 .env 文件"
+            return
+        fi
+    fi
+
+    # 复制示例文件
+    cp .env.example .env
+
+    # 生成随机密钥
+    AUTH_SECRET=$(generate_secret)
+    JWT_SECRET=$(generate_secret)
+    DB_PASSWORD=$(generate_secret | tr -d '/' | head -c 16)
+
+    # 替换密钥
+    sed -i "s/CHANGE_THIS_TO_RANDOM_STRING_32_CHARS/$AUTH_SECRET/" .env
+    sed -i "s/CHANGE_THIS_TO_SECURE_PASSWORD/$DB_PASSWORD/" .env
+
+    # JWT_SECRET 需要单独替换（第二个出现的位置）
+    sed -i "0,/CHANGE_THIS_TO_RANDOM_STRING_32_CHARS/{s/CHANGE_THIS_TO_RANDOM_STRING_32_CHARS/$JWT_SECRET/}" .env
+
+    log_success "环境变量已初始化"
+    log_info "请编辑 .env 文件以配置管理员邮箱等信息："
+    log_info "  nano .env"
+}
+
+# 初始化部署
+init_deploy() {
+    log_info "开始初始化部署..."
+
+    check_requirements
+    init_env
+
+    log_info "拉取 Docker 镜像..."
+    docker-compose -f docker-compose.prod.yml pull
+
+    log_info "启动服务..."
+    docker-compose -f docker-compose.prod.yml up -d
+
+    log_info "等待服务启动..."
+    sleep 10
+
+    # 检查服务状态
+    docker-compose -f docker-compose.prod.yml ps
+
+    log_success "部署完成！"
+    log_info "访问地址: http://$(curl -s ifconfig.me):${AFFINE_SERVER_PORT:-3000}"
+    log_info "查看日志: ./deploy.sh logs"
+}
+
+# 启动服务
+start_services() {
+    log_info "启动服务..."
+    docker-compose -f docker-compose.prod.yml up -d
+    log_success "服务已启动"
+}
+
+# 停止服务
+stop_services() {
+    log_info "停止服务..."
+    docker-compose -f docker-compose.prod.yml down
+    log_success "服务已停止"
+}
+
+# 重启服务
+restart_services() {
+    log_info "重启服务..."
+    docker-compose -f docker-compose.prod.yml restart
+    log_success "服务已重启"
+}
+
+# 查看日志
+view_logs() {
+    docker-compose -f docker-compose.prod.yml logs -f "${@:2}"
+}
+
+# 查看状态
+check_status() {
+    log_info "服务状态:"
+    docker-compose -f docker-compose.prod.yml ps
+
+    echo ""
+    log_info "资源使用情况:"
+    docker stats --no-stream $(docker-compose -f docker-compose.prod.yml ps -q)
+}
+
+# 更新应用
+update_app() {
+    log_info "开始更新应用..."
+
+    # 备份数据
+    log_info "自动备份数据..."
+    backup_data
+
+    # 拉取最新代码（如果是 Git 仓库）
+    if [ -d .git ]; then
+        log_info "拉取最新代码..."
+        git pull
+    fi
+
+    # 拉取最新镜像
+    log_info "拉取最新镜像..."
+    docker-compose -f docker-compose.prod.yml pull
+
+    # 重启服务
+    log_info "重启服务..."
+    docker-compose -f docker-compose.prod.yml up -d
+
+    log_success "更新完成"
+}
+
+# 备份数据
+backup_data() {
+    log_info "开始备份数据..."
+
+    BACKUP_DIR="./backups"
+    mkdir -p "$BACKUP_DIR"
+
+    TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+    BACKUP_FILE="$BACKUP_DIR/backup_$TIMESTAMP"
+
+    # 备份数据库
+    log_info "备份数据库..."
+    docker-compose -f docker-compose.prod.yml exec -T postgres pg_dump -U affine affine > "$BACKUP_FILE.sql"
+
+    # 备份文件存储
+    log_info "备份文件存储..."
+    VOLUME_NAME=$(docker volume ls -q | grep storage)
+    if [ -n "$VOLUME_NAME" ]; then
+        docker run --rm -v "$VOLUME_NAME":/data -v "$(pwd)/$BACKUP_DIR":/backup alpine tar czf "/backup/storage_$TIMESTAMP.tar.gz" -C /data .
+    fi
+
+    # 备份环境变量
+    cp .env "$BACKUP_FILE.env"
+
+    log_success "备份完成: $BACKUP_FILE"
+
+    # 清理旧备份（保留最近 7 天）
+    find "$BACKUP_DIR" -name "backup_*" -mtime +7 -delete
+}
+
+# 恢复数据
+restore_data() {
+    log_warning "数据恢复将覆盖现有数据！"
+    read -p "是否继续？(y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+
+    BACKUP_DIR="./backups"
+
+    # 列出可用备份
+    log_info "可用备份:"
+    ls -lh "$BACKUP_DIR"/backup_*.sql
+
+    read -p "请输入备份文件名（不含.sql后缀）: " BACKUP_NAME
+
+    if [ ! -f "$BACKUP_DIR/$BACKUP_NAME.sql" ]; then
+        log_error "备份文件不存在"
+        exit 1
+    fi
+
+    log_info "恢复数据库..."
+    docker-compose -f docker-compose.prod.yml exec -T postgres psql -U affine affine < "$BACKUP_DIR/$BACKUP_NAME.sql"
+
+    log_info "恢复文件存储..."
+    if [ -f "$BACKUP_DIR/storage_$(echo $BACKUP_NAME | cut -d'_' -f2-).tar.gz" ]; then
+        VOLUME_NAME=$(docker volume ls -q | grep storage)
+        docker run --rm -v "$VOLUME_NAME":/data -v "$(pwd)/$BACKUP_DIR":/backup alpine tar xzf "/backup/storage_$(echo $BACKUP_NAME | cut -d'_' -f2-).tar.gz" -C /data
+    fi
+
+    log_success "数据恢复完成"
+}
+
+# 清理数据
+cleanup() {
+    log_warning "此操作将删除所有数据和容器！"
+    read -p "是否继续？(y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+
+    log_info "停止并删除容器..."
+    docker-compose -f docker-compose.prod.yml down -v
+
+    log_info "删除镜像..."
+    docker-compose -f docker-compose.prod.yml down --rmi all
+
+    log_success "清理完成"
+}
+
+# 显示帮助
+show_help() {
+    cat << EOF
+MingNote 部署脚本
+
+用法: ./deploy.sh [命令] [选项]
+
+命令:
+  init          初始化并部署应用
+  start         启动服务
+  stop          停止服务
+  restart       重启服务
+  status        查看服务状态
+  logs          查看日志 (可选参数: backend/postgres/redis)
+  update        更新应用
+  backup        备份数据
+  restore       恢复数据
+  cleanup       清理所有数据（危险！）
+  help          显示此帮助信息
+
+示例:
+  ./deploy.sh init              # 初始化部署
+  ./deploy.sh logs backend      # 查看后端日志
+  ./deploy.sh backup            # 备份数据
+  ./deploy.sh update            # 更新应用
+
+更多信息请参考: docs/DEPLOY_ORACLE_CLOUD.md
+EOF
+}
+
+# 主函数
+main() {
+    case "${1:-help}" in
+        init)
+            check_root
+            init_deploy
+            ;;
+        start)
+            start_services
+            ;;
+        stop)
+            stop_services
+            ;;
+        restart)
+            restart_services
+            ;;
+        status)
+            check_status
+            ;;
+        logs)
+            view_logs "$@"
+            ;;
+        update)
+            update_app
+            ;;
+        backup)
+            backup_data
+            ;;
+        restore)
+            restore_data
+            ;;
+        cleanup)
+            cleanup
+            ;;
+        help|--help|-h)
+            show_help
+            ;;
+        *)
+            log_error "未知命令: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+}
+
+# 运行主函数
+main "$@"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,178 @@
+version: '3.8'
+
+# MingNote 生产环境部署配置
+# 适用于 Oracle Cloud、VPS 等服务器部署
+
+services:
+  # PostgreSQL 数据库（带 pgvector 扩展）
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: mingnote-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-affine}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-affine}
+      POSTGRES_DB: ${POSTGRES_DB:-affine}
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-affine}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mingnote-network
+
+  # Redis 缓存
+  redis:
+    image: redis:7-alpine
+    container_name: mingnote-redis
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - mingnote-network
+
+  # Manticore Search 全文搜索引擎
+  indexer:
+    image: manticoresearch/manticore:6.2.12
+    container_name: mingnote-indexer
+    restart: unless-stopped
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - manticore_data:/var/lib/manticore
+    ports:
+      - "9308:9308"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:9308 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - mingnote-network
+
+  # AFFiNE 后端服务
+  backend:
+    image: ghcr.io/toeverything/affine-graphql:stable
+    container_name: mingnote-backend
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      indexer:
+        condition: service_healthy
+    environment:
+      # 节点环境
+      NODE_ENV: production
+
+      # 服务器配置
+      AFFINE_SERVER_HOST: ${AFFINE_SERVER_HOST:-0.0.0.0}
+      AFFINE_SERVER_PORT: ${AFFINE_SERVER_PORT:-3000}
+      AFFINE_SERVER_HTTPS: ${AFFINE_SERVER_HTTPS:-false}
+
+      # 数据库配置
+      DATABASE_URL: postgresql://${POSTGRES_USER:-affine}:${POSTGRES_PASSWORD:-affine}@postgres:5432/${POSTGRES_DB:-affine}
+
+      # Redis 配置
+      REDIS_SERVER_HOST: redis
+      REDIS_SERVER_PORT: 6379
+
+      # 搜索引擎配置
+      AFFINE_INDEXER_SEARCH_ENDPOINT: http://indexer:9308
+
+      # 认证配置
+      AUTH_SECRET: ${AUTH_SECRET}
+      JWT_SECRET: ${JWT_SECRET}
+
+      # 存储配置
+      AFFINE_STORAGE_PROVIDER: ${AFFINE_STORAGE_PROVIDER:-local}
+      AFFINE_LOCAL_STORAGE_PATH: /app/storage
+
+      # 功能开关
+      AFFINE_ADMIN_EMAIL: ${AFFINE_ADMIN_EMAIL:-}
+      AFFINE_ADMIN_PASSWORD: ${AFFINE_ADMIN_PASSWORD:-}
+
+      # Telemetry（可选）
+      TELEMETRY_ENABLE: ${TELEMETRY_ENABLE:-false}
+
+    volumes:
+      # 文件存储
+      - storage_data:/app/storage
+      # 配置文件
+      - ./config:/app/config:ro
+    ports:
+      - "${AFFINE_SERVER_PORT:-3000}:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:3000/api/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+    networks:
+      - mingnote-network
+
+  # 前端应用（可选，如果需要完全自托管）
+  # 如果使用 GitHub Pages，可以注释掉这部分
+  frontend:
+    image: ghcr.io/toeverything/affine-web:stable
+    container_name: mingnote-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    environment:
+      AFFINE_BACKEND_URL: http://backend:3000
+    ports:
+      - "8080:80"
+    networks:
+      - mingnote-network
+
+  # Nginx 反向代理（可选）
+  nginx:
+    image: nginx:alpine
+    container_name: mingnote-nginx
+    restart: unless-stopped
+    depends_on:
+      - backend
+      - frontend
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./ssl:/etc/nginx/ssl:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - mingnote-network
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local
+  manticore_data:
+    driver: local
+  storage_data:
+    driver: local
+
+networks:
+  mingnote-network:
+    driver: bridge

--- a/docs/DEPLOY_ORACLE_CLOUD.md
+++ b/docs/DEPLOY_ORACLE_CLOUD.md
@@ -1,0 +1,466 @@
+# MingNote 部署到 Oracle Cloud 永久免费指南
+
+## 📋 目录
+- [准备工作](#准备工作)
+- [注册 Oracle Cloud](#注册-oracle-cloud)
+- [创建免费服务器](#创建免费服务器)
+- [配置服务器环境](#配置服务器环境)
+- [部署 MingNote](#部署-mingnote)
+- [域名配置（可选）](#域名配置可选)
+- [常见问题](#常见问题)
+
+---
+
+## 准备工作
+
+### 你需要准备：
+- ✅ 一个邮箱账号
+- ✅ 一张信用卡或借记卡（仅用于验证，不会扣费）
+- ✅ 30-60 分钟的时间
+
+### Oracle Cloud 永久免费资源：
+- 🖥️ **2 台 AMD VM**（每台 1/8 OCPU + 1GB RAM）
+- 🖥️ **或 4 台 ARM VM**（Ampere A1，总共 4 OCPU + 24GB RAM）推荐！
+- 💾 **200GB 块存储**
+- 🌐 **10TB/月 出站流量**
+- 📦 **20GB 对象存储**
+- ⚡ **永久免费**（不是试用期）
+
+---
+
+## 注册 Oracle Cloud
+
+### 步骤 1：访问 Oracle Cloud
+1. 打开浏览器，访问：https://www.oracle.com/cloud/free/
+2. 点击 "Start for free" 或 "免费开始"
+
+### 步骤 2：填写注册信息
+1. **选择区域**：
+   - 推荐选择：**Japan Central (Osaka)** 或 **South Korea Central (Seoul)**
+   - 这些区域离中国近，速度更快
+   - ⚠️ **注意**：注册后无法更改区域，请慎重选择！
+
+2. **填写账号信息**：
+   - 邮箱地址
+   - 国家/地区：选择你的所在地
+   - 姓名（建议使用拼音）
+
+3. **验证邮箱**：
+   - 检查邮箱，输入验证码
+
+### 步骤 3：账号验证
+1. **手机验证**：
+   - 输入你的手机号码
+   - 接收并输入验证码
+
+2. **信用卡验证**：
+   - 输入信用卡信息（仅验证身份，会预授权 $1-2 后退回）
+   - 支持 Visa、Mastercard、银联等
+   - ⚠️ 确保卡片信息真实有效
+
+3. **完成注册**：
+   - 等待账号激活（通常 5-10 分钟）
+   - 收到欢迎邮件后登录
+
+---
+
+## 创建免费服务器
+
+### 步骤 1：登录 Oracle Cloud Console
+1. 访问：https://cloud.oracle.com/
+2. 输入你的云账户名（Cloud Account Name）
+3. 输入用户名和密码登录
+
+### 步骤 2：创建虚拟机（推荐 ARM 架构）
+
+1. **进入 Compute Instances 页面**：
+   - 左上角菜单 ≡ → Compute → Instances
+   - 点击 "Create Instance"
+
+2. **配置实例**：
+
+   **基本信息**：
+   - Name: `mingnote-server` （或任意名称）
+   - Compartment: 保持默认
+
+   **Image and Shape**：
+   - 点击 "Edit" 编辑
+   - **Image**: 选择 `Canonical Ubuntu 22.04`
+   - **Shape**:
+     - 点击 "Change Shape"
+     - 选择 "Ampere" (ARM)
+     - 选择 `VM.Standard.A1.Flex`
+     - **OCPU**: 4（最大值）
+     - **Memory**: 24 GB（最大值）
+     - ✅ 这是永久免费的最强配置！
+
+   **Networking**：
+   - 保持默认设置（会自动创建 VCN）
+   - ✅ 确保 "Assign a public IPv4 address" 已勾选
+
+   **Add SSH Keys**：
+   - 选择 "Generate a key pair for me"
+   - 点击 "Save Private Key" 下载私钥（重要！保存好）
+   - 点击 "Save Public Key" 下载公钥
+
+   **Boot Volume**：
+   - Size: 最少 50GB（建议 100GB+）
+   - 永久免费最多 200GB
+
+3. **创建实例**：
+   - 点击底部 "Create" 按钮
+   - 等待状态变为 "RUNNING"（绿色）
+   - 记下你的 **Public IP Address**
+
+   ⚠️ **如果创建失败提示 "Out of capacity"**：
+   - ARM 实例很抢手，可能需要多试几次
+   - 可以尝试在凌晨或其他时间段创建
+   - 或者选择其他区域（Region）
+
+### 步骤 3：配置网络安全规则
+
+1. **打开必要端口**：
+   - 在 Instance Details 页面，找到 "Virtual Cloud Network"
+   - 点击你的 VCN 名称
+   - 左侧点击 "Security Lists"
+   - 点击 "Default Security List"
+
+2. **添加入站规则**：
+   点击 "Add Ingress Rules"，添加以下规则：
+
+   **规则 1 - HTTP**:
+   - Source CIDR: `0.0.0.0/0`
+   - IP Protocol: `TCP`
+   - Destination Port Range: `80`
+   - Description: `HTTP`
+
+   **规则 2 - HTTPS**:
+   - Source CIDR: `0.0.0.0/0`
+   - IP Protocol: `TCP`
+   - Destination Port Range: `443`
+   - Description: `HTTPS`
+
+   **规则 3 - 自定义应用端口**:
+   - Source CIDR: `0.0.0.0/0`
+   - IP Protocol: `TCP`
+   - Destination Port Range: `3000`
+   - Description: `AFFiNE Backend`
+
+---
+
+## 配置服务器环境
+
+### 步骤 1：连接到服务器
+
+**Windows 用户**：
+```bash
+# 使用 PowerShell 或 Windows Terminal
+ssh -i "path\to\your\private-key.key" ubuntu@YOUR_SERVER_IP
+```
+
+**Mac/Linux 用户**：
+```bash
+# 设置私钥权限
+chmod 400 ~/Downloads/your-private-key.key
+
+# SSH 连接
+ssh -i ~/Downloads/your-private-key.key ubuntu@YOUR_SERVER_IP
+```
+
+替换 `YOUR_SERVER_IP` 为你的服务器公网 IP
+
+### 步骤 2：更新系统并安装必要软件
+
+```bash
+# 更新系统
+sudo apt update && sudo apt upgrade -y
+
+# 安装必要工具
+sudo apt install -y curl git wget vim ufw
+
+# 配置防火墙
+sudo ufw allow 22/tcp    # SSH
+sudo ufw allow 80/tcp    # HTTP
+sudo ufw allow 443/tcp   # HTTPS
+sudo ufw allow 3000/tcp  # Backend API
+sudo ufw --force enable
+
+# 安装 Docker
+curl -fsSL https://get.docker.com -o get-docker.sh
+sudo sh get-docker.sh
+
+# 添加当前用户到 docker 组
+sudo usermod -aG docker ubuntu
+
+# 安装 Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+
+# 退出并重新登录使权限生效
+exit
+```
+
+重新连接：
+```bash
+ssh -i ~/Downloads/your-private-key.key ubuntu@YOUR_SERVER_IP
+```
+
+### 步骤 3：验证安装
+
+```bash
+# 验证 Docker
+docker --version
+docker-compose --version
+
+# 测试 Docker
+docker run hello-world
+```
+
+---
+
+## 部署 MingNote
+
+### 步骤 1：克隆项目
+
+```bash
+# 创建项目目录
+mkdir -p ~/apps
+cd ~/apps
+
+# 克隆项目（替换为你的仓库地址）
+git clone https://github.com/YOUR_USERNAME/MingNote.git
+cd MingNote
+```
+
+### 步骤 2：配置环境变量
+
+```bash
+# 复制环境变量模板
+cp .env.example .env
+
+# 编辑环境变量
+nano .env
+```
+
+修改以下配置：
+```bash
+# 应用配置
+NODE_ENV=production
+AFFINE_SERVER_HOST=0.0.0.0
+AFFINE_SERVER_PORT=3000
+
+# 数据库配置
+DATABASE_URL=postgresql://affine:YOUR_SECURE_PASSWORD@postgres:5432/affine
+POSTGRES_USER=affine
+POSTGRES_PASSWORD=YOUR_SECURE_PASSWORD
+POSTGRES_DB=affine
+
+# Redis 配置
+REDIS_SERVER_HOST=redis
+REDIS_SERVER_PORT=6379
+
+# 安全配置（生成随机密钥）
+AUTH_SECRET=$(openssl rand -base64 32)
+JWT_SECRET=$(openssl rand -base64 32)
+
+# 文件存储（使用本地存储）
+AFFINE_STORAGE_PROVIDER=local
+AFFINE_LOCAL_STORAGE_PATH=/app/storage
+
+# 搜索配置
+AFFINE_INDEXER_SEARCH_ENDPOINT=http://indexer:9308
+```
+
+⚠️ **重要**：
+- 替换 `YOUR_SECURE_PASSWORD` 为强密码
+- 保存好你的环境变量文件
+
+### 步骤 3：启动服务
+
+```bash
+# 使用 Docker Compose 启动所有服务
+docker-compose up -d
+
+# 查看服务状态
+docker-compose ps
+
+# 查看日志
+docker-compose logs -f
+```
+
+### 步骤 4：等待服务启动
+
+```bash
+# 查看后端日志，等待数据库迁移完成
+docker-compose logs -f backend
+
+# 当看到类似 "Server is running on http://0.0.0.0:3000" 的消息时，说明启动成功
+```
+
+### 步骤 5：访问应用
+
+打开浏览器，访问：
+```
+http://YOUR_SERVER_IP:3000
+```
+
+🎉 如果能看到 MingNote/AFFiNE 的登录页面，说明部署成功！
+
+---
+
+## 域名配置（可选）
+
+### 免费域名选项：
+
+1. **Freenom**（.tk, .ml, .ga 等）- 免费但不太稳定
+2. **eu.org** - 免费二级域名，较稳定
+3. **afraid.org** - 免费 DNS 服务
+4. **Cloudflare** - 购买域名后免费 CDN 和 SSL
+
+### 配置步骤：
+
+1. **在域名 DNS 设置中添加 A 记录**：
+   - Type: `A`
+   - Name: `@` 或 `mingnote`
+   - Value: `YOUR_SERVER_IP`
+   - TTL: `Auto` 或 `3600`
+
+2. **配置 Nginx 反向代理**（可选，用于 HTTPS）：
+
+```bash
+# 安装 Nginx
+sudo apt install -y nginx certbot python3-certbot-nginx
+
+# 创建 Nginx 配置
+sudo nano /etc/nginx/sites-available/mingnote
+```
+
+添加配置：
+```nginx
+server {
+    listen 80;
+    server_name your-domain.com;
+
+    location / {
+        proxy_pass http://localhost:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+启用配置：
+```bash
+sudo ln -s /etc/nginx/sites-available/mingnote /etc/nginx/sites-enabled/
+sudo nginx -t
+sudo systemctl restart nginx
+```
+
+3. **配置 SSL（HTTPS）**：
+```bash
+sudo certbot --nginx -d your-domain.com
+```
+
+按提示操作，完成后即可通过 HTTPS 访问。
+
+---
+
+## 常见问题
+
+### Q1: 创建 ARM 实例时提示 "Out of capacity"
+**A**: ARM 实例很抢手，建议：
+- 尝试不同时间段（如凌晨）
+- 多尝试几次
+- 或选择 AMD 实例（性能较低但也够用）
+
+### Q2: 无法访问服务器
+**A**: 检查：
+1. Oracle Cloud 安全列表是否已添加入站规则
+2. 服务器防火墙是否开放端口：`sudo ufw status`
+3. Docker 服务是否正常运行：`docker-compose ps`
+
+### Q3: 服务启动失败
+**A**: 查看日志排查：
+```bash
+docker-compose logs backend
+docker-compose logs postgres
+```
+
+### Q4: 数据库连接失败
+**A**: 确认：
+1. `.env` 文件中的数据库密码与 `docker-compose.yml` 一致
+2. PostgreSQL 容器已启动：`docker-compose ps postgres`
+
+### Q5: 内存不足
+**A**:
+- ARM 实例有 24GB 内存，应该足够
+- 如果还不够，可以配置 swap：
+```bash
+sudo fallocate -l 4G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+```
+
+### Q6: 如何备份数据
+**A**:
+```bash
+# 备份数据库
+docker-compose exec postgres pg_dump -U affine affine > backup_$(date +%Y%m%d).sql
+
+# 备份文件存储
+tar -czf storage_backup_$(date +%Y%m%d).tar.gz ./storage
+```
+
+### Q7: 如何更新应用
+**A**:
+```bash
+cd ~/apps/MingNote
+git pull
+docker-compose down
+docker-compose build
+docker-compose up -d
+```
+
+---
+
+## 🎉 完成！
+
+现在你拥有了：
+- ✅ 一个完全免费的云服务器
+- ✅ 可以在线使用的 MingNote/AFFiNE
+- ✅ 数据永久保存不会丢失
+- ✅ 全球任何地方都可以访问
+
+### 下一步：
+- 🔒 配置域名和 HTTPS（推荐）
+- 👥 邀请团队成员使用
+- 📱 在手机浏览器中访问
+- 💾 设置定期备份计划
+
+---
+
+## 📚 有用的资源
+
+- Oracle Cloud 文档: https://docs.oracle.com/en-us/iaas/
+- AFFiNE 官方文档: https://docs.affine.pro/
+- Docker 文档: https://docs.docker.com/
+- Nginx 文档: https://nginx.org/en/docs/
+
+---
+
+## 🆘 需要帮助？
+
+如果遇到问题：
+1. 查看项目的 GitHub Issues
+2. 查看 Docker 日志：`docker-compose logs -f`
+3. 检查服务器资源：`htop` 或 `docker stats`
+
+祝你部署顺利！🚀

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,137 @@
+user nginx;
+worker_processes auto;
+error_log /var/log/nginx/error.log warn;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    client_max_body_size 100M;
+
+    gzip on;
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript
+               application/json application/javascript application/xml+rss
+               application/rss+xml font/truetype font/opentype
+               application/vnd.ms-fontobject image/svg+xml;
+
+    # HTTP 服务器 - 重定向到 HTTPS
+    server {
+        listen 80;
+        server_name _;
+
+        # 允许 Let's Encrypt 验证
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
+        }
+
+        # 重定向到 HTTPS（如果配置了 SSL）
+        # location / {
+        #     return 301 https://$host$request_uri;
+        # }
+
+        # 或直接代理到后端（不使用 HTTPS）
+        location / {
+            proxy_pass http://backend:3000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_cache_bypass $http_upgrade;
+        }
+
+        # 前端静态文件（如果使用自托管前端）
+        location /static/ {
+            proxy_pass http://frontend;
+        }
+    }
+
+    # HTTPS 服务器（配置 SSL 后启用）
+    # server {
+    #     listen 443 ssl http2;
+    #     server_name your-domain.com;
+
+    #     # SSL 证书配置
+    #     ssl_certificate /etc/nginx/ssl/fullchain.pem;
+    #     ssl_certificate_key /etc/nginx/ssl/privkey.pem;
+
+    #     # SSL 优化配置
+    #     ssl_protocols TLSv1.2 TLSv1.3;
+    #     ssl_ciphers HIGH:!aNULL:!MD5;
+    #     ssl_prefer_server_ciphers on;
+    #     ssl_session_cache shared:SSL:10m;
+    #     ssl_session_timeout 10m;
+
+    #     # HSTS (可选)
+    #     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+    #     # 安全头
+    #     add_header X-Frame-Options "SAMEORIGIN" always;
+    #     add_header X-Content-Type-Options "nosniff" always;
+    #     add_header X-XSS-Protection "1; mode=block" always;
+
+    #     # 反向代理到后端
+    #     location / {
+    #         proxy_pass http://backend:3000;
+    #         proxy_http_version 1.1;
+    #         proxy_set_header Upgrade $http_upgrade;
+    #         proxy_set_header Connection 'upgrade';
+    #         proxy_set_header Host $host;
+    #         proxy_set_header X-Real-IP $remote_addr;
+    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #         proxy_set_header X-Forwarded-Proto $scheme;
+    #         proxy_cache_bypass $http_upgrade;
+
+    #         # WebSocket 支持
+    #         proxy_read_timeout 86400;
+    #     }
+
+    #     # 前端静态文件
+    #     location /static/ {
+    #         proxy_pass http://frontend;
+    #         expires 1y;
+    #         add_header Cache-Control "public, immutable";
+    #     }
+
+    #     # API 端点
+    #     location /api/ {
+    #         proxy_pass http://backend:3000;
+    #         proxy_http_version 1.1;
+    #         proxy_set_header Host $host;
+    #         proxy_set_header X-Real-IP $remote_addr;
+    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #         proxy_set_header X-Forwarded-Proto $scheme;
+    #     }
+
+    #     # GraphQL 端点
+    #     location /graphql {
+    #         proxy_pass http://backend:3000;
+    #         proxy_http_version 1.1;
+    #         proxy_set_header Host $host;
+    #         proxy_set_header X-Real-IP $remote_addr;
+    #         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    #         proxy_set_header X-Forwarded-Proto $scheme;
+    #     }
+    # }
+}


### PR DESCRIPTION
Add comprehensive deployment documentation and automation scripts for deploying MingNote to Oracle Cloud's forever-free tier.

Features:
- Complete Oracle Cloud deployment guide (Chinese)
- Quick start guide for 5-minute deployment
- Docker Compose production configuration
- Automated deployment script with backup/restore
- Nginx reverse proxy configuration
- GitHub Actions workflow for auto-deployment
- Environment variables template with security defaults

This allows users to deploy MingNote online for free with:
- Persistent data storage (PostgreSQL + Redis + Manticore Search)
- No cost (Oracle Cloud free tier)
- Global access via public IP
- Optional HTTPS with Let's Encrypt or Cloudflare

Files added:
- docs/DEPLOY_ORACLE_CLOUD.md - Detailed deployment guide
- QUICK_START.md - Quick start instructions
- docker-compose.prod.yml - Production Docker setup
- deploy.sh - Automated deployment management script
- .env.example - Environment configuration template
- nginx.conf - Nginx reverse proxy config
- .github/workflows/deploy-to-oracle-cloud.yml - CI/CD workflow

Updated:
- README.md - Added deployment links in Self-Host section
- .gitignore - Added deployment-related files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Oracle Cloud deployment automation and GitHub Actions workflow for streamlined deployment pipelines.
  * Included production-ready Docker Compose configuration for complete service orchestration.

* **Documentation**
  * Added comprehensive Oracle Cloud deployment guide and quick-start deployment guide.
  * Updated README with deployment options and quick-start setup instructions.

* **Chores**
  * Added environment configuration template and nginx reverse proxy configuration.
  * Updated .gitignore to exclude deployment and environment artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->