### PR TITLE
fix: apple sign

### DIFF
--- a/packages/backend/server/src/plugins/oauth/config.ts
+++ b/packages/backend/server/src/plugins/oauth/config.ts
@@ -4,7 +4,7 @@ import { defineModuleConfig, JSONSchema } from '../../base';
 
 export interface OAuthProviderConfig {
   clientId: string;
-  clientSecret: string;
+  clientSecret?: string;
   args?: Record<string, string>;
 }
 

--- a/packages/backend/server/src/plugins/oauth/providers/apple.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/apple.ts
@@ -2,6 +2,7 @@ import { JsonWebKey } from 'node:crypto';
 
 import { Injectable } from '@nestjs/common';
 import jwt, { type JwtPayload } from 'jsonwebtoken';
+import { z } from 'zod';
 
 import {
   InternalServerError,
@@ -19,12 +20,54 @@ interface AuthTokenResponse {
   expires_in: number;
 }
 
+const AppleProviderArgsSchema = z.object({
+  privateKey: z.string().nonempty(),
+  keyId: z.string().nonempty(),
+  teamId: z.string().nonempty(),
+});
+
 @Injectable()
 export class AppleOAuthProvider extends OAuthProvider {
   provider = OAuthProviderName.Apple;
+  private readonly args: z.infer<typeof AppleProviderArgsSchema> | null;
 
   constructor(private readonly url: URLHelper) {
     super();
+    const result = AppleProviderArgsSchema.safeParse(this.config?.args);
+    if (result.success) {
+      this.args = result.data;
+    } else {
+      this.args = null;
+    }
+  }
+
+  override get configured() {
+    return (
+      !!this.config &&
+      !!this.config.clientId &&
+      (!!this.config.clientSecret || !!this.args)
+    );
+  }
+
+  private get clientSecret() {
+    if (this.config.clientSecret) {
+      return this.config.clientSecret;
+    }
+
+    if (!this.args) {
+      throw new Error('Missing Apple OAuth configuration');
+    }
+
+    const { privateKey, keyId, teamId } = this.args;
+
+    return jwt.sign({}, privateKey, {
+      algorithm: 'ES256',
+      keyid: keyId,
+      expiresIn: '5m',
+      issuer: teamId,
+      audience: 'https://appleid.apple.com',
+      subject: this.config.clientId,
+    });
   }
 
   getAuthUrl(state: string, clientNonce?: string): string {
@@ -46,7 +89,7 @@ export class AppleOAuthProvider extends OAuthProvider {
       body: this.url.stringify({
         code,
         client_id: this.config.clientId,
-        client_secret: this.config.clientSecret,
+        client_secret: this.clientSecret,
         redirect_uri: this.url.link('/api/oauth/callback'),
         grant_type: 'authorization_code',
       }),

--- a/packages/backend/server/src/plugins/oauth/providers/apple.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/apple.ts
@@ -29,19 +29,20 @@ const AppleProviderArgsSchema = z.object({
 @Injectable()
 export class AppleOAuthProvider extends OAuthProvider {
   provider = OAuthProviderName.Apple;
-  private readonly args: z.infer<typeof AppleProviderArgsSchema> | null;
+  private args: z.infer<typeof AppleProviderArgsSchema> | null = null;
 
   constructor(private readonly url: URLHelper) {
     super();
-    const result = AppleProviderArgsSchema.safeParse(this.config?.args);
-    if (result.success) {
-      this.args = result.data;
-    } else {
-      this.args = null;
-    }
   }
 
   override get configured() {
+    if (this.config && !this.args) {
+      const result = AppleProviderArgsSchema.safeParse(this.config?.args);
+      if (result.success) {
+        this.args = result.data;
+      }
+    }
+
     return (
       !!this.config &&
       !!this.config.clientId &&

--- a/packages/backend/server/src/plugins/oauth/providers/apple.ts
+++ b/packages/backend/server/src/plugins/oauth/providers/apple.ts
@@ -30,6 +30,7 @@ const AppleProviderArgsSchema = z.object({
 export class AppleOAuthProvider extends OAuthProvider {
   provider = OAuthProviderName.Apple;
   private args: z.infer<typeof AppleProviderArgsSchema> | null = null;
+  private _jwtCache: { token: string; expiresAt: number } | null = null;
 
   constructor(private readonly url: URLHelper) {
     super();
@@ -59,16 +60,33 @@ export class AppleOAuthProvider extends OAuthProvider {
       throw new Error('Missing Apple OAuth configuration');
     }
 
-    const { privateKey, keyId, teamId } = this.args;
+    if (this._jwtCache && this._jwtCache.expiresAt > Date.now()) {
+      return this._jwtCache.token;
+    }
 
-    return jwt.sign({}, privateKey, {
-      algorithm: 'ES256',
-      keyid: keyId,
-      expiresIn: '5m',
-      issuer: teamId,
-      audience: 'https://appleid.apple.com',
-      subject: this.config.clientId,
-    });
+    const { privateKey, keyId, teamId } = this.args;
+    const expiresIn = 300; // 5 minutes
+
+    try {
+      const token = jwt.sign({}, privateKey, {
+        algorithm: 'ES256',
+        keyid: keyId,
+        expiresIn,
+        issuer: teamId,
+        audience: 'https://appleid.apple.com',
+        subject: this.config.clientId,
+      });
+
+      this._jwtCache = {
+        token,
+        expiresAt: Date.now() + (expiresIn - 30) * 1000,
+      };
+
+      return token;
+    } catch (e) {
+      this.logger.error('Failed to generate Apple client secret JWT', e);
+      throw new Error('Failed to generate client secret');
+    }
   }
 
   getAuthUrl(state: string, clientNonce?: string): string {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple OAuth now supports automatic client-secret generation (JWT) when a client secret is not provided.
  * Providers can omit the OAuth client secret in configs for more flexible setups.

* **Refactor**
  * Improved OAuth configuration validation, runtime checks, and caching for more reliable token exchanges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->