### PR TITLE
fix: doc icon emoji clipped on the right (#14073)

### DIFF
--- a/packages/frontend/component/src/ui/button/button.css.ts
+++ b/packages/frontend/component/src/ui/button/button.css.ts
@@ -196,6 +196,10 @@ export const content = style({
   overflow: 'hidden',
 });
 
+globalStyle(`${button}[data-icon-type='emoji'] > ${content}`, {
+  overflow: 'visible',
+});
+
 export const icon = style({
   flexShrink: 0,
   // There are two kinds of icon size:


### PR DESCRIPTION
## Issue
When setting an emoji in the page, the right part of some wider emojis (e.g. 🔑) is cut off.

Before
<img width="1054" height="290" alt="before" src="https://github.com/user-attachments/assets/fb36ed8e-7f9c-4280-9489-d0c19c97c6dc" />

After
<img width="1054" height="290" alt="after" src="https://github.com/user-attachments/assets/1026b5e2-f27a-4a08-adb7-ab479c90b9af" />

Fixes #14073 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button styling for emoji icons. Updated CSS to optimize overflow rendering for emoji-type icons, ensuring enhanced visual presentation and consistent display across button components using emoji content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->