### PR TITLE
fix(ai-components): use CSS logical properties for RTL-aware AI panel styling

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/blocks/ai-chat-block/components/ai-chat-messages.ts
+++ b/packages/frontend/core/src/blocksuite/ai/blocks/ai-chat-block/components/ai-chat-messages.ts
@@ -28,7 +28,7 @@ export class AIChatBlockMessage extends LitElement {
     .ai-chat-content {
       display: block;
       width: calc(100% - 34px);
-      padding-left: 34px;
+      padding-inline-start: 34px;
       font-weight: 400;
     }
 

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/actions/action-wrapper.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/actions/action-wrapper.ts
@@ -80,7 +80,7 @@ export class ActionWrapper extends WithDisposable(LitElement) {
         flex: 1;
 
         div:last-child svg {
-          margin-left: auto;
+          margin-inline-start: auto;
         }
       }
     }

--- a/packages/frontend/core/src/blocksuite/ai/chat-panel/message/user.ts
+++ b/packages/frontend/core/src/blocksuite/ai/chat-panel/message/user.ts
@@ -24,7 +24,7 @@ export class ChatMessageUser extends WithDisposable(ShadowlessElement) {
       justify-content: flex-end;
 
       .images-row {
-        margin-left: auto;
+        margin-inline-start: auto;
       }
     }
 

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/ai-chat-input.ts
@@ -98,7 +98,7 @@ export class AIChatInput extends SignalWatcher(
 
       .chat-selection-quote {
         padding: 4px 0px 8px 0px;
-        padding-left: 15px;
+        padding-inline-start: 15px;
         max-height: 56px;
         font-size: 14px;
         font-weight: 400;
@@ -138,7 +138,7 @@ export class AIChatInput extends SignalWatcher(
         height: calc(100% - 10px);
         margin-top: 5px;
         position: absolute;
-        left: 0;
+        inset-inline-start: 0;
         top: 0;
         background: var(--affine-quote-color);
         border-radius: 18px;
@@ -174,7 +174,7 @@ export class AIChatInput extends SignalWatcher(
       }
 
       .chat-input-icon:nth-child(2) {
-        margin-left: auto;
+        margin-inline-start: auto;
       }
 
       .chat-input-icon:hover {

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/preference-popup.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-chat-input/preference-popup.ts
@@ -73,7 +73,7 @@ export class ChatInputPreference extends SignalWatcher(
       font-size: 14px;
       color: ${unsafeCSSVarV2('text/secondary')};
       line-height: 22px;
-      margin-left: 40px;
+      margin-inline-start: 40px;
     }
     .ai-model-prefix {
       width: 20px;
@@ -89,7 +89,7 @@ export class ChatInputPreference extends SignalWatcher(
       font-size: 12px;
       color: ${unsafeCSSVarV2('text/tertiary')};
       line-height: 20px;
-      margin-right: 40px;
+      margin-inline-end: 40px;
     }
   `;
 

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-item/styles.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-item/styles.ts
@@ -69,7 +69,7 @@ export const menuItemStyles = css`
     color: ${unsafeCSSVarV2('text/secondary')};
     font-size: var(--affine-font-xs);
     font-weight: 500;
-    margin-left: 0.5em;
+    margin-inline-start: 0.5em;
   }
 
   .enter-icon,

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-message-content/pure-text.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-message-content/pure-text.ts
@@ -7,7 +7,7 @@ export class ChatContentPureText extends ShadowlessElement {
   static override styles = css`
     .chat-content-pure-text {
       display: inline-block;
-      text-align: left;
+      text-align: start;
       max-width: 100%;
       max-height: 500px;
       overflow-y: auto;

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/artifacts-preview-panel.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/artifacts-preview-panel.ts
@@ -89,7 +89,7 @@ export class ArtifactPreviewPanel extends WithDisposable(ShadowlessElement) {
     }
 
     .artifact-panel-close {
-      margin-left: 4px;
+      margin-inline-start: 4px;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/code-artifact.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/code-artifact.ts
@@ -60,7 +60,7 @@ export class CodeHighlighter extends SignalWatcher(WithDisposable(LitElement)) {
     /* Line numbers */
     .code-highlighter .line-numbers {
       user-select: none;
-      text-align: right;
+      text-align: end;
       line-height: 20px;
       color: ${unsafeCSSVarV2('text/secondary')};
       white-space: nowrap;

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-edit.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/doc-edit.ts
@@ -114,7 +114,7 @@ export class DocEditTool extends WithDisposable(ShadowlessElement) {
           align-items: center;
           gap: 8px;
           cursor: pointer;
-          padding-right: 8px;
+          padding-inline-end: 8px;
           color: ${unsafeCSSVarV2('text/secondary')};
 
           button {

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/tool-call-card.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/tool-call-card.ts
@@ -36,8 +36,8 @@ export class ToolCallCard extends WithDisposable(ShadowlessElement) {
         font-size: 14px;
         font-weight: 500;
         line-height: 24px;
-        margin-left: 0px;
-        margin-right: auto;
+        margin-inline-start: 0px;
+        margin-inline-end: auto;
         color: ${unsafeCSSVarV2('icon/activated')};
         overflow: hidden;
         text-overflow: ellipsis;
@@ -46,7 +46,7 @@ export class ToolCallCard extends WithDisposable(ShadowlessElement) {
 
       .loading-dots {
         display: inline;
-        margin-left: 2px;
+        margin-inline-start: 2px;
         color: ${unsafeCSSVarV2('icon/activated')};
       }
     }

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/tool-failed-card.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/tool-failed-card.ts
@@ -35,8 +35,8 @@ export class ToolFailedCard extends WithDisposable(ShadowlessElement) {
         font-size: 14px;
         font-weight: 500;
         line-height: 24px;
-        margin-left: 0px;
-        margin-right: auto;
+        margin-inline-start: 0px;
+        margin-inline-end: auto;
         color: ${unsafeCSSVarV2('button/error')};
         overflow: hidden;
         text-overflow: ellipsis;

--- a/packages/frontend/core/src/blocksuite/ai/components/ai-tools/tool-result-card.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-tools/tool-result-card.ts
@@ -34,7 +34,7 @@ export class ToolResultCard extends SignalWatcher(
         justify-content: space-between;
         align-items: center;
         gap: 8px;
-        margin-right: 3px;
+        margin-inline-end: 3px;
         cursor: pointer;
       }
 
@@ -52,8 +52,8 @@ export class ToolResultCard extends SignalWatcher(
         font-size: 14px;
         font-weight: 500;
         line-height: 24px;
-        margin-left: 0px;
-        margin-right: auto;
+        margin-inline-start: 0px;
+        margin-inline-end: auto;
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
@@ -67,7 +67,7 @@ export class ToolResultCard extends SignalWatcher(
           opacity 0.4s ease,
           margin-top 0.23s ease,
           transform 0.43s ease;
-        padding-left: 11px;
+        padding-inline-start: 11px;
         margin-top: 4px;
         transform-origin: bottom;
       }
@@ -220,7 +220,7 @@ export class ToolResultCard extends SignalWatcher(
       }
 
       .footer-icon:not(:first-child) {
-        margin-left: -8px;
+        margin-inline-start: -8px;
       }
     }
     .ai-tool-result-wrapper:hover {

--- a/packages/frontend/core/src/blocksuite/ai/components/ask-ai-icon.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ask-ai-icon.ts
@@ -35,7 +35,7 @@ export class AskAIIcon extends WithDisposable(LitElement) {
       font-size: var(--affine-font-xs);
       svg {
         scale: 0.8;
-        margin-right: 2px;
+        margin-inline-end: 2px;
       }
     }
 
@@ -51,7 +51,7 @@ export class AskAIIcon extends WithDisposable(LitElement) {
     }
 
     .ask-ai-icon-button svg {
-      margin-right: 4px;
+      margin-inline-end: 4px;
       color: var(--affine-brand-color);
     }
   `;

--- a/packages/frontend/core/src/blocksuite/ai/components/copy-more.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/copy-more.ts
@@ -71,7 +71,7 @@ export class ChatCopyMore extends WithDisposable(LitElement) {
         cursor: pointer;
 
         svg {
-          margin-left: 12px;
+          margin-inline-start: 12px;
         }
       }
 

--- a/packages/frontend/core/src/blocksuite/ai/components/playground/chat.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/playground/chat.ts
@@ -122,12 +122,12 @@ export class PlaygroundChat extends SignalWatcher(
       }
 
       .chat-panel-add {
-        margin-left: 8px;
-        margin-right: auto;
+        margin-inline-start: 8px;
+        margin-inline-end: auto;
       }
 
       .chat-panel-delete {
-        margin-left: 8px;
+        margin-inline-start: 8px;
         display: none;
       }
 

--- a/packages/frontend/core/src/blocksuite/ai/components/text-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/text-renderer.ts
@@ -125,7 +125,7 @@ export class TextRenderer extends SignalWatcher(
         line-height: 22px;
 
         .h6 {
-          padding-left: 16px;
+          padding-inline-start: 16px;
           color: ${unsafeCSSVarV2('text/link')};
           font-size: var(--affine-font-base);
 

--- a/packages/frontend/core/src/blocksuite/ai/messages/slides-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/messages/slides-renderer.ts
@@ -169,7 +169,7 @@ export class AISlidesRenderer extends WithDisposable(LitElement) {
         }
 
         .affine-block-children-container.edgeless {
-          padding-left: 0;
+          padding-inline-start: 0;
           position: relative;
           overflow: hidden;
           height: 100%;

--- a/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/typst-preview.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/typst-preview.ts
@@ -42,7 +42,7 @@ export class TypstPreview extends SignalWatcher(
 
     details.typst-error-details {
       margin-top: 8px;
-      text-align: left;
+      text-align: start;
       border: 1px dashed ${unsafeCSSVarV2('layer/insideBorder/border')};
       border-radius: 6px;
       padding: 8px;


### PR DESCRIPTION
## Problem
AI chat panel and AI tool components use hardcoded physical CSS properties.

## Solution
Replace physical CSS with logical equivalents across 19 files (32 changes).

## Testing
Switch UI to Arabic → AI panel elements appear on correct side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated layout and spacing across AI chat UI, input controls, tool cards, artifact previews and code views to use direction-aware CSS, improving alignment and spacing in RTL and LTR contexts.
  * Adjusted text and line-number alignment for code and error displays for more consistent presentation across writing modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->