### PR TITLE
fix(core): pressing ENTER on database title now switches focus instead of creating new record

### DIFF
--- a/blocksuite/affine/blocks/database/src/components/title/index.ts
+++ b/blocksuite/affine/blocks/database/src/components/title/index.ts
@@ -176,7 +176,7 @@ export class DatabaseTitle extends SignalWatcher(
   private readonly isFocus$ = signal(false);
 
   private onPressEnterKey() {
-    this.dataViewLogic.addRow?.('start');
+    this.input.blur();
   }
 
   get readonly$() {


### PR DESCRIPTION
Initial bug report: Issue https://github.com/toeverything/AFFiNE/issues/13966

Description of bug: When a database header/title is in focus and the user presses ENTER, a new record is created and shown to the user. 

Expected outcome: When the user presses enter in the header title field, the new title should be applied and then the title field should loose focus. 

Short summary of fix: When the ENTER key is pressed within the title, the `onPressEnterKey()` function is called. As of now, this calls the function `this.dataViewLogic.addRow?.('start');` which creates a new record. In this fix, this has been changed to `this.input.blur()` which instead essentially switches focus away from the title field and does not create a new record, as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified Enter key behavior in the database title field. Pressing Enter now blurs the input instead of automatically inserting a new row.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->