### PR TITLE
fix(attachment): use CSS logical properties for RTL-aware status indicator

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/styles.ts
+++ b/blocksuite/affine/blocks/attachment/src/styles.ts
@@ -149,7 +149,7 @@ export const styles = css`
 
   .affine-attachment-embed-status {
     position: absolute;
-    left: 14px;
+    inset-inline-start: 14px;
     bottom: 64px;
   }
 


### PR DESCRIPTION
## Problem
Attachment block status indicator uses hardcoded `left: 14px`, pinning it to the left side regardless of text direction.

## Solution
Replace `left: 14px` with `inset-inline-start: 14px` so the indicator automatically appears on the correct side in RTL layouts.

## Testing
Switch UI to Arabic → attachment status indicator appears on right side
Switch UI to English → layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted attachment embed positioning to use logical inline-start offset instead of a physical left offset, preserving vertical placement. This improves layout correctness in right-to-left and alternate writing-mode contexts while maintaining existing visual placement in left-to-right layouts. No functional or behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->