### PR TITLE
[helm chart] Support external secrets for Postgres, plus other small changes

### DIFF
--- a/.github/helm/affine/charts/common/Chart.yaml
+++ b/.github/helm/affine/charts/common/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: common
+description: templates and helpers common to the affine chart and its sub-charts
+type: application
+version: 0.0.0
+appVersion: "0.26.1"

--- a/.github/helm/affine/charts/common/Chart.yaml
+++ b/.github/helm/affine/charts/common/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: common
 description: templates and helpers common to the affine chart and its sub-charts
-type: application
+type: library
 version: 0.0.0
 appVersion: "0.26.1"

--- a/.github/helm/affine/charts/common/templates/_helpers.tpl
+++ b/.github/helm/affine/charts/common/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "common.environment" -}}
+{{- .Values.global.app.environment | default .Release.Namespace -}}
+{{- end -}}

--- a/.github/helm/affine/charts/common/templates/_indexer_env.yaml
+++ b/.github/helm/affine/charts/common/templates/_indexer_env.yaml
@@ -14,4 +14,3 @@
       key: indexer-apiKey
 {{- end }}
 {{- end }}
-{{- end }}

--- a/.github/helm/affine/charts/common/templates/_indexer_env.yaml
+++ b/.github/helm/affine/charts/common/templates/_indexer_env.yaml
@@ -1,0 +1,16 @@
+{{/* environment variables required for AFFiNE to connect to Indexer */}}
+{{- define "common.indexer-env" }}
+- name: AFFINE_INDEXER_ENABLED
+  value: {{ quote .Values.global.indexer.enabled }}
+- name: AFFINE_INDEXER_SEARCH_PROVIDER
+  value: "{{ .Values.global.indexer.provider }}"
+- name: AFFINE_INDEXER_SEARCH_ENDPOINT
+  value: "{{ .Values.global.indexer.endpoint }}"
+{{- if .Values.global.indexer.apiKey -}}
+- name: AFFINE_INDEXER_SEARCH_API_KEY
+  valueFrom:
+    secretKeyRef:
+    name: indexer
+    key: indexer-apiKey
+{{- end }}
+{{- end }}

--- a/.github/helm/affine/charts/common/templates/_indexer_env.yaml
+++ b/.github/helm/affine/charts/common/templates/_indexer_env.yaml
@@ -6,11 +6,12 @@
   value: "{{ .Values.global.indexer.provider }}"
 - name: AFFINE_INDEXER_SEARCH_ENDPOINT
   value: "{{ .Values.global.indexer.endpoint }}"
-{{- if .Values.global.indexer.apiKey -}}
+{{- if .Values.global.indexer.apiKey }}
 - name: AFFINE_INDEXER_SEARCH_API_KEY
   valueFrom:
     secretKeyRef:
-    name: indexer
-    key: indexer-apiKey
+      name: indexer
+      key: indexer-apiKey
+{{- end }}
 {{- end }}
 {{- end }}

--- a/.github/helm/affine/charts/common/templates/_pg_env.yaml
+++ b/.github/helm/affine/charts/common/templates/_pg_env.yaml
@@ -1,0 +1,16 @@
+{{/* environment variables required for AFFiNE to connect to Postgres */}}
+{{- define "common.pg-env" }}
+- name: DATABASE_USERNAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ quote .Values.global.database.secretName }}
+      key: {{ quote .Values.global.database.secretUsernameField }}
+- name: DATABASE_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ quote .Values.global.database.secretName }}
+      key: {{ quote .Values.global.database.secretPasswordField }}
+- name: DATABASE_URL
+  # TODO: make this more resilient (eg; username/password should be URL-escaped)
+  value: "postgres://$(DATABASE_USERNAME):$(DATABASE_PASSWORD)@{{ .Values.global.database.host }}:{{ .Values.global.database.port }}/{{ .Values.global.database.name }}?schema=data"
+{{- end }}

--- a/.github/helm/affine/charts/common/templates/_redis_env.yaml
+++ b/.github/helm/affine/charts/common/templates/_redis_env.yaml
@@ -1,0 +1,18 @@
+{{/* environment variables required for AFFiNE to connect to Redis */}}
+{{- define "common.redis-env" }}
+- name: REDIS_SERVER_HOST
+  value: "{{ .Values.global.redis.host }}"
+- name: REDIS_SERVER_PORT
+  value: "{{ .Values.global.redis.port }}"
+- name: REDIS_SERVER_USER
+  value: "{{ .Values.global.redis.username }}"
+- name: REDIS_SERVER_DATABASE
+  value: "{{ .Values.global.redis.database }}"
+{{- if .Values.global.redis.password }}
+- name: REDIS_SERVER_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: redis
+      key: redis-password
+{{- end }}
+{{- end }}

--- a/.github/helm/affine/charts/front/Chart.yaml
+++ b/.github/helm/affine/charts/front/Chart.yaml
@@ -5,6 +5,9 @@ type: application
 version: 0.0.0
 appVersion: "0.26.3"
 dependencies:
+  - name: common
+    version: 0.0.0
+    repository: "file://../common"
   - name: gcloud-sql-proxy
     version: 0.0.0
     repository: "file://../gcloud-sql-proxy"

--- a/.github/helm/affine/charts/front/templates/deployment.yaml
+++ b/.github/helm/affine/charts/front/templates/deployment.yaml
@@ -48,38 +48,10 @@ spec:
             - name: SERVER_FLAVOR
               value: "front"
             - name: AFFINE_ENV
-              value: "{{ .Release.Namespace }}"
-            - name: DATABASE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: pg-postgresql
-                  key: postgres-password
-            - name: DATABASE_URL
-              value: postgres://{{ .Values.global.database.user }}:$(DATABASE_PASSWORD)@{{ .Values.global.database.host }}:{{ .Values.global.database.port }}/{{ .Values.global.database.name }}
-            - name: REDIS_SERVER_ENABLED
-              value: "true"
-            - name: REDIS_SERVER_HOST
-              value: "{{ .Values.global.redis.host }}"
-            - name: REDIS_SERVER_PORT
-              value: "{{ .Values.global.redis.port }}"
-            - name: REDIS_SERVER_USER
-              value: "{{ .Values.global.redis.username }}"
-            - name: REDIS_SERVER_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: redis
-                  key: redis-password
-            - name: REDIS_SERVER_DATABASE
-              value: "{{ .Values.global.redis.database }}"
-            - name: AFFINE_INDEXER_SEARCH_PROVIDER
-              value: "{{ .Values.global.indexer.provider }}"
-            - name: AFFINE_INDEXER_SEARCH_ENDPOINT
-              value: "{{ .Values.global.indexer.endpoint }}"
-            - name: AFFINE_INDEXER_SEARCH_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: indexer
-                  key: indexer-apiKey
+              value: "{{ include "common.environment" . }}"
+            {{- include "common.pg-env" . | nindent 12 }}
+            {{- include "common.redis-env" . | nindent 12 }}
+            {{- include "common.indexer-env" . | nindent 12 }}
             - name: AFFINE_SERVER_PORT
               value: "{{ .Values.app.port }}"
             - name: AFFINE_SERVER_SUB_PATH

--- a/.github/helm/affine/charts/graphql/Chart.yaml
+++ b/.github/helm/affine/charts/graphql/Chart.yaml
@@ -5,6 +5,9 @@ type: application
 version: 0.0.0
 appVersion: "0.26.3"
 dependencies:
+  - name: common
+    version: 0.0.0
+    repository: "file://../common"
   - name: gcloud-sql-proxy
     version: 0.0.0
     repository: "file://../gcloud-sql-proxy"

--- a/.github/helm/affine/charts/graphql/templates/deployment.yaml
+++ b/.github/helm/affine/charts/graphql/templates/deployment.yaml
@@ -46,36 +46,10 @@ spec:
           - name: SERVER_FLAVOR
             value: "graphql"
           - name: AFFINE_ENV
-            value: "{{ .Release.Namespace }}"
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: pg-postgresql
-                key: postgres-password
-          - name: DATABASE_URL
-            value: postgres://{{ .Values.global.database.user }}:$(DATABASE_PASSWORD)@{{ .Values.global.database.host }}:{{ .Values.global.database.port }}/{{ .Values.global.database.name }}
-          - name: REDIS_SERVER_HOST
-            value: "{{ .Values.global.redis.host }}"
-          - name: REDIS_SERVER_PORT
-            value: "{{ .Values.global.redis.port }}"
-          - name: REDIS_SERVER_USER
-            value: "{{ .Values.global.redis.username }}"
-          - name: REDIS_SERVER_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: redis
-                key: redis-password
-          - name: REDIS_SERVER_DATABASE
-            value: "{{ .Values.global.redis.database }}"
-          - name: AFFINE_INDEXER_SEARCH_PROVIDER
-            value: "{{ .Values.global.indexer.provider }}"
-          - name: AFFINE_INDEXER_SEARCH_ENDPOINT
-            value: "{{ .Values.global.indexer.endpoint }}"
-          - name: AFFINE_INDEXER_SEARCH_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: indexer
-                key: indexer-apiKey
+            value: "{{ include "common.environment" . }}"
+          {{- include "common.pg-env" . | nindent 10 }}
+          {{- include "common.redis-env" . | nindent 10 }}
+          {{- include "common.indexer-env" . | nindent 10 }}
           - name: AFFINE_SERVER_PORT
             value: "{{ .Values.service.port }}"
           - name: AFFINE_SERVER_SUB_PATH

--- a/.github/helm/affine/charts/graphql/templates/migration.yaml
+++ b/.github/helm/affine/charts/graphql/templates/migration.yaml
@@ -21,38 +21,14 @@ spec:
           - name: NODE_ENV
             value: "{{ .Values.env }}"
           - name: AFFINE_ENV
-            value: "{{ .Release.Namespace }}"
+            value: "{{ include "common.environment" . }}"
           - name: DEPLOYMENT_TYPE
             value: "{{ .Values.global.deployment.type }}"
           - name: DEPLOYMENT_PLATFORM
             value: "{{ .Values.global.deployment.platform }}"
-          - name: DATABASE_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: pg-postgresql
-                key: postgres-password
-          - name: DATABASE_URL
-            value: postgres://{{ .Values.global.database.user }}:$(DATABASE_PASSWORD)@{{ .Values.global.database.host }}:{{ .Values.global.database.port }}/{{ .Values.global.database.name }}
-          - name: REDIS_SERVER_HOST
-            value: "{{ .Values.global.redis.host }}"
-          - name: REDIS_SERVER_PORT
-            value: "{{ .Values.global.redis.port }}"
-          - name: REDIS_SERVER_USER
-            value: "{{ .Values.global.redis.username }}"
-          - name: REDIS_SERVER_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: redis
-                key: redis-password
-          - name: AFFINE_INDEXER_SEARCH_PROVIDER
-            value: "{{ .Values.global.indexer.provider }}"
-          - name: AFFINE_INDEXER_SEARCH_ENDPOINT
-            value: "{{ .Values.global.indexer.endpoint }}"
-          - name: AFFINE_INDEXER_SEARCH_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: indexer
-                key: indexer-apiKey
+          {{- include "common.pg-env" . | nindent 10 }}
+          {{- include "common.redis-env" . | nindent 10 }}
+          {{- include "common.indexer-env" . | nindent 10 }}
         resources:
           requests:
             cpu: '100m'

--- a/.github/helm/affine/templates/pg-secret.yaml
+++ b/.github/helm/affine/templates/pg-secret.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ quote .Values.global.database.secretName }}
 type: Opaque
 data:
-  {{ quote .Values.global.database.secretUsernameField }}: {{ .Values.global.database.secretUsernameField | b64enc }}
+  {{ quote .Values.global.database.secretUsernameField }}: {{ .Values.global.database.username | b64enc }}
   {{ quote .Values.global.database.secretPasswordField }}: {{ .Values.global.database.password | b64enc }}
 {{- end }}

--- a/.github/helm/affine/templates/pg-secret.yaml
+++ b/.github/helm/affine/templates/pg-secret.yaml
@@ -5,6 +5,6 @@ metadata:
   name: {{ quote .Values.global.database.secretName }}
 type: Opaque
 data:
-  {{ quote .Values.global.database.secretUsernameField }}: {{ .Values.global.database.username | b64enc }}
+  {{ quote .Values.global.database.secretUsernameField }}: {{ .Values.global.database.user | b64enc }}
   {{ quote .Values.global.database.secretPasswordField }}: {{ .Values.global.database.password | b64enc }}
 {{- end }}

--- a/.github/helm/affine/templates/pg-secret.yaml
+++ b/.github/helm/affine/templates/pg-secret.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: pg-postgresql
+  name: {{ quote .Values.global.database.secretName }}
 type: Opaque
 data:
-  postgres-password: {{ .Values.global.database.password | b64enc }}
+  {{ quote .Values.global.database.secretUsernameField }}: {{ .Values.global.database.secretUsernameField | b64enc }}
+  {{ quote .Values.global.database.secretPasswordField }}: {{ .Values.global.database.password | b64enc }}
 {{- end }}

--- a/.github/helm/affine/values.yaml
+++ b/.github/helm/affine/values.yaml
@@ -1,6 +1,9 @@
 global:
   app:
     buildType: 'stable'
+    # set to 'dev', 'beta', or 'production'.
+    # if not set, will use the name of the kubernetes namespace.
+    environment: ''
   ingress:
     enabled: false
     className: ''
@@ -16,6 +19,14 @@ global:
     secretName: 'server-private-key'
     privateKey: ''
   database:
+    # if "password" is set, this chart will store that password in a secret
+    # that AFFiNE will use to connect.
+    #
+    # if you want to reuse an existing secret, leave 'password' blank
+    # and change `secretName` (and optionally `secretPasswordField`).
+    secretName: 'pg-postgresql'
+    secretUsernameField: 'postgres-username'
+    secretPasswordField: 'postgres-password'
     user: 'postgres'
     host: 'pg-postgresql'
     port: '5432'
@@ -28,10 +39,10 @@ global:
     password: ''
     database: 0
   indexer:
+    enabled: true
     provider: ''
     endpoint: ''
-    username: ''
-    password: ''
+    apiKey: ''
   docService:
     name: 'affine-doc'
     port: 3020


### PR DESCRIPTION
I am deploying AFFiNE to a cluster where I use the [Postgres Operator](https://github.com/zalando/postgres-operator) to deploy my databases. Both this operator, and the AFFiNE chart, are opinionated about the format of the Postgres secret. This change both adds the Postgres username to the secret, and allows you to choose the field names for username/password.

I then use chart values like the following to deploy AFFiNE:

```yaml
global:
  database:
    secretName: "affine-website-im-owner-user.db.credentials.postgresql.acid.zalan.do"
    secretUsernameField: "username"
    secretPasswordField: "password"
    host: db.mori.svc
    name: affine_website_im
    user: affine_website_im
```

I also have made the following changes to the chart, in order to deploy it to my cluster (self-hosted K3S):

* New value `global.app.environment`: The current chart uses the K8S namespace as the name of the AFFiNE environment by default. `global.app.environment` lets you override this, so I don't have to place my AFFiNE in a namespace called "production".

* Doesn't crash if indexer is not configured

* Removed `global.indexer.username`/`password` as they are not used by the code

* Removed references to enabling/disabling Redis as AFFiNE will crash if there is no Redis

* Created a sub-chart, "common", to contain things that were previously being copy-pasted across three charts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared chart delivering reusable environment and service configuration templates.
  * Added centralized templates for Postgres, Redis, and Indexer environment setup.

* **Chores**
  * Refactored deployments to use the new reusable env templates.
  * Added configurable deployment environment variable.
  * Switched Indexer auth to API-key mode with an explicit enable flag.
  * Made database secret handling configurable (secret name and field names).
* **Dependencies**
  * Frontend and GraphQL charts now include the shared chart as a dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->