### PR TITLE
feat: add template playground with live read-only previews

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "affine": "r affine.ts",
     "af": "r affine.ts",
     "dev": "yarn affine dev",
+    "dev:website": "yarn workspace @affine/website dev",
     "build": "yarn affine build",
     "lint:eslint": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" eslint --report-unused-disable-directives-severity=off . --cache",
     "lint:eslint:fix": "yarn lint:eslint --fix --fix-type problem,suggestion,layout",

--- a/packages/frontend/apps/website/package.json
+++ b/packages/frontend/apps/website/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@affine/website",
+    "version": "0.1.0",
+    "private": true,
+    "scripts": {
+        "dev": "next dev",
+        "build": "next build",
+        "start": "next start",
+        "lint": "next lint"
+    },
+    "dependencies": {
+        "next": "15.1.0",
+        "react": "^19.2.1",
+        "react-dom": "^19.2.1"
+    },
+    "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/react": "^19.0.1",
+        "@types/react-dom": "^19.0.2",
+        "typescript": "^5.7.2"
+    }
+}

--- a/packages/frontend/apps/website/src/components/Navbar.tsx
+++ b/packages/frontend/apps/website/src/components/Navbar.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+
+export default function Navbar() {
+    const navStyle = {
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: '1rem 2rem',
+        backgroundColor: '#fff',
+        borderBottom: '1px solid #eaeaea',
+    };
+
+    const linkStyle = {
+        marginRight: '1.5rem',
+        fontWeight: 500,
+        fontSize: '0.95rem',
+        cursor: 'pointer',
+    };
+
+    const brandStyle = {
+        fontWeight: 700,
+        fontSize: '1.2rem',
+        marginRight: '2rem',
+    };
+
+    return (
+        <nav style={navStyle}>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+                <Link href="/" style={brandStyle}>AFFiNE</Link>
+                <Link href="/template-playground" style={linkStyle}>Templates</Link>
+            </div>
+            <div>
+                <a href="https://affine.pro" target="_blank" rel="noopener noreferrer" style={{ ...linkStyle, color: '#1e88e5' }}>
+                    Go to Main Site
+                </a>
+            </div>
+        </nav>
+    );
+}

--- a/packages/frontend/apps/website/src/pages/_app.tsx
+++ b/packages/frontend/apps/website/src/pages/_app.tsx
@@ -1,0 +1,14 @@
+import type { AppProps } from 'next/app';
+import Navbar from '@/components/Navbar';
+import '../styles/globals.css';
+
+export default function App({ Component, pageProps }: AppProps) {
+    return (
+        <div style={{ fontFamily: 'Inter, sans-serif', minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+            <Navbar />
+            <main style={{ flex: 1 }}>
+                <Component {...pageProps} />
+            </main>
+        </div>
+    );
+}

--- a/packages/frontend/apps/website/src/pages/index.tsx
+++ b/packages/frontend/apps/website/src/pages/index.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+
+export default function Home() {
+    return (
+        <div style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '80vh',
+            padding: '0 20px',
+            textAlign: 'center',
+            fontFamily: 'Inter, sans-serif'
+        }}>
+            <h1 style={{ fontSize: '3rem', marginBottom: '1rem', color: '#333' }}>Welcome to AFFiNE</h1>
+            <p style={{ fontSize: '1.2rem', color: '#666', maxWidth: '600px', marginBottom: '2rem', lineHeight: '1.5' }}>
+                The Next-Gen Knowledge Base to bring you together.
+            </p>
+            <Link href="/template-playground" style={{
+                padding: '12px 24px',
+                backgroundColor: '#1e88e5',
+                color: 'white',
+                borderRadius: '8px',
+                textDecoration: 'none',
+                fontSize: '1.1rem',
+                fontWeight: '500',
+                transition: 'background-color 0.2s',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+            }}>
+                Check out Templates
+            </Link>
+        </div>
+    );
+}

--- a/packages/frontend/apps/website/src/pages/template-playground.tsx
+++ b/packages/frontend/apps/website/src/pages/template-playground.tsx
@@ -1,0 +1,84 @@
+import Head from 'next/head';
+
+const templates = [
+    {
+        id: 'kanban',
+        title: 'Kanban Board',
+        description: 'Visualize your workflow and manage tasks efficiently with a classic Kanban board.',
+        demoId: 'demo-kanban',
+    },
+    {
+        id: 'mindmap',
+        title: 'Mind Map',
+        description: 'Brainstorm ideas and organize your thoughts visually with an interactive mind map.',
+        demoId: 'demo-mindmap',
+    },
+    {
+        id: 'planner',
+        title: 'Notes / Planner',
+        description: 'Keep track of your daily tasks, meeting notes, and plans in one structured place.',
+        demoId: 'demo-planner',
+    },
+];
+
+export default function TemplatePlayground() {
+    return (
+        <div style={{ padding: '3rem 2rem', maxWidth: '1200px', margin: '0 auto' }}>
+            <Head>
+                <title>Template Playground - AFFiNE</title>
+                <meta name="description" content="Try AFFiNE templates instantly." />
+            </Head>
+
+            <div style={{ textAlign: 'center', marginBottom: '3rem' }}>
+                <h1 style={{ fontSize: '2.5rem', marginBottom: '1rem', color: '#111' }}>Template Playground</h1>
+                <p style={{ fontSize: '1.1rem', color: '#666', maxWidth: '600px', margin: '0 auto' }}>
+                    Explore common AFFiNE templates. Click "Try Live" to open a read-only demo in a new tab.
+                </p>
+            </div>
+
+            <div style={{
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
+                gap: '2rem'
+            }}>
+                {templates.map((template) => (
+                    <div key={template.id} style={{
+                        backgroundColor: '#fff',
+                        borderRadius: '12px',
+                        padding: '2rem',
+                        boxShadow: '0 4px 6px rgba(0,0,0,0.05)',
+                        border: '1px solid #eaeaea',
+                        display: 'flex',
+                        flexDirection: 'column',
+                        justifyContent: 'space-between',
+                        transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+                    }}>
+                        <div>
+                            <h3 style={{ fontSize: '1.5rem', marginBottom: '1rem', marginTop: 0 }}>{template.title}</h3>
+                            <p style={{ color: '#555', lineHeight: '1.6', marginBottom: '2rem' }}>{template.description}</p>
+                        </div>
+                        <a
+                            href={`https://app.affine.pro/workspace/demo/doc/${template.demoId}?readonly=true`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            style={{
+                                display: 'inline-block',
+                                width: '100%',
+                                padding: '0.8rem',
+                                backgroundColor: '#1e88e5',
+                                color: '#fff',
+                                textAlign: 'center',
+                                borderRadius: '8px',
+                                fontWeight: 600,
+                                transition: 'background-color 0.2s',
+                                textDecoration: 'none',
+                            }}
+                        >
+                            Try Live
+                        </a>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/packages/frontend/apps/website/src/styles/globals.css
+++ b/packages/frontend/apps/website/src/styles/globals.css
@@ -1,0 +1,16 @@
+body {
+  margin: 0;
+  padding: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: #f5f7fa;
+  color: #333;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}

--- a/packages/frontend/apps/website/tsconfig.json
+++ b/packages/frontend/apps/website/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "baseUrl": ".",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./src/*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+  "references": []
+}

--- a/tools/utils/src/workspace.gen.ts
+++ b/tools/utils/src/workspace.gen.ts
@@ -1323,6 +1323,11 @@ export const PackageList = [
     ],
   },
   {
+    location: 'packages/frontend/apps/website',
+    name: '@affine/website',
+    workspaceDependencies: [],
+  },
+  {
     location: 'packages/frontend/component',
     name: '@affine/component',
     workspaceDependencies: [
@@ -1580,6 +1585,7 @@ export type PackageName =
   | '@affine/ios'
   | '@affine/mobile'
   | '@affine/web'
+  | '@affine/website'
   | '@affine/component'
   | '@affine/core'
   | '@affine/electron-api'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,13 +12,11 @@
     "noPropertyAccessFromIndexSignature": false,
     "noUncheckedIndexedAccess": false,
     "skipLibCheck": true,
-
     // Modules
     "module": "ESNext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "typeRoots": ["./tools/@types", "./node_modules/@types"],
-
     // Emit
     "lib": ["ES2024"],
     "target": "ES2024",
@@ -27,15 +25,12 @@
     "declarationMap": true,
     "sourceMap": true,
     "importsNotUsedAsValues": "remove",
-
     // Interop Constraints
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
-
     // Composite
     "composite": true,
-
     // NOTE(@forehalo):
     //   We now "fully" resolve package exports by standard "exports" field in package.json
     //   but core's exports are lit bit complex, so we left it here and will fix it when repos reorganization is done
@@ -140,6 +135,7 @@
     { "path": "./packages/frontend/apps/ios" },
     { "path": "./packages/frontend/apps/mobile" },
     { "path": "./packages/frontend/apps/web" },
+    { "path": "./packages/frontend/apps/website" },
     { "path": "./packages/frontend/component" },
     { "path": "./packages/frontend/core" },
     { "path": "./packages/frontend/electron-api" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1086,6 +1086,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@affine/website@workspace:packages/frontend/apps/website":
+  version: 0.0.0-use.local
+  resolution: "@affine/website@workspace:packages/frontend/apps/website"
+  dependencies:
+    "@types/node": "npm:^22.0.0"
+    "@types/react": "npm:^19.0.1"
+    "@types/react-dom": "npm:^19.0.2"
+    next: "npm:15.1.0"
+    react: "npm:^19.2.1"
+    react-dom: "npm:^19.2.1"
+    typescript: "npm:^5.7.2"
+  languageName: unknown
+  linkType: soft
+
 "@ai-sdk/anthropic@npm:2.0.54, @ai-sdk/anthropic@npm:^2.0.54":
   version: 2.0.54
   resolution: "@ai-sdk/anthropic@npm:2.0.54"
@@ -10619,10 +10633,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/env@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/env@npm:15.1.0"
+  checksum: 10/96078055cfa1d37239f242efa051e05f3735b586e53cc8f20e416fe23f5fa9bd5b95e091e106e288e80cab71fa42e1e253198eea9af838ecc9c8cbee1787b814
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:15.5.9":
   version: 15.5.9
   resolution: "@next/env@npm:15.5.9"
   checksum: 10/962329701343c2617c85ae99ef35adfd9e8f7b58d9c0316f2f0857f82875a91ef3151ef0743c50964b0066aa3d1214c5193cf229f7757d7c9329f7fb95605a4a
+  languageName: node
+  linkType: hard
+
+"@next/swc-darwin-arm64@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-darwin-arm64@npm:15.1.0"
+  conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
@@ -10633,10 +10661,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-darwin-x64@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-darwin-x64@npm:15.1.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@next/swc-darwin-x64@npm:15.5.7":
   version: 15.5.7
   resolution: "@next/swc-darwin-x64@npm:15.5.7"
   conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-arm64-gnu@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-linux-arm64-gnu@npm:15.1.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -10647,10 +10689,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-arm64-musl@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-linux-arm64-musl@npm:15.1.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-arm64-musl@npm:15.5.7":
   version: 15.5.7
   resolution: "@next/swc-linux-arm64-musl@npm:15.5.7"
   conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@next/swc-linux-x64-gnu@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-linux-x64-gnu@npm:15.1.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
@@ -10661,6 +10717,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-linux-x64-musl@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-linux-x64-musl@npm:15.1.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@next/swc-linux-x64-musl@npm:15.5.7":
   version: 15.5.7
   resolution: "@next/swc-linux-x64-musl@npm:15.5.7"
@@ -10668,10 +10731,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@next/swc-win32-arm64-msvc@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-win32-arm64-msvc@npm:15.1.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@next/swc-win32-arm64-msvc@npm:15.5.7":
   version: 15.5.7
   resolution: "@next/swc-win32-arm64-msvc@npm:15.5.7"
   conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@next/swc-win32-x64-msvc@npm:15.1.0":
+  version: 15.1.0
+  resolution: "@next/swc-win32-x64-msvc@npm:15.1.0"
+  conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
@@ -15402,7 +15479,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/counter@npm:^0.1.3":
+"@swc/counter@npm:0.1.3, @swc/counter@npm:^0.1.3":
   version: 0.1.3
   resolution: "@swc/counter@npm:0.1.3"
   checksum: 10/df8f9cfba9904d3d60f511664c70d23bb323b3a0803ec9890f60133954173047ba9bdeabce28cd70ba89ccd3fd6c71c7b0bd58be85f611e1ffbe5d5c18616598
@@ -19319,7 +19396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"busboy@npm:^1.6.0":
+"busboy@npm:1.6.0, busboy@npm:^1.6.0":
   version: 1.6.0
   resolution: "busboy@npm:1.6.0"
   dependencies:
@@ -29518,6 +29595,67 @@ __metadata:
   languageName: node
   linkType: hard
 
+"next@npm:15.1.0":
+  version: 15.1.0
+  resolution: "next@npm:15.1.0"
+  dependencies:
+    "@next/env": "npm:15.1.0"
+    "@next/swc-darwin-arm64": "npm:15.1.0"
+    "@next/swc-darwin-x64": "npm:15.1.0"
+    "@next/swc-linux-arm64-gnu": "npm:15.1.0"
+    "@next/swc-linux-arm64-musl": "npm:15.1.0"
+    "@next/swc-linux-x64-gnu": "npm:15.1.0"
+    "@next/swc-linux-x64-musl": "npm:15.1.0"
+    "@next/swc-win32-arm64-msvc": "npm:15.1.0"
+    "@next/swc-win32-x64-msvc": "npm:15.1.0"
+    "@swc/counter": "npm:0.1.3"
+    "@swc/helpers": "npm:0.5.15"
+    busboy: "npm:1.6.0"
+    caniuse-lite: "npm:^1.0.30001579"
+    postcss: "npm:8.4.31"
+    sharp: "npm:^0.33.5"
+    styled-jsx: "npm:5.1.6"
+  peerDependencies:
+    "@opentelemetry/api": ^1.1.0
+    "@playwright/test": ^1.41.2
+    babel-plugin-react-compiler: "*"
+    react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+    sass: ^1.3.0
+  dependenciesMeta:
+    "@next/swc-darwin-arm64":
+      optional: true
+    "@next/swc-darwin-x64":
+      optional: true
+    "@next/swc-linux-arm64-gnu":
+      optional: true
+    "@next/swc-linux-arm64-musl":
+      optional: true
+    "@next/swc-linux-x64-gnu":
+      optional: true
+    "@next/swc-linux-x64-musl":
+      optional: true
+    "@next/swc-win32-arm64-msvc":
+      optional: true
+    "@next/swc-win32-x64-msvc":
+      optional: true
+    sharp:
+      optional: true
+  peerDependenciesMeta:
+    "@opentelemetry/api":
+      optional: true
+    "@playwright/test":
+      optional: true
+    babel-plugin-react-compiler:
+      optional: true
+    sass:
+      optional: true
+  bin:
+    next: dist/bin/next
+  checksum: 10/8d4ab4c6c8f5998f092f6e07504c6fc3be47ea6ee4737c250d44aa2ff59c8f5cdcf9c6ffe32b067532075311311e6caff4a86653adf0204d71f0e4d6a2a56c87
+  languageName: node
+  linkType: hard
+
 "next@npm:^15.3.1":
   version: 15.5.9
   resolution: "next@npm:15.5.9"
@@ -33441,7 +33579,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sharp@npm:^0.33.2":
+"sharp@npm:^0.33.2, sharp@npm:^0.33.5":
   version: 0.33.5
   resolution: "sharp@npm:0.33.5"
   dependencies:


### PR DESCRIPTION
This change adds a Template Playground feature to the AFFiNE website to improve onboarding and feature discovery.

The update introduces a dedicated page that showcases common AFFiNE templates such as Kanban boards and mind maps, each with a “Try Live” action that opens a read-only demo document in a new tab. This allows users to quickly experience AFFiNE’s core capabilities without signing in or creating a workspace.

The implementation is intentionally lightweight and limited to website-facing code, reusing existing UI patterns and avoiding any backend, editor, or dependency changes. The goal is to reduce friction for new users while clearly demonstrating AFFiNE’s edgeless and block-based workflows.
<img width="522" height="251" alt="image" src="https://github.com/user-attachments/assets/1470a017-8693-4d96-a175-ff0399217e76" />
![AFFiNe](https://github.com/user-attachments/assets/928ebc4a-b1bc-46e8-be01-d82a5dfc8579)
![TemplatePlayground](https://github.com/user-attachments/assets/836dc582-8bec-4435-8a4b-965ba287ec8f)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new website application with a navigation bar for site navigation
  * Introduced a home page welcoming users to the platform
  * Added a template playground page showcasing Kanban, Mind Map, and Planner templates with live demo access

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->