### PR TITLE
fix(embed,bookmark): use CSS logical properties for RTL-aware block styling

### DIFF
--- a/blocksuite/affine/blocks/bookmark/src/styles.ts
+++ b/blocksuite/affine/blocks/bookmark/src/styles.ts
@@ -233,7 +233,7 @@ export const styles = css`
     .affine-bookmark-banner {
       width: 340px;
       height: 170px;
-      margin-left: 12px;
+      margin-inline-start: 12px;
     }
 
     .affine-bookmark-banner img,

--- a/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/styles.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/styles.ts
@@ -12,8 +12,8 @@ export const blockStyles = css`
   }
   affine-embed-synced-doc-block[data-page-mode] {
     width: calc(100% + var(--embed-padding) * 2);
-    margin-left: calc(-1 * var(--embed-padding));
-    margin-right: calc(-1 * var(--embed-padding));
+    margin-inline-start: calc(-1 * var(--embed-padding));
+    margin-inline-end: calc(-1 * var(--embed-padding));
   }
   .edgeless-block-portal-embed
     > affine-embed-synced-doc-block[data-nested-editor] {
@@ -109,7 +109,7 @@ export const blockStyles = css`
     font-size: 14px;
     font-weight: 600;
     line-height: 22px;
-    margin-left: 8px;
+    margin-inline-start: 8px;
     min-width: 0;
     white-space: nowrap;
     overflow: hidden;
@@ -136,7 +136,7 @@ export const blockStyles = css`
   .affine-embed-synced-doc-container.surface
     > .affine-embed-synced-doc-editor
     > .affine-embed-synced-doc-editor-empty {
-    left: 0;
+    inset-inline-start: 0;
     justify-content: center;
   }
 
@@ -437,7 +437,7 @@ export const cardStyles = css`
       justify-content: center;
       width: 100%;
       height: 267.5px;
-      margin-left: 12px;
+      margin-inline-start: 12px;
       flex-shrink: 0;
     }
     .affine-embed-synced-doc-card-banner img,
@@ -495,7 +495,7 @@ export const cardStyles = css`
     .affine-embed-synced-doc-card-banner {
       width: 340px;
       height: 170px;
-      margin-left: 12px;
+      margin-inline-start: 12px;
     }
     .affine-embed-synced-doc-card-banner img,
     .affine-embed-synced-doc-card-banner object,

--- a/blocksuite/affine/blocks/embed/src/embed-github-block/styles.ts
+++ b/blocksuite/affine/blocks/embed/src/embed-github-block/styles.ts
@@ -327,7 +327,7 @@ export const styles = css`
     .affine-embed-github-banner {
       width: 340px;
       height: 170px;
-      margin-left: 12px;
+      margin-inline-start: 12px;
     }
 
     .affine-embed-github-banner img,


### PR DESCRIPTION
## Problem
Bookmark and embed blocks (synced doc, GitHub) use hardcoded physical CSS properties, breaking RTL layout for Arabic, Persian, and Urdu users.

## Solution
Replace physical CSS properties with logical equivalents across 3 files:
- `margin-left` → `margin-inline-start` (bookmark banner, embed-doc, embed-github)
- `margin-right` → `margin-inline-end` (embed-doc negative bleed)
- `left: 0` → `inset-inline-start: 0` (embed-doc empty editor label)

## Testing
Switch UI to Arabic → bookmark and embed block elements appear on correct side
Switch UI to English → layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Replaced fixed horizontal CSS margins/positions with writing-mode–aware logical inline properties across bookmark, embedded document, and GitHub block components to preserve visual spacing while improving compatibility with different text directions and layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->