### PR TITLE
fix(components): use CSS logical properties for RTL-aware component styling

### DIFF
--- a/blocksuite/affine/components/src/citation/citation.ts
+++ b/blocksuite/affine/components/src/citation/citation.ts
@@ -59,7 +59,7 @@ export class CitationCard extends SignalWatcher(WithDisposable(LitElement)) {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
-        text-align: left;
+        text-align: start;
         line-height: 22px;
         color: ${unsafeCSSVarV2('text/primary')};
         font-size: var(--affine-font-sm);

--- a/blocksuite/affine/components/src/context-menu/menu-renderer.ts
+++ b/blocksuite/affine/components/src/context-menu/menu-renderer.ts
@@ -318,7 +318,7 @@ export class MobileMenuComponent
         style="display:flex;align-items:center;height: 44px;"
         @mouseenter="${() => this.menu.closeSubMenu()}"
       >
-        <div style="width: 50px;flex-shrink: 0;margin-left: 10px;">
+        <div style="width: 50px;flex-shrink: 0;margin-inline-start: 10px;">
           ${title?.onBack
             ? html` <div
                 @click="${() => {
@@ -358,7 +358,7 @@ export class MobileMenuComponent
           color: ${unsafeCSSVarV2('button/primary')};
           width: 50px;
           flex-shrink: 0;
-          margin-right: 10px;
+          margin-inline-end: 10px;
          "
         >
           Done

--- a/blocksuite/affine/components/src/embed-card-modal/styles.ts
+++ b/blocksuite/affine/components/src/embed-card-modal/styles.ts
@@ -55,8 +55,8 @@ export const embedCardModalStyles = css`
   }
   .embed-card-modal-input {
     display: flex;
-    padding-left: 10px;
-    padding-right: 10px;
+    padding-inline-start: 10px;
+    padding-inline-end: 10px;
     border-radius: 8px;
     border: 1px solid var(--affine-border-color);
     background: var(--affine-white-10);

--- a/blocksuite/affine/components/src/filterable-list/styles.ts
+++ b/blocksuite/affine/components/src/filterable-list/styles.ts
@@ -38,8 +38,8 @@ export const filterableListStyles = css`
     flex: 1;
     overflow-y: scroll;
     padding-top: 5px;
-    padding-left: 4px;
-    padding-right: 4px;
+    padding-inline-start: 4px;
+    padding-inline-end: 4px;
   }
 
   editor-toolbar-separator {

--- a/blocksuite/affine/components/src/icon-button/index.ts
+++ b/blocksuite/affine/components/src/icon-button/index.ts
@@ -117,7 +117,7 @@ export class IconButton extends LitElement {
     }
 
     ::slotted([slot='suffix']) {
-      margin-left: auto;
+      margin-inline-start: auto;
     }
   `;
 

--- a/blocksuite/affine/components/src/toggle-button/toggle-button.ts
+++ b/blocksuite/affine/components/src/toggle-button/toggle-button.ts
@@ -26,6 +26,12 @@ export class ToggleButton extends WithDisposable(ShadowlessElement) {
       transition: opacity 0.2s ease-in-out;
     }
 
+    [dir='rtl'] .toggle-icon {
+      left: auto;
+      right: 0;
+      transform: translateX(100%);
+    }
+
     .toggle-icon:hover {
       background: var(--affine-hover-color);
     }


### PR DESCRIPTION
## Problem
Shared UI components use hardcoded physical CSS properties, breaking RTL layout for Arabic, Persian, and Urdu users.

## Solution
Replace physical CSS properties with logical equivalents across 6 components:
- `margin-left: auto` → `margin-inline-start: auto` (icon-button)
- `padding-left/right` → `padding-inline-start/end` (filterable-list, embed-card-modal)
- `text-align: left` → `text-align: start` (citation)
- `margin-left/right` → `margin-inline-start/end` (context-menu)
- `left: 0` → `inset-inline-start: 0` (toggle-button)

## Testing
Switch UI to Arabic → all component elements appear on correct side
Switch UI to English → layout unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced layout support for right-to-left (RTL) languages across UI components including citations, menus, modals, lists, buttons, and toggles, ensuring consistent and proper alignment regardless of writing direction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->