### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -46,7 +46,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           PERFSEE_TOKEN: ${{ secrets.PERFSEE_TOKEN }}
       - name: Upload web artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: web
           path: ./packages/frontend/apps/web/dist
@@ -78,7 +78,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           PERFSEE_TOKEN: ${{ secrets.PERFSEE_TOKEN }}
       - name: Upload admin artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: admin
           path: ./packages/frontend/admin/dist
@@ -110,7 +110,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           PERFSEE_TOKEN: ${{ secrets.PERFSEE_TOKEN }}
       - name: Upload mobile artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mobile
           path: ./packages/frontend/apps/mobile/dist
@@ -154,7 +154,7 @@ jobs:
         run: |
           mv ./packages/backend/native/server-native.node ./packages/backend/native/${{ matrix.targets.file }}
       - name: Upload ${{ matrix.targets.file }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-native-${{ matrix.targets.file }}
           path: ./packages/backend/native/${{ matrix.targets.file }}
@@ -177,7 +177,7 @@ jobs:
           electron-install: false
           extra-flags: workspaces focus @affine/server @types/affine__env
       - name: Download server-native
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: server-native-*
           merge-multiple: true
@@ -187,7 +187,7 @@ jobs:
       - name: Build Server
         run: yarn workspace @affine/server build
       - name: Upload server dist
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-dist
           path: ./packages/backend/server/dist
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download server dist
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-dist
           path: ./packages/backend/server/dist
@@ -229,19 +229,19 @@ jobs:
           scope: '@toeverything'
 
       - name: Download web artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: web
           path: ./packages/frontend/apps/web/dist
 
       - name: Download mobile artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mobile
           path: ./packages/frontend/apps/mobile/dist
 
       - name: Download admin artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: admin
           path: ./packages/frontend/admin/dist

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -189,7 +189,7 @@ jobs:
           full-cache: true
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -246,7 +246,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-bs-${{ matrix.shard }}
           path: ./test-results
@@ -276,7 +276,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-bs-cross-browser
           path: ./test-results
@@ -309,7 +309,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-${{ matrix.shard }}
           path: ./test-results
@@ -340,7 +340,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-mobile-${{ matrix.shard }}
           path: ./test-results
@@ -368,7 +368,7 @@ jobs:
           full-cache: true
 
       - name: Download affine.linux-x64-gnu.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine.linux-x64-gnu.node
           path: ./packages/frontend/native
@@ -410,7 +410,7 @@ jobs:
           target: x86_64-unknown-linux-gnu
           package: '@affine/native'
       - name: Upload ${{ steps.filename.outputs.filename }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ steps.filename.outputs.filename }}
@@ -449,7 +449,7 @@ jobs:
           target: ${{ matrix.spec.target }}
           package: '@affine/native'
       - name: Upload ${{ steps.filename.outputs.filename }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ steps.filename.outputs.filename }}
@@ -498,7 +498,7 @@ jobs:
           target: ${{ matrix.spec.target }}
           package: '@affine/native'
       - name: Upload ${{ steps.filename.outputs.filename }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: ${{ steps.filename.outputs.filename }}
@@ -523,7 +523,7 @@ jobs:
           target: 'x86_64-unknown-linux-gnu'
           package: '@affine/server-native'
       - name: Upload server-native.node
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: server-native.node
@@ -548,7 +548,7 @@ jobs:
       - name: zip web
         run: tar -czf dist.tar.gz --directory=packages/frontend/apps/electron-renderer/dist .
       - name: Upload web artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: web
@@ -568,7 +568,7 @@ jobs:
           extra-flags: workspaces focus @affine-tools/cli @affine/monorepo @affine/native
           electron-install: false
       - name: Download affine.linux-x64-gnu.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine.linux-x64-gnu.node
           path: ./packages/frontend/native
@@ -625,7 +625,7 @@ jobs:
           full-cache: true
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -706,7 +706,7 @@ jobs:
           full-cache: true
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -769,7 +769,7 @@ jobs:
           full-cache: true
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -877,7 +877,7 @@ jobs:
 
       - name: upload fuzz artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: fuzz-artifact
           path: packages/common/y-octo/utils/fuzz/artifacts/**/*
@@ -993,7 +993,7 @@ jobs:
           full-cache: true
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -1068,7 +1068,7 @@ jobs:
           hard-link-nm: false
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -1151,13 +1151,13 @@ jobs:
           hard-link-nm: false
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
 
       - name: Download affine.linux-x64-gnu.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine.linux-x64-gnu.node
           path: ./packages/frontend/native
@@ -1173,7 +1173,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-server-${{ matrix.tests.shard }}
           path: ./test-results
@@ -1239,7 +1239,7 @@ jobs:
           echo "filename=affine.$PLATFORM_ARCH_ABI.node" >> "$GITHUB_OUTPUT"
 
       - name: Download ${{ steps.filename.outputs.filename }}
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ${{ steps.filename.outputs.filename }}
           path: ./packages/frontend/native
@@ -1311,7 +1311,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results-e2e-${{ matrix.spec.os }}-${{ matrix.spec.arch }}
           path: ./test-results

--- a/.github/workflows/copilot-test.yml
+++ b/.github/workflows/copilot-test.yml
@@ -22,7 +22,7 @@ jobs:
           target: 'x86_64-unknown-linux-gnu'
           package: '@affine/server-native'
       - name: Upload server-native.node
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: server-native.node
           path: ./packages/backend/native/server-native.node
@@ -74,7 +74,7 @@ jobs:
           full-cache: true
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native
@@ -144,7 +144,7 @@ jobs:
           hard-link-nm: false
 
       - name: Download server-native.node
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: server-native.node
           path: ./packages/backend/native

--- a/.github/workflows/release-desktop-platform.yml
+++ b/.github/workflows/release-desktop-platform.yml
@@ -91,7 +91,7 @@ jobs:
           target: ${{ inputs.target }}
           package: '@affine/native'
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: desktop-web
           path: packages/frontend/apps/electron/resources/web-static
@@ -196,7 +196,7 @@ jobs:
 
       - name: Upload Artifact
         if: ${{ inputs.platform == 'darwin' || inputs.platform == 'linux' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: affine-${{ inputs.platform }}-${{ inputs.arch }}-builds
           path: builds
@@ -217,7 +217,7 @@ jobs:
 
       - name: Save packaged artifacts for signing
         if: ${{ inputs.platform == 'win32' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: packaged-${{ inputs.platform }}-${{ inputs.arch }}
           path: |

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -68,7 +68,7 @@ jobs:
           RELEASE_VERSION: ${{ inputs.app-version }}
 
       - name: Upload web artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: desktop-web
           path: packages/frontend/apps/electron/resources/web-static
@@ -202,14 +202,14 @@ jobs:
         env:
           npm_config_arch: ${{ matrix.spec.arch }}
       - name: Download packaged artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: packaged-${{ matrix.spec.platform }}-${{ matrix.spec.arch }}
           path: packaged-unsigned
       - name: unzip packaged artifacts
         run: Expand-Archive -Path packaged-unsigned/archive.zip -DestinationPath packages/frontend/apps/electron/out
       - name: Download signed packaged file diff
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: signed-packaged-${{ matrix.spec.platform }}-${{ matrix.spec.arch }}
           path: signed-packaged-diff
@@ -257,7 +257,7 @@ jobs:
           echo $FILES_TO_BE_SIGNED
 
       - name: Save installer for signing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: installer-${{ matrix.spec.platform }}-${{ matrix.spec.arch }}
           path: archive.zip
@@ -299,14 +299,14 @@ jobs:
     runs-on: ${{ matrix.spec.runner }}
     steps:
       - name: Download installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: installer-${{ matrix.spec.platform }}-${{ matrix.spec.arch }}
           path: installer-unsigned
       - name: unzip installer artifacts
         run: Expand-Archive -Path installer-unsigned/archive.zip -DestinationPath packages/frontend/apps/electron/out/${{ env.BUILD_TYPE }}/make
       - name: Download signed installer file diff
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: signed-installer-${{ matrix.spec.platform }}-${{ matrix.spec.arch }}
           path: signed-installer-diff
@@ -352,7 +352,7 @@ jobs:
             ./builds/affine-${{ env.RELEASE_VERSION }}-${{ env.BUILD_TYPE }}-windows-${{ matrix.spec.arch }}.nsis.exe
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: affine-${{ matrix.spec.platform }}-${{ matrix.spec.arch }}-builds
           path: builds
@@ -371,27 +371,27 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download Artifacts (macos-x64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine-darwin-x64-builds
           path: ./release
       - name: Download Artifacts (macos-arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine-darwin-arm64-builds
           path: ./release
       - name: Download Artifacts (windows-x64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine-win32-x64-builds
           path: ./release
       - name: Download Artifacts (windows-arm64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine-win32-arm64-builds
           path: ./release
       - name: Download Artifacts (linux-x64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: affine-linux-x64-builds
           path: ./release

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -46,7 +46,7 @@ jobs:
           SENTRY_RELEASE: ${{ inputs.app-version }}
           RELEASE_VERSION: ${{ inputs.app-version }}
       - name: Upload ios artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ios
           path: packages/frontend/apps/ios/dist
@@ -73,7 +73,7 @@ jobs:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
           SENTRY_RELEASE: ${{ inputs.app-version }}
       - name: Upload android artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android
           path: packages/frontend/apps/android/dist
@@ -93,7 +93,7 @@ jobs:
         shell: bash
         run: ./packages/frontend/apps/ios/update_code_sign_identity.sh
       - name: Download mobile artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ios
           path: packages/frontend/apps/ios/dist
@@ -153,7 +153,7 @@ jobs:
         with:
           app-version: ${{ inputs.app-version }}
       - name: Download mobile artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: android
           path: packages/frontend/apps/android/dist

--- a/.github/workflows/windows-signer.yml
+++ b/.github/workflows/windows-signer.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       ARCHIVE_DIR: ${{ github.run_id }}-${{ github.run_attempt }}-${{ inputs.artifact-name }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ env.ARCHIVE_DIR }}
@@ -66,7 +66,7 @@ jobs:
           $Manifest | ConvertTo-Json -Depth 4 | Out-File -FilePath (Join-Path $DiffDir 'manifest.json') -Encoding utf8
           Write-Host "Collected $($SignedFiles.Count) signed files."
       - name: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: signed-${{ inputs.artifact-name }}
           path: ${{ env.ARCHIVE_DIR }}/signed-diff


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/download-artifact` | [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v8`](https://github.com/actions/download-artifact/releases/tag/v8) | [Release](https://github.com/actions/download-artifact/releases/tag/v8) | build-images.yml, build-test.yml, copilot-test.yml, release-desktop-platform.yml, release-desktop.yml, release-mobile.yml, windows-signer.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Release](https://github.com/actions/upload-artifact/releases/tag/v7) | build-images.yml, build-test.yml, copilot-test.yml, release-desktop-platform.yml, release-desktop.yml, release-mobile.yml, windows-signer.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting June 2nd, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: June 2nd, 2026
- **Action**: Update to latest action versions that support Node 24

### ⚠️ Breaking Changes

- **actions/upload-artifact** (v4 → v7): Major version upgrade — review the [release notes](https://github.com/actions/upload-artifact/releases) for breaking changes
- **actions/download-artifact** (v4 → v8): Major version upgrade — review the [release notes](https://github.com/actions/download-artifact/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions artifact handling tools across all build and deployment workflows to latest versions for improved pipeline stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->