### PR TITLE
fix: docTitle unexpectedly translated

### DIFF
--- a/packages/frontend/core/src/desktop/components/navigation-panel/nodes/doc/index.tsx
+++ b/packages/frontend/core/src/desktop/components/navigation-panel/nodes/doc/index.tsx
@@ -271,7 +271,7 @@ export const NavigationPanelDocNode = ({
   return (
     <NavigationPanelTreeNode
       icon={Icon}
-      name={t.t(docTitle)}
+      name={docTitle}
       dndData={dndData}
       onDrop={handleDropOnDoc}
       renameable

--- a/packages/frontend/core/src/mobile/components/navigation/nodes/doc/index.tsx
+++ b/packages/frontend/core/src/mobile/components/navigation/nodes/doc/index.tsx
@@ -152,7 +152,7 @@ export const NavigationPanelDocNode = ({
   return (
     <NavigationPanelTreeNode
       icon={Icon}
-      name={t.t(docTitle)}
+      name={docTitle}
       extractEmojiAsIcon={enableEmojiIcon}
       collapsed={collapsed}
       setCollapsed={setCollapsed}


### PR DESCRIPTION
fix #14465

In Chinese mode, the document with the specified name may not be displayed correctly in the sidebar, and it may be mistaken for the translation of the content that needs to be translated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document title display in navigation panels on desktop and mobile to properly render without additional processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->