### PR TITLE
fix(ai-chat): restore scrolling in AI chat panel and sidebar

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-scrollable-text-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-scrollable-text-renderer.ts
@@ -46,10 +46,12 @@ export class AIScrollableTextRenderer extends WithDisposable(
 
   private readonly _onWheel = (e: WheelEvent) => {
     const container = this._scrollableTextRenderer;
-    if (container && container.scrollHeight > container.clientHeight) {
+    const canScroll =
+      container && container.scrollHeight > container.clientHeight;
+    if (canScroll) {
       e.stopPropagation();
     }
-    if (this.state === 'generating') {
+    if (this.state === 'generating' && !canScroll) {
       e.preventDefault();
     }
   };

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-scrollable-text-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-scrollable-text-renderer.ts
@@ -45,7 +45,10 @@ export class AIScrollableTextRenderer extends WithDisposable(
   private readonly _throttledScrollToEnd = throttle(this._scrollToEnd, 300);
 
   private readonly _onWheel = (e: WheelEvent) => {
-    e.stopPropagation();
+    const container = this._scrollableTextRenderer;
+    if (container && container.scrollHeight > container.clientHeight) {
+      e.stopPropagation();
+    }
     if (this.state === 'generating') {
       e.preventDefault();
     }

--- a/packages/frontend/core/src/blocksuite/ai/components/text-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/text-renderer.ts
@@ -143,7 +143,7 @@ export class TextRenderer extends SignalWatcher(
       overflow-y: auto;
       overflow-x: hidden;
       padding: 0;
-      overscroll-behavior-y: none;
+      min-height: 0;
     }
     .text-renderer-container.show-scrollbar::-webkit-scrollbar {
       width: 5px;


### PR DESCRIPTION
Fixes #14612 

## Summary

Fix scrolling issues in the AI chat panel and the right sidebar.

Previously the text renderer prevented scroll chaining due to the CSS rule
`overscroll-behavior-y: none`, which blocked scroll events from propagating
to parent containers when the renderer itself was not scrollable.

## Changes

* Removed `overscroll-behavior-y: none` from `.text-renderer-container`
* Added `min-height: 0` to ensure proper scrolling behavior within flex layouts

## Result

The AI chat window and sidebar can now scroll correctly when the content
exceeds the container height.

Users can scroll using the mouse wheel, trackpad, or scrollbar as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unwanted scroll blocking during content generation so scrolling is smoother and only suppressed when necessary.

* **Style**
  * Adjusted text container sizing and scroll behavior to improve layout consistency and prevent overscroll-related layout issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->