### PR TITLE
feat: set admin name when self hosted init

### DIFF
--- a/packages/backend/server/src/core/selfhost/controller.ts
+++ b/packages/backend/server/src/core/selfhost/controller.ts
@@ -15,6 +15,7 @@ import { ServerService } from '../config';
 import { validators } from '../utils/validators';
 
 interface CreateUserInput {
+  name?: string;
   email: string;
   password: string;
 }
@@ -58,6 +59,7 @@ export class CustomSetupController {
       throw new InternalServerError();
     }
     const user = await this.models.user.create({
+      name: input.name || undefined,
       email: input.email,
       password: input.password,
       registered: true,

--- a/packages/frontend/admin/src/modules/setup/form.tsx
+++ b/packages/frontend/admin/src/modules/setup/form.tsx
@@ -99,6 +99,7 @@ export const Form = () => {
       const createResponse = await affineFetch('/api/setup/create-admin-user', {
         method: 'POST',
         body: JSON.stringify({
+          name: nameValue,
           email: emailValue,
           password: passwordValue,
         }),


### PR DESCRIPTION
fix #14134 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin users can now set their name during the initial setup process.

* **Chores**
  * Updated internal dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->