### PR TITLE
fix(editor): disable OS-level autocorrect causing aggressive "im" replacement (#14477)

### DIFF
--- a/blocksuite/affine/blocks/edgeless-text/src/edgeless-text-block.ts
+++ b/blocksuite/affine/blocks/edgeless-text/src/edgeless-text-block.ts
@@ -297,6 +297,15 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
 
     this.contentEditable = String(editing && !this.store.readonly$.value);
 
+    // Disable macOS text replacement to prevent aggressive autocorrect
+    if (editing && !this.store.readonly$.value) {
+      this.setAttribute('autocorrect', 'off');
+      this.setAttribute('autocapitalize', 'off');
+    } else {
+      this.removeAttribute('autocorrect');
+      this.removeAttribute('autocapitalize');
+    }
+
     return html`
       <div
         class="edgeless-text-block-container"

--- a/blocksuite/affine/blocks/root/src/page/page-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/page/page-root-block.ts
@@ -415,6 +415,15 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
 
     this.contentEditable = String(!this.store.readonly$.value);
 
+    // Disable macOS text replacement to prevent aggressive autocorrect
+    if (!this.store.readonly$.value) {
+      this.setAttribute('autocorrect', 'off');
+      this.setAttribute('autocapitalize', 'off');
+    } else {
+      this.removeAttribute('autocorrect');
+      this.removeAttribute('autocapitalize');
+    }
+
     return html`
       <div class="affine-page-root-block-container">${children} ${widgets}</div>
     `;

--- a/blocksuite/affine/rich-text/src/rich-text.ts
+++ b/blocksuite/affine/rich-text/src/rich-text.ts
@@ -401,6 +401,8 @@ export class RichText extends WithDisposable(ShadowlessElement) {
 
     return html`<div
       contenteditable=${this.readonly ? 'false' : 'true'}
+      autocorrect="off"
+      autocapitalize="off"
       class=${classes}
     ></div>`;
   }

--- a/blocksuite/playground/examples/inline/test-page.ts
+++ b/blocksuite/playground/examples/inline/test-page.ts
@@ -128,6 +128,11 @@ export class TestRichText extends ShadowlessElement {
   override firstUpdated() {
     this.contentEditable = 'true';
     this.style.outline = 'none';
+
+    // Disable macOS text replacement to prevent aggressive autocorrect
+    this.setAttribute('autocorrect', 'off');
+    this.setAttribute('autocapitalize', 'off');
+
     this.inlineEditor.mount(this._container, this);
 
     this.inlineEditor.slots.textChange.subscribe(() => {

--- a/packages/frontend/core/src/blocksuite/ai/blocks/ai-chat-block/ai-transcription-block.ts
+++ b/packages/frontend/core/src/blocksuite/ai/blocks/ai-chat-block/ai-transcription-block.ts
@@ -31,6 +31,10 @@ export class LitTranscriptionBlock extends BlockComponent<TranscriptionBlockMode
 
     // to allow text selection across paragraphs in the callout block
     this.contentEditable = 'true';
+
+    // Disable macOS text replacement to prevent aggressive autocorrect
+    this.setAttribute('autocorrect', 'off');
+    this.setAttribute('autocapitalize', 'off');
   }
 
   override firstUpdated(changedProperties: PropertyValues) {


### PR DESCRIPTION
Closes #14477

## Summary

Fixes an issue where typing words starting with "im" (e.g., "implicit", "image", "important") would automatically be replaced with "I'm".

## Root Cause

On macOS, `contenteditable` elements without:

- autocorrect="off"
- autocapitalize="off"

allow OS-level text replacement.

macOS includes a built-in rule:
im → I'm

This incorrectly triggers even when "im" is part of a longer word.

## Solution

Added:

- autocorrect="off"
- autocapitalize="off"

to relevant contenteditable elements to prevent OS-level interference.

## Result

- Normal words are no longer modified
- Markdown shortcuts continue working
- No regression observed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled macOS autocorrect and automatic text replacement across multiple text editing components.
  * Affects rich text editors, edgeless text blocks, page blocks, and transcription features to prevent unwanted automatic modifications.
  * Improves editing experience by maintaining user control over text input without OS-level interference during content creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->