### PR TITLE
fix(server): config typo

### DIFF
--- a/packages/backend/server/src/core/mail/config.ts
+++ b/packages/backend/server/src/core/mail/config.ts
@@ -61,7 +61,7 @@ defineModuleConfig('mailer', {
     env: 'MAILER_SENDER',
   },
   'SMTP.ignoreTLS': {
-    desc: "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.",
+    desc: "Whether ignore email server's TLS certificate verification. Enable it for self-signed certificates.",
     default: false,
     env: ['MAILER_IGNORE_TLS', 'boolean'],
   },
@@ -96,7 +96,7 @@ defineModuleConfig('mailer', {
     default: '',
   },
   'fallbackSMTP.ignoreTLS': {
-    desc: "Whether ignore email server's TSL certification verification. Enable it for self-signed certificates.",
+    desc: "Whether ignore email server's TLS certificate verification. Enable it for self-signed certificates.",
     default: false,
   },
 });


### PR DESCRIPTION
Fix a typo on the SMTP configuration page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in mail server configuration descriptions for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->