### PR TITLE
feat: support markdown preview

### DIFF
--- a/packages/backend/server/src/core/doc-renderer/__tests__/controller.spec.ts
+++ b/packages/backend/server/src/core/doc-renderer/__tests__/controller.spec.ts
@@ -138,7 +138,7 @@ test('should return markdown content and skip page view when content-type is tex
 
   const res = await app
     .GET(`/workspace/${workspace.id}/${docId}`)
-    .set('content-type', 'text/markdown')
+    .set('accept', 'text/markdown')
     .expect(200);
 
   t.true(markdown.calledOnceWithExactly(workspace.id, docId, false));

--- a/packages/backend/server/src/core/doc-renderer/__tests__/controller.spec.ts
+++ b/packages/backend/server/src/core/doc-renderer/__tests__/controller.spec.ts
@@ -109,3 +109,45 @@ test('should record page view when rendering shared page', async t => {
   docContent.restore();
   record.restore();
 });
+
+test('should return markdown content and skip page view when content-type is text/markdown', async t => {
+  const docId = randomUUID();
+  const { app, adapter, models, docReader } = t.context;
+
+  const doc = new YDoc();
+  const text = doc.getText('content');
+  const updates: Buffer[] = [];
+
+  doc.on('update', update => {
+    updates.push(Buffer.from(update));
+  });
+
+  text.insert(0, 'markdown');
+  await adapter.pushDocUpdates(workspace.id, docId, updates, user.id);
+  await models.doc.publish(workspace.id, docId);
+
+  const markdown = Sinon.stub(docReader, 'getDocMarkdown').resolves({
+    title: 'markdown-doc',
+    markdown: '# markdown-doc',
+  });
+  const docContent = Sinon.stub(docReader, 'getDocContent');
+  const record = Sinon.stub(
+    models.workspaceAnalytics,
+    'recordDocView'
+  ).resolves();
+
+  const res = await app
+    .GET(`/workspace/${workspace.id}/${docId}`)
+    .set('content-type', 'text/markdown')
+    .expect(200);
+
+  t.true(markdown.calledOnceWithExactly(workspace.id, docId, false));
+  t.is(res.text, '# markdown-doc');
+  t.true((res.headers['content-type'] as string).startsWith('text/markdown'));
+  t.true(docContent.notCalled);
+  t.true(record.notCalled);
+
+  markdown.restore();
+  docContent.restore();
+  record.restore();
+});

--- a/packages/backend/server/src/core/doc-renderer/__tests__/controller.spec.ts
+++ b/packages/backend/server/src/core/doc-renderer/__tests__/controller.spec.ts
@@ -110,7 +110,7 @@ test('should record page view when rendering shared page', async t => {
   record.restore();
 });
 
-test('should return markdown content and skip page view when content-type is text/markdown', async t => {
+test('should return markdown content and skip page view when accept is text/markdown', async t => {
   const docId = randomUUID();
   const { app, adapter, models, docReader } = t.context;
 

--- a/packages/backend/server/src/core/doc-renderer/controller.ts
+++ b/packages/backend/server/src/core/doc-renderer/controller.ts
@@ -102,27 +102,23 @@ export class DocRendererController {
 
     let opts: RenderOptions | null = null;
     // /workspace/:workspaceId/{:docId | staticPaths}
-    const [, , workspaceId, subPath, ...restPaths] = req.path.split('/');
-    const isWorkspacePath =
-      workspaceId && !staticPaths.has(subPath) && restPaths.length === 0;
-    const isWorkspaceDocPath = isWorkspacePath && workspaceId !== subPath;
+    const [, , workspaceId, sub, ...rest] = req.path.split('/');
+    const isWorkspace =
+      workspaceId && sub && !staticPaths.has(sub) && rest.length === 0;
+    const isWorkspaceDocPath = isWorkspace && workspaceId !== sub;
 
     if (
       isWorkspaceDocPath &&
       req.accepts().some(t => markdownType.includes(t.toLowerCase()))
     ) {
       try {
-        const allowPreview = await this.allowDocPreview(workspaceId, subPath);
+        const allowPreview = await this.allowDocPreview(workspaceId, sub);
         if (!allowPreview) {
           res.status(404).end();
           return;
         }
 
-        const markdown = await this.doc.getDocMarkdown(
-          workspaceId,
-          subPath,
-          false
-        );
+        const markdown = await this.doc.getDocMarkdown(workspaceId, sub, false);
         if (markdown) {
           res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
           res.send(markdown.markdown);
@@ -137,24 +133,24 @@ export class DocRendererController {
     }
 
     // /:workspaceId/:docId
-    if (isWorkspacePath) {
+    if (isWorkspace) {
       try {
         opts = isWorkspaceDocPath
           ? await this.getWorkspaceContent(workspaceId)
-          : await this.getPageContent(workspaceId, subPath);
+          : await this.getPageContent(workspaceId, sub);
         metrics.doc.counter('render').add(1);
 
         if (opts && isWorkspaceDocPath) {
           void this.models.workspaceAnalytics
             .recordDocView({
               workspaceId,
-              docId: subPath,
-              visitorId: this.buildVisitorId(req, workspaceId, subPath),
+              docId: sub,
+              visitorId: this.buildVisitorId(req, workspaceId, sub),
               isGuest: true,
             })
             .catch(error => {
               this.logger.warn(
-                `Failed to record shared page view: ${workspaceId}/${subPath}`,
+                `Failed to record shared page view: ${workspaceId}/${sub}`,
                 error as Error
               );
             });

--- a/packages/backend/server/src/core/doc-renderer/controller.ts
+++ b/packages/backend/server/src/core/doc-renderer/controller.ts
@@ -44,6 +44,12 @@ const staticPaths = new Set([
   'trash',
 ]);
 
+const markdownType = [
+  'text/markdown',
+  'application/markdown',
+  'text/x-markdown',
+];
+
 @Controller('/workspace')
 export class DocRendererController {
   private readonly logger = new Logger(DocRendererController.name);
@@ -66,24 +72,6 @@ export class DocRendererController {
     return createHash('sha256')
       .update(`${workspaceId}:${docId}:${tracker}`)
       .digest('hex');
-  }
-
-  private isMarkdownContentRequest(req: Request) {
-    const headerContentType = req.header('content-type');
-    if (!headerContentType) {
-      return false;
-    }
-
-    const mimeType = headerContentType.split(';', 1)[0]?.trim().toLowerCase();
-    if (!mimeType) {
-      return false;
-    }
-
-    return (
-      mimeType === 'text/markdown' ||
-      mimeType === 'application/markdown' ||
-      mimeType === 'text/x-markdown'
-    );
   }
 
   private async allowDocPreview(workspaceId: string, docId: string) {
@@ -119,7 +107,10 @@ export class DocRendererController {
       workspaceId && !staticPaths.has(subPath) && restPaths.length === 0;
     const isWorkspaceDocPath = isWorkspacePath && workspaceId !== subPath;
 
-    if (isWorkspaceDocPath && this.isMarkdownContentRequest(req)) {
+    if (
+      isWorkspaceDocPath &&
+      req.accepts().some(t => markdownType.includes(t.toLowerCase()))
+    ) {
       try {
         const allowPreview = await this.allowDocPreview(workspaceId, subPath);
         if (!allowPreview) {

--- a/packages/backend/server/src/core/doc-renderer/controller.ts
+++ b/packages/backend/server/src/core/doc-renderer/controller.ts
@@ -105,10 +105,10 @@ export class DocRendererController {
     const [, , workspaceId, sub, ...rest] = req.path.split('/');
     const isWorkspace =
       workspaceId && sub && !staticPaths.has(sub) && rest.length === 0;
-    const isWorkspaceDocPath = isWorkspace && workspaceId !== sub;
+    const isDocPath = isWorkspace && workspaceId !== sub;
 
     if (
-      isWorkspaceDocPath &&
+      isDocPath &&
       req.accepts().some(t => markdownType.includes(t.toLowerCase()))
     ) {
       try {
@@ -135,12 +135,12 @@ export class DocRendererController {
     // /:workspaceId/:docId
     if (isWorkspace) {
       try {
-        opts = isWorkspaceDocPath
-          ? await this.getWorkspaceContent(workspaceId)
-          : await this.getPageContent(workspaceId, sub);
+        opts = isDocPath
+          ? await this.getPageContent(workspaceId, sub)
+          : await this.getWorkspaceContent(workspaceId);
         metrics.doc.counter('render').add(1);
 
-        if (opts && isWorkspaceDocPath) {
+        if (opts && isDocPath) {
           void this.models.workspaceAnalytics
             .recordDocView({
               workspaceId,

--- a/packages/backend/server/src/core/doc-renderer/controller.ts
+++ b/packages/backend/server/src/core/doc-renderer/controller.ts
@@ -68,6 +68,39 @@ export class DocRendererController {
       .digest('hex');
   }
 
+  private isMarkdownContentRequest(req: Request) {
+    const headerContentType = req.header('content-type');
+    if (!headerContentType) {
+      return false;
+    }
+
+    const mimeType = headerContentType.split(';', 1)[0]?.trim().toLowerCase();
+    if (!mimeType) {
+      return false;
+    }
+
+    return (
+      mimeType === 'text/markdown' ||
+      mimeType === 'application/markdown' ||
+      mimeType === 'text/x-markdown'
+    );
+  }
+
+  private async allowDocPreview(workspaceId: string, docId: string) {
+    const allowSharing = await this.models.workspace.allowSharing(workspaceId);
+    if (!allowSharing) return false;
+
+    let allowUrlPreview = await this.models.doc.isPublic(workspaceId, docId);
+
+    if (!allowUrlPreview) {
+      // if page is private, but workspace url preview is on
+      allowUrlPreview =
+        await this.models.workspace.allowUrlPreview(workspaceId);
+    }
+
+    return allowUrlPreview;
+  }
+
   @Public()
   @Get('/*path')
   async render(@Req() req: Request, @Res() res: Response) {
@@ -82,17 +115,45 @@ export class DocRendererController {
     let opts: RenderOptions | null = null;
     // /workspace/:workspaceId/{:docId | staticPaths}
     const [, , workspaceId, subPath, ...restPaths] = req.path.split('/');
+    const isWorkspacePath =
+      workspaceId && !staticPaths.has(subPath) && restPaths.length === 0;
+    const isWorkspaceDocPath = isWorkspacePath && workspaceId !== subPath;
+
+    if (isWorkspaceDocPath && this.isMarkdownContentRequest(req)) {
+      try {
+        const allowPreview = await this.allowDocPreview(workspaceId, subPath);
+        if (!allowPreview) {
+          res.status(404).end();
+          return;
+        }
+
+        const markdown = await this.doc.getDocMarkdown(
+          workspaceId,
+          subPath,
+          false
+        );
+        if (markdown) {
+          res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+          res.send(markdown.markdown);
+          return;
+        }
+      } catch (e) {
+        this.logger.error('failed to render markdown page', e);
+      }
+
+      res.status(404).end();
+      return;
+    }
 
     // /:workspaceId/:docId
-    if (workspaceId && !staticPaths.has(subPath) && restPaths.length === 0) {
+    if (isWorkspacePath) {
       try {
-        opts =
-          workspaceId === subPath
-            ? await this.getWorkspaceContent(workspaceId)
-            : await this.getPageContent(workspaceId, subPath);
+        opts = isWorkspaceDocPath
+          ? await this.getWorkspaceContent(workspaceId)
+          : await this.getPageContent(workspaceId, subPath);
         metrics.doc.counter('render').add(1);
 
-        if (opts && workspaceId !== subPath) {
+        if (opts && isWorkspaceDocPath) {
           void this.models.workspaceAnalytics
             .recordDocView({
               workspaceId,
@@ -124,20 +185,7 @@ export class DocRendererController {
     workspaceId: string,
     docId: string
   ): Promise<RenderOptions | null> {
-    const allowSharing = await this.models.workspace.allowSharing(workspaceId);
-    if (!allowSharing) {
-      return null;
-    }
-
-    let allowUrlPreview = await this.models.doc.isPublic(workspaceId, docId);
-
-    if (!allowUrlPreview) {
-      // if page is private, but workspace url preview is on
-      allowUrlPreview =
-        await this.models.workspace.allowUrlPreview(workspaceId);
-    }
-
-    if (allowUrlPreview) {
+    if (await this.allowDocPreview(workspaceId, docId)) {
       return this.doc.getDocContent(workspaceId, docId);
     }
 


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #14447** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents can be served as markdown when requested via the Accept header.
  * Workspace document previews now use consolidated preview/sharing permission checks and return 404 when not allowed.
  * Successful workspace doc renders are recorded for analytics; markdown responses skip recording a page view.

* **Tests**
  * Added test coverage for markdown responses, ensuring markdown is served and that page views are not recorded for markdown requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->