### PR TITLE
fix: improved user feedback for proxy file size limits

### DIFF
--- a/packages/common/nbstore/src/impls/cloud/blob.ts
+++ b/packages/common/nbstore/src/impls/cloud/blob.ts
@@ -116,7 +116,10 @@ export class CloudBlobStorage extends BlobStorageBase {
         throw new OverSizeError(this.humanReadableBlobSizeLimitCache);
       }
       if (userFriendlyError.is('CONTENT_TOO_LARGE')) {
-        throw new OverSizeError(this.humanReadableBlobSizeLimitCache);
+        throw new OverSizeError(
+          null,
+          'Upload stopped by network proxy: file size exceeds the set limit.'
+        );
       }
       throw err;
     }

--- a/packages/common/nbstore/src/storage/errors/over-size.ts
+++ b/packages/common/nbstore/src/storage/errors/over-size.ts
@@ -1,6 +1,10 @@
 export class OverSizeError extends Error {
-  constructor(limit: string | null) {
-    const formattedLimit = limit ? `${limit} ` : '';
-    super(`File size exceeds the ${formattedLimit}limit.`);
+  constructor(limit: string | null, message?: string) {
+    if (message) {
+      super(message);
+    } else {
+      const formattedLimit = limit ? `${limit} ` : '';
+      super(`File size exceeds the ${formattedLimit}limit.`);
+    }
   }
 }


### PR DESCRIPTION
**Summary:**
This PR improves the user feedback when encountering an HTTP 413 (_CONTENT_TOO_LARGE)_ error caused by a file size limit in the proxy / ingress controller in a self-hosted environment. 
fix #13992

**Example scenario:**
A self-hosted environment serves AFFiNE through an nginx proxy, and the `client_max_body_size` variable in the configuration file is set to a smaller size (e.g. 1MB) than AFFiNE's own file size limit (typically 100MB). Previously, the user would get an error saying the file is larger than 100MB regardless of file size, as all of these cases resulted in the same internal error. With this fix, the  _CONTENT_TOO_LARGE_ error is now handled separately and gives better feedback to the user that the failing upload is caused by a fault in the proxy configuration. 

**Screenshot of new error message**

<img width="798" height="171" alt="1MB_now" src="https://github.com/user-attachments/assets/07b00cd3-ce37-4049-8674-2f3dcb916ab5" />


**Affected files:**
  1. packages/common/nbstore/src/storage/errors/over-size.ts
  2. packages/common/nbstore/src/impls/cloud/blob.ts


I'm open to any suggestions in terms of the wording used in the message to the user. The fix has been tested with an nginx proxy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user-facing error messages for file upload failures. When an upload exceeds the file size limit, users now receive a clearer message indicating that the upload was stopped by the network proxy due to the size restriction, providing better understanding of why the upload was rejected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->