### PR TITLE
fix: add expose port 3010 in Dockerfile

### DIFF
--- a/.github/deployment/node/Dockerfile
+++ b/.github/deployment/node/Dockerfile
@@ -13,4 +13,6 @@ RUN apt-get update && \
 # Enable jemalloc by preloading the library
 ENV LD_PRELOAD=libjemalloc.so.2
 
+EXPOSE 3010
+
 CMD ["node", "./dist/main.js"]


### PR DESCRIPTION
Expose is requierd for automatic port finding with load balancers like Traefik without having to configure the port explict.

> error="service \"affine-affine\" error: port is missing" container=affine-affine-a76ca4362da101be5a53279db7aac67595a9df0783b0026efc3e5431009cbd66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration for container port exposure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->