### PR TITLE
fix: adjust index loading timing

### DIFF
--- a/packages/common/nbstore/src/impls/cloud/indexer.ts
+++ b/packages/common/nbstore/src/impls/cloud/indexer.ts
@@ -147,4 +147,8 @@ export class CloudIndexerStorage extends IndexerStorageBase {
   override async indexVersion(): Promise<number> {
     return 1;
   }
+
+  override async loadIndexSnapshots(): Promise<void> {
+    return;
+  }
 }

--- a/packages/common/nbstore/src/impls/idb/indexer/index.ts
+++ b/packages/common/nbstore/src/impls/idb/indexer/index.ts
@@ -224,4 +224,9 @@ export class IndexedDBIndexerStorage extends IndexerStorageBase {
   async indexVersion(): Promise<number> {
     return 1;
   }
+
+  override async loadIndexSnapshots(): Promise<void> {
+    // TODO: implement index snapshots loading for IndexedDB
+    return;
+  }
 }

--- a/packages/common/nbstore/src/impls/sqlite/db.ts
+++ b/packages/common/nbstore/src/impls/sqlite/db.ts
@@ -125,6 +125,7 @@ export interface NativeDBApis {
   ) => Promise<{ start: number; end: number }[]>;
   ftsFlushIndex: (id: string) => Promise<void>;
   ftsIndexVersion: () => Promise<number>;
+  ftsLoadIndexSnapshots: (id: string) => Promise<void>;
 }
 
 type NativeDBApisWrapper = NativeDBApis extends infer APIs

--- a/packages/common/nbstore/src/impls/sqlite/indexer/index.ts
+++ b/packages/common/nbstore/src/impls/sqlite/indexer/index.ts
@@ -246,4 +246,8 @@ export class SqliteIndexerStorage extends IndexerStorageBase {
   async indexVersion(): Promise<number> {
     return this.connection.apis.ftsIndexVersion();
   }
+
+  async loadIndexSnapshots(): Promise<void> {
+    await this.connection.apis.ftsLoadIndexSnapshots();
+  }
 }

--- a/packages/common/nbstore/src/storage/dummy/indexer.ts
+++ b/packages/common/nbstore/src/storage/dummy/indexer.ts
@@ -91,4 +91,8 @@ export class DummyIndexerStorage extends IndexerStorageBase {
   override async indexVersion(): Promise<number> {
     return 0;
   }
+
+  override async loadIndexSnapshots(): Promise<void> {
+    return;
+  }
 }

--- a/packages/common/nbstore/src/storage/indexer.ts
+++ b/packages/common/nbstore/src/storage/indexer.ts
@@ -65,6 +65,7 @@ export interface IndexerStorage extends Storage {
   refresh<T extends keyof IndexerSchema>(table: T): Promise<void>;
   refreshIfNeed(): Promise<void>;
   indexVersion(): Promise<number>;
+  loadIndexSnapshots(): Promise<void>;
 }
 
 type ResultPagination = {
@@ -181,4 +182,6 @@ export abstract class IndexerStorageBase implements IndexerStorage {
   abstract refreshIfNeed(): Promise<void>;
 
   abstract indexVersion(): Promise<number>;
+
+  abstract loadIndexSnapshots(): Promise<void>;
 }

--- a/packages/common/nbstore/src/sync/indexer/index.ts
+++ b/packages/common/nbstore/src/sync/indexer/index.ts
@@ -207,6 +207,8 @@ export class IndexerSyncImpl implements IndexerSync {
       return;
     }
 
+    await this.indexer.loadIndexSnapshots();
+
     while (true) {
       try {
         await this.retryLoop(signal);
@@ -476,7 +478,7 @@ export class IndexerSyncImpl implements IndexerSync {
         this.status.completeJob();
       }
     } finally {
-      await this.refreshIfNeed();
+      await this.indexer.refreshIfNeed();
       unsubscribe();
     }
   }

--- a/packages/common/nbstore/src/sync/indexer/index.ts
+++ b/packages/common/nbstore/src/sync/indexer/index.ts
@@ -207,8 +207,6 @@ export class IndexerSyncImpl implements IndexerSync {
       return;
     }
 
-    await this.indexer.loadIndexSnapshots();
-
     while (true) {
       try {
         await this.retryLoop(signal);
@@ -263,6 +261,8 @@ export class IndexerSyncImpl implements IndexerSync {
 
     this.status.errorMessage = null;
     this.status.statusUpdatedSubject$.next(true);
+
+    await this.indexer.loadIndexSnapshots();
 
     const indexVersion = await this.indexer.indexVersion();
     console.log('indexer sync start, version: ', indexVersion);

--- a/packages/frontend/apps/electron/src/helper/nbstore/handlers.ts
+++ b/packages/frontend/apps/electron/src/helper/nbstore/handlers.ts
@@ -58,4 +58,5 @@ export const nbstoreHandlers: NativeDBApis = {
   ftsGetMatches: POOL.ftsGetMatches.bind(POOL),
   ftsFlushIndex: POOL.ftsFlushIndex.bind(POOL),
   ftsIndexVersion: POOL.ftsIndexVersion.bind(POOL),
+  ftsLoadIndexSnapshots: POOL.ftsLoadIndexSnapshots.bind(POOL),
 };

--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page-header.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page-header.tsx
@@ -97,8 +97,7 @@ export function JournalPageHeader({ page, workspace }: PageHeaderProps) {
     useDetailPageHeaderResponsive(containerWidth);
 
   const docDisplayMetaService = useService(DocDisplayMetaService);
-  const i18n = useI18n();
-  const title = i18n.t(useLiveData(docDisplayMetaService.title$(page.id)));
+  const title = useLiveData(docDisplayMetaService.title$(page.id));
 
   return (
     <Header className={styles.header} ref={containerRef}>
@@ -147,8 +146,7 @@ export function NormalPageHeader({ page, workspace }: PageHeaderProps) {
   }, []);
 
   const docDisplayMetaService = useService(DocDisplayMetaService);
-  const i18n = useI18n();
-  const title = i18n.t(useLiveData(docDisplayMetaService.title$(page.id)));
+  const title = useLiveData(docDisplayMetaService.title$(page.id));
 
   const editor = useService(EditorService).editor;
   const currentMode = useLiveData(editor.mode$);

--- a/packages/frontend/native/index.d.ts
+++ b/packages/frontend/native/index.d.ts
@@ -86,6 +86,7 @@ export declare class DocStoragePool {
   setBlobUploadedAt(universalId: string, peer: string, blobId: string, uploadedAt?: Date | undefined | null): Promise<void>
   getBlobUploadedAt(universalId: string, peer: string, blobId: string): Promise<Date | null>
   ftsAddDocument(id: string, indexName: string, docId: string, text: string, index: boolean): Promise<void>
+  ftsLoadIndexSnapshots(id: string): Promise<void>
   ftsFlushIndex(id: string): Promise<void>
   ftsIndexVersion(): Promise<number>
   ftsDeleteDocument(id: string, indexName: string, docId: string): Promise<void>

--- a/packages/frontend/native/nbstore/src/lib.rs
+++ b/packages/frontend/native/nbstore/src/lib.rs
@@ -418,6 +418,13 @@ impl DocStoragePool {
   }
 
   #[napi]
+  pub async fn fts_load_index_snapshots(&self, id: String) -> Result<()> {
+    let storage = self.pool.get(id).await?;
+    storage.init_index().await?;
+    Ok(())
+  }
+
+  #[napi]
   pub async fn fts_flush_index(&self, id: String) -> Result<()> {
     let storage = self.pool.get(id).await?;
     storage.flush_index().await?;

--- a/packages/frontend/native/nbstore/src/storage.rs
+++ b/packages/frontend/native/nbstore/src/storage.rs
@@ -63,6 +63,11 @@ impl SqliteDocStorage {
   }
 
   pub async fn connect(&self) -> Result<()> {
+    // if database is running and there are unpersisted changes in the memory, flush them to the database before reconnecting.
+    if !self.is_closed() && self.index.read().await.has_unpersisted_changes(None) {
+      self.flush_index().await?;
+    }
+
     if !Sqlite::database_exists(&self.path).await? {
       Sqlite::create_database(&self.path).await?;
     };

--- a/packages/frontend/native/nbstore/src/storage.rs
+++ b/packages/frontend/native/nbstore/src/storage.rs
@@ -63,18 +63,11 @@ impl SqliteDocStorage {
   }
 
   pub async fn connect(&self) -> Result<()> {
-    // if database is running and there are unpersisted changes in the memory, flush
-    // them to the database before reconnecting.
-    if !self.is_closed() && self.index.read().await.has_unpersisted_changes(None) {
-      self.flush_index().await?;
-    }
-
     if !Sqlite::database_exists(&self.path).await? {
       Sqlite::create_database(&self.path).await?;
     };
 
     self.migrate().await?;
-    self.init_index().await?;
 
     Ok(())
   }

--- a/packages/frontend/native/nbstore/src/storage.rs
+++ b/packages/frontend/native/nbstore/src/storage.rs
@@ -63,7 +63,8 @@ impl SqliteDocStorage {
   }
 
   pub async fn connect(&self) -> Result<()> {
-    // if database is running and there are unpersisted changes in the memory, flush them to the database before reconnecting.
+    // if database is running and there are unpersisted changes in the memory, flush
+    // them to the database before reconnecting.
     if !self.is_closed() && self.index.read().await.has_unpersisted_changes(None) {
       self.flush_index().await?;
     }


### PR DESCRIPTION
fix #14467
fix #14191

In Electron apps, the default timer for flushing the FTS index (`fts_flush_index`) is 30 seconds. This can lead to a scenario where:

1. A user modifies a document, triggering an indexer update.
2. The updated indexes remain in memory because the flush timer hasn't expired.
3. The user opens settings, causing a database reconnection.
4. The in-memory indexes are lost due to idx_snapshot being reloaded.

This fix calls `fts_flush_index` before reconnecting the database when it is running, ensuring any pending index updates are flushed to disk and preventing data loss.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for loading index snapshots before the indexing/sync loop and a native API to trigger FTS index snapshot loading.
  * Indexer can now delegate refresh responsibilities to storage implementations.

* **Bug Fixes**
  * Removed redundant in-memory index initialization during connection startup.

* **Refactor**
  * Workspace header titles now display live data directly (removed prior translation wrapping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->