### PR TITLE
feat(server): add LISTEN_ADDR env var for allowing server to listen on ipv6

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -595,6 +595,11 @@
           "description": "Multiple hosts the server will accept requests from.\n@default []",
           "default": []
         },
+        "listenAddr": {
+          "type": "string",
+          "description": "The address to listen on (e.g., 0.0.0.0 for IPv4, :: for IPv6).\n@default \"0.0.0.0\"\n@environment `LISTEN_ADDR`",
+          "default": "0.0.0.0"
+        },
         "port": {
           "type": "number",
           "description": "Which port the server will listen on.\n@default 3010\n@environment `AFFINE_SERVER_PORT`",

--- a/packages/backend/server/src/core/config/config.ts
+++ b/packages/backend/server/src/core/config/config.ts
@@ -13,6 +13,7 @@ declare global {
       https: boolean;
       host: string;
       hosts: ConfigItem<string[]>;
+      listenAddr: string;
       port: number;
       path: string;
       name?: string;
@@ -57,6 +58,11 @@ Default to be \`[server.protocol]://[server.host][:server.port]\` if not specifi
     desc: 'Multiple hosts the server will accept requests from.',
     default: [],
     shape: z.array(z.string()),
+  },
+  listenAddr: {
+    desc: 'The address to listen on (e.g., 0.0.0.0 for IPv4, :: for IPv6).',
+    default: '0.0.0.0',
+    env: 'LISTEN_ADDR',
   },
   port: {
     desc: 'Which port the server will listen on.',

--- a/packages/backend/server/src/server.ts
+++ b/packages/backend/server/src/server.ts
@@ -75,11 +75,12 @@ export async function run() {
   }
 
   const url = app.get(URLHelper);
-  const listeningHost = '0.0.0.0';
 
-  await app.listen(config.server.port, listeningHost);
+  await app.listen(config.server.port, config.server.listenAddr);
 
   logger.log(`AFFiNE Server is running in [${env.DEPLOYMENT_TYPE}] mode`);
-  logger.log(`Listening on http://${listeningHost}:${config.server.port}`);
+  logger.log(
+    `Listening on http://${config.server.listenAddr}:${config.server.port}`
+  );
   logger.log(`And the public server should be recognized as ${url.baseUrl}`);
 }

--- a/packages/backend/server/src/server.ts
+++ b/packages/backend/server/src/server.ts
@@ -78,9 +78,11 @@ export async function run() {
 
   await app.listen(config.server.port, config.server.listenAddr);
 
+  const formattedAddr = config.server.listenAddr.includes(':')
+    ? `[${config.server.listenAddr}]`
+    : config.server.listenAddr;
+
   logger.log(`AFFiNE Server is running in [${env.DEPLOYMENT_TYPE}] mode`);
-  logger.log(
-    `Listening on http://${config.server.listenAddr}:${config.server.port}`
-  );
+  logger.log(`Listening on http://${formattedAddr}:${config.server.port}`);
   logger.log(`And the public server should be recognized as ${url.baseUrl}`);
 }

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -216,6 +216,11 @@
       "type": "Array",
       "desc": "Multiple hosts the server will accept requests from."
     },
+    "listenAddr": {
+      "type": "String",
+      "desc": "The address to listen on (e.g., 0.0.0.0 for IPv4, :: for IPv6).",
+      "env": "LISTEN_ADDR"
+    },
     "port": {
       "type": "Number",
       "desc": "Which port the server will listen on.",


### PR DESCRIPTION
The old code hardcoded 0.0.0.0 which means the server only listened for ipv4 connections, making it not work on ipv6-only networks.

This change adds a LISTEN_ADDR env var which allows the server to bind to ipv6 as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server listen address is now configurable via the LISTEN_ADDR environment variable (default: 0.0.0.0), enabling IPv4/IPv6 or interface-specific binding.
  * Configuration schemas and admin UI now expose the listen address option so deployments can view and override it.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->