### PR TITLE
feat(server): make OIDC refresh_token field optional

### DIFF
--- a/packages/backend/server/src/plugins/oauth/providers/oidc.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/oidc.ts
@@ -13,7 +13,7 @@ import { OAuthAccount, OAuthProvider, Tokens } from './def';
 const OIDCTokenSchema = z.object({
   access_token: z.string(),
   expires_in: z.number(),
-  refresh_token: z.string(),
+  refresh_token: z.string().optional(),
   scope: z.string().optional(),
   token_type: z.string(),
 });


### PR DESCRIPTION
Hello. I faced with OIDC implementation, which doesn't return refresh_token, and it doesn't work with affine. This patch should solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OIDC authentication now accepts tokens that may lack a refresh token, improving compatibility with providers that do not return refresh tokens and reducing sign-in errors for affected accounts.
  * Minor stability improvements to token handling to prevent unexpected authentication failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->