### PR TITLE
fix(core): fixed keyboard shortcut help for Windows and Linux

### DIFF
--- a/packages/frontend/core/src/components/hooks/affine/use-shortcuts.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-shortcuts.ts
@@ -86,7 +86,7 @@ export const useWinGeneralKeyboardShortcuts = (): ShortcutMap => {
       [t('expandOrCollapseSidebar')]: ['Ctrl', '/'],
       [t('goBack')]: ['Ctrl', '['],
       [t('goForward')]: ['Ctrl', ']'],
-      [t('copy-private-link')]: ['⌘', '⇧', 'C'],
+      [t('copy-private-link')]: ['Ctrl', '⇧', 'C'],
     }),
     [t]
   );


### PR DESCRIPTION
This PR is related to issue https://github.com/toeverything/AFFiNE/issues/13290

Keyboard shortcut for copying a private link works as expected, but the overview of shortcuts shows the Mac shortcut for Windows, web and Linux users. This fix shows the correct (Ctrl+Shift+C) shortcut to the aforementioned users. 

I have not tested this on a Mac (neither in browser nor in the app), but ideally this should not have an impact for Mac users as the logic for showing the correct shortcut is already implemented.

Affected files: 
- packages/frontend/core/src/components/hooks/affine/use-shortcuts.ts


Old: 
<img width="1402" height="946" alt="old_shortcut" src="https://github.com/user-attachments/assets/5c8f2133-2b4d-49c7-8054-851c7de8f3cd" />

New:
<img width="650" height="379" alt="Keyboard shortcut fix" src="https://github.com/user-attachments/assets/a29e2f7a-53d7-4743-a9b1-aa30e7622dd1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the keyboard shortcut for copying private links on Windows from Command+Shift+C to Ctrl+Shift+C.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->