### PR TITLE
Fix image paste failures by prioritizing clipboard image files over blob URLs

### DIFF
--- a/blocksuite/framework/std/src/view/element/lit-host.ts
+++ b/blocksuite/framework/std/src/view/element/lit-host.ts
@@ -104,6 +104,28 @@ export class EditorHost extends SignalWatcher(
     )}`;
   };
 
+  private readonly _handlePaste = (e: ClipboardEvent) => {
+    const files = e.clipboardData?.files;
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    // when copy-pasting from some websites, the clipboard may contain both an image file
+    // and an html string with a `blob:` url. The `blob:` url is not accessible,
+    // so we should prioritize handling the image file.
+    const imageFile = Array.from(files).find(file =>
+      file.type.startsWith('image/')
+    );
+
+    if (imageFile) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.command.execute('editor:insert-file', {
+        file: imageFile,
+      });
+    }
+  };
+
   get command(): CommandManager {
     return this.std.command;
   }
@@ -136,11 +158,13 @@ export class EditorHost extends SignalWatcher(
 
     this.std.mount();
     this.tabIndex = 0;
+    this.addEventListener('paste', this._handlePaste);
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
     this.std.unmount();
+    this.removeEventListener('paste', this._handlePaste);
   }
 
   override async getUpdateComplete(): Promise<boolean> {


### PR DESCRIPTION
### Summary
This PR fixes an issue where copying images from certain websites fails to paste correctly in Affine. Some pages place both an image file and an HTML snippet containing a `blob:` URL into the clipboard. The `blob:` URL is not accessible outside the original page context, causing the paste operation to fail.

### What This Change Does
- Adds a paste event handler to `lit-host.ts`.
- Detects and prioritizes actual image files from the clipboard.
- Prevents default behavior when an image file is present and inserts the file directly via `editor:insert-file`.
- Cleans up the event listener on disconnect.

### Why This Fix Works
Previously, the paste handler attempted to use a `blob:` URL from the HTML clipboard data, which is invalid in our environment. By checking for and using the real image file first, Affine can reliably paste images from webpages that include such mixed clipboard content.

### Testing
- Verified paste works from websites that previously failed (e.g., pages that produce both `blob:` and image file entries).
- Confirmed existing paste behavior remains unchanged for normal image clipboard data.

This resolves the image copy-paste issue reported in v0.24.1 (web + Chrome + self-hosted).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Images can now be pasted directly from clipboard into the editor. When you paste content containing an image file, the image is automatically detected and inserted into the document while maintaining existing paste behavior for other content types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->