### PR TITLE
fix: resolve navbar overlay issue on sign-in page

### DIFF
--- a/packages/frontend/component/src/components/auth-components/share.css.ts
+++ b/packages/frontend/component/src/components/auth-components/share.css.ts
@@ -141,8 +141,6 @@ export const signInPageContainer = style({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  position: 'relative',
-  zIndex: 1,
 });
 export const input = style({
   width: '330px',

--- a/packages/frontend/core/src/desktop/pages/auth/sign-in.tsx
+++ b/packages/frontend/core/src/desktop/pages/auth/sign-in.tsx
@@ -64,7 +64,7 @@ export const SignIn = ({
 
   return (
     <SignInPageContainer>
-      <div style={{ maxWidth: '400px', width: '100%' }}>
+      <div style={{ maxWidth: '400px', width: '100%', zIndex: 1 }}>
         <SignInPanel
           onSkip={handleClose}
           onAuthenticated={handleAuthenticated}


### PR DESCRIPTION
This pr fixes #14273.

I have implemented two minor CSS adjustments to resolve the navbar interaction issue on the sign-in page:

- Removed position: relative and z-index: 1 from signInPageContainer.
- Set z-index: 1 on the SignInPanel div (prevent SignInBackgroundArts from overlapping the SignInPanel)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted z-index layering for the sign-in page component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->