### PR TITLE
fix: roll back electron version to v35

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@vitest/coverage-istanbul": "^3.2.4",
     "@vitest/ui": "^3.2.4",
     "cross-env": "^10.1.0",
-    "electron": "^36.0.0",
+    "electron": "^35.0.0",
     "eslint": "^9.16.0",
     "eslint-config-prettier": "^10.0.0",
     "eslint-import-resolver-typescript": "^4.0.0",

--- a/packages/frontend/apps/electron/package.json
+++ b/packages/frontend/apps/electron/package.json
@@ -59,7 +59,7 @@
     "builder-util-runtime": "^9.5.0",
     "cross-env": "^10.1.0",
     "debug": "^4.4.0",
-    "electron": "^36.0.0",
+    "electron": "^35.0.0",
     "electron-log": "^5.4.3",
     "electron-squirrel-startup": "1.0.1",
     "electron-window-state": "^5.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -583,7 +583,7 @@ __metadata:
     builder-util-runtime: "npm:^9.5.0"
     cross-env: "npm:^10.1.0"
     debug: "npm:^4.4.0"
-    electron: "npm:^36.0.0"
+    electron: "npm:^35.0.0"
     electron-log: "npm:^5.4.3"
     electron-squirrel-startup: "npm:1.0.1"
     electron-updater: "npm:^6.6.2"
@@ -786,7 +786,7 @@ __metadata:
     "@vitest/coverage-istanbul": "npm:^3.2.4"
     "@vitest/ui": "npm:^3.2.4"
     cross-env: "npm:^10.1.0"
-    electron: "npm:^36.0.0"
+    electron: "npm:^35.0.0"
     eslint: "npm:^9.16.0"
     eslint-config-prettier: "npm:^10.0.0"
     eslint-import-resolver-typescript: "npm:^4.0.0"
@@ -22380,16 +22380,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron@npm:^36.0.0":
-  version: 36.9.5
-  resolution: "electron@npm:36.9.5"
+"electron@npm:^35.0.0":
+  version: 35.7.5
+  resolution: "electron@npm:35.7.5"
   dependencies:
     "@electron/get": "npm:^2.0.0"
     "@types/node": "npm:^22.7.7"
     extract-zip: "npm:^2.0.1"
   bin:
     electron: cli.js
-  checksum: 10/2c78ce37b6cdcf2388dc3f3932f2104f7bd529c51ee8d00e0201ce86089966309c0ba62c2045abc4dad81893ebe7f7070bb047dcb9c05366f31ddd7fb73790ca
+  checksum: 10/f3757f0b6f21ddd5ebf8b83becdaa3e47dc13473e5375e6e6aee638d7029e73d08d6a4170b37ad8c594057da139e7cdf4c8b82b70c2c1ad0306abdcc274c5fee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In electron v36, all workers do not work. 
The webpack configuration is too complicated, so go back first.

If start a new project with [forge](https://www.electronforge.io/) and latest electron, the worker works well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Downgraded the Electron development/runtime used for building and testing the desktop app from v36 to v35; this is a development-environment change with no functional or API changes affecting end users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->