### PR TITLE
fix: refine handling for non-standard keyboards to avoid incorrect keyCode fallback

### DIFF
--- a/blocksuite/framework/std/src/event/keymap.ts
+++ b/blocksuite/framework/std/src/event/keymap.ts
@@ -86,14 +86,13 @@ export function bindKeymap(
       }
     }
 
-    // none standard keyboard, fallback to keyCode
-    const special =
-      event.shiftKey ||
-      event.altKey ||
-      event.metaKey ||
-      name.charCodeAt(0) > 127;
+    // For non-standard keyboards, fallback to keyCode only when modifier keys are pressed.
+    // Do NOT fallback when the key produces a non-ASCII character (e.g., Cyrillic 'х' on Russian keyboard),
+    // because the user intends to type that character, not trigger a shortcut bound to the physical key.
+    // See: https://github.com/toeverything/AFFiNE/issues/14059
+    const hasModifier = event.shiftKey || event.altKey || event.metaKey;
     const baseName = base[event.keyCode];
-    if (special && baseName && baseName !== name) {
+    if (hasModifier && baseName && baseName !== name) {
       const fromCode = map[modifiers(baseName, event)];
       if (fromCode && fromCode(ctx)) {
         return true;


### PR DESCRIPTION
Fix https://github.com/toeverything/AFFiNE/issues/14059

With the help of Claude Opus 4.5

Improve handling of keyCode fallback for non-standard keyboards by only applying it when modifier keys are pressed. This change prevents incorrect fallback behavior for non-ASCII characters, ensuring users can type intended characters without triggering shortcuts.

After

https://github.com/user-attachments/assets/00ab4fb2-4bc2-4ca7-a284-9782686d298c

Event dump for Cyrillic x

```json

{
 "key": "х",
 "keyCode": 219,
 "which": 219,
 "code": "BracketLeft",
 "location": 0,
 "altKey": false,
 "ctrlKey": false,
 "metaKey": false,
 "shiftKey": false,
 "repeat": false
}
```

blocksuite commit https://github.com/toeverything/blocksuite/commit/4c0d39890fb65e8de974169fa1c96b038f6d4a83#diff-68c46455e0eece88312235df85f8ce27ae254efccde6fb987f2505180730bd8c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined keyboard input handling to properly support non-ASCII characters (e.g., Cyrillic, Greek) by ensuring user-typed characters are preserved instead of inadvertently triggering keyboard shortcuts. The fix maintains keyboard shortcut functionality while improving compatibility with international keyboards and input methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->