### PR TITLE
feat: add AFFiNE MCP server with full read/write support

### DIFF
--- a/affine-mcp-server/.env.example
+++ b/affine-mcp-server/.env.example
@@ -1,0 +1,11 @@
+# AFFiNE MCP Server - Environment Variables
+# Copy to .env and fill in your values
+
+# Required
+AFFINE_BASE_URL=https://affine.example.com
+AFFINE_EMAIL=your-email@example.com
+AFFINE_PASSWORD=your-password
+AFFINE_WORKSPACE_ID=your-workspace-uuid
+
+# Optional
+# AFFINE_CLIENT_VERSION=0.26.2

--- a/affine-mcp-server/.gitignore
+++ b/affine-mcp-server/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env
+*.tsbuildinfo

--- a/affine-mcp-server/README.md
+++ b/affine-mcp-server/README.md
@@ -1,0 +1,150 @@
+# AFFiNE MCP Server
+
+Full read/write MCP server for self-hosted AFFiNE workspaces. Provides 15 tools covering document CRUD, collection management, comments, search, and user info.
+
+Built for AFFiNE 0.26.2 (self-hosted, allinone).
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────┐
+│  MCP Client (OpenClaw / Claude Code)        │
+│  ← stdio transport →                       │
+├─────────────────────────────────────────────┤
+│  MCP Server (15 tools)                      │
+│  ├── documents (5): list, create, read,     │
+│  │                   edit, delete            │
+│  ├── collections (4): list, create,         │
+│  │                     update, delete        │
+│  ├── comments (4): list, create,            │
+│  │                  resolve, delete          │
+│  └── utility (2): search, current_user      │
+├─────────────────────────────────────────────┤
+│  Services                                   │
+│  ├── auth.ts      REST sign-in, cookies     │
+│  ├── websocket.ts Socket.IO + Yjs CRDT      │
+│  ├── yjs-helpers.ts  Block tree ↔ markdown  │
+│  └── graphql.ts   Comments & user queries   │
+├─────────────────────────────────────────────┤
+│  AFFiNE Server (self-hosted)                │
+│  REST · WebSocket (Socket.IO) · GraphQL     │
+└─────────────────────────────────────────────┘
+```
+
+## Setup
+
+### Prerequisites
+
+- Node.js 18+
+- Self-hosted AFFiNE 0.26.2 instance
+- Email/password account on that instance
+
+### Install
+
+```bash
+cd affine-mcp-server
+npm install
+npm run build
+```
+
+### Configure
+
+Copy `.env.example` to `.env` and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Required environment variables:
+
+| Variable | Description |
+|---|---|
+| `AFFINE_BASE_URL` | AFFiNE server URL (e.g., `https://affine.example.com`) |
+| `AFFINE_EMAIL` | Login email |
+| `AFFINE_PASSWORD` | Login password |
+| `AFFINE_WORKSPACE_ID` | Target workspace UUID |
+
+Optional:
+
+| Variable | Default | Description |
+|---|---|---|
+| `AFFINE_CLIENT_VERSION` | `0.26.2` | Must match server version for WebSocket join |
+
+### OpenClaw / Claude Code Config
+
+Add to your `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "affine": {
+      "command": "node",
+      "args": ["/path/to/affine-mcp-server/dist/index.js"],
+      "env": {
+        "AFFINE_BASE_URL": "https://affine.example.com",
+        "AFFINE_EMAIL": "your-email@example.com",
+        "AFFINE_PASSWORD": "your-password",
+        "AFFINE_WORKSPACE_ID": "your-workspace-uuid"
+      }
+    }
+  }
+}
+```
+
+## Tools Reference
+
+### Documents
+
+| Tool | Description |
+|---|---|
+| `affine_list_docs` | List all documents with metadata |
+| `affine_create_doc` | Create a new document (title + optional markdown body) |
+| `affine_read_doc` | Read document content as markdown |
+| `affine_edit_doc` | Edit document blocks (append, update, delete) |
+| `affine_delete_doc` | Delete a document |
+
+### Collections
+
+| Tool | Description |
+|---|---|
+| `affine_list_collections` | List all collections |
+| `affine_create_collection` | Create a collection with doc IDs |
+| `affine_update_collection` | Rename or change docs in a collection |
+| `affine_delete_collection` | Delete a collection |
+
+### Comments
+
+| Tool | Description |
+|---|---|
+| `affine_list_comments` | List comments on a document |
+| `affine_create_comment` | Add a comment to a document |
+| `affine_resolve_comment` | Mark a comment as resolved |
+| `affine_delete_comment` | Delete a comment |
+
+### Utility
+
+| Tool | Description |
+|---|---|
+| `affine_search` | Search across all documents (with fallback) |
+| `affine_current_user` | Get current authenticated user info |
+
+## Technical Details
+
+- **Transport**: stdio (for subprocess integration with OpenClaw/Claude Code)
+- **Auth**: REST sign-in → session cookies (not Bearer tokens)
+- **Documents**: Yjs CRDT via Socket.IO WebSocket
+- **Comments/Users**: GraphQL API
+- **Write safety**: Sequential per-document write queues prevent CRDT conflicts
+- **Search**: Tries built-in MCP search first, falls back to manual doc scanning
+- **Auto-reauth**: Session cookies are refreshed automatically on 401/403
+
+## Development
+
+```bash
+npm run build    # Compile TypeScript
+npm run dev      # Watch mode (tsc --watch)
+```
+
+## License
+
+ISC

--- a/affine-mcp-server/package-lock.json
+++ b/affine-mcp-server/package-lock.json
@@ -1,0 +1,2006 @@
+{
+  "name": "affine-mcp-server",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "affine-mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.6.1",
+        "axios": "^1.7.9",
+        "nanoid": "^5.0.9",
+        "socket.io-client": "^4.8.0",
+        "yjs": "^13.6.20",
+        "zod": "^3.23.8"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
+      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lib0": {
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.6.tgz",
+      "integrity": "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
+      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.29",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
+      "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/affine-mcp-server/package.json
+++ b/affine-mcp-server/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "affine-mcp-server",
+  "version": "1.0.0",
+  "description": "MCP server providing full read/write access to a self-hosted AFFiNE workspace",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "clean": "rm -rf dist"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.6.1",
+    "socket.io-client": "^4.8.0",
+    "yjs": "^13.6.20",
+    "zod": "^3.23.8",
+    "axios": "^1.7.9",
+    "nanoid": "^5.0.9"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/affine-mcp-server/src/constants.ts
+++ b/affine-mcp-server/src/constants.ts
@@ -1,0 +1,28 @@
+/**
+ * AFFiNE MCP Server - Constants and Configuration
+ */
+
+export const AFFINE_BASE_URL = process.env.AFFINE_BASE_URL || "https://affine.agentic-lawyer.xyz";
+export const AFFINE_EMAIL = process.env.AFFINE_EMAIL || "";
+export const AFFINE_PASSWORD = process.env.AFFINE_PASSWORD || "";
+export const AFFINE_WORKSPACE_ID = process.env.AFFINE_WORKSPACE_ID || "";
+export const AFFINE_CLIENT_VERSION = process.env.AFFINE_CLIENT_VERSION || "0.26.2";
+
+/** Maximum response size in characters before truncation */
+export const CHARACTER_LIMIT = 25000;
+
+/** Socket.IO reconnection settings */
+export const WS_RECONNECT_MAX_DELAY = 30000;
+export const WS_RECONNECT_BASE_DELAY = 1000;
+
+/** API request timeout in ms */
+export const API_TIMEOUT = 30000;
+
+/** GraphQL endpoint path */
+export const GRAPHQL_PATH = "/graphql";
+
+/** Auth endpoint path */
+export const AUTH_SIGN_IN_PATH = "/api/auth/sign-in";
+
+/** Socket.IO path */
+export const SOCKET_IO_PATH = "/socket.io/";

--- a/affine-mcp-server/src/index.ts
+++ b/affine-mcp-server/src/index.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/**
+ * AFFiNE MCP Server
+ *
+ * Full read/write MCP server for self-hosted AFFiNE workspaces.
+ * Provides 15 tools: document CRUD, collection management, comments, search, and user info.
+ *
+ * Transport: stdio (for OpenClaw / Claude Code subprocess integration)
+ * Auth: Email/password sign-in → session cookies for WebSocket + GraphQL
+ *
+ * Required env vars:
+ *   AFFINE_BASE_URL      - AFFiNE server URL (e.g., https://affine.example.com)
+ *   AFFINE_EMAIL          - Login email
+ *   AFFINE_PASSWORD       - Login password
+ *   AFFINE_WORKSPACE_ID   - Target workspace UUID
+ *
+ * Optional:
+ *   AFFINE_CLIENT_VERSION - Server version for WebSocket join (default: "0.26.2")
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  AFFINE_BASE_URL,
+  AFFINE_EMAIL,
+  AFFINE_WORKSPACE_ID,
+} from "./constants.js";
+import { registerDocumentTools } from "./tools/documents.js";
+import { registerCollectionTools } from "./tools/collections.js";
+import { registerCommentTools } from "./tools/comments.js";
+import { registerUtilityTools } from "./tools/utility.js";
+import { disconnect } from "./services/websocket.js";
+
+// Validate required env vars
+function validateEnv(): void {
+  const missing: string[] = [];
+  if (!AFFINE_BASE_URL) missing.push("AFFINE_BASE_URL");
+  if (!AFFINE_EMAIL) missing.push("AFFINE_EMAIL");
+  if (!process.env.AFFINE_PASSWORD) missing.push("AFFINE_PASSWORD");
+  if (!AFFINE_WORKSPACE_ID) missing.push("AFFINE_WORKSPACE_ID");
+
+  if (missing.length > 0) {
+    console.error(`ERROR: Missing required environment variables: ${missing.join(", ")}`);
+    console.error("");
+    console.error("Required:");
+    console.error("  AFFINE_BASE_URL       - AFFiNE server URL");
+    console.error("  AFFINE_EMAIL          - Login email");
+    console.error("  AFFINE_PASSWORD       - Login password");
+    console.error("  AFFINE_WORKSPACE_ID   - Workspace UUID");
+    console.error("");
+    console.error("Optional:");
+    console.error("  AFFINE_CLIENT_VERSION - Server version (default: 0.26.2)");
+    process.exit(1);
+  }
+}
+
+async function main(): Promise<void> {
+  validateEnv();
+
+  // Create MCP server
+  const server = new McpServer({
+    name: "affine-mcp-server",
+    version: "1.0.0",
+  });
+
+  // Register all tool groups
+  registerDocumentTools(server);
+  registerCollectionTools(server);
+  registerCommentTools(server);
+  registerUtilityTools(server);
+
+  // Connect via stdio transport
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  console.error("AFFiNE MCP Server running via stdio");
+  console.error(`  Base URL:     ${AFFINE_BASE_URL}`);
+  console.error(`  Workspace:    ${AFFINE_WORKSPACE_ID}`);
+  console.error(`  User:         ${AFFINE_EMAIL}`);
+  console.error(`  Tools:        15 (docs, collections, comments, search, user)`);
+
+  // Graceful shutdown
+  const shutdown = (): void => {
+    console.error("Shutting down...");
+    disconnect();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  console.error("Fatal error:", error);
+  disconnect();
+  process.exit(1);
+});

--- a/affine-mcp-server/src/schemas/inputs.ts
+++ b/affine-mcp-server/src/schemas/inputs.ts
@@ -1,0 +1,234 @@
+/**
+ * AFFiNE MCP Server - Zod Input Schemas
+ *
+ * All tool input validation schemas in one place.
+ */
+
+import { z } from "zod";
+
+// ─── Shared Enums ───────────────────────────────────────────────────────────
+
+export const ResponseFormatSchema = z
+  .enum(["markdown", "json"])
+  .default("markdown")
+  .describe("Output format: 'markdown' for human-readable or 'json' for machine-readable");
+
+// ─── Document Schemas ───────────────────────────────────────────────────────
+
+export const ListDocsInputSchema = z
+  .object({
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const CreateDocInputSchema = z
+  .object({
+    title: z
+      .string()
+      .min(1, "Title is required")
+      .max(500, "Title must not exceed 500 characters")
+      .describe("Title for the new document"),
+    markdown: z
+      .string()
+      .optional()
+      .describe("Optional markdown content to populate the document with"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const ReadDocInputSchema = z
+  .object({
+    docId: z
+      .string()
+      .min(1, "docId is required")
+      .describe("The document ID to read"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const EditDocInputSchema = z
+  .object({
+    docId: z
+      .string()
+      .min(1, "docId is required")
+      .describe("The document ID to edit"),
+    operations: z
+      .array(
+        z
+          .object({
+            action: z
+              .enum(["append", "update", "delete"])
+              .describe("The edit action to perform"),
+            blockType: z
+              .string()
+              .optional()
+              .describe(
+                "Block type for append: 'paragraph', 'list', 'code', 'divider'. For paragraph, use propType for heading/quote."
+              ),
+            propType: z
+              .string()
+              .optional()
+              .describe(
+                "Property type: 'text', 'h1'-'h6', 'quote' for paragraph; 'bulleted', 'numbered', 'todo' for list"
+              ),
+            content: z
+              .string()
+              .optional()
+              .describe("Text content (supports inline markdown formatting)"),
+            blockId: z
+              .string()
+              .optional()
+              .describe("Block ID (required for update and delete actions)"),
+          })
+          .strict()
+      )
+      .min(1, "At least one operation is required")
+      .describe("Array of edit operations to apply sequentially"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const DeleteDocInputSchema = z
+  .object({
+    docId: z
+      .string()
+      .min(1, "docId is required")
+      .describe("The document ID to delete (moves to trash)"),
+  })
+  .strict();
+
+// ─── Collection Schemas ─────────────────────────────────────────────────────
+
+export const ListCollectionsInputSchema = z
+  .object({
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const CreateCollectionInputSchema = z
+  .object({
+    name: z
+      .string()
+      .min(1, "Collection name is required")
+      .max(200, "Collection name must not exceed 200 characters")
+      .describe("Name for the new collection"),
+    docIds: z
+      .array(z.string())
+      .optional()
+      .describe("Optional list of document IDs to include in the collection"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const UpdateCollectionInputSchema = z
+  .object({
+    collectionId: z
+      .string()
+      .min(1, "collectionId is required")
+      .describe("The collection ID to update"),
+    name: z
+      .string()
+      .optional()
+      .describe("New name for the collection"),
+    addDocIds: z
+      .array(z.string())
+      .optional()
+      .describe("Document IDs to add to the collection"),
+    removeDocIds: z
+      .array(z.string())
+      .optional()
+      .describe("Document IDs to remove from the collection"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const DeleteCollectionInputSchema = z
+  .object({
+    collectionId: z
+      .string()
+      .min(1, "collectionId is required")
+      .describe("The collection ID to delete (does not delete documents)"),
+  })
+  .strict();
+
+// ─── Comment Schemas ────────────────────────────────────────────────────────
+
+export const ListCommentsInputSchema = z
+  .object({
+    docId: z
+      .string()
+      .min(1, "docId is required")
+      .describe("The document ID to list comments for"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const CreateCommentInputSchema = z
+  .object({
+    docId: z
+      .string()
+      .min(1, "docId is required")
+      .describe("The document ID to comment on"),
+    content: z
+      .string()
+      .min(1, "Comment content is required")
+      .max(5000, "Comment must not exceed 5000 characters")
+      .describe("The comment text"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const ResolveCommentInputSchema = z
+  .object({
+    commentId: z
+      .string()
+      .min(1, "commentId is required")
+      .describe("The comment ID to mark as resolved"),
+  })
+  .strict();
+
+export const DeleteCommentInputSchema = z
+  .object({
+    commentId: z
+      .string()
+      .min(1, "commentId is required")
+      .describe("The comment ID to delete"),
+  })
+  .strict();
+
+// ─── Utility Schemas ────────────────────────────────────────────────────────
+
+export const SearchInputSchema = z
+  .object({
+    query: z
+      .string()
+      .min(1, "Search query is required")
+      .max(500, "Query must not exceed 500 characters")
+      .describe("Search query to match against document content"),
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+export const CurrentUserInputSchema = z
+  .object({
+    response_format: ResponseFormatSchema,
+  })
+  .strict();
+
+// ─── Type Exports ───────────────────────────────────────────────────────────
+
+export type ListDocsInput = z.infer<typeof ListDocsInputSchema>;
+export type CreateDocInput = z.infer<typeof CreateDocInputSchema>;
+export type ReadDocInput = z.infer<typeof ReadDocInputSchema>;
+export type EditDocInput = z.infer<typeof EditDocInputSchema>;
+export type DeleteDocInput = z.infer<typeof DeleteDocInputSchema>;
+export type ListCollectionsInput = z.infer<typeof ListCollectionsInputSchema>;
+export type CreateCollectionInput = z.infer<typeof CreateCollectionInputSchema>;
+export type UpdateCollectionInput = z.infer<typeof UpdateCollectionInputSchema>;
+export type DeleteCollectionInput = z.infer<typeof DeleteCollectionInputSchema>;
+export type ListCommentsInput = z.infer<typeof ListCommentsInputSchema>;
+export type CreateCommentInput = z.infer<typeof CreateCommentInputSchema>;
+export type ResolveCommentInput = z.infer<typeof ResolveCommentInputSchema>;
+export type DeleteCommentInput = z.infer<typeof DeleteCommentInputSchema>;
+export type SearchInput = z.infer<typeof SearchInputSchema>;
+export type CurrentUserInput = z.infer<typeof CurrentUserInputSchema>;

--- a/affine-mcp-server/src/services/auth.ts
+++ b/affine-mcp-server/src/services/auth.ts
@@ -1,0 +1,136 @@
+/**
+ * AFFiNE Authentication Service
+ *
+ * Handles REST sign-in to obtain session cookies required for WebSocket auth.
+ * Bearer tokens work for GraphQL but NOT for WebSocket connections.
+ */
+
+import axios from "axios";
+import {
+  AFFINE_BASE_URL,
+  AFFINE_EMAIL,
+  AFFINE_PASSWORD,
+  AUTH_SIGN_IN_PATH,
+  API_TIMEOUT,
+} from "../constants.js";
+import type { AuthSession } from "../types.js";
+
+let cachedSession: AuthSession | null = null;
+
+/**
+ * Sign in via REST and extract session cookies.
+ * Caches the session for reuse across requests.
+ */
+export async function signIn(): Promise<AuthSession> {
+  if (cachedSession) {
+    return cachedSession;
+  }
+
+  if (!AFFINE_EMAIL || !AFFINE_PASSWORD) {
+    throw new Error(
+      "AFFINE_EMAIL and AFFINE_PASSWORD environment variables are required for authentication"
+    );
+  }
+
+  const url = `${AFFINE_BASE_URL}${AUTH_SIGN_IN_PATH}`;
+
+  try {
+    const response = await axios.post(
+      url,
+      { email: AFFINE_EMAIL, password: AFFINE_PASSWORD },
+      {
+        timeout: API_TIMEOUT,
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+        // Capture Set-Cookie headers without following redirects
+        maxRedirects: 0,
+        validateStatus: (status) => status >= 200 && status < 400,
+      }
+    );
+
+    const setCookieHeaders = response.headers["set-cookie"];
+    if (!setCookieHeaders || setCookieHeaders.length === 0) {
+      throw new Error(
+        "No session cookies returned from sign-in. Check credentials."
+      );
+    }
+
+    // Extract cookie name=value pairs (strip attributes like Path, HttpOnly, etc.)
+    const cookiePairs = setCookieHeaders
+      .map((header: string) => header.split(";")[0].trim())
+      .filter((pair: string) => pair.length > 0);
+
+    const cookieString = cookiePairs.join("; ");
+
+    // Verify we have the expected cookies
+    const hasSession = cookiePairs.some((p: string) =>
+      p.startsWith("affine_session=")
+    );
+    if (!hasSession) {
+      // Some versions may use different cookie names - accept whatever we got
+      console.error(
+        `Warning: affine_session cookie not found. Got: ${cookiePairs.map((p: string) => p.split("=")[0]).join(", ")}`
+      );
+    }
+
+    cachedSession = {
+      cookies: cookieString,
+    };
+
+    console.error(`Auth: Signed in as ${AFFINE_EMAIL}`);
+    return cachedSession;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      if (error.response) {
+        throw new Error(
+          `Auth failed (HTTP ${error.response.status}): ${JSON.stringify(error.response.data)}`
+        );
+      }
+      throw new Error(`Auth failed: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Get current session cookies, signing in if needed.
+ */
+export async function getSessionCookies(): Promise<string> {
+  const session = await signIn();
+  return session.cookies;
+}
+
+/**
+ * Clear cached session to force re-authentication.
+ */
+export function clearSession(): void {
+  cachedSession = null;
+  console.error("Auth: Session cleared, will re-authenticate on next request");
+}
+
+/**
+ * Execute a function with automatic re-auth on failure.
+ * If the function throws, clears session and retries once.
+ */
+export async function withAutoReauth<T>(
+  fn: () => Promise<T>
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (
+      msg.includes("401") ||
+      msg.includes("403") ||
+      msg.includes("unauthorized") ||
+      msg.includes("session")
+    ) {
+      console.error("Auth: Request failed, re-authenticating...");
+      clearSession();
+      return await fn();
+    }
+    throw error;
+  }
+}

--- a/affine-mcp-server/src/services/graphql.ts
+++ b/affine-mcp-server/src/services/graphql.ts
@@ -1,0 +1,218 @@
+/**
+ * AFFiNE GraphQL Client
+ *
+ * Handles GraphQL queries and mutations for comments, user info, and doc metadata.
+ */
+
+import axios from "axios";
+import {
+  AFFINE_BASE_URL,
+  AFFINE_WORKSPACE_ID,
+  GRAPHQL_PATH,
+  API_TIMEOUT,
+} from "../constants.js";
+import { getSessionCookies, withAutoReauth } from "./auth.js";
+import type { CommentData } from "../types.js";
+
+/**
+ * Execute a GraphQL request.
+ */
+async function graphqlRequest<T>(
+  query: string,
+  variables?: Record<string, unknown>
+): Promise<T> {
+  return withAutoReauth(async () => {
+    const cookies = await getSessionCookies();
+    const url = `${AFFINE_BASE_URL}${GRAPHQL_PATH}`;
+
+    const response = await axios.post(
+      url,
+      { query, variables },
+      {
+        timeout: API_TIMEOUT,
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+          Cookie: cookies,
+        },
+      }
+    );
+
+    if (response.data.errors?.length) {
+      const errMsg = response.data.errors
+        .map((e: { message: string }) => e.message)
+        .join("; ");
+      throw new Error(`GraphQL error: ${errMsg}`);
+    }
+
+    return response.data.data as T;
+  });
+}
+
+// ─── User Operations ────────────────────────────────────────────────────────
+
+interface CurrentUserResult {
+  currentUser: {
+    id: string;
+    name: string;
+    email: string;
+    avatarUrl?: string;
+  } | null;
+}
+
+/**
+ * Get the currently authenticated user.
+ */
+export async function getCurrentUser(): Promise<CurrentUserResult["currentUser"]> {
+  const result = await graphqlRequest<CurrentUserResult>(`
+    query {
+      currentUser {
+        id
+        name
+        email
+        avatarUrl
+      }
+    }
+  `);
+  return result.currentUser;
+}
+
+// ─── Comment Operations ─────────────────────────────────────────────────────
+
+interface DocCommentsResult {
+  workspace: {
+    doc: {
+      comments: Array<{
+        id: string;
+        content: unknown;
+        createdAt: string;
+        author: {
+          id: string;
+          name: string;
+        };
+        resolved: boolean;
+      }>;
+    };
+  };
+}
+
+/**
+ * List comments on a document.
+ */
+export async function listComments(docId: string): Promise<CommentData[]> {
+  // Try the workspace doc comments query
+  try {
+    const result = await graphqlRequest<DocCommentsResult>(
+      `query($workspaceId: String!, $docId: String!) {
+        workspace(id: $workspaceId) {
+          doc(docId: $docId) {
+            comments {
+              id
+              content
+              createdAt
+              author {
+                id
+                name
+              }
+              resolved
+            }
+          }
+        }
+      }`,
+      { workspaceId: AFFINE_WORKSPACE_ID, docId }
+    );
+
+    return (result.workspace?.doc?.comments || []).map((c) => ({
+      id: c.id,
+      content: c.content,
+      createdAt: c.createdAt,
+      userId: c.author?.id,
+      resolved: c.resolved,
+    }));
+  } catch {
+    // If the schema doesn't match, try an alternative query shape
+    console.error("Warning: Comment listing may need schema adjustment for this AFFiNE version");
+    return [];
+  }
+}
+
+interface CreateCommentResult {
+  createComment: {
+    id: string;
+    content: unknown;
+    createdAt: string;
+  };
+}
+
+/**
+ * Create a document-level comment.
+ * Uses the BlockSuite JSON format for comment content.
+ */
+export async function createComment(
+  docId: string,
+  text: string,
+  docTitle?: string
+): Promise<{ id: string }> {
+  const contentJson = {
+    type: "doc",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text }],
+      },
+    ],
+  };
+
+  const result = await graphqlRequest<CreateCommentResult>(
+    `mutation($input: CommentCreateInput!) {
+      createComment(input: $input) {
+        id
+        content
+        createdAt
+      }
+    }`,
+    {
+      input: {
+        docId,
+        docMode: "page",
+        docTitle: docTitle || "",
+        workspaceId: AFFINE_WORKSPACE_ID,
+        content: contentJson,
+      },
+    }
+  );
+
+  return { id: result.createComment.id };
+}
+
+interface ResolveCommentResult {
+  resolveComment: {
+    id: string;
+  };
+}
+
+/**
+ * Mark a comment as resolved.
+ */
+export async function resolveComment(commentId: string): Promise<void> {
+  await graphqlRequest<ResolveCommentResult>(
+    `mutation($input: CommentResolveInput!) {
+      resolveComment(input: $input) {
+        id
+      }
+    }`,
+    { input: { id: commentId, resolved: true } }
+  );
+}
+
+/**
+ * Delete a comment.
+ */
+export async function deleteComment(commentId: string): Promise<void> {
+  await graphqlRequest<{ deleteComment: boolean }>(
+    `mutation($id: String!) {
+      deleteComment(id: $id)
+    }`,
+    { id: commentId }
+  );
+}

--- a/affine-mcp-server/src/services/websocket.ts
+++ b/affine-mcp-server/src/services/websocket.ts
@@ -1,0 +1,242 @@
+/**
+ * AFFiNE WebSocket Service
+ *
+ * Manages a persistent Socket.IO connection for Yjs document operations.
+ * Handles workspace join, doc loading, update pushing, and sequential write discipline.
+ */
+
+import { io, Socket } from "socket.io-client";
+import {
+  AFFINE_BASE_URL,
+  AFFINE_WORKSPACE_ID,
+  AFFINE_CLIENT_VERSION,
+  SOCKET_IO_PATH,
+  WS_RECONNECT_BASE_DELAY,
+  WS_RECONNECT_MAX_DELAY,
+} from "../constants.js";
+import { getSessionCookies, clearSession } from "./auth.js";
+import type { JoinResult, LoadDocResult, PushUpdateResult } from "../types.js";
+
+let socket: Socket | null = null;
+let joined = false;
+
+/** Per-doc write queues to enforce sequential write discipline */
+const writeQueues = new Map<string, Promise<void>>();
+
+/**
+ * Emit a Socket.IO event and wait for its callback response.
+ */
+function emitWithCallback<T>(
+  sock: Socket,
+  event: string,
+  data: unknown
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`WebSocket: ${event} timed out after 30s`));
+    }, 30000);
+
+    sock.emit(event, data, (response: { data?: T; error?: string }) => {
+      clearTimeout(timer);
+      if (response?.error) {
+        reject(new Error(`WebSocket ${event} error: ${response.error}`));
+      } else if (response?.data !== undefined) {
+        resolve(response.data as T);
+      } else {
+        // Some events return the response directly
+        resolve(response as unknown as T);
+      }
+    });
+  });
+}
+
+/**
+ * Establish and maintain a WebSocket connection.
+ * Returns the connected and workspace-joined socket.
+ */
+export async function getSocket(): Promise<Socket> {
+  if (socket?.connected && joined) {
+    return socket;
+  }
+
+  // Disconnect any stale socket
+  if (socket) {
+    socket.disconnect();
+    socket = null;
+    joined = false;
+  }
+
+  const cookies = await getSessionCookies();
+
+  return new Promise<Socket>((resolve, reject) => {
+    const sock = io(AFFINE_BASE_URL, {
+      path: SOCKET_IO_PATH,
+      transports: ["websocket"],
+      extraHeaders: {
+        Cookie: cookies,
+      },
+      reconnection: true,
+      reconnectionDelay: WS_RECONNECT_BASE_DELAY,
+      reconnectionDelayMax: WS_RECONNECT_MAX_DELAY,
+      timeout: 30000,
+    });
+
+    const connectTimeout = setTimeout(() => {
+      sock.disconnect();
+      reject(new Error("WebSocket: Connection timed out after 30s"));
+    }, 30000);
+
+    sock.on("connect", async () => {
+      clearTimeout(connectTimeout);
+      console.error("WebSocket: Connected");
+
+      try {
+        // Join the workspace
+        const joinResult = await emitWithCallback<JoinResult>(
+          sock,
+          "space:join",
+          {
+            spaceType: "workspace",
+            spaceId: AFFINE_WORKSPACE_ID,
+            clientVersion: AFFINE_CLIENT_VERSION,
+          }
+        );
+
+        if (!joinResult.success) {
+          sock.disconnect();
+          reject(
+            new Error(
+              `WebSocket: space:join failed. Check clientVersion (using "${AFFINE_CLIENT_VERSION}") or auth.`
+            )
+          );
+          return;
+        }
+
+        console.error(
+          `WebSocket: Joined workspace ${AFFINE_WORKSPACE_ID} (clientId: ${joinResult.clientId})`
+        );
+        socket = sock;
+        joined = true;
+        resolve(sock);
+      } catch (err) {
+        sock.disconnect();
+        reject(err);
+      }
+    });
+
+    sock.on("connect_error", (err) => {
+      clearTimeout(connectTimeout);
+      console.error(`WebSocket: Connection error: ${err.message}`);
+      reject(
+        new Error(`WebSocket: Connection failed: ${err.message}`)
+      );
+    });
+
+    sock.on("disconnect", (reason) => {
+      console.error(`WebSocket: Disconnected (${reason})`);
+      joined = false;
+      if (reason === "io server disconnect") {
+        // Server kicked us — clear auth and let next call reconnect
+        clearSession();
+      }
+    });
+  });
+}
+
+/**
+ * Load a document via WebSocket.
+ * Returns the base64-encoded Yjs update (in the `missing` field).
+ */
+export async function loadDoc(docId: string): Promise<LoadDocResult> {
+  const sock = await getSocket();
+
+  const result = await emitWithCallback<LoadDocResult>(
+    sock,
+    "space:load-doc",
+    {
+      spaceType: "workspace",
+      spaceId: AFFINE_WORKSPACE_ID,
+      docId,
+    }
+  );
+
+  if (!result.missing && !result.state) {
+    throw new Error(`DOC_NOT_FOUND: Document "${docId}" does not exist`);
+  }
+
+  return result;
+}
+
+/**
+ * Push a Yjs update to the server.
+ * Enforces sequential writes per document.
+ */
+export async function pushDocUpdate(
+  docId: string,
+  updateBase64: string
+): Promise<PushUpdateResult> {
+  // Queue writes per document to prevent CRDT scrambling
+  const previous = writeQueues.get(docId) ?? Promise.resolve();
+
+  const current = previous.then(async () => {
+    const sock = await getSocket();
+
+    const result = await emitWithCallback<PushUpdateResult>(
+      sock,
+      "space:push-doc-update",
+      {
+        spaceType: "workspace",
+        spaceId: AFFINE_WORKSPACE_ID,
+        docId,
+        update: updateBase64,
+      }
+    );
+
+    if (!result.accepted) {
+      throw new Error(
+        `Push rejected for doc "${docId}". Possible conflict — try re-reading the doc first.`
+      );
+    }
+
+    return result;
+  });
+
+  // Store the queue chain (strip the return value for the map)
+  writeQueues.set(
+    docId,
+    current.then(() => {})
+  );
+
+  return current;
+}
+
+/**
+ * Delete a document via WebSocket.
+ * Note: This emits a fire-and-forget event (no callback).
+ */
+export async function deleteDoc(docId: string): Promise<void> {
+  const sock = await getSocket();
+
+  sock.emit("space:delete-doc", {
+    spaceType: "workspace",
+    spaceId: AFFINE_WORKSPACE_ID,
+    docId,
+  });
+
+  // Give the server a moment to process
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  console.error(`WebSocket: Deleted doc ${docId}`);
+}
+
+/**
+ * Disconnect the WebSocket cleanly.
+ */
+export function disconnect(): void {
+  if (socket) {
+    socket.disconnect();
+    socket = null;
+    joined = false;
+    writeQueues.clear();
+    console.error("WebSocket: Disconnected");
+  }
+}

--- a/affine-mcp-server/src/services/yjs-helpers.ts
+++ b/affine-mcp-server/src/services/yjs-helpers.ts
@@ -1,0 +1,831 @@
+/**
+ * AFFiNE Yjs Helpers
+ *
+ * Handles Yjs document creation, traversal, block tree <-> markdown conversion,
+ * and CRDT mutations for the BlockSuite document model.
+ */
+
+import * as Y from "yjs";
+import { nanoid } from "nanoid";
+import { loadDoc, pushDocUpdate } from "./websocket.js";
+import { AFFINE_WORKSPACE_ID } from "../constants.js";
+import type { BlockInfo, EditOperation, DocMeta, CollectionMeta, TextDelta } from "../types.js";
+
+// ─── YDoc Loading ───────────────────────────────────────────────────────────
+
+/**
+ * Load a remote Yjs document by ID.
+ */
+export async function loadYDoc(docId: string): Promise<Y.Doc> {
+  const result = await loadDoc(docId);
+  const ydoc = new Y.Doc();
+
+  if (result.missing) {
+    const update = new Uint8Array(Buffer.from(result.missing, "base64"));
+    Y.applyUpdate(ydoc, update);
+  }
+
+  return ydoc;
+}
+
+/**
+ * Encode a Yjs update as base64 for pushing.
+ */
+function encodeUpdate(update: Uint8Array): string {
+  return Buffer.from(update).toString("base64");
+}
+
+/**
+ * Push the full state of a YDoc to the server.
+ */
+export async function pushYDoc(docId: string, ydoc: Y.Doc): Promise<void> {
+  const update = Y.encodeStateAsUpdate(ydoc);
+  await pushDocUpdate(docId, encodeUpdate(update));
+}
+
+// ─── Workspace Root Doc Operations ──────────────────────────────────────────
+
+/**
+ * Load the workspace root doc and read document metadata.
+ */
+export async function listDocsMeta(): Promise<DocMeta[]> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const meta = ydoc.getMap("meta");
+  const pages = meta.get("pages") as Y.Array<Y.Map<unknown>> | undefined;
+
+  if (!pages) return [];
+
+  const docs: DocMeta[] = [];
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages.get(i);
+    if (page instanceof Y.Map) {
+      const id = page.get("id") as string;
+      const title = page.get("title") as string;
+      const createDate = page.get("createDate") as number;
+      const updatedDate = page.get("updatedDate") as number | undefined;
+
+      const tagsArray = page.get("tags") as Y.Array<string> | undefined;
+      const tags = tagsArray ? tagsArray.toArray() : undefined;
+
+      docs.push({ id, title, createDate, updatedDate, tags });
+    }
+  }
+
+  return docs;
+}
+
+/**
+ * Add a document entry to the workspace root doc's meta.pages.
+ */
+export async function addDocToMeta(docId: string, title: string): Promise<void> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const meta = ydoc.getMap("meta");
+
+  let pages = meta.get("pages") as Y.Array<Y.Map<unknown>> | undefined;
+  if (!pages) {
+    pages = new Y.Array<Y.Map<unknown>>();
+    meta.set("pages", pages);
+  }
+
+  const pageMap = new Y.Map<unknown>();
+  pageMap.set("id", docId);
+  pageMap.set("title", title);
+  pageMap.set("createDate", Date.now());
+
+  const tagsArray = new Y.Array<string>();
+  pageMap.set("tags", tagsArray);
+
+  pages.push([pageMap]);
+
+  await pushYDoc(AFFINE_WORKSPACE_ID, ydoc);
+}
+
+/**
+ * Remove a document entry from the workspace root doc's meta.pages.
+ */
+export async function removeDocFromMeta(docId: string): Promise<void> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const meta = ydoc.getMap("meta");
+  const pages = meta.get("pages") as Y.Array<Y.Map<unknown>> | undefined;
+
+  if (!pages) return;
+
+  for (let i = 0; i < pages.length; i++) {
+    const page = pages.get(i);
+    if (page instanceof Y.Map && page.get("id") === docId) {
+      pages.delete(i, 1);
+      break;
+    }
+  }
+
+  await pushYDoc(AFFINE_WORKSPACE_ID, ydoc);
+}
+
+// ─── Collection Operations ──────────────────────────────────────────────────
+
+/**
+ * List all collections from the workspace root doc.
+ */
+export async function listCollections(): Promise<CollectionMeta[]> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const setting = ydoc.getMap("setting");
+  const collections = setting.get("collections") as Y.Array<Y.Map<unknown>> | undefined;
+
+  if (!collections) return [];
+
+  const result: CollectionMeta[] = [];
+  for (let i = 0; i < collections.length; i++) {
+    const col = collections.get(i);
+    if (col instanceof Y.Map) {
+      const id = col.get("id") as string;
+      const name = col.get("name") as string;
+      const allowList = col.get("allowList") as Y.Array<string> | undefined;
+      const docIds = allowList ? allowList.toArray() : [];
+      result.push({ id, name, docIds, docCount: docIds.length });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Create a new collection in the workspace root doc.
+ */
+export async function createCollection(
+  name: string,
+  docIds: string[] = []
+): Promise<string> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const setting = ydoc.getMap("setting");
+
+  let collections = setting.get("collections") as Y.Array<Y.Map<unknown>> | undefined;
+  if (!collections) {
+    collections = new Y.Array<Y.Map<unknown>>();
+    setting.set("collections", collections);
+  }
+
+  const id = nanoid(21);
+  const colMap = new Y.Map<unknown>();
+  colMap.set("id", id);
+  colMap.set("name", name);
+
+  // rules: YMap with filters YArray
+  const rules = new Y.Map<unknown>();
+  const filters = new Y.Array<unknown>();
+  rules.set("filters", filters);
+  colMap.set("rules", rules);
+
+  // allowList: YArray of doc IDs
+  const allowList = new Y.Array<string>();
+  if (docIds.length > 0) {
+    allowList.push(docIds);
+  }
+  colMap.set("allowList", allowList);
+
+  collections.push([colMap]);
+
+  await pushYDoc(AFFINE_WORKSPACE_ID, ydoc);
+  return id;
+}
+
+/**
+ * Update a collection: add/remove docs, rename.
+ */
+export async function updateCollection(
+  collectionId: string,
+  opts: { addDocIds?: string[]; removeDocIds?: string[]; name?: string }
+): Promise<void> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const setting = ydoc.getMap("setting");
+  const collections = setting.get("collections") as Y.Array<Y.Map<unknown>> | undefined;
+
+  if (!collections) throw new Error(`Collection "${collectionId}" not found`);
+
+  let found = false;
+  for (let i = 0; i < collections.length; i++) {
+    const col = collections.get(i);
+    if (col instanceof Y.Map && col.get("id") === collectionId) {
+      found = true;
+
+      if (opts.name !== undefined) {
+        col.set("name", opts.name);
+      }
+
+      const allowList = col.get("allowList") as Y.Array<string> | undefined;
+      if (allowList) {
+        // Remove docs
+        if (opts.removeDocIds?.length) {
+          const removeSet = new Set(opts.removeDocIds);
+          for (let j = allowList.length - 1; j >= 0; j--) {
+            if (removeSet.has(allowList.get(j))) {
+              allowList.delete(j, 1);
+            }
+          }
+        }
+
+        // Add docs (avoid duplicates)
+        if (opts.addDocIds?.length) {
+          const existing = new Set(allowList.toArray());
+          const toAdd = opts.addDocIds.filter((id) => !existing.has(id));
+          if (toAdd.length > 0) {
+            allowList.push(toAdd);
+          }
+        }
+      }
+
+      break;
+    }
+  }
+
+  if (!found) throw new Error(`Collection "${collectionId}" not found`);
+
+  await pushYDoc(AFFINE_WORKSPACE_ID, ydoc);
+}
+
+/**
+ * Delete a collection from the workspace root doc.
+ */
+export async function deleteCollection(collectionId: string): Promise<void> {
+  const ydoc = await loadYDoc(AFFINE_WORKSPACE_ID);
+  const setting = ydoc.getMap("setting");
+  const collections = setting.get("collections") as Y.Array<Y.Map<unknown>> | undefined;
+
+  if (!collections) throw new Error(`Collection "${collectionId}" not found`);
+
+  let found = false;
+  for (let i = 0; i < collections.length; i++) {
+    const col = collections.get(i);
+    if (col instanceof Y.Map && col.get("id") === collectionId) {
+      collections.delete(i, 1);
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) throw new Error(`Collection "${collectionId}" not found`);
+
+  await pushYDoc(AFFINE_WORKSPACE_ID, ydoc);
+}
+
+// ─── Block Tree <-> Markdown ────────────────────────────────────────────────
+
+/**
+ * Extract all block info from a YDoc.
+ */
+function getBlocks(ydoc: Y.Doc): Map<string, BlockInfo> {
+  const blocksMap = ydoc.getMap("blocks");
+  const result = new Map<string, BlockInfo>();
+
+  for (const [blockId, value] of blocksMap.entries()) {
+    if (!(value instanceof Y.Map)) continue;
+
+    const flavour = (value.get("sys:flavour") as string) || "";
+    const type = value.get("prop:type") as string | undefined;
+    const checked = value.get("prop:checked") as boolean | undefined;
+    const language = value.get("prop:language") as string | undefined;
+
+    // Extract text from YText
+    let text: string | undefined;
+    const ytext = value.get("prop:text");
+    if (ytext instanceof Y.Text) {
+      text = ytextToMarkdown(ytext);
+    }
+
+    // Get children IDs
+    const childrenArr = value.get("sys:children") as Y.Array<string> | undefined;
+    const children = childrenArr ? childrenArr.toArray() : [];
+
+    result.set(blockId, {
+      id: blockId,
+      flavour,
+      type,
+      text,
+      children,
+      checked,
+      language,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Convert a YText with Quill-style deltas to markdown.
+ */
+function ytextToMarkdown(ytext: Y.Text): string {
+  const deltas = ytext.toDelta() as TextDelta[];
+  let md = "";
+
+  for (const delta of deltas) {
+    let segment = delta.insert;
+    const attrs = delta.attributes;
+
+    if (attrs) {
+      if (attrs.code) segment = `\`${segment}\``;
+      if (attrs.bold) segment = `**${segment}**`;
+      if (attrs.italic) segment = `*${segment}*`;
+      if (attrs.strike) segment = `~~${segment}~~`;
+      if (attrs.underline) segment = `<u>${segment}</u>`;
+      if (attrs.link) segment = `[${segment}](${attrs.link})`;
+    }
+
+    md += segment;
+  }
+
+  return md;
+}
+
+/**
+ * Find the root page block in a document.
+ */
+function findRootPageBlock(blocks: Map<string, BlockInfo>): BlockInfo | undefined {
+  for (const block of blocks.values()) {
+    if (block.flavour === "affine:page") return block;
+  }
+  return undefined;
+}
+
+/**
+ * Find the note block (content container) in a document.
+ */
+function findNoteBlock(
+  blocks: Map<string, BlockInfo>,
+  pageBlock: BlockInfo
+): BlockInfo | undefined {
+  for (const childId of pageBlock.children) {
+    const child = blocks.get(childId);
+    if (child?.flavour === "affine:note") return child;
+  }
+  return undefined;
+}
+
+/**
+ * Convert a document's block tree to markdown.
+ */
+export function docToMarkdown(ydoc: Y.Doc): { title: string; markdown: string; blockCount: number } {
+  const blocks = getBlocks(ydoc);
+  const pageBlock = findRootPageBlock(blocks);
+
+  if (!pageBlock) {
+    return { title: "", markdown: "", blockCount: 0 };
+  }
+
+  // Get title from page block's YText
+  const blocksMap = ydoc.getMap("blocks");
+  const pageYMap = blocksMap.get(pageBlock.id) as Y.Map<unknown> | undefined;
+  let title = "";
+  if (pageYMap) {
+    const titleYText = pageYMap.get("prop:title");
+    if (titleYText instanceof Y.Text) {
+      title = titleYText.toString();
+    }
+  }
+
+  const noteBlock = findNoteBlock(blocks, pageBlock);
+  if (!noteBlock) {
+    return { title, markdown: "", blockCount: 0 };
+  }
+
+  const lines: string[] = [];
+  let blockCount = 0;
+
+  function renderBlock(blockId: string, indent: number = 0): void {
+    const block = blocks.get(blockId);
+    if (!block) return;
+    blockCount++;
+
+    const prefix = "  ".repeat(indent);
+    const text = block.text ?? "";
+
+    switch (block.flavour) {
+      case "affine:paragraph":
+        switch (block.type) {
+          case "h1": lines.push(`${prefix}# ${text}`); break;
+          case "h2": lines.push(`${prefix}## ${text}`); break;
+          case "h3": lines.push(`${prefix}### ${text}`); break;
+          case "h4": lines.push(`${prefix}#### ${text}`); break;
+          case "h5": lines.push(`${prefix}##### ${text}`); break;
+          case "h6": lines.push(`${prefix}###### ${text}`); break;
+          case "quote": lines.push(`${prefix}> ${text}`); break;
+          default: lines.push(`${prefix}${text}`); break;
+        }
+        break;
+
+      case "affine:list":
+        switch (block.type) {
+          case "bulleted": lines.push(`${prefix}- ${text}`); break;
+          case "numbered": lines.push(`${prefix}1. ${text}`); break;
+          case "todo":
+            lines.push(`${prefix}- [${block.checked ? "x" : " "}] ${text}`);
+            break;
+          case "toggle": lines.push(`${prefix}<details><summary>${text}</summary>`); break;
+          default: lines.push(`${prefix}- ${text}`); break;
+        }
+        break;
+
+      case "affine:code":
+        lines.push(`${prefix}\`\`\`${block.language || ""}`);
+        lines.push(text);
+        lines.push(`${prefix}\`\`\``);
+        break;
+
+      case "affine:divider":
+        lines.push(`${prefix}---`);
+        break;
+
+      case "affine:image":
+        lines.push(`${prefix}![image](blob)`);
+        break;
+
+      case "affine:bookmark": {
+        const blocksMapRef = ydoc.getMap("blocks");
+        const bm = blocksMapRef.get(blockId) as Y.Map<unknown> | undefined;
+        const url = bm?.get("prop:url") as string | undefined;
+        const bmTitle = bm?.get("prop:title") as string | undefined;
+        if (url) {
+          lines.push(`${prefix}[${bmTitle || url}](${url})`);
+        }
+        break;
+      }
+
+      default:
+        if (text) lines.push(`${prefix}${text}`);
+        break;
+    }
+
+    // Render children
+    for (const childId of block.children) {
+      renderBlock(childId, block.flavour === "affine:list" ? indent + 1 : indent);
+    }
+
+    // Close toggle
+    if (block.flavour === "affine:list" && block.type === "toggle") {
+      lines.push(`${prefix}</details>`);
+    }
+  }
+
+  for (const childId of noteBlock.children) {
+    renderBlock(childId);
+  }
+
+  return { title, markdown: lines.join("\n"), blockCount };
+}
+
+// ─── Document Creation ──────────────────────────────────────────────────────
+
+/**
+ * Parse simple markdown into block operations.
+ */
+function parseMarkdownToBlockOps(
+  markdown: string
+): Array<{ flavour: string; type: string; text: string; language?: string }> {
+  const lines = markdown.split("\n");
+  const ops: Array<{ flavour: string; type: string; text: string; language?: string }> = [];
+  let inCodeBlock = false;
+  let codeContent = "";
+  let codeLang = "";
+
+  for (const line of lines) {
+    if (line.startsWith("```")) {
+      if (inCodeBlock) {
+        ops.push({ flavour: "affine:code", type: "", text: codeContent.trimEnd(), language: codeLang });
+        inCodeBlock = false;
+        codeContent = "";
+        codeLang = "";
+      } else {
+        inCodeBlock = true;
+        codeLang = line.slice(3).trim();
+      }
+      continue;
+    }
+
+    if (inCodeBlock) {
+      codeContent += (codeContent ? "\n" : "") + line;
+      continue;
+    }
+
+    if (line.trim() === "---" || line.trim() === "***") {
+      ops.push({ flavour: "affine:divider", type: "", text: "" });
+    } else if (line.startsWith("######")) {
+      ops.push({ flavour: "affine:paragraph", type: "h6", text: line.slice(7).trim() });
+    } else if (line.startsWith("#####")) {
+      ops.push({ flavour: "affine:paragraph", type: "h5", text: line.slice(6).trim() });
+    } else if (line.startsWith("####")) {
+      ops.push({ flavour: "affine:paragraph", type: "h4", text: line.slice(5).trim() });
+    } else if (line.startsWith("###")) {
+      ops.push({ flavour: "affine:paragraph", type: "h3", text: line.slice(4).trim() });
+    } else if (line.startsWith("##")) {
+      ops.push({ flavour: "affine:paragraph", type: "h2", text: line.slice(3).trim() });
+    } else if (line.startsWith("# ")) {
+      ops.push({ flavour: "affine:paragraph", type: "h1", text: line.slice(2).trim() });
+    } else if (line.startsWith("> ")) {
+      ops.push({ flavour: "affine:paragraph", type: "quote", text: line.slice(2).trim() });
+    } else if (/^\s*- \[[ x]\]/.test(line)) {
+      const checked = line.includes("[x]");
+      const text = line.replace(/^\s*- \[[ x]\]\s*/, "");
+      ops.push({ flavour: "affine:list", type: "todo", text });
+      // Store checked state — will handle in block creation
+    } else if (/^\s*[-*]\s/.test(line)) {
+      ops.push({ flavour: "affine:list", type: "bulleted", text: line.replace(/^\s*[-*]\s+/, "") });
+    } else if (/^\s*\d+\.\s/.test(line)) {
+      ops.push({ flavour: "affine:list", type: "numbered", text: line.replace(/^\s*\d+\.\s+/, "") });
+    } else if (line.trim() === "") {
+      // Skip empty lines
+    } else {
+      ops.push({ flavour: "affine:paragraph", type: "text", text: line });
+    }
+  }
+
+  // Close unclosed code block
+  if (inCodeBlock) {
+    ops.push({ flavour: "affine:code", type: "", text: codeContent.trimEnd(), language: codeLang });
+  }
+
+  return ops;
+}
+
+/**
+ * Insert markdown-formatted text into a YText with proper deltas.
+ */
+function insertMarkdownText(ytext: Y.Text, markdownText: string): void {
+  // Simple inline formatting parser
+  const segments = parseInlineMarkdown(markdownText);
+
+  let offset = 0;
+  for (const seg of segments) {
+    const attrs: Record<string, boolean | string> = {};
+    if (seg.bold) attrs.bold = true;
+    if (seg.italic) attrs.italic = true;
+    if (seg.code) attrs.code = true;
+    if (seg.strike) attrs.strike = true;
+    if (seg.link) attrs.link = seg.link;
+
+    if (Object.keys(attrs).length > 0) {
+      ytext.insert(offset, seg.text, attrs);
+    } else {
+      ytext.insert(offset, seg.text);
+    }
+    offset += seg.text.length;
+  }
+}
+
+interface InlineSegment {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+  code?: boolean;
+  strike?: boolean;
+  link?: string;
+}
+
+/**
+ * Parse inline markdown formatting into segments.
+ */
+function parseInlineMarkdown(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = [];
+
+  // Simple regex-based parsing for common inline formatting
+  // Order matters: handle code first (no nesting), then bold, italic, links, strike
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    // Inline code
+    const codeMatch = remaining.match(/^`([^`]+)`/);
+    if (codeMatch) {
+      segments.push({ text: codeMatch[1], code: true });
+      remaining = remaining.slice(codeMatch[0].length);
+      continue;
+    }
+
+    // Bold
+    const boldMatch = remaining.match(/^\*\*([^*]+)\*\*/);
+    if (boldMatch) {
+      segments.push({ text: boldMatch[1], bold: true });
+      remaining = remaining.slice(boldMatch[0].length);
+      continue;
+    }
+
+    // Italic
+    const italicMatch = remaining.match(/^\*([^*]+)\*/);
+    if (italicMatch) {
+      segments.push({ text: italicMatch[1], italic: true });
+      remaining = remaining.slice(italicMatch[0].length);
+      continue;
+    }
+
+    // Strikethrough
+    const strikeMatch = remaining.match(/^~~([^~]+)~~/);
+    if (strikeMatch) {
+      segments.push({ text: strikeMatch[1], strike: true });
+      remaining = remaining.slice(strikeMatch[0].length);
+      continue;
+    }
+
+    // Link
+    const linkMatch = remaining.match(/^\[([^\]]+)\]\(([^)]+)\)/);
+    if (linkMatch) {
+      segments.push({ text: linkMatch[1], link: linkMatch[2] });
+      remaining = remaining.slice(linkMatch[0].length);
+      continue;
+    }
+
+    // Plain text: consume up to the next special character
+    const nextSpecial = remaining.search(/[`*~[]/);
+    if (nextSpecial === -1) {
+      segments.push({ text: remaining });
+      break;
+    } else if (nextSpecial === 0) {
+      // Special char that didn't match a pattern — treat as plain text
+      segments.push({ text: remaining[0] });
+      remaining = remaining.slice(1);
+    } else {
+      segments.push({ text: remaining.slice(0, nextSpecial) });
+      remaining = remaining.slice(nextSpecial);
+    }
+  }
+
+  return segments;
+}
+
+/**
+ * Create a new document YDoc with the required BlockSuite structure.
+ */
+export function createDocYDoc(
+  title: string,
+  markdown?: string
+): { ydoc: Y.Doc; docId: string } {
+  const docId = nanoid(21);
+  const ydoc = new Y.Doc();
+  const blocks = ydoc.getMap("blocks");
+
+  // IDs
+  const pageId = nanoid(21);
+  const surfaceId = nanoid(21);
+  const noteId = nanoid(21);
+
+  // Page block (root)
+  const pageBlock = new Y.Map<unknown>();
+  pageBlock.set("sys:id", pageId);
+  pageBlock.set("sys:flavour", "affine:page");
+  const pageChildren = new Y.Array<string>();
+  pageChildren.push([surfaceId, noteId]);
+  pageBlock.set("sys:children", pageChildren);
+  const titleText = new Y.Text();
+  titleText.insert(0, title);
+  pageBlock.set("prop:title", titleText);
+  blocks.set(pageId, pageBlock);
+
+  // Surface block
+  const surfaceBlock = new Y.Map<unknown>();
+  surfaceBlock.set("sys:id", surfaceId);
+  surfaceBlock.set("sys:flavour", "affine:surface");
+  surfaceBlock.set("sys:children", new Y.Array<string>());
+  blocks.set(surfaceId, surfaceBlock);
+
+  // Note block (content container)
+  const noteBlock = new Y.Map<unknown>();
+  noteBlock.set("sys:id", noteId);
+  noteBlock.set("sys:flavour", "affine:note");
+  const noteChildren = new Y.Array<string>();
+  noteBlock.set("sys:children", noteChildren);
+  blocks.set(noteId, noteBlock);
+
+  // Add content blocks from markdown
+  if (markdown) {
+    const ops = parseMarkdownToBlockOps(markdown);
+    for (const op of ops) {
+      const blockId = nanoid(21);
+      const block = new Y.Map<unknown>();
+      block.set("sys:id", blockId);
+      block.set("sys:flavour", op.flavour);
+      block.set("sys:children", new Y.Array<string>());
+
+      if (op.type) {
+        block.set("prop:type", op.type);
+      }
+
+      if (op.flavour === "affine:code") {
+        const codeText = new Y.Text();
+        codeText.insert(0, op.text);
+        block.set("prop:text", codeText);
+        if (op.language) {
+          block.set("prop:language", op.language);
+        }
+      } else if (op.flavour === "affine:divider") {
+        // Dividers have no text
+      } else {
+        const ytext = new Y.Text();
+        insertMarkdownText(ytext, op.text);
+        block.set("prop:text", ytext);
+      }
+
+      // Handle todo checked state
+      if (op.flavour === "affine:list" && op.type === "todo") {
+        block.set("prop:checked", false);
+      }
+
+      blocks.set(blockId, block);
+      noteChildren.push([blockId]);
+    }
+  }
+
+  return { ydoc, docId };
+}
+
+// ─── Block Editing Operations ───────────────────────────────────────────────
+
+/**
+ * Apply edit operations to an existing document.
+ */
+export async function applyEditOperations(
+  docId: string,
+  operations: EditOperation[]
+): Promise<string[]> {
+  const ydoc = await loadYDoc(docId);
+  const blocks = ydoc.getMap("blocks");
+  const blockIds: string[] = [];
+
+  // Find the note block
+  const allBlocks = getBlocks(ydoc);
+  const pageBlock = findRootPageBlock(allBlocks);
+  if (!pageBlock) throw new Error("Document has no page block");
+  const noteBlock = findNoteBlock(allBlocks, pageBlock);
+  if (!noteBlock) throw new Error("Document has no note block");
+
+  const noteYMap = blocks.get(noteBlock.id) as Y.Map<unknown>;
+  const noteChildren = noteYMap.get("sys:children") as Y.Array<string>;
+
+  for (const op of operations) {
+    switch (op.action) {
+      case "append": {
+        const blockId = nanoid(21);
+        const block = new Y.Map<unknown>();
+        block.set("sys:id", blockId);
+
+        const flavour = op.blockType?.includes(":") ? op.blockType : `affine:${op.blockType || "paragraph"}`;
+        block.set("sys:flavour", flavour);
+        block.set("sys:children", new Y.Array<string>());
+
+        if (op.propType) {
+          block.set("prop:type", op.propType);
+        } else if (flavour === "affine:paragraph") {
+          block.set("prop:type", "text");
+        }
+
+        if (flavour !== "affine:divider") {
+          const ytext = new Y.Text();
+          if (op.content) {
+            insertMarkdownText(ytext, op.content);
+          }
+          block.set("prop:text", ytext);
+        }
+
+        blocks.set(blockId, block);
+        noteChildren.push([blockId]);
+        blockIds.push(blockId);
+        break;
+      }
+
+      case "update": {
+        if (!op.blockId) throw new Error("update operation requires blockId");
+        const block = blocks.get(op.blockId) as Y.Map<unknown> | undefined;
+        if (!block) throw new Error(`Block "${op.blockId}" not found`);
+
+        if (op.content !== undefined) {
+          const existingText = block.get("prop:text");
+          if (existingText instanceof Y.Text) {
+            existingText.delete(0, existingText.length);
+            insertMarkdownText(existingText, op.content);
+          }
+        }
+
+        if (op.propType) {
+          block.set("prop:type", op.propType);
+        }
+
+        blockIds.push(op.blockId);
+        break;
+      }
+
+      case "delete": {
+        if (!op.blockId) throw new Error("delete operation requires blockId");
+
+        // Remove from note children
+        for (let i = 0; i < noteChildren.length; i++) {
+          if (noteChildren.get(i) === op.blockId) {
+            noteChildren.delete(i, 1);
+            break;
+          }
+        }
+
+        // Delete the block itself
+        blocks.delete(op.blockId);
+        blockIds.push(op.blockId);
+        break;
+      }
+    }
+  }
+
+  await pushYDoc(docId, ydoc);
+  return blockIds;
+}

--- a/affine-mcp-server/src/tools/collections.ts
+++ b/affine-mcp-server/src/tools/collections.ts
@@ -1,0 +1,218 @@
+/**
+ * AFFiNE MCP Tools - Collection Operations
+ *
+ * list_collections, create_collection, update_collection, delete_collection
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ListCollectionsInputSchema,
+  CreateCollectionInputSchema,
+  UpdateCollectionInputSchema,
+  DeleteCollectionInputSchema,
+} from "../schemas/inputs.js";
+import type {
+  ListCollectionsInput,
+  CreateCollectionInput,
+  UpdateCollectionInput,
+  DeleteCollectionInput,
+} from "../schemas/inputs.js";
+import {
+  listCollections as listCollectionsHelper,
+  createCollection as createCollectionHelper,
+  updateCollection as updateCollectionHelper,
+  deleteCollection as deleteCollectionHelper,
+} from "../services/yjs-helpers.js";
+
+function handleError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  const msg = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${msg}` }],
+    isError: true,
+  };
+}
+
+export function registerCollectionTools(server: McpServer): void {
+  // ─── affine_list_collections ────────────────────────────────────────────
+  server.registerTool(
+    "affine_list_collections",
+    {
+      title: "List AFFiNE Collections",
+      description: `List all collections in the AFFiNE workspace.
+
+Collections are user-defined groups of documents (similar to folders but more flexible). Returns each collection's ID, name, and the documents it contains.
+
+Args:
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  Array of collections with: id, name, docCount, docIds`,
+      inputSchema: ListCollectionsInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: ListCollectionsInput) => {
+      try {
+        const collections = await listCollectionsHelper();
+
+        if (collections.length === 0) {
+          return { content: [{ type: "text", text: "No collections found in workspace." }] };
+        }
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify({ total: collections.length, collections }, null, 2) }] };
+        }
+
+        const lines = [`# Collections (${collections.length})`, ""];
+        for (const col of collections) {
+          lines.push(`- **${col.name}** (${col.id}) — ${col.docCount} doc(s)`);
+          if (col.docIds.length > 0) {
+            for (const docId of col.docIds) {
+              lines.push(`  - ${docId}`);
+            }
+          }
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_create_collection ───────────────────────────────────────────
+  server.registerTool(
+    "affine_create_collection",
+    {
+      title: "Create AFFiNE Collection",
+      description: `Create a new collection in the AFFiNE workspace.
+
+Collections group related documents together. Optionally include document IDs to add to the collection at creation time.
+
+Args:
+  - name (string, required): Collection name
+  - docIds (string[], optional): Document IDs to include
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  The new collection's ID and name.`,
+      inputSchema: CreateCollectionInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (params: CreateCollectionInput) => {
+      try {
+        const id = await createCollectionHelper(params.name, params.docIds);
+
+        const output = { id, name: params.name, docCount: params.docIds?.length ?? 0 };
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+        }
+
+        return {
+          content: [{ type: "text", text: `Created collection **${params.name}** (${id})` }],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_update_collection ───────────────────────────────────────────
+  server.registerTool(
+    "affine_update_collection",
+    {
+      title: "Update AFFiNE Collection",
+      description: `Update a collection: rename it, add documents, or remove documents.
+
+Args:
+  - collectionId (string, required): The collection ID to update
+  - name (string, optional): New name for the collection
+  - addDocIds (string[], optional): Document IDs to add
+  - removeDocIds (string[], optional): Document IDs to remove
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  Confirmation of the update.`,
+      inputSchema: UpdateCollectionInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: UpdateCollectionInput) => {
+      try {
+        await updateCollectionHelper(params.collectionId, {
+          name: params.name,
+          addDocIds: params.addDocIds,
+          removeDocIds: params.removeDocIds,
+        });
+
+        const changes: string[] = [];
+        if (params.name) changes.push(`renamed to "${params.name}"`);
+        if (params.addDocIds?.length) changes.push(`added ${params.addDocIds.length} doc(s)`);
+        if (params.removeDocIds?.length) changes.push(`removed ${params.removeDocIds.length} doc(s)`);
+
+        const output = { success: true, collectionId: params.collectionId, changes };
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+        }
+
+        return {
+          content: [
+            { type: "text", text: `Updated collection ${params.collectionId}: ${changes.join(", ")}` },
+          ],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_delete_collection ───────────────────────────────────────────
+  server.registerTool(
+    "affine_delete_collection",
+    {
+      title: "Delete AFFiNE Collection",
+      description: `Delete a collection from the workspace.
+
+This removes the collection grouping only — documents within the collection are NOT deleted.
+
+Args:
+  - collectionId (string, required): The collection ID to delete
+
+Returns:
+  Confirmation of deletion.`,
+      inputSchema: DeleteCollectionInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: DeleteCollectionInput) => {
+      try {
+        await deleteCollectionHelper(params.collectionId);
+
+        return {
+          content: [{ type: "text", text: `Deleted collection ${params.collectionId}. Documents were not affected.` }],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+}

--- a/affine-mcp-server/src/tools/comments.ts
+++ b/affine-mcp-server/src/tools/comments.ts
@@ -1,0 +1,198 @@
+/**
+ * AFFiNE MCP Tools - Comment Operations
+ *
+ * list_comments, create_comment, resolve_comment, delete_comment
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ListCommentsInputSchema,
+  CreateCommentInputSchema,
+  ResolveCommentInputSchema,
+  DeleteCommentInputSchema,
+} from "../schemas/inputs.js";
+import type {
+  ListCommentsInput,
+  CreateCommentInput,
+  ResolveCommentInput,
+  DeleteCommentInput,
+} from "../schemas/inputs.js";
+import {
+  listComments as gqlListComments,
+  createComment as gqlCreateComment,
+  resolveComment as gqlResolveComment,
+  deleteComment as gqlDeleteComment,
+} from "../services/graphql.js";
+
+function handleError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  const msg = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${msg}` }],
+    isError: true,
+  };
+}
+
+export function registerCommentTools(server: McpServer): void {
+  // ─── affine_list_comments ───────────────────────────────────────────────
+  server.registerTool(
+    "affine_list_comments",
+    {
+      title: "List AFFiNE Comments",
+      description: `List all comments on an AFFiNE document.
+
+Returns document-level comments with their content, author, timestamp, and resolution status.
+
+Args:
+  - docId (string, required): The document ID to list comments for
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  Array of comments with: id, content, createdAt, userId, resolved
+
+Note: Comments are document-level. Inline text-anchored comments are not yet supported via API.`,
+      inputSchema: ListCommentsInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: ListCommentsInput) => {
+      try {
+        const comments = await gqlListComments(params.docId);
+
+        if (comments.length === 0) {
+          return { content: [{ type: "text", text: `No comments found on document ${params.docId}.` }] };
+        }
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify({ total: comments.length, comments }, null, 2) }] };
+        }
+
+        const lines = [`# Comments (${comments.length})`, ""];
+        for (const comment of comments) {
+          const status = comment.resolved ? "✅ Resolved" : "💬 Open";
+          const date = comment.createdAt ? new Date(comment.createdAt).toLocaleString() : "unknown";
+          const contentText = typeof comment.content === "string"
+            ? comment.content
+            : JSON.stringify(comment.content);
+          lines.push(`- [${status}] **${comment.id}** (${date})`);
+          lines.push(`  ${contentText}`);
+          lines.push("");
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_create_comment ──────────────────────────────────────────────
+  server.registerTool(
+    "affine_create_comment",
+    {
+      title: "Create AFFiNE Comment",
+      description: `Add a document-level comment to an AFFiNE document.
+
+Creates a comment visible to all workspace members. Comments are attached at the document level (not anchored to specific text).
+
+Args:
+  - docId (string, required): The document ID to comment on
+  - content (string, required): The comment text
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  The new comment's ID.`,
+      inputSchema: CreateCommentInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (params: CreateCommentInput) => {
+      try {
+        const result = await gqlCreateComment(params.docId, params.content);
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+        }
+
+        return {
+          content: [{ type: "text", text: `Created comment (${result.id}) on document ${params.docId}` }],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_resolve_comment ─────────────────────────────────────────────
+  server.registerTool(
+    "affine_resolve_comment",
+    {
+      title: "Resolve AFFiNE Comment",
+      description: `Mark a comment as resolved.
+
+Args:
+  - commentId (string, required): The comment ID to resolve
+
+Returns:
+  Confirmation of resolution.`,
+      inputSchema: ResolveCommentInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: ResolveCommentInput) => {
+      try {
+        await gqlResolveComment(params.commentId);
+        return {
+          content: [{ type: "text", text: `Comment ${params.commentId} marked as resolved.` }],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_delete_comment ──────────────────────────────────────────────
+  server.registerTool(
+    "affine_delete_comment",
+    {
+      title: "Delete AFFiNE Comment",
+      description: `Delete a comment from a document.
+
+Args:
+  - commentId (string, required): The comment ID to delete
+
+Returns:
+  Confirmation of deletion.
+
+Warning: This permanently removes the comment.`,
+      inputSchema: DeleteCommentInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: DeleteCommentInput) => {
+      try {
+        await gqlDeleteComment(params.commentId);
+        return {
+          content: [{ type: "text", text: `Comment ${params.commentId} deleted.` }],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+}

--- a/affine-mcp-server/src/tools/documents.ts
+++ b/affine-mcp-server/src/tools/documents.ts
@@ -1,0 +1,297 @@
+/**
+ * AFFiNE MCP Tools - Document Operations
+ *
+ * list_docs, create_doc, read_doc, edit_doc, delete_doc
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CHARACTER_LIMIT } from "../constants.js";
+import {
+  ListDocsInputSchema,
+  CreateDocInputSchema,
+  ReadDocInputSchema,
+  EditDocInputSchema,
+  DeleteDocInputSchema,
+} from "../schemas/inputs.js";
+import type {
+  ListDocsInput,
+  CreateDocInput,
+  ReadDocInput,
+  EditDocInput,
+  DeleteDocInput,
+} from "../schemas/inputs.js";
+import {
+  listDocsMeta,
+  addDocToMeta,
+  removeDocFromMeta,
+  loadYDoc,
+  pushYDoc,
+  createDocYDoc,
+  docToMarkdown,
+  applyEditOperations,
+} from "../services/yjs-helpers.js";
+import { deleteDoc as wsDeleteDoc } from "../services/websocket.js";
+
+function handleError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  const msg = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${msg}` }],
+    isError: true,
+  };
+}
+
+export function registerDocumentTools(server: McpServer): void {
+  // ─── affine_list_docs ───────────────────────────────────────────────────
+  server.registerTool(
+    "affine_list_docs",
+    {
+      title: "List AFFiNE Documents",
+      description: `List all documents in the AFFiNE workspace with metadata.
+
+Returns document IDs, titles, creation dates, and tags for every document in the workspace.
+
+Args:
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  Array of documents with: docId, title, createDate, updatedDate, tags`,
+      inputSchema: ListDocsInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: ListDocsInput) => {
+      try {
+        const docs = await listDocsMeta();
+
+        if (docs.length === 0) {
+          return { content: [{ type: "text", text: "No documents found in workspace." }] };
+        }
+
+        if (params.response_format === "json") {
+          const output = { total: docs.length, docs };
+          return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+        }
+
+        const lines = [`# Documents (${docs.length})`, ""];
+        for (const doc of docs) {
+          const date = doc.createDate ? new Date(doc.createDate).toISOString().split("T")[0] : "unknown";
+          const tags = doc.tags?.length ? ` [${doc.tags.join(", ")}]` : "";
+          lines.push(`- **${doc.title || "(untitled)"}** (${doc.id}) — created ${date}${tags}`);
+        }
+
+        let text = lines.join("\n");
+        if (text.length > CHARACTER_LIMIT) {
+          text = text.slice(0, CHARACTER_LIMIT) + "\n\n... (truncated)";
+        }
+
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_create_doc ──────────────────────────────────────────────────
+  server.registerTool(
+    "affine_create_doc",
+    {
+      title: "Create AFFiNE Document",
+      description: `Create a new document in the AFFiNE workspace.
+
+Creates a document with the given title and optional markdown content. The document will appear in the workspace sidebar for all users.
+
+Args:
+  - title (string, required): Document title
+  - markdown (string, optional): Markdown content to populate the document
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  The new document's ID and title.
+
+Examples:
+  - Create empty doc: {title: "Meeting Notes"}
+  - Create with content: {title: "README", markdown: "# Project\\n\\nDescription here"}`,
+      inputSchema: CreateDocInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (params: CreateDocInput) => {
+      try {
+        const { ydoc, docId } = createDocYDoc(params.title, params.markdown);
+
+        // Push the document
+        await pushYDoc(docId, ydoc);
+
+        // Add to workspace metadata so it appears in sidebar
+        await addDocToMeta(docId, params.title);
+
+        const output = { docId, title: params.title };
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Created document **${params.title}** (${docId})`,
+            },
+          ],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_read_doc ────────────────────────────────────────────────────
+  server.registerTool(
+    "affine_read_doc",
+    {
+      title: "Read AFFiNE Document",
+      description: `Read the full content of an AFFiNE document as markdown.
+
+Loads the document's Yjs state and converts the block tree to markdown, preserving headings, lists, code blocks, formatting, and links.
+
+Args:
+  - docId (string, required): The document ID to read
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  Document title, markdown content, and block count.
+
+Error Handling:
+  - Returns "DOC_NOT_FOUND" if the document doesn't exist`,
+      inputSchema: ReadDocInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: ReadDocInput) => {
+      try {
+        const ydoc = await loadYDoc(params.docId);
+        const { title, markdown, blockCount } = docToMarkdown(ydoc);
+
+        if (params.response_format === "json") {
+          const output = { docId: params.docId, title, markdown, blockCount };
+          return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+        }
+
+        let text = `# ${title || "(untitled)"}\n\n${markdown}`;
+        if (text.length > CHARACTER_LIMIT) {
+          text = text.slice(0, CHARACTER_LIMIT) + "\n\n... (truncated, " + blockCount + " blocks total)";
+        }
+
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_edit_doc ────────────────────────────────────────────────────
+  server.registerTool(
+    "affine_edit_doc",
+    {
+      title: "Edit AFFiNE Document",
+      description: `Edit blocks in an existing AFFiNE document.
+
+Supports appending new blocks, updating existing block content, and deleting blocks. Operations are applied sequentially with CRDT safety.
+
+Args:
+  - docId (string, required): The document ID to edit
+  - operations (array, required): Array of edit operations:
+    - append: Add a new block. Specify blockType ('paragraph', 'list', 'code', 'divider'), propType ('text', 'h1'-'h6', 'quote', 'bulleted', 'numbered', 'todo'), and content.
+    - update: Modify an existing block. Specify blockId and new content.
+    - delete: Remove a block. Specify blockId.
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  List of affected block IDs.
+
+Examples:
+  - Append heading: {docId: "...", operations: [{action: "append", blockType: "paragraph", propType: "h2", content: "New Section"}]}
+  - Append bullet list: {docId: "...", operations: [{action: "append", blockType: "list", propType: "bulleted", content: "Item one"}]}
+  - Update block: {docId: "...", operations: [{action: "update", blockId: "abc123", content: "Updated text"}]}
+  - Delete block: {docId: "...", operations: [{action: "delete", blockId: "abc123"}]}`,
+      inputSchema: EditDocInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: true,
+      },
+    },
+    async (params: EditDocInput) => {
+      try {
+        const blockIds = await applyEditOperations(params.docId, params.operations);
+
+        if (params.response_format === "json") {
+          const output = { success: true, blockIds, operationCount: params.operations.length };
+          return { content: [{ type: "text", text: JSON.stringify(output, null, 2) }] };
+        }
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Applied ${params.operations.length} operation(s) to document. Affected blocks: ${blockIds.join(", ")}`,
+            },
+          ],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_delete_doc ──────────────────────────────────────────────────
+  server.registerTool(
+    "affine_delete_doc",
+    {
+      title: "Delete AFFiNE Document",
+      description: `Move an AFFiNE document to trash.
+
+This removes the document from the workspace. The operation is performed via WebSocket and also removes the document from workspace metadata.
+
+Args:
+  - docId (string, required): The document ID to delete
+
+Returns:
+  Confirmation of deletion.
+
+Warning: This action moves the document to trash. Recovery may depend on server configuration.`,
+      inputSchema: DeleteDocInputSchema,
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: DeleteDocInput) => {
+      try {
+        await wsDeleteDoc(params.docId);
+        await removeDocFromMeta(params.docId);
+
+        return {
+          content: [{ type: "text", text: `Document ${params.docId} moved to trash.` }],
+        };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+}

--- a/affine-mcp-server/src/tools/utility.ts
+++ b/affine-mcp-server/src/tools/utility.ts
@@ -1,0 +1,215 @@
+/**
+ * AFFiNE MCP Tools - Utility Operations
+ *
+ * search, current_user
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import axios from "axios";
+import { AFFINE_BASE_URL, AFFINE_WORKSPACE_ID, API_TIMEOUT, CHARACTER_LIMIT } from "../constants.js";
+import { getSessionCookies } from "../services/auth.js";
+import { getCurrentUser } from "../services/graphql.js";
+import { listDocsMeta, loadYDoc, docToMarkdown } from "../services/yjs-helpers.js";
+import {
+  SearchInputSchema,
+  CurrentUserInputSchema,
+} from "../schemas/inputs.js";
+import type { SearchInput, CurrentUserInput } from "../schemas/inputs.js";
+
+function handleError(error: unknown): { content: Array<{ type: "text"; text: string }>; isError: true } {
+  const msg = error instanceof Error ? error.message : String(error);
+  return {
+    content: [{ type: "text" as const, text: `Error: ${msg}` }],
+    isError: true,
+  };
+}
+
+export function registerUtilityTools(server: McpServer): void {
+  // ─── affine_search ──────────────────────────────────────────────────────
+  server.registerTool(
+    "affine_search",
+    {
+      title: "Search AFFiNE Documents",
+      description: `Search across all documents in the AFFiNE workspace.
+
+First attempts to use the built-in MCP keyword search. If that's unavailable (no search provider configured), falls back to loading each document and scanning its text content.
+
+Args:
+  - query (string, required): Search query to match against document content
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  List of matching documents with relevant snippets.
+
+Note: Fallback search loads all docs which may be slow for large workspaces.`,
+      inputSchema: SearchInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: SearchInput) => {
+      try {
+        // Try built-in MCP keyword search first
+        try {
+          const cookies = await getSessionCookies();
+          const mcpUrl = `${AFFINE_BASE_URL}/api/workspaces/${AFFINE_WORKSPACE_ID}/mcp`;
+
+          const response = await axios.post(
+            mcpUrl,
+            {
+              jsonrpc: "2.0",
+              id: 1,
+              method: "tools/call",
+              params: {
+                name: "keyword_search",
+                arguments: { query: params.query },
+              },
+            },
+            {
+              timeout: API_TIMEOUT,
+              headers: {
+                "Content-Type": "application/json",
+                Cookie: cookies,
+              },
+              responseType: "text",
+            }
+          );
+
+          // Parse SSE response
+          const text = typeof response.data === "string" ? response.data : JSON.stringify(response.data);
+          const dataLines = text.split("\n").filter((l: string) => l.startsWith("data:"));
+
+          if (dataLines.length > 0) {
+            const lastData = dataLines[dataLines.length - 1].replace("data:", "").trim();
+            const parsed = JSON.parse(lastData);
+
+            if (parsed.result?.content?.[0]?.text) {
+              const resultText = parsed.result.content[0].text;
+              if (!resultText.includes("Search provider not found")) {
+                return { content: [{ type: "text", text: resultText }] };
+              }
+            }
+          }
+        } catch {
+          // Built-in search unavailable, fall through to manual search
+        }
+
+        // Fallback: manual search across all docs
+        console.error("Search: Falling back to manual document scanning");
+        const docs = await listDocsMeta();
+        const queryLower = params.query.toLowerCase();
+        const matches: Array<{ docId: string; title: string; snippet: string }> = [];
+
+        for (const doc of docs) {
+          try {
+            // Check title first
+            if (doc.title?.toLowerCase().includes(queryLower)) {
+              matches.push({
+                docId: doc.id,
+                title: doc.title || "(untitled)",
+                snippet: `Title match: "${doc.title}"`,
+              });
+              continue;
+            }
+
+            // Load and search content
+            const ydoc = await loadYDoc(doc.id);
+            const { markdown } = docToMarkdown(ydoc);
+
+            const idx = markdown.toLowerCase().indexOf(queryLower);
+            if (idx !== -1) {
+              const start = Math.max(0, idx - 50);
+              const end = Math.min(markdown.length, idx + params.query.length + 50);
+              const snippet = (start > 0 ? "..." : "") + markdown.slice(start, end) + (end < markdown.length ? "..." : "");
+
+              matches.push({
+                docId: doc.id,
+                title: doc.title || "(untitled)",
+                snippet,
+              });
+            }
+          } catch {
+            // Skip docs that fail to load
+          }
+        }
+
+        if (matches.length === 0) {
+          return { content: [{ type: "text", text: `No documents found matching "${params.query}".` }] };
+        }
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify({ total: matches.length, matches }, null, 2) }] };
+        }
+
+        const lines = [`# Search Results for "${params.query}" (${matches.length} match${matches.length === 1 ? "" : "es"})`, ""];
+        for (const m of matches) {
+          lines.push(`- **${m.title}** (${m.docId})`);
+          lines.push(`  ${m.snippet}`);
+          lines.push("");
+        }
+
+        let text = lines.join("\n");
+        if (text.length > CHARACTER_LIMIT) {
+          text = text.slice(0, CHARACTER_LIMIT) + "\n\n... (truncated)";
+        }
+
+        return { content: [{ type: "text", text }] };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+
+  // ─── affine_current_user ────────────────────────────────────────────────
+  server.registerTool(
+    "affine_current_user",
+    {
+      title: "Get Current AFFiNE User",
+      description: `Get information about the currently authenticated AFFiNE user.
+
+Args:
+  - response_format ('markdown' | 'json'): Output format (default: 'markdown')
+
+Returns:
+  User ID, name, email, and avatar URL.`,
+      inputSchema: CurrentUserInputSchema,
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    async (params: CurrentUserInput) => {
+      try {
+        const user = await getCurrentUser();
+
+        if (!user) {
+          return { content: [{ type: "text", text: "No user session found. Authentication may have failed." }] };
+        }
+
+        if (params.response_format === "json") {
+          return { content: [{ type: "text", text: JSON.stringify(user, null, 2) }] };
+        }
+
+        const lines = [
+          `# Current User`,
+          "",
+          `- **Name**: ${user.name}`,
+          `- **Email**: ${user.email}`,
+          `- **ID**: ${user.id}`,
+        ];
+        if (user.avatarUrl) {
+          lines.push(`- **Avatar**: ${user.avatarUrl}`);
+        }
+
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (error) {
+        return handleError(error);
+      }
+    }
+  );
+}

--- a/affine-mcp-server/src/types.ts
+++ b/affine-mcp-server/src/types.ts
@@ -1,0 +1,94 @@
+/**
+ * AFFiNE MCP Server - Type Definitions
+ */
+
+/** Document metadata from workspace root doc */
+export interface DocMeta {
+  id: string;
+  title: string;
+  createDate: number;
+  updatedDate?: number;
+  tags?: string[];
+}
+
+/** Collection metadata from workspace root doc */
+export interface CollectionMeta {
+  id: string;
+  name: string;
+  docIds: string[];
+  docCount: number;
+}
+
+/** Block data within a document */
+export interface BlockInfo {
+  id: string;
+  flavour: string;
+  type?: string;
+  text?: string;
+  children: string[];
+  checked?: boolean;
+  language?: string;
+}
+
+/** Edit operation for affine_edit_doc */
+export interface EditOperation {
+  action: "append" | "update" | "delete";
+  blockType?: string;
+  content?: string;
+  blockId?: string;
+  propType?: string;
+}
+
+/** Comment data from GraphQL */
+export interface CommentData {
+  id: string;
+  content: unknown;
+  createdAt: string;
+  userId?: string;
+  resolved?: boolean;
+}
+
+/** Result of a WebSocket space:join */
+export interface JoinResult {
+  clientId?: string;
+  success: boolean;
+}
+
+/** Result of a WebSocket space:load-doc */
+export interface LoadDocResult {
+  missing: string; // base64-encoded Yjs update (full doc state despite the name)
+  state: string;   // base64-encoded state vector
+  timestamp: number;
+}
+
+/** Result of a WebSocket space:push-doc-update */
+export interface PushUpdateResult {
+  accepted: boolean;
+  timestamp?: number;
+}
+
+/** Auth session cookies */
+export interface AuthSession {
+  cookies: string;
+  expiresAt?: number;
+}
+
+/** Response format enum */
+export enum ResponseFormat {
+  MARKDOWN = "markdown",
+  JSON = "json",
+}
+
+/** Rich text delta attribute */
+export interface TextDelta {
+  insert: string;
+  attributes?: {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    strike?: boolean;
+    code?: boolean;
+    link?: string;
+    reference?: unknown;
+  };
+}

--- a/affine-mcp-server/tsconfig.json
+++ b/affine-mcp-server/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Custom MCP server for self-hosted AFFiNE 0.26.2 workspaces. Provides 15 tools via stdio transport for OpenClaw/Claude Code:

- Documents (5): list, create, read, edit, delete
- Collections (4): list, create, update, delete
- Comments (4): list, create, resolve, delete
- Utility (2): search, current_user

Uses REST auth (session cookies), Socket.IO/Yjs CRDT for document operations, and GraphQL for comments/user queries. Sequential per-doc write queues prevent CRDT conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AFFINE MCP Server integration for Model Context Protocol support
  * Added document management tools (list, create, read, edit, delete documents)
  * Added collection management tools (create, update, delete, organize documents)
  * Added comment management tools (create, resolve, delete document comments)
  * Added search functionality across documents
  * Added current user information retrieval
  * Support for markdown and JSON output formats

* **Documentation**
  * Added comprehensive README with setup, configuration, and usage guide
  * Added environment configuration template

* **Chores**
  * Added TypeScript project configuration and build scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->