### PR TITLE
WIP: feat: right mouse button panning

### DIFF
--- a/blocksuite/affine/blocks/surface/src/tool/default-tool.ts
+++ b/blocksuite/affine/blocks/surface/src/tool/default-tool.ts
@@ -1,3 +1,4 @@
+import { EditorSettingProvider } from '@blocksuite/affine-shared/services';
 import { resetNativeSelection } from '@blocksuite/affine-shared/utils';
 import { DisposableGroup } from '@blocksuite/global/disposable';
 import type { IVec } from '@blocksuite/global/gfx';
@@ -27,6 +28,13 @@ export class DefaultTool extends BaseTool {
   static override toolName: string = 'default';
 
   private _edgeScrollingTimer: number | null = null;
+
+  override get allowDragWithRightButton(): boolean {
+    const editorSetting = this.std.getOptional(EditorSettingProvider)?.setting$;
+    const enableRightButtonPanning =
+      editorSetting?.peek().enableRightButtonPanning ?? false;
+    return !enableRightButtonPanning;
+  }
 
   private readonly _clearDisposable = () => {
     if (this._disposables) {

--- a/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
+++ b/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
@@ -2,6 +2,7 @@ import {
   DefaultTool,
   EdgelessLegacySlotIdentifier,
 } from '@blocksuite/affine-block-surface';
+import { EditorSettingProvider } from '@blocksuite/affine-shared/services';
 import { on } from '@blocksuite/affine-shared/utils';
 import type { PointerEventState } from '@blocksuite/std';
 import { BaseTool, MouseButton, type ToolOptions } from '@blocksuite/std/gfx';
@@ -54,9 +55,18 @@ export class PanTool extends BaseTool<PanToolOption> {
 
   override mounted(): void {
     this.addHook('pointerDown', evt => {
-      const shouldPanWithMiddle = evt.raw.button === MouseButton.MIDDLE;
+      const editorSetting = this.std.getOptional(
+        EditorSettingProvider
+      )?.setting$;
+      const enableRightButtonPanning =
+        editorSetting?.peek().enableRightButtonPanning ?? false;
 
-      if (!shouldPanWithMiddle) {
+      const button = evt.raw.button;
+      const shouldPan = enableRightButtonPanning
+        ? button === MouseButton.SECONDARY
+        : button === MouseButton.MIDDLE;
+
+      if (!shouldPan) {
         return;
       }
 
@@ -111,7 +121,11 @@ export class PanTool extends BaseTool<PanToolOption> {
       });
 
       const dispose = on(document, 'pointerup', evt => {
-        if (evt.button === MouseButton.MIDDLE) {
+        const shouldRestore = enableRightButtonPanning
+          ? evt.button === MouseButton.SECONDARY
+          : evt.button === MouseButton.MIDDLE;
+
+        if (shouldRestore) {
           restoreToPrevious();
         }
         dispose();

--- a/blocksuite/affine/shared/src/services/editor-setting-service.ts
+++ b/blocksuite/affine/shared/src/services/editor-setting-service.ts
@@ -10,6 +10,7 @@ export const GeneralSettingSchema = z
   .object({
     edgelessScrollZoom: z.boolean().default(false),
     edgelessDisableScheduleUpdate: z.boolean().default(false),
+    enableRightButtonPanning: z.boolean().default(false),
     docCanvasPreferView: z
       .enum(['affine:embed-linked-doc', 'affine:embed-synced-doc'])
       .default('affine:embed-synced-doc'),

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/general.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/edgeless/general.tsx
@@ -85,6 +85,13 @@ export const GeneralEdgelessSetting = () => {
     [editorSetting]
   );
 
+  const handleRightButtonPanningChange = useCallback(
+    (checked: boolean) => {
+      editorSetting.set('enableRightButtonPanning', checked);
+    },
+    [editorSetting]
+  );
+
   return (
     <>
       <SettingRow
@@ -122,6 +129,19 @@ export const GeneralEdgelessSetting = () => {
           checked={editorSetting.edgelessScrollZoom.$.value}
           onChange={handleScrollZoomChange}
         ></Switch>
+      </SettingRow>
+      <SettingRow
+        name={t[
+          'com.affine.settings.editorSettings.page.edgeless-right-mouse-button-panning.title'
+        ]()}
+        desc={t[
+          'com.affine.settings.editorSettings.page.edgeless-right-mouse-button-panning.description'
+        ]()}
+      >
+        <Switch
+          checked={editorSetting.enableRightButtonPanning.$.value}
+          onChange={handleRightButtonPanningChange}
+        />
       </SettingRow>
     </>
   );

--- a/packages/frontend/core/src/modules/editor-setting/schema.ts
+++ b/packages/frontend/core/src/modules/editor-setting/schema.ts
@@ -35,6 +35,7 @@ const AffineEditorSettingSchema = z.object({
       'open-in-center-peek',
     ])
     .default('open-in-active-view'),
+  enableRightButtonPanning: z.boolean().default(false),
   // linux only:
   enableMiddleClickPaste: z.boolean().default(false),
 });

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1365,6 +1365,8 @@
   "com.affine.settings.editorSettings.page.edgeless-default-theme.specified": "Specified by current color mode",
   "com.affine.settings.editorSettings.page.edgeless-scroll-wheel-zoom.title": "Scroll wheel zoom",
   "com.affine.settings.editorSettings.page.edgeless-scroll-wheel-zoom.description": "Use the scroll wheel to zoom in and out.",
+  "com.affine.settings.editorSettings.page.edgeless-right-mouse-button-panning.title": "Right-click panning",
+  "com.affine.settings.editorSettings.page.edgeless-right-mouse-button-panning.description": "Use right mouse button to pan.",
   "com.affine.settings.editorSettings.preferences": "Preferences",
   "com.affine.settings.editorSettings.preferences.export.description": "You can export the entire preferences data for backup, and the exported data can be re-imported.",
   "com.affine.settings.editorSettings.preferences.export.title": "Export Settings",


### PR DESCRIPTION
Issue: https://github.com/toeverything/AFFiNE/issues/14236

### Description
Panning in edgeless mode is one of the core user stories, and it would be great to have an option to do it with the right mouse button, because the middle mouse button is a very inconvenient mouse control for most users: it breaks muscle memory and causes frustration.

Moreover, this option would provide a better experience for Miro users

### Use case
A checkbox in the settings that allows using the right mouse button (RMB) for panning instead of the middle mouse button (MMB).
In this case, the MMB can hold RMB responsibility (so checkbox actually about swaping functionality between RMB and MMB)