### PR TITLE
Fix: Disable GFM auto-linking for Windows-style file paths

### DIFF
--- a/blocksuite/affine/shared/src/adapters/markdown/markdown.ts
+++ b/blocksuite/affine/shared/src/adapters/markdown/markdown.ts
@@ -204,10 +204,40 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
       .replace(/&#x20;\n/g, ' \n');
   }
 
-  private _markdownToAst(markdown: Markdown) {
+ private _markdownToAst(markdown: Markdown) {
     const processor = unified()
       .use(remarkParse)
       .use(remarkGfm)
+      // Custom plugin to disable autolinking of file paths.
+      // remark-gfm autolinks things like `api\views\project.py` which is not desired.
+      .use(() => {
+        return (tree: Root) => {
+          const visitor = (node: any) => {
+            if (!node.children) {
+              return;
+            }
+
+            for (let i = 0; i < node.children.length; i++) {
+              const child = node.children[i];
+
+              if (
+                child.type === 'link' &&
+                child.children.length === 1 &&
+                child.children[0].type === 'text' &&
+                child.url === child.children[0].value &&
+                (child.url as string).includes('\\')
+              ) {
+                // This is an autolink that contains backslashes, likely a file path.
+                // Replace the link node with a text node.
+                node.children[i] = { type: 'text', value: child.url };
+              } else {
+                visitor(child);
+              }
+            }
+          };
+          visitor(tree);
+        };
+      })
       .use(remarkMath)
       .use(remarkCallout);
     const ast = processor.parse(markdown);


### PR DESCRIPTION
This PR prevents `remark-gfm` from auto-linking strings like `api\views\project.py`, which incorrectly turn into `<api\views\project.py>` when pasted into Affine.

### Key Changes
- Added a custom unified plugin to detect and convert backslash-containing auto-links into plain text nodes.
- Ensures Windows file paths are pasted and rendered correctly without unwanted angle brackets or link transformations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect autolinking of file paths in Markdown content, ensuring file path references are displayed as plain text rather than clickable links

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->