### PR TITLE
fix(app-layout): use CSS logical properties for RTL-aware app shell styling

### DIFF
--- a/packages/frontend/core/src/components/explorer/docs-view/doc-list-item.css.ts
+++ b/packages/frontend/core/src/components/explorer/docs-view/doc-list-item.css.ts
@@ -47,7 +47,7 @@ export const dragHandle = style({
 export const listDragHandle = style([
   dragHandle,
   {
-    left: -4,
+    insetInlineStart: -4,
     top: '50%',
     transform: 'translateY(-50%) translateX(-100%)',
     opacity: 0,
@@ -65,21 +65,21 @@ export const listSelect = style({
   padding: 2,
   // to make sure won't take place when hidden
   // 12 = gap + padding * 2
-  marginLeft: -12,
+  marginInlineStart: -12,
   flexShrink: 0,
   display: 'flex',
   color: cssVarV2.icon.primary,
   overflow: 'hidden',
   alignItems: 'center',
   justifyContent: 'end',
-  transition: 'width 0.25s ease, margin-left 0.25s ease',
+  transition: 'width 0.25s ease, margin-inline-start 0.25s ease',
   // when select mode is on, the whole item can be clicked,
   // the selection will be handled by the parent, the checkbox here just for the visual effect
   pointerEvents: 'none',
   selectors: {
     '&[data-select-mode="true"]': {
       width: 24,
-      marginLeft: 0,
+      marginInlineStart: 0,
     },
   },
 });
@@ -108,7 +108,7 @@ export const listBrief = style({
   display: 'flex',
   flexDirection: 'column',
   justifyContent: 'center',
-  marginLeft: 4,
+  marginInlineStart: 4,
   minWidth: 200,
 });
 export const listSpace = style({
@@ -265,7 +265,7 @@ export const cardViewCheckbox = style({
 export const cardDragHandle = style([
   dragHandle,
   {
-    left: -4,
+    insetInlineStart: -4,
     top: 0,
     transform: 'translateX(-100%)',
     opacity: 0,

--- a/packages/frontend/core/src/desktop/components/navigation-panel/tree/node.css.ts
+++ b/packages/frontend/core/src/desktop/components/navigation-panel/tree/node.css.ts
@@ -9,7 +9,7 @@ export const itemRoot = style({
   display: 'inline-flex',
   alignItems: 'center',
   borderRadius: '4px',
-  textAlign: 'left',
+  textAlign: 'start',
   color: 'inherit',
   width: '100%',
   minHeight: '30px',
@@ -50,12 +50,12 @@ export const toggleIcon = style({
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  marginRight: 12,
+  marginInlineEnd: 12,
 });
 export const itemRenameAnchor = style({
   pointerEvents: 'none',
   position: 'absolute',
-  left: 0,
+  insetInlineStart: 0,
   top: -10,
   width: 10,
   height: 10,
@@ -72,7 +72,7 @@ export const itemContent = style({
 export const postfix = style({
   display: 'flex',
   alignItems: 'center',
-  right: 0,
+  insetInlineEnd: 0,
   position: 'absolute',
   opacity: 0,
   pointerEvents: 'none',
@@ -171,7 +171,7 @@ const draggedOverAnimation = keyframes({
 
 export const contentContainer = style({
   marginTop: 2,
-  paddingLeft: levelIndent,
+  paddingInlineStart: levelIndent,
   position: 'relative',
 });
 
@@ -191,7 +191,7 @@ export const draggedOverEffect = style({
         position: 'absolute',
         zIndex: 1,
         background: cssVar('--affine-hover-color'),
-        left: levelIndent,
+        insetInlineStart: levelIndent,
         top: 0,
         width: `calc(100% - ${levelIndent})`,
         height: '100%',

--- a/packages/frontend/core/src/modules/app-sidebar/views/index.css.ts
+++ b/packages/frontend/core/src/modules/app-sidebar/views/index.css.ts
@@ -11,7 +11,7 @@ export const navWrapperStyle = style({
   paddingBottom: 8,
   selectors: {
     '&[data-has-border=true]': {
-      borderRight: `0.5px solid ${cssVarV2('layer/insideBorder/border')}`,
+      borderInlineEnd: `0.5px solid ${cssVarV2('layer/insideBorder/border')}`,
     },
     '&[data-is-floating="true"], &[data-is-electron="false"]': {
       backgroundColor: cssVarV2('layer/background/primary'),
@@ -24,7 +24,7 @@ export const hoverNavWrapperStyle = style({
       backgroundColor: cssVarV2('layer/background/primary'),
       height: 'calc(100% - 60px)',
       marginTop: '52px',
-      marginLeft: '4px',
+      marginInlineStart: '4px',
       boxShadow: cssVar('--affine-popover-shadow'),
       borderRadius: '6px',
     },
@@ -86,15 +86,15 @@ export const sidebarFloatMaskStyle = style({
   pointerEvents: 'none',
   position: 'fixed',
   top: 0,
-  left: 0,
-  right: '100%',
+  insetInlineStart: 0,
+  insetInlineEnd: '100%',
   bottom: 0,
   background: cssVarV2('layer/background/modal'),
   selectors: {
     '&[data-open="true"][data-is-floating="true"]': {
       opacity: 1,
       pointerEvents: 'auto',
-      right: '0',
+      insetInlineEnd: '0',
       zIndex: 3,
     },
   },

--- a/packages/frontend/core/src/modules/app-sidebar/views/sidebar-containers/index.css.ts
+++ b/packages/frontend/core/src/modules/app-sidebar/views/sidebar-containers/index.css.ts
@@ -18,8 +18,8 @@ export const scrollableContainerRoot = style({
 export const scrollTopBorder = style({
   position: 'absolute',
   top: 0,
-  left: '16px',
-  right: '16px',
+  insetInlineStart: '16px',
+  insetInlineEnd: '16px',
   height: '1px',
   transition: 'opacity .3s .2s',
   opacity: 0,

--- a/packages/frontend/core/src/modules/app-tabs-header/views/styles.css.ts
+++ b/packages/frontend/core/src/modules/app-tabs-header/views/styles.css.ts
@@ -18,7 +18,7 @@ export const root = style({
   ['WebkitAppRegion' as string]: 'drag',
   selectors: {
     '&[data-is-windows="false"]': {
-      paddingRight: 8,
+      paddingInlineEnd: 8,
     },
   },
 });
@@ -28,7 +28,7 @@ export const headerLeft = style({
   flexFlow: 'row',
   alignItems: 'center',
   justifyContent: 'space-between',
-  paddingRight: 12,
+  paddingInlineEnd: 12,
   gap: 10,
   flexShrink: 0,
   selectors: {
@@ -42,7 +42,7 @@ export const tabs = style({
   display: 'flex',
   flexDirection: 'row',
   alignItems: 'center',
-  paddingLeft: 8,
+  paddingInlineStart: 8,
   overflow: 'hidden',
   height: '100%',
   selectors: {
@@ -57,7 +57,7 @@ export const pinSeparator = style({
   width: 1,
   height: 16,
   flexShrink: 0,
-  marginRight: 8,
+  marginInlineEnd: 8,
 });
 
 export const splitViewSeparator = style({
@@ -94,7 +94,7 @@ export const tab = style({
   ['WebkitAppRegion' as string]: 'no-drag',
   selectors: {
     [`${tabWrapper} &`]: {
-      marginRight: 8,
+      marginInlineEnd: 8,
     },
     '&[data-active="true"]': {
       boxShadow: `0 0 0 1px ${cssVarV2('button/innerBlackBorder')}`,
@@ -125,7 +125,7 @@ export const splitViewLabel = style({
 export const tabCloseButtonWrapper = style({
   pointerEvents: 'none',
   position: 'absolute',
-  right: 0,
+  insetInlineEnd: 0,
   top: 0,
   bottom: 0,
   height: '100%',
@@ -133,7 +133,7 @@ export const tabCloseButtonWrapper = style({
   overflow: 'clip',
   display: 'flex',
   alignItems: 'center',
-  paddingRight: 6,
+  paddingInlineEnd: 6,
   justifyContent: 'flex-end',
   selectors: {
     [`${tab}:is([data-active=true], :hover) &:not(:empty)`]: {
@@ -202,7 +202,7 @@ export const splitViewLabelText = style({
   whiteSpace: 'nowrap',
   color: cssVarV2('tab/fontColor/default'),
   fontSize: cssVar('fontXs'),
-  paddingRight: 4,
+  paddingInlineEnd: 4,
   selectors: {
     [`${splitViewLabel}:hover &, ${tab}:has(${tabCloseButtonWrapper}:hover) ${splitViewLabel}:last-of-type &`]:
       {
@@ -215,7 +215,7 @@ export const splitViewLabelText = style({
       textOverflow: 'clip',
     },
     [`${splitViewLabel}:last-of-type [data-padding-right="true"]&`]: {
-      paddingRight: 32,
+      paddingInlineEnd: 32,
     },
   },
 });
@@ -225,7 +225,7 @@ export const spacer = style({
   height: '100%',
   display: 'flex',
   alignItems: 'center',
-  marginLeft: -8,
+  marginInlineStart: -8,
   position: 'relative',
   selectors: {
     '&[data-dragged-over=true]:after': {
@@ -233,8 +233,8 @@ export const spacer = style({
       position: 'absolute',
       top: 10,
       height: 32,
-      left: -5,
-      right: 0,
+      insetInlineStart: -5,
+      insetInlineEnd: 0,
       width: 2,
       borderRadius: 2,
       background: cssVar('primaryColor'),
@@ -262,7 +262,7 @@ export const dropIndicator = style({
       transform: 'translateX(-5px)',
     },
     '&[data-edge="right"]': {
-      right: 0,
+      insetInlineEnd: 0,
       opacity: 1,
       transform: 'translateX(-9px)',
     },

--- a/packages/frontend/core/src/modules/workbench/view/split-view/split-view.css.ts
+++ b/packages/frontend/core/src/modules/workbench/view/split-view/split-view.css.ts
@@ -48,7 +48,7 @@ export const splitViewPanel = style({
     },
     '[data-client-border="false"] &:not([data-is-last="true"]):not([data-is-dragging="true"])':
       {
-        borderRight: `0.5px solid ${cssVarV2('layer/insideBorder/border')}`,
+        borderInlineEnd: `0.5px solid ${cssVarV2('layer/insideBorder/border')}`,
       },
     '[data-client-border="true"] &': {
       border: `0.5px solid ${cssVarV2('layer/insideBorder/border')}`,
@@ -120,16 +120,16 @@ export const resizeHandle = style({
       },
     },
     '&[data-edge="left"]': {
-      left: `calc(${resizeHandleWidth} * -0.5)`,
-      right: 'auto',
+      insetInlineStart: `calc(${resizeHandleWidth} * -0.5)`,
+      insetInlineEnd: 'auto',
     },
     '&[data-edge="right"]': {
-      left: 'auto',
-      right: `calc(${resizeHandleWidth} * -0.5)`,
+      insetInlineStart: 'auto',
+      insetInlineEnd: `calc(${resizeHandleWidth} * -0.5)`,
     },
     '&[data-edge="right"][data-is-last="true"]': {
-      right: 0,
-      left: 'auto',
+      insetInlineEnd: 0,
+      insetInlineStart: 'auto',
     },
     '[data-client-border="false"] &[data-is-last="true"][data-edge="right"]::before, [data-client-border="false"] &[data-is-last="true"][data-edge="right"]::after':
       {
@@ -140,7 +140,7 @@ export const resizeHandle = style({
       cursor: 'col-resize',
     },
     '[data-client-border="true"] &[data-edge="right"]': {
-      right: `calc(${resizeHandleWidth} * -0.5 - 0.5px - ${gap} / 2)`,
+      insetInlineEnd: `calc(${resizeHandleWidth} * -0.5 - 0.5px - ${gap} / 2)`,
     },
     [`.${splitViewPanel}[data-is-dragging="true"] &`]: {
       display: 'none',


### PR DESCRIPTION
## Problem
App shell components (tabs header, sidebar, split view, navigation panel) use hardcoded physical CSS properties, breaking RTL layout.

## Solution
Replace physical CSS with logical equivalents across 6 files (40 changes):
- app-tabs-header, split-view, app-sidebar, sidebar-containers, doc-list-item, navigation-panel

## Testing
Switch UI to Arabic → app shell layout flips correctly to RTL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved support for right-to-left (RTL) languages and text directions throughout the application. UI components including navigation panels, sidebars, document viewers, tab headers, and editor layouts now properly align and position elements according to RTL language requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->