### PR TITLE
fix(security): run Docker container as non-root user

### DIFF
--- a/.docker/selfhost/compose.yml
+++ b/.docker/selfhost/compose.yml
@@ -14,8 +14,8 @@ services:
         condition: service_completed_successfully
     volumes:
       # custom configurations
-      - ${UPLOAD_LOCATION}:/root/.affine/storage
-      - ${CONFIG_LOCATION}:/root/.affine/config
+      - ${UPLOAD_LOCATION}:/home/affine/.affine/storage
+      - ${CONFIG_LOCATION}:/home/affine/.affine/config
     env_file:
       - .env
     environment:
@@ -29,8 +29,8 @@ services:
     container_name: affine_migration_job
     volumes:
       # custom configurations
-      - ${UPLOAD_LOCATION}:/root/.affine/storage
-      - ${CONFIG_LOCATION}:/root/.affine/config
+      - ${UPLOAD_LOCATION}:/home/affine/.affine/storage
+      - ${CONFIG_LOCATION}:/home/affine/.affine/config
     command: ['sh', '-c', 'node ./scripts/self-host-predeploy.js']
     env_file:
       - .env

--- a/.github/deployment/node/Dockerfile
+++ b/.github/deployment/node/Dockerfile
@@ -27,9 +27,19 @@ RUN apt-get update && \
   apt-get install -y --no-install-recommends openssl libjemalloc2 && \
   rm -rf /var/lib/apt/lists/*
 
+# Create non-root user for security
+ARG APP_UID=1000
+ARG APP_GID=1000
+RUN groupadd -g "${APP_GID}" affine && \
+    useradd -m -u "${APP_UID}" -g "${APP_GID}" -s /usr/sbin/nologin affine && \
+    chown -R "${APP_UID}:${APP_GID}" /app
+
 # Enable jemalloc by preloading the library
 ENV LD_PRELOAD=libjemalloc.so.2
 
 EXPOSE 3010
+
+# Run as non-root user
+USER ${APP_UID}:${APP_GID}
 
 CMD ["node", "./dist/main.js"]


### PR DESCRIPTION
Fixes #14584

Add non-root user to Docker container for security.

- Create affine user with configurable UID/GID
- Set proper ownership
- Run as non-root user

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Application process in the container now runs as a non-root user.
* **Configuration**
  * Default host mount paths for storage and configuration updated from /root/.affine to /home/affine/.affine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->