### PR TITLE
fix: fix typo in link shortcut key binding

### DIFF
--- a/packages/frontend/core/src/components/hooks/affine/use-shortcuts.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-shortcuts.ts
@@ -237,7 +237,7 @@ export const useWinPageKeyboardShortcuts = (): ShortcutMap => {
       [t('strikethrough')]: ['Ctrl', 'Shift', 'S'],
       [t('inlineCode')]: [' Ctrl', 'E'],
       [t('codeBlock')]: ['Ctrl', 'Alt', 'C'],
-      [t('link')]: ['Ctr', 'K'],
+      [t('link')]: ['Ctrl', 'K'],
       [t('quickSearch')]: ['Ctrl', 'K'],
       [t('bodyText')]: ['Ctrl', 'Shift', '0'],
       [tH('1')]: ['Ctrl', 'Shift', '1'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected keyboard shortcut mapping for link function, ensuring it properly recognizes Ctrl+K command.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->