### PR TITLE
fix(server): make email and name optional in OIDC user info

### DIFF
--- a/packages/backend/server/src/plugins/oauth/providers/oidc.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/oidc.ts
@@ -22,8 +22,8 @@ const OIDCUserInfoSchema = z
   .object({
     sub: z.string(),
     preferred_username: z.string().optional(),
-    email: z.string().email(),
-    name: z.string(),
+    email: z.string().email().optional(),
+    name: z.string().optional(),
     groups: z.array(z.string()).optional(),
   })
   .passthrough();


### PR DESCRIPTION
This change updates the `OIDCUserInfoSchema` to make the `name` and `email` fields optional because these values are already resolved through the configurable `claimsMap`. Since different OIDC Providers may use different claim names—or omit certain claims entirely—the schema should not require fields that are not guaranteed to exist.

This problem is particularly visible when using [Synology SSO Server](https://www.synology.com/dsm/7.3/software_spec/sso_server)’s OIDC Provider. Synology SSO Server returns a `username` claim instead of `name` or `preferred_username`. Because the previous schema required `name` and `email`, parsing the userinfo response resulted in validation errors despite the presence of equivalent data under different claim keys.

By marking `name` and `email` as optional, the schema now correctly reflects real-world provider behavior, allowing `claimsMap` to map the appropriate fields without causing runtime errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced OpenID Connect authentication to support a broader range of identity providers. Email and name fields are now optional in user profile validation, allowing authentication to proceed even when these fields are missing. Email format validation is preserved when the email field is present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->