### PR TITLE
feat: Export to PDF via Chromium printToPDF

### DIFF
--- a/packages/frontend/apps/electron/src/main/ui/handlers.ts
+++ b/packages/frontend/apps/electron/src/main/ui/handlers.ts
@@ -237,11 +237,16 @@ export const uiHandlers = {
         preferCSSPageSize: true,
       });
 
-      await writeFile(ret.filePath, pdfData);
-      return { filePath: ret.filePath };
+      const outputPath = ret.filePath.toLowerCase().endsWith('.pdf')
+        ? ret.filePath
+        : `${ret.filePath}.pdf`;
+
+      await writeFile(outputPath, pdfData);
+      return { filePath: outputPath };
     } catch (err) {
       logger.error('exportToPdf', err);
-      return { error: (err as Error).message };
+      const message = err instanceof Error ? err.message : String(err);
+      return { error: message || 'unknown-error' };
     }
   },
 

--- a/packages/frontend/apps/electron/src/main/ui/handlers.ts
+++ b/packages/frontend/apps/electron/src/main/ui/handlers.ts
@@ -1,4 +1,14 @@
-import { app, clipboard, nativeImage, nativeTheme } from 'electron';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  nativeImage,
+  nativeTheme,
+} from 'electron';
 import { getLinkPreview } from 'link-preview-js';
 import { map, shareReplay } from 'rxjs';
 
@@ -36,6 +46,12 @@ import { showTabContextMenu } from '../windows-manager/context-menu';
 import { getOrCreateCustomThemeWindow } from '../windows-manager/custom-theme-window';
 import { getChallengeResponse } from './challenge';
 import { uiSubjects } from './subject';
+
+interface ExportPdfResult {
+  filePath?: string;
+  canceled?: boolean;
+  error?: string;
+}
 
 const TraySettingsState = {
   $: globalStateStorage.watch<MenubarStateSchema>(MenubarStateKey).pipe(
@@ -184,6 +200,49 @@ export const uiHandlers = {
   },
   openExternal(_, url: string) {
     return openExternalSafely(url);
+  },
+  exportToPdf: async (
+    e,
+    { title }: { title?: string }
+  ): Promise<ExportPdfResult> => {
+    try {
+      const window =
+        BrowserWindow.fromWebContents(e.sender) ?? (await getMainWindow());
+      if (!window) {
+        return { error: 'main-window-not-found' };
+      }
+
+      const sanitizedTitle = (title || 'Untitled')
+        .trim()
+        .replace(/[/\\?%*:|"<>]/g, '-');
+      const defaultPath = join(
+        app.getPath('downloads'),
+        `${sanitizedTitle || 'Untitled'}.pdf`
+      );
+
+      const ret = await dialog.showSaveDialog(window, {
+        properties: ['showOverwriteConfirmation'],
+        title: 'Export to PDF',
+        buttonLabel: 'Export',
+        filters: [{ name: 'PDF', extensions: ['pdf'] }],
+        defaultPath,
+      });
+
+      if (ret.canceled || !ret.filePath) {
+        return { canceled: true };
+      }
+
+      const pdfData = await e.sender.printToPDF({
+        printBackground: true,
+        preferCSSPageSize: true,
+      });
+
+      await writeFile(ret.filePath, pdfData);
+      return { filePath: ret.filePath };
+    } catch (err) {
+      logger.error('exportToPdf', err);
+      return { error: (err as Error).message };
+    }
   },
 
   // tab handlers

--- a/packages/frontend/core/src/components/hooks/affine/use-export-page.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-export-page.ts
@@ -245,15 +245,11 @@ async function preparePrintFrameForPdfExport(
                 const target = iframe.contentWindow.document.styleSheets[0];
                 target.insertRule(cssRule.cssText, target.cssRules.length);
               }
-            } catch (e) {
-              if (element.href) {
-                console.warn(
-                  '[export pdf] css cannot be applied when exporting pdf, this may be because of CORS policy from its domain.',
-                  element.href
-                );
-              } else {
-                throw e;
-              }
+            } catch {
+              console.warn(
+                '[export pdf] css cannot be applied when exporting pdf; skipping this stylesheet.',
+                element.href ?? 'inline stylesheet'
+              );
             }
           }
 

--- a/packages/frontend/core/src/components/hooks/affine/use-export-page.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-export-page.ts
@@ -4,7 +4,9 @@ import {
   resolveGlobalLoadingEventAtom,
 } from '@affine/component/global-loading';
 import type { AffineEditorContainer } from '@affine/core/blocksuite/block-suite-editor/blocksuite-editor';
+import { DesktopApiService } from '@affine/core/modules/desktop-api';
 import { EditorService } from '@affine/core/modules/editor';
+import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { getAFFiNEWorkspaceSchema } from '@affine/core/modules/workspace/global-schema';
 import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
@@ -27,7 +29,11 @@ import {
   PdfTransformer,
   ZipTransformer,
 } from '@blocksuite/affine/widgets/linked-doc';
-import { useLiveData, useService } from '@toeverything/infra';
+import {
+  useLiveData,
+  useService,
+  useServiceOptional,
+} from '@toeverything/infra';
 import { useSetAtom } from 'jotai';
 import { nanoid } from 'nanoid';
 
@@ -41,10 +47,14 @@ type ExportType =
   | 'snapshot'
   | 'pdf-export';
 
+type ExportResult = 'completed' | 'canceled';
+
 interface ExportHandlerOptions {
   page: Store;
   editorContainer: AffineEditorContainer;
   type: ExportType;
+  enablePdfmakeExport: boolean;
+  desktopApiHandler?: DesktopApiService['handler'];
 }
 
 interface AdapterResult {
@@ -141,10 +151,203 @@ async function exportToMarkdown(doc: Store, std?: BlockStdScope) {
   }
 }
 
+async function preparePrintFrameForPdfExport(
+  rootElement: HTMLElement
+): Promise<{
+  cleanup: () => void;
+}> {
+  const iframeId = 'affine-export-pdf-frame';
+  const iframe = document.createElement('iframe');
+  iframe.id = iframeId;
+  iframe.style.display = 'none';
+  iframe.style.border = '0';
+  iframe.setAttribute('aria-hidden', 'true');
+  document.body.append(iframe);
+
+  const style = document.createElement('style');
+  style.dataset.affineExportPdf = 'true';
+  style.textContent = `@media print {
+    body > * {
+      display: none !important;
+    }
+    body > #${iframeId} {
+      display: block !important;
+      position: fixed !important;
+      inset: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      margin: 0 !important;
+      padding: 0 !important;
+    }
+  }`;
+  document.head.append(style);
+
+  const canvasImgObjectUrlMap = new Map<string, string>();
+  const allCanvas = rootElement.getElementsByTagName('canvas');
+
+  let cleanedUp = false;
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+
+    iframe.remove();
+    style.remove();
+
+    for (const canvas of allCanvas) {
+      delete canvas.dataset['printToPdfCanvasKey'];
+    }
+    for (const url of canvasImgObjectUrlMap.values()) {
+      URL.revokeObjectURL(url);
+    }
+  };
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      iframe.onload = async () => {
+        try {
+          if (!iframe.contentWindow) {
+            throw new Error('unable to prepare print iframe for pdf export');
+          }
+
+          iframe.contentWindow.document
+            .write(`<!DOCTYPE html><html><head><style>
+            html, body {
+              margin: 0 !important;
+              padding: 0 !important;
+              height: initial !important;
+              overflow: initial !important;
+              print-color-adjust: exact;
+              -webkit-print-color-adjust: exact;
+              background: white;
+            }
+            ::-webkit-scrollbar {
+              display: none;
+            }
+            :root {
+              --affine-note-shadow-box: none !important;
+              --affine-note-shadow-sticker: none !important;
+            }
+          </style></head><body></body></html>`);
+
+          const currentTheme =
+            document.documentElement.getAttribute('data-theme');
+          if (currentTheme) {
+            iframe.contentWindow.document.documentElement.setAttribute(
+              'data-theme',
+              currentTheme
+            );
+          }
+
+          // copy all styles to iframe
+          for (const element of document.styleSheets) {
+            try {
+              for (const cssRule of element.cssRules) {
+                const target = iframe.contentWindow.document.styleSheets[0];
+                target.insertRule(cssRule.cssText, target.cssRules.length);
+              }
+            } catch (e) {
+              if (element.href) {
+                console.warn(
+                  '[export pdf] css cannot be applied when exporting pdf, this may be because of CORS policy from its domain.',
+                  element.href
+                );
+              } else {
+                throw e;
+              }
+            }
+          }
+
+          // convert all canvas to image
+          let canvasKey = 1;
+          for (const canvas of allCanvas) {
+            canvas.dataset['printToPdfCanvasKey'] = canvasKey.toString();
+            canvasKey++;
+            const canvasImgBlob = await new Promise<Blob | null>(resolve => {
+              try {
+                canvas.toBlob(resolve);
+              } catch {
+                resolve(null);
+              }
+            });
+            if (!canvasImgBlob) {
+              console.warn(
+                '[export pdf] canvas cannot be converted to image when exporting pdf, this may be because of CORS policy'
+              );
+              continue;
+            }
+            canvasImgObjectUrlMap.set(
+              canvas.dataset['printToPdfCanvasKey'],
+              URL.createObjectURL(canvasImgBlob)
+            );
+          }
+
+          const importedRoot = iframe.contentWindow.document.importNode(
+            rootElement,
+            true
+          ) as HTMLDivElement;
+
+          // draw saved canvas image to canvas
+          const allImportedCanvas = importedRoot.getElementsByTagName('canvas');
+          for (const importedCanvas of allImportedCanvas) {
+            const importedCanvasKey =
+              importedCanvas.dataset['printToPdfCanvasKey'];
+            if (!importedCanvasKey) continue;
+
+            const canvasImg = canvasImgObjectUrlMap.get(importedCanvasKey);
+            const ctx = importedCanvas.getContext('2d');
+            if (!canvasImg || !ctx) continue;
+
+            const image = new Image();
+            image.src = canvasImg;
+            await image.decode();
+            ctx.drawImage(image, 0, 0, ctx.canvas.width, ctx.canvas.height);
+          }
+
+          iframe.contentWindow.document.body.append(importedRoot);
+
+          // wait a bit for fonts/assets
+          await (iframe.contentWindow.document as any).fonts?.ready?.catch?.(
+            () => undefined
+          );
+          await new Promise<void>(resolve => setTimeout(resolve, 300));
+
+          resolve();
+        } catch (e) {
+          reject(e);
+        }
+      };
+      iframe.srcdoc = '<!DOCTYPE html>';
+    });
+  } catch (e) {
+    cleanup();
+    throw e;
+  }
+
+  return { cleanup };
+}
+
+async function exportPdfUsingElectronPrintToPDF(
+  page: Store,
+  editorContainer: AffineEditorContainer,
+  desktopApiHandler: DesktopApiService['handler']
+): Promise<ExportResult> {
+  const { cleanup } = await preparePrintFrameForPdfExport(editorContainer);
+  try {
+    const result = await desktopApiHandler.ui.exportToPdf({
+      title: page.meta?.title,
+    });
+    return result?.canceled ? 'canceled' : 'completed';
+  } finally {
+    cleanup();
+  }
+}
+
 async function exportHandler({
   page,
   type,
   editorContainer,
+  enablePdfmakeExport,
+  desktopApiHandler,
 }: ExportHandlerOptions) {
   const editorRoot = document.querySelector('editor-host');
   track.$.sharePanel.$.export({
@@ -153,33 +356,48 @@ async function exportHandler({
   switch (type) {
     case 'html':
       await exportToHtml(page, editorRoot?.std);
-      return;
+      return 'completed';
     case 'markdown':
       await exportToMarkdown(page, editorRoot?.std);
-      return;
+      return 'completed';
     case 'snapshot':
       await ZipTransformer.exportDocs(
         page.workspace,
         getAFFiNEWorkspaceSchema(),
         [page]
       );
-      return;
+      return 'completed';
     case 'pdf':
       await printToPdf(editorContainer);
-      return;
+      return 'completed';
     case 'png': {
       await editorRoot?.std.get(ExportManager).exportPng();
-      return;
+      return 'completed';
     }
     case 'pdf-export': {
-      await PdfTransformer.exportDoc(page);
-      return;
+      if (enablePdfmakeExport) {
+        await PdfTransformer.exportDoc(page);
+        return 'completed';
+      }
+
+      if (BUILD_CONFIG.isElectron && desktopApiHandler) {
+        return await exportPdfUsingElectronPrintToPDF(
+          page,
+          editorContainer,
+          desktopApiHandler
+        );
+      }
+
+      await printToPdf(editorContainer);
+      return 'completed';
     }
   }
 }
 
 export const useExportPage = () => {
   const editor = useService(EditorService).editor;
+  const featureFlags = useService(FeatureFlagService).flags;
+  const desktopApi = useServiceOptional(DesktopApiService);
   const editorContainer = useLiveData(editor.editorContainer$);
   const blocksuiteDoc = editor.doc.blockSuiteDoc;
   const pushGlobalLoadingEvent = useSetAtom(pushGlobalLoadingEventAtom);
@@ -199,15 +417,21 @@ export const useExportPage = () => {
         key: globalLoadingID,
       });
       try {
-        await exportHandler({
+        const result = await exportHandler({
           page: blocksuiteDoc,
           type,
           editorContainer: originEditorContainer,
+          enablePdfmakeExport: Boolean(
+            featureFlags.enable_pdfmake_export.value
+          ),
+          desktopApiHandler: desktopApi?.handler,
         });
-        notify.success({
-          title: t['com.affine.export.success.title'](),
-          message: t['com.affine.export.success.message'](),
-        });
+        if (result === 'completed') {
+          notify.success({
+            title: t['com.affine.export.success.title'](),
+            message: t['com.affine.export.success.message'](),
+          });
+        }
       } catch (err) {
         console.error(err);
         notify.error({
@@ -221,6 +445,8 @@ export const useExportPage = () => {
     [
       blocksuiteDoc,
       editorContainer,
+      featureFlags,
+      desktopApi,
       pushGlobalLoadingEvent,
       resolveGlobalLoadingEvent,
       t,

--- a/packages/frontend/core/src/components/hooks/affine/use-export-page.ts
+++ b/packages/frontend/core/src/components/hooks/affine/use-export-page.ts
@@ -332,7 +332,13 @@ async function exportPdfUsingElectronPrintToPDF(
     const result = await desktopApiHandler.ui.exportToPdf({
       title: page.meta?.title,
     });
-    return result?.canceled ? 'canceled' : 'completed';
+    if (!result) {
+      throw new Error('export-to-pdf-failed');
+    }
+    if (result.error) {
+      throw new Error(result.error);
+    }
+    return result.canceled ? 'canceled' : 'completed';
   } finally {
     cleanup();
   }

--- a/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
+++ b/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
@@ -75,9 +75,7 @@ export const ExportMenuItems = ({
 }: ExportProps) => {
   const t = useI18n();
   const featureFlags = useService(FeatureFlagService).flags;
-  const enable_pdfmake_export = useLiveData(
-    featureFlags.enable_pdfmake_export.$
-  );
+  const enablePdfmakeExport = useLiveData(featureFlags.enable_pdfmake_export.$);
 
   return (
     <>
@@ -104,15 +102,16 @@ export const ExportMenuItems = ({
         icon={<ExportToMarkdownIcon />}
         label={t['Export to Markdown']()}
       />
-      {pageMode !== 'edgeless' && enable_pdfmake_export && (
-        <ExportMenuItem
-          onSelect={() => exportHandler('pdf-export')}
-          className={className}
-          type="pdf-export"
-          icon={<PrinterIcon />}
-          label={t['Export to PDF']()}
-        />
-      )}
+      {pageMode !== 'edgeless' &&
+        (BUILD_CONFIG.isElectron || enablePdfmakeExport) && (
+          <ExportMenuItem
+            onSelect={() => exportHandler('pdf-export')}
+            className={className}
+            type="pdf-export"
+            icon={<PrinterIcon />}
+            label={t['Export to PDF']()}
+          />
+        )}
       <ExportMenuItem
         onSelect={() => exportHandler('snapshot')}
         className={className}

--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -291,7 +291,7 @@ export const AFFINE_FLAGS = {
   enable_pdfmake_export: {
     category: 'blocksuite',
     bsFlag: 'enable_pdfmake_export',
-    displayName: 'Enable PDF Export',
+    displayName: 'Enable PDF Export (Experimental)',
     description:
       'Experimental export PDFs support, it may contain the wrong style.',
     configurable: true,

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -236,6 +236,10 @@ export function useAFFiNEI18N(): {
       */
     ["Export to PNG"](): string;
     /**
+      * `Export to PDF`
+      */
+    ["Export to PDF"](): string;
+    /**
       * `File already exists`
       */
     FILE_ALREADY_EXISTS(): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -49,6 +49,7 @@
   "Export to HTML": "Export to HTML",
   "Export to Markdown": "Export to Markdown",
   "Export to PNG": "Export to PNG",
+  "Export to PDF": "Export to PDF",
   "FILE_ALREADY_EXISTS": "File already exists",
   "Favorite": "Favourite",
   "Favorited": "Favourited",

--- a/packages/frontend/i18n/src/resources/zh-Hans.json
+++ b/packages/frontend/i18n/src/resources/zh-Hans.json
@@ -49,6 +49,7 @@
   "Export to HTML": "导出为 HTML",
   "Export to Markdown": "导出为 Markdown",
   "Export to PNG": "导出为 PNG",
+  "Export to PDF": "导出为 PDF",
   "FILE_ALREADY_EXISTS": "文件已存在",
   "Favorite": "收藏",
   "Favorited": "已收藏",

--- a/packages/frontend/i18n/src/resources/zh-Hant.json
+++ b/packages/frontend/i18n/src/resources/zh-Hant.json
@@ -48,6 +48,7 @@
   "Export to HTML": "匯出為 HTML",
   "Export to Markdown": "匯出為 Markdown",
   "Export to PNG": "匯出為 PNG",
+  "Export to PDF": "匯出為 PDF",
   "FILE_ALREADY_EXISTS": "檔已存在",
   "Favorite": "收藏",
   "Favorited": "已收藏",


### PR DESCRIPTION
## What & Why
  pdfmake-exported PDFs currently have significant styling issues, so this PR does **not** enable pdfmake as the default PDF exporter.

  Instead, it adds a Desktop (Electron) "Export to PDF" option powered by Chromium's `webContents.printToPDF`, which produces output much closer to what users see in the editor.

  ## Changes
  - Keep the existing pdfmake exporter behind `enable_pdfmake_export` (renamed to “Enable PDF Export (Experimental)”).
  - Add `ui.exportToPdf` IPC handler in the Electron main process:
    - Prompts for a save location
    - Calls `printToPDF({ printBackground: true, preferCSSPageSize: true })`
    - Writes the PDF to disk
  - Renderer prepares a print-only iframe (copies styles + snapshots canvases) so the PDF contains the document content only.
  - "Export to PDF" is shown by default on Desktop; on Web it remains gated by the pdfmake feature flag (users can still use browser Print → Save as PDF).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental PDF export for desktop (Electron) with a Save dialog and improved export flow.
  * PDF export menu item now appears in Electron builds or when the PDF feature is enabled.
  * Feature flag label updated to "Enable PDF Export (Experimental)".

* **Internationalization**
  * Added "Export to PDF" translations for English, Simplified Chinese, and Traditional Chinese.

* **Bug Fixes**
  * Notifications now show success only when export completes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->