### PR TITLE
feat(core): add 'Learn More' button for proxy size limit errors

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -4,6 +4,7 @@ import {
 } from '@blocksuite/affine-components/caption';
 import {
   getAttachmentFileIcon,
+  HelpIcon,
   LoadingIcon,
 } from '@blocksuite/affine-components/icons';
 import { Peekable } from '@blocksuite/affine-components/peek';
@@ -266,6 +267,29 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
     }
   }
 
+  protected renderProxySizeLimitInfoButton = () => {
+    if (this.std.store.readonly) return null;
+
+    const onProxySizeLimit = this.std.get(
+      FileSizeLimitProvider
+    ).onProxySizeLimit;
+
+    return when(
+      onProxySizeLimit,
+      () => html`
+        <button
+          class="affine-attachment-content-button"
+          @click=${(event: MouseEvent) => {
+            event.stopPropagation();
+            onProxySizeLimit?.();
+          }}
+        >
+          ${HelpIcon} Learn More
+        </button>
+      `
+    );
+  };
+
   protected renderUpgradeButton = () => {
     if (this.std.store.readonly) return null;
 
@@ -371,6 +395,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
             ${choose(state, [
               ['error', () => this.renderNormalButton(needUpload)],
               ['error:oversize', this.renderUpgradeButton],
+              ['error:proxy-limit', this.renderProxySizeLimitInfoButton],
             ])}
           </div>
         </div>
@@ -411,6 +436,7 @@ export class AttachmentBlockComponent extends CaptionedBlockComponent<Attachment
           ${choose(state, [
             ['error', () => this.renderNormalButton(needUpload)],
             ['error:oversize', this.renderUpgradeButton],
+            ['error:proxy-limit', this.renderProxySizeLimitInfoButton],
           ])}
         </div>
       </div>

--- a/blocksuite/affine/components/src/resource/resource.ts
+++ b/blocksuite/affine/components/src/resource/resource.ts
@@ -15,6 +15,7 @@ export type StateKind =
   | 'uploading'
   | 'error'
   | 'error:oversize'
+  | 'error:proxy-limit'
   | 'none';
 
 export type StateInfo = {
@@ -46,12 +47,15 @@ export class ResourceController implements Disposable {
       uploading = false,
       downloading = false,
       overSize = false,
+      proxyLimit = false,
       errorMessage,
     } = this.state$.value;
     const hasExceeded = overSize;
-    const hasError = hasExceeded || Boolean(errorMessage);
+    const hasProxyLimit = proxyLimit;
+    const hasError = hasExceeded || hasProxyLimit || Boolean(errorMessage);
     const state = this.determineState(
       hasExceeded,
+      hasProxyLimit,
       hasError,
       uploading,
       downloading
@@ -83,11 +87,13 @@ export class ResourceController implements Disposable {
 
   determineState(
     hasExceeded: boolean,
+    hasProxyLimit: boolean,
     hasError: boolean,
     uploading: boolean,
     downloading: boolean
   ): StateKind {
     if (hasExceeded) return 'error:oversize';
+    if (hasProxyLimit) return 'error:proxy-limit';
     if (hasError) return 'error';
     if (uploading) return 'uploading';
     if (downloading) return 'loading';
@@ -140,7 +146,7 @@ export class ResourceController implements Disposable {
 
       const subscription = blobState$.subscribe(state => {
         let { uploading, downloading, errorMessage } = state;
-        if (state.overSize) {
+        if (state.overSize || state.proxyLimit) {
           uploading = false;
           downloading = false;
         } else if ((uploading || downloading) && errorMessage) {

--- a/blocksuite/affine/shared/src/services/file-size-limit-service.ts
+++ b/blocksuite/affine/shared/src/services/file-size-limit-service.ts
@@ -4,6 +4,7 @@ import { Extension } from '@blocksuite/store';
 export interface IFileSizeLimitService {
   maxFileSize: number;
   onOverFileSize?: () => void;
+  onProxySizeLimit?: () => void;
 }
 
 export const FileSizeLimitProvider = createIdentifier<IFileSizeLimitService>(

--- a/blocksuite/framework/sync/src/blob/source.ts
+++ b/blocksuite/framework/sync/src/blob/source.ts
@@ -5,6 +5,7 @@ export interface BlobState {
   downloading: boolean;
   errorMessage?: string | null;
   overSize: boolean;
+  proxyLimit: boolean;
   needUpload: boolean;
   needDownload: boolean;
 }

--- a/packages/common/nbstore/src/impls/cloud/blob.ts
+++ b/packages/common/nbstore/src/impls/cloud/blob.ts
@@ -12,6 +12,7 @@ import {
   BlobStorageBase,
   OverCapacityError,
   OverSizeError,
+  ProxyLimitError,
 } from '../../storage';
 import { HttpConnection } from './http';
 
@@ -116,10 +117,7 @@ export class CloudBlobStorage extends BlobStorageBase {
         throw new OverSizeError(this.humanReadableBlobSizeLimitCache);
       }
       if (userFriendlyError.is('CONTENT_TOO_LARGE')) {
-        throw new OverSizeError(
-          null,
-          'Upload stopped by network proxy: file size exceeds the set limit.'
-        );
+        throw new ProxyLimitError(null);
       }
       throw err;
     }

--- a/packages/common/nbstore/src/storage/errors/index.ts
+++ b/packages/common/nbstore/src/storage/errors/index.ts
@@ -1,2 +1,3 @@
 export * from './over-capacity';
 export * from './over-size';
+export * from './proxy-limit';

--- a/packages/common/nbstore/src/storage/errors/proxy-limit.ts
+++ b/packages/common/nbstore/src/storage/errors/proxy-limit.ts
@@ -1,0 +1,5 @@
+export class ProxyLimitError extends Error {
+  constructor(public originError?: any) {
+    super('Upload stopped by network proxy: file size exceeds the set limit.');
+  }
+}

--- a/packages/common/nbstore/src/sync/blob/index.ts
+++ b/packages/common/nbstore/src/sync/blob/index.ts
@@ -25,6 +25,7 @@ export interface BlobSyncBlobState {
   downloading: boolean;
   errorMessage?: string | null;
   overSize: boolean;
+  proxyLimit: boolean;
 }
 
 export interface BlobSync {
@@ -107,6 +108,7 @@ export class BlobSyncImpl implements BlobSync {
             downloading: peers.some(p => p.downloading),
             errorMessage: peers.find(p => p.errorMessage)?.errorMessage,
             overSize: peers.some(p => p.overSize),
+            proxyLimit: peers.some(p => p.proxyLimit),
             needUpload: peers.some(p => p.needUpload),
             needDownload: peers.some(p => p.needDownload),
           }) satisfies BlobSyncBlobState

--- a/packages/common/nbstore/src/sync/blob/peer.ts
+++ b/packages/common/nbstore/src/sync/blob/peer.ts
@@ -2,7 +2,11 @@ import { difference } from 'lodash-es';
 import { filter, Observable, ReplaySubject, share, Subject } from 'rxjs';
 
 import type { BlobRecord, BlobStorage } from '../../storage';
-import { OverCapacityError, OverSizeError } from '../../storage';
+import {
+  OverCapacityError,
+  OverSizeError,
+  ProxyLimitError,
+} from '../../storage';
 import type { BlobSyncStorage } from '../../storage/blob-sync';
 import { MANUALLY_STOP, throwIfAborted } from '../../utils/throw-if-aborted';
 
@@ -19,6 +23,7 @@ export interface BlobSyncPeerBlobState {
   uploading: boolean;
   downloading: boolean;
   overSize: boolean;
+  proxyLimit: boolean;
   errorMessage?: string | null;
 }
 
@@ -194,6 +199,8 @@ export class BlobSyncPeer {
           this.status.blobError(blob.key, 'Remote storage over capacity');
         } else if (err instanceof OverSizeError) {
           this.status.blobOverSizeWithError(blob.key, err.message);
+        } else if (err instanceof ProxyLimitError) {
+          this.status.blobProxyLimitWithError(blob.key, err.message);
         } else {
           this.status.blobError(
             blob.key,
@@ -391,6 +398,7 @@ class BlobSyncPeerStatus {
   willDownload = new Set<string>();
   error = new Map<string, string>();
   overSize = new Set<string>();
+  proxyLimit = new Set<string>();
 
   peerState$ = new Observable<BlobSyncPeerState>(subscribe => {
     const next = () => {
@@ -425,6 +433,7 @@ class BlobSyncPeerStatus {
             this.willDownload.has(blobId) || this.downloading.has(blobId),
           errorMessage: this.error.get(blobId) ?? null,
           overSize: this.overSize.has(blobId),
+          proxyLimit: this.proxyLimit.has(blobId),
         });
       };
       next();
@@ -569,10 +578,17 @@ class BlobSyncPeerStatus {
     this.statusUpdatedSubject$.next(blobId);
   }
 
+  blobProxyLimitWithError(blobId: string, errorMessage: string) {
+    this.proxyLimit.add(blobId);
+    this.error.set(blobId, errorMessage);
+    this.statusUpdatedSubject$.next(blobId);
+  }
+
   blobErrorFree(blobId: string) {
     let deleted = false;
     deleted = this.error.delete(blobId) || deleted;
     deleted = this.overSize.delete(blobId) || deleted;
+    deleted = this.proxyLimit.delete(blobId) || deleted;
     if (deleted) {
       this.statusUpdatedSubject$.next(blobId);
     }
@@ -588,6 +604,7 @@ class BlobSyncPeerStatus {
     deleted = this.downloading.delete(blobId) || deleted;
     deleted = this.error.delete(blobId) || deleted;
     deleted = this.overSize.delete(blobId) || deleted;
+    deleted = this.proxyLimit.delete(blobId) || deleted;
     if (deleted) {
       this.statusUpdatedSubject$.next(blobId);
     }

--- a/packages/frontend/core/src/blocksuite/view-extensions/editor-view/file-size-limit.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/editor-view/file-size-limit.ts
@@ -26,6 +26,10 @@ export function patchFileSizeLimitExtension(framework: FrameworkProvider) {
       track.$.paywall.storage.viewPlans();
     }
 
+    onProxySizeLimit() {
+      window.open('https://affine.pro', '_blank');
+    }
+
     static override setup(di: Container) {
       di.override(FileSizeLimitProvider, AffineFileSizeLimitService);
     }


### PR DESCRIPTION
This PR expands on https://github.com/toeverything/AFFiNE/pull/14016, changing the "Upgrade" button - which has no relevance for this error - to a "Learn More" button, which I think we should set to point to a separate page on the wiki/documentation. That page should give the user some information about what causes this error, and what to do (if they are the ones running the self-hosted instance). 

This was made possible by adding an additional field in the FileSizeLimitProvider which is set to true when a ProxyLimitError occurs. 

I will leave the PR as is right now, and will coordinate with team member silencer.xyz to create a page on the wiki. Then amend this PR to change the URL for the "Learn More" button to point to that page. 

<img width="778" height="118" alt="Screenshot from 2025-12-11 13-16-34" src="https://github.com/user-attachments/assets/82fde1a2-2a3d-4116-b2dc-1e13e24c86c2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting and handling uploads blocked by network proxy size limits
  * Added informational UI element to help users understand proxy-related upload failures

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->