### PR TITLE
fix(paragraph): use CSS logical properties for RTL-aware placeholder and quote styling

### DIFF
--- a/blocksuite/affine/blocks/paragraph/src/styles.ts
+++ b/blocksuite/affine/blocks/paragraph/src/styles.ts
@@ -110,7 +110,7 @@ export const paragraphBlockStyles = css`
 
   .quote {
     line-height: 26px;
-    padding-left: 17px;
+    padding-inline-start: 17px;
     margin-top: var(--affine-paragraph-space);
     padding-top: 10px;
     padding-bottom: 10px;
@@ -123,7 +123,7 @@ export const paragraphBlockStyles = css`
     margin-top: 10px;
     margin-bottom: 10px;
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
     background: var(--affine-quote-color);
     border-radius: 18px;
@@ -136,7 +136,7 @@ export const paragraphBlockStyles = css`
     overflow-x: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    left: 0;
+    inset-inline-start: 0;
     bottom: 0;
     pointer-events: none;
     color: var(--affine-black-30);


### PR DESCRIPTION
## Problem
Paragraph block placeholder and quote block styling use hardcoded `left` values, breaking RTL layout for Arabic, Persian, and Urdu users.

## Solution
Replace physical CSS properties with logical equivalents:
- `padding-left` → `padding-inline-start` (quote padding)
- `left: 0` → `inset-inline-start: 0` (quote bar position)
- `left: 0` → `inset-inline-start: 0` (placeholder position)

CSS logical properties automatically adapt to the text direction — right side in RTL, left side in LTR.

## Testing
Switch UI to Arabic → quote bar appears on right side, placeholder appears on right side
Switch UI to English → layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated CSS to use logical inline layout properties instead of left-based properties, improving support for different writing modes (e.g., RTL) while preserving existing visual appearance and behavior in LTR contexts. No public APIs or exported declarations were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->