### PR TITLE
fix(list,code): use CSS logical properties for RTL-aware list and code block styling

### DIFF
--- a/blocksuite/affine/blocks/code/src/styles.ts
+++ b/blocksuite/affine/blocks/code/src/styles.ts
@@ -58,12 +58,12 @@ export const codeBlockStyles = css`
 
   .affine-code-block-container .line-number {
     position: sticky;
-    text-align: left;
-    padding-right: 12px;
+    text-align: start;
+    padding-inline-end: 12px;
     width: 32px;
     word-break: break-word;
     white-space: nowrap;
-    left: -0.5px;
+    inset-inline-start: -0.5px;
     z-index: 1;
     background: var(--affine-background-code-block);
     font-size: var(--affine-font-xs);

--- a/blocksuite/affine/blocks/list/src/styles.ts
+++ b/blocksuite/affine/blocks/list/src/styles.ts
@@ -12,7 +12,7 @@ export const listPrefix = css`
   .affine-list-block__numbered {
     min-width: 22px;
     height: 24px;
-    margin-left: 2px;
+    margin-inline-start: 2px;
   }
 
   .affine-list-block__todo-prefix {


### PR DESCRIPTION
## Problem
List and code block styles use hardcoded physical CSS properties, breaking RTL layout for Arabic, Persian, and Urdu users.

## Solution
Replace physical CSS properties with logical equivalents:
- `margin-left` → `margin-inline-start` (list numbered bullet)
- `text-align: left` → `text-align: start` (code block line numbers)
- `padding-right` → `padding-inline-end` (code block line numbers)
- `left` → `inset-inline-start` (code block line numbers position)

## Testing
Switch UI to Arabic → list bullets and code line numbers appear on correct side
Switch UI to English → layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code block line number styling for improved layout rendering.
  * Enhanced numbered list item styling for consistent multi-directional text support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->