### PR TITLE
feat(admin): add platform-wide custom CSS configuration for self-hosted deployments

### DIFF
--- a/packages/backend/server/src/__tests__/e2e/config/resolver.spec.ts
+++ b/packages/backend/server/src/__tests__/e2e/config/resolver.spec.ts
@@ -31,3 +31,9 @@ e2e('should enable local workspace feature by default', async t => {
     JSON.stringify(serverConfig, null, 2)
   );
 });
+
+e2e('should return customCss field in serverConfig', async t => {
+  const { serverConfig } = await app.gql({ query: serverConfigQuery });
+
+  t.is(typeof serverConfig.customCss, 'string');
+});

--- a/packages/backend/server/src/core/config/__tests__/service.spec.ts
+++ b/packages/backend/server/src/core/config/__tests__/service.spec.ts
@@ -136,3 +136,21 @@ test('should emit config changed event', async t => {
     })
   );
 });
+
+test('should update appearance.customCss config', async t => {
+  const customCss = ':root { --test-color: red; }';
+
+  await service.updateConfig(user.id, [
+    {
+      module: 'appearance',
+      key: 'customCss',
+      value: customCss,
+    },
+  ]);
+
+  t.is(service.getConfig().appearance.customCss, customCss);
+});
+
+test('should default appearance.customCss to empty string', async t => {
+  t.is(typeof service.getConfig().appearance.customCss, 'string');
+});

--- a/packages/backend/server/src/core/config/config.ts
+++ b/packages/backend/server/src/core/config/config.ts
@@ -19,6 +19,9 @@ declare global {
       name?: string;
     };
     flags: ServerFlags;
+    appearance: {
+      customCss: string;
+    };
   }
 }
 
@@ -68,6 +71,15 @@ Default to be \`[server.protocol]://[server.host][:server.port]\` if not specifi
     desc: 'Subpath where the server get deployed if there is one.(e.g. /affine)',
     default: '',
     env: 'AFFINE_SERVER_SUB_PATH',
+  },
+});
+
+defineModuleConfig('appearance', {
+  customCss: {
+    desc: 'Custom CSS to be applied platform-wide for all users. Useful for branding and styling customizations.',
+    default: '',
+    env: 'AFFINE_APPEARANCE_CUSTOM_CSS',
+    shape: z.string(),
   },
 });
 

--- a/packages/backend/server/src/core/config/resolver.ts
+++ b/packages/backend/server/src/core/config/resolver.ts
@@ -87,6 +87,7 @@ export class ServerConfigResolver {
       features: this.server.features,
       // TODO(@fengmk2): remove this field after the feature 0.25.0 is released
       allowGuestDemoWorkspace: this.config.flags.allowGuestDemoWorkspace,
+      customCss: this.config.appearance.customCss || '',
     };
   }
 

--- a/packages/backend/server/src/core/config/types.ts
+++ b/packages/backend/server/src/core/config/types.ts
@@ -47,4 +47,10 @@ export class ServerConfigType {
       'This field is deprecated, please use `features` instead. Will be removed in 0.25.0',
   })
   allowGuestDemoWorkspace!: boolean;
+
+  @Field({
+    description: 'Custom CSS for platform-wide styling',
+    nullable: true,
+  })
+  customCss?: string;
 }

--- a/packages/backend/server/src/schema.gql
+++ b/packages/backend/server/src/schema.gql
@@ -1859,6 +1859,9 @@ type ServerConfigType {
   """credentials requirement"""
   credentialsRequirement: CredentialsRequirementType!
 
+  """Custom CSS for platform-wide styling"""
+  customCss: String
+
   """enabled server features"""
   features: [ServerFeature!]!
 

--- a/packages/common/graphql/src/graphql/index.ts
+++ b/packages/common/graphql/src/graphql/index.ts
@@ -2199,6 +2199,7 @@ export const serverConfigQuery = {
     features
     type
     initialized
+    customCss
     credentialsRequirement {
       ...CredentialsRequirements
     }

--- a/packages/common/graphql/src/graphql/server-config.gql
+++ b/packages/common/graphql/src/graphql/server-config.gql
@@ -9,6 +9,7 @@ query serverConfig {
     features
     type
     initialized
+    customCss
     credentialsRequirement {
       ...CredentialsRequirements
     }

--- a/packages/common/graphql/src/schema.ts
+++ b/packages/common/graphql/src/schema.ts
@@ -2476,6 +2476,8 @@ export interface ServerConfigType {
   baseUrl: Scalars['String']['output'];
   /** credentials requirement */
   credentialsRequirement: CredentialsRequirementType;
+  /** Custom CSS for platform-wide styling */
+  customCss: Maybe<Scalars['String']['output']>;
   /** enabled server features */
   features: Array<ServerFeature>;
   /** whether server has been initialized */
@@ -5983,6 +5985,7 @@ export type ServerConfigQuery = {
     features: Array<ServerFeature>;
     type: ServerDeploymentType;
     initialized: boolean;
+    customCss: string | null;
     credentialsRequirement: {
       __typename?: 'CredentialsRequirementType';
       password: {

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -227,6 +227,13 @@
       "env": "AFFINE_SERVER_SUB_PATH"
     }
   },
+  "appearance": {
+    "customCss": {
+      "type": "String",
+      "desc": "Custom CSS to be applied platform-wide for all users. Useful for branding and styling customizations.",
+      "env": "AFFINE_APPEARANCE_CUSTOM_CSS"
+    }
+  },
   "flags": {
     "earlyAccessControl": {
       "type": "Boolean",

--- a/packages/frontend/admin/src/modules/settings/config-input-row.tsx
+++ b/packages/frontend/admin/src/modules/settings/config-input-row.tsx
@@ -19,7 +19,7 @@ export type ConfigInputProps = {
   error?: string;
 } & (
   | {
-      type: 'String' | 'Number' | 'Boolean' | 'JSON';
+      type: 'String' | 'Number' | 'Boolean' | 'JSON' | 'Textarea';
     }
   | {
       type: 'Enum';
@@ -105,6 +105,20 @@ const Inputs: Record<
           ))}
         </SelectContent>
       </Select>
+    );
+  },
+  Textarea: function TextareaInput({ defaultValue, onChange }) {
+    const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange(e.target.value);
+    };
+
+    return (
+      <Textarea
+        defaultValue={defaultValue ?? ''}
+        onChange={handleInputChange}
+        className="w-full min-h-[200px] font-mono text-sm"
+        placeholder="/* Enter custom CSS here */"
+      />
     );
   },
 };

--- a/packages/frontend/admin/src/modules/settings/config.ts
+++ b/packages/frontend/admin/src/modules/settings/config.ts
@@ -51,6 +51,17 @@ export const KNOWN_CONFIG_GROUPS = [
     fields: ['externalUrl', 'name', 'hosts'],
   } as ConfigGroup<'server'>,
   {
+    name: 'Appearance',
+    module: 'appearance',
+    fields: [
+      {
+        key: 'customCss',
+        type: 'Textarea',
+        desc: 'Custom CSS applied to all users platform-wide. Use for branding and styling.',
+      },
+    ],
+  } as ConfigGroup<'appearance'>,
+  {
     name: 'Auth',
     module: 'auth',
     fields: [

--- a/packages/frontend/core/src/components/custom-css/index.tsx
+++ b/packages/frontend/core/src/components/custom-css/index.tsx
@@ -1,0 +1,35 @@
+import { DefaultServerService } from '@affine/core/modules/cloud';
+import { useLiveData, useService } from '@toeverything/infra';
+import { useEffect, useRef } from 'react';
+
+export const CustomCssInjector = () => {
+  const defaultServerService = useService(DefaultServerService);
+  const config = useLiveData(defaultServerService.server?.config$);
+  const styleRef = useRef<HTMLStyleElement | null>(null);
+
+  useEffect(() => {
+    const customCss = config?.customCss;
+
+    // Remove existing style element
+    if (styleRef.current) {
+      styleRef.current.remove();
+      styleRef.current = null;
+    }
+
+    // Inject new CSS if provided
+    if (customCss?.trim()) {
+      const styleElement = document.createElement('style');
+      styleElement.setAttribute('data-affine-custom-css', 'true');
+      styleElement.textContent = customCss;
+      document.head.appendChild(styleElement);
+      styleRef.current = styleElement;
+    }
+
+    return () => {
+      styleRef.current?.remove();
+      styleRef.current = null;
+    };
+  }, [config?.customCss]);
+
+  return null;
+};

--- a/packages/frontend/core/src/desktop/pages/root/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/root/index.tsx
@@ -1,4 +1,5 @@
 import { NotificationCenter } from '@affine/component';
+import { CustomCssInjector } from '@affine/core/components/custom-css';
 import { DefaultServerService } from '@affine/core/modules/cloud';
 import { FrameworkScope, useService } from '@toeverything/infra';
 import { useEffect, useState } from 'react';
@@ -30,6 +31,7 @@ export const RootWrapper = () => {
       <NotificationCenter />
       <Outlet />
       <CustomThemeModifier />
+      <CustomCssInjector />
       {BUILD_CONFIG.isElectron && <FindInPagePopup />}
     </FrameworkScope>
   );

--- a/packages/frontend/core/src/mobile/pages/root/index.tsx
+++ b/packages/frontend/core/src/mobile/pages/root/index.tsx
@@ -1,4 +1,5 @@
 import { NotificationCenter } from '@affine/component';
+import { CustomCssInjector } from '@affine/core/components/custom-css';
 import { DefaultServerService } from '@affine/core/modules/cloud';
 import { FrameworkScope, useService } from '@toeverything/infra';
 import { useEffect, useState } from 'react';
@@ -27,6 +28,7 @@ export const RootWrapper = () => {
       <GlobalDialogs />
       <NotificationCenter />
       <Outlet />
+      <CustomCssInjector />
     </FrameworkScope>
   );
 };

--- a/packages/frontend/core/src/modules/cloud/entities/server.ts
+++ b/packages/frontend/core/src/modules/cloud/entities/server.ts
@@ -86,6 +86,7 @@ export class Server extends Entity<{
             type: config.type,
             version: config.version,
             initialized: config.initialized,
+            customCss: config.customCss,
           });
         }),
         onStart(() => {

--- a/packages/frontend/core/src/modules/cloud/types.ts
+++ b/packages/frontend/core/src/modules/cloud/types.ts
@@ -19,4 +19,5 @@ export interface ServerConfig {
   initialized?: boolean;
   version?: string;
   credentialsRequirement: CredentialsRequirementType;
+  customCss?: string;
 }


### PR DESCRIPTION
## Summary

Add admin-level configuration for custom CSS that applies platform-wide to all users. This enables self-hosted deployments to customize branding and styling without modifying source code.

### Changes
- Add `appearance.customCss` configuration option with environment variable support (`AFFINE_APPEARANCE_CUSTOM_CSS`)
- Expose `customCss` field in GraphQL `serverConfig` query
- Add "Appearance" settings section in admin panel with textarea input
- Create `CustomCssInjector` component to inject CSS into document head
- Integrate injector in desktop and mobile root components
- Fix config revalidation to include `customCss` field

### Use Case
Self-hosted AFFiNE administrators can now add custom CSS (e.g., theming, branding colors, font overrides) via the admin panel at `/admin/settings`, which applies to all users on the platform.

## Test Plan
- [x] Added e2e test for `customCss` field in serverConfig query
- [x] Added service tests for updating `appearance.customCss`
- [x] Manual testing: CSS injected into `<head>` as `<style data-affine-custom-css="true">`
- [x] Typecheck passes
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added platform-wide custom CSS configuration. Administrators can now define custom CSS through the admin panel's new Appearance settings section with a dedicated textarea editor. The CSS is automatically applied to all users, enabling consistent branding and styling customization.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->