### PR TITLE
feat(core): add export to PDF in page menu

### DIFF
--- a/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
+++ b/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
@@ -1,4 +1,5 @@
 import { MenuItem, MenuSeparator, MenuSub } from '@affine/component';
+import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import {
@@ -9,6 +10,7 @@ import {
   PageIcon,
   PrinterIcon,
 } from '@blocksuite/icons/rc';
+import { useLiveData, useService } from '@toeverything/infra';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 
@@ -72,6 +74,10 @@ export const ExportMenuItems = ({
   pageMode = 'page',
 }: ExportProps) => {
   const t = useI18n();
+  const featureFlags = useService(FeatureFlagService).flags;
+  const enable_pdfmake_export = useLiveData(
+    featureFlags.enable_pdfmake_export.$
+  );
 
   return (
     <>
@@ -98,7 +104,7 @@ export const ExportMenuItems = ({
         icon={<ExportToMarkdownIcon />}
         label={t['Export to Markdown']()}
       />
-      {pageMode !== 'edgeless' && (
+      {pageMode !== 'edgeless' && enable_pdfmake_export && (
         <ExportMenuItem
           onSelect={() => exportHandler('pdf-export')}
           className={className}

--- a/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
+++ b/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
@@ -1,5 +1,4 @@
 import { MenuItem, MenuSeparator, MenuSub } from '@affine/component';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import {
@@ -10,7 +9,6 @@ import {
   PageIcon,
   PrinterIcon,
 } from '@blocksuite/icons/rc';
-import { useLiveData, useService } from '@toeverything/infra';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 
@@ -74,10 +72,6 @@ export const ExportMenuItems = ({
   pageMode = 'page',
 }: ExportProps) => {
   const t = useI18n();
-  const featureFlags = useService(FeatureFlagService).flags;
-  const enable_pdfmake_export = useLiveData(
-    featureFlags.enable_pdfmake_export.$
-  );
 
   return (
     <>
@@ -104,7 +98,7 @@ export const ExportMenuItems = ({
         icon={<ExportToMarkdownIcon />}
         label={t['Export to Markdown']()}
       />
-      {pageMode !== 'edgeless' && enable_pdfmake_export && (
+      {pageMode !== 'edgeless' && (
         <ExportMenuItem
           onSelect={() => exportHandler('pdf-export')}
           className={className}

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -295,7 +295,7 @@ export const AFFINE_FLAGS = {
     description:
       'Experimental export PDFs support, it may contain the wrong style.',
     configurable: true,
-    defaultState: false,
+    defaultState: !isMobile,
   },
 } satisfies { [key in string]: FlagInfo };
 

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -236,6 +236,10 @@ export function useAFFiNEI18N(): {
       */
     ["Export to PNG"](): string;
     /**
+      * `Export to PDF`
+      */
+    ["Export to PDF"](): string;
+    /**
       * `File already exists`
       */
     FILE_ALREADY_EXISTS(): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -49,6 +49,7 @@
   "Export to HTML": "Export to HTML",
   "Export to Markdown": "Export to Markdown",
   "Export to PNG": "Export to PNG",
+  "Export to PDF": "Export to PDF",
   "FILE_ALREADY_EXISTS": "File already exists",
   "Favorite": "Favourite",
   "Favorited": "Favourited",

--- a/packages/frontend/i18n/src/resources/zh-Hans.json
+++ b/packages/frontend/i18n/src/resources/zh-Hans.json
@@ -49,6 +49,7 @@
   "Export to HTML": "导出为 HTML",
   "Export to Markdown": "导出为 Markdown",
   "Export to PNG": "导出为 PNG",
+  "Export to PDF": "导出为 PDF",
   "FILE_ALREADY_EXISTS": "文件已存在",
   "Favorite": "收藏",
   "Favorited": "已收藏",

--- a/packages/frontend/i18n/src/resources/zh-Hant.json
+++ b/packages/frontend/i18n/src/resources/zh-Hant.json
@@ -48,6 +48,7 @@
   "Export to HTML": "匯出為 HTML",
   "Export to Markdown": "匯出為 Markdown",
   "Export to PNG": "匯出為 PNG",
+  "Export to PDF": "匯出為 PDF",
   "FILE_ALREADY_EXISTS": "檔已存在",
   "Favorite": "收藏",
   "Favorited": "已收藏",


### PR DESCRIPTION
 This PR adds a new “Export to PDF” action in the document (article) page menu (Page mode only). The export uses the existing pdfmake-based exporter to generate and download a PDF, and enables the related feature flag by default on non-mobile builds.

  What changed

  - Add “Export to PDF” entry under Export in the page header menu (Page mode only)
  - Enable enable_pdfmake_export by default for non-mobile builds (still configurable)
  - Add i18n string for “Export to PDF” (en/zh-Hans/zh-Hant) and regenerate i18n typings

  How to test

  1. Open any document in Page mode
  2. Click ... (page header menu) → Export → Export to PDF
  3. Confirm a <doc title>.pdf file is downloaded

  Notes

  - The option is hidden in Edgeless mode (not supported)
  - Mobile builds keep the feature disabled by default; it can still be toggled via Experimental Features if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF export is now enabled by default on desktop platforms
  * Added localization support for PDF export feature in English, Simplified Chinese, and Traditional Chinese

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->