### PR TITLE
fix(blocks): use CSS logical properties for RTL-aware root, table, note, callout, and embed blocks

### DIFF
--- a/blocksuite/affine/blocks/callout/src/callout-block-styles.ts
+++ b/blocksuite/affine/blocks/callout/src/callout-block-styles.ts
@@ -39,7 +39,7 @@ export const calloutEmojiStyles = css({
 export const calloutChildrenStyles = css({
   flex: 1,
   minWidth: 0,
-  paddingLeft: '10px',
+  paddingInlineStart: '10px',
 });
 
 export const iconPickerContainerStyles = css({

--- a/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/styles.ts
+++ b/blocksuite/affine/blocks/embed-doc/src/embed-linked-doc-block/styles.ts
@@ -286,7 +286,7 @@ export const styles = css`
     .affine-embed-linked-doc-banner {
       width: 340px;
       height: 170px;
-      margin-left: 12px;
+      margin-inline-start: 12px;
     }
     .affine-embed-linked-doc-banner img,
     .affine-embed-linked-doc-banner object,

--- a/blocksuite/affine/blocks/note/src/components/edgeless-page-block-title.css.ts
+++ b/blocksuite/affine/blocks/note/src/components/edgeless-page-block-title.css.ts
@@ -6,6 +6,6 @@ export const pageBlockTitle = style({
 
 globalStyle(`${pageBlockTitle} .doc-title-container`, {
   padding: '26px 0px',
-  marginLeft: 'unset',
-  marginRight: 'unset',
+  marginInlineStart: 'unset',
+  marginInlineEnd: 'unset',
 });

--- a/blocksuite/affine/blocks/root/src/page/page-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/page/page-root-block.ts
@@ -77,9 +77,9 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
       /* Leave a place for drag-handle */
       /* Do not use prettier format this style, or it will be broken */
       /* prettier-ignore */
-      padding-left: var(--affine-editor-side-padding, ${DOC_BLOCK_CHILD_PADDING}px);
+      padding-inline-start: var(--affine-editor-side-padding, ${DOC_BLOCK_CHILD_PADDING}px);
       /* prettier-ignore */
-      padding-right: var(--affine-editor-side-padding, ${DOC_BLOCK_CHILD_PADDING}px);
+      padding-inline-end: var(--affine-editor-side-padding, ${DOC_BLOCK_CHILD_PADDING}px);
       /* prettier-ignore */
       padding-bottom: var(--affine-editor-bottom-padding, ${DOC_BOTTOM_PADDING}px);
     }
@@ -87,8 +87,8 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
     /* Extra small devices (phones, 640px and down) */
     @container viewport (width <= 640px) {
       .affine-page-root-block-container {
-        padding-left: ${DOC_BLOCK_CHILD_PADDING}px;
-        padding-right: ${DOC_BLOCK_CHILD_PADDING}px;
+        padding-inline-start: ${DOC_BLOCK_CHILD_PADDING}px;
+        padding-inline-end: ${DOC_BLOCK_CHILD_PADDING}px;
       }
     }
 

--- a/blocksuite/affine/blocks/table/src/table-block.ts
+++ b/blocksuite/affine/blocks/table/src/table-block.ts
@@ -135,21 +135,21 @@ export class TableBlockComponent extends CaptionedBlockComponent<TableBlockModel
         contenteditable="false"
         class=${tableContainer}
         style=${styleMap({
-          marginLeft: `-${virtualPadding + 10}px`,
-          marginRight: `-${virtualPadding}px`,
+          marginInlineStart: `-${virtualPadding + 10}px`,
+          marginInlineEnd: `-${virtualPadding}px`,
           position: 'relative',
         })}
       >
         <div
           style=${styleMap({
-            paddingLeft: `${virtualPadding}px`,
-            paddingRight: `${virtualPadding}px`,
-            marginLeft:
+            paddingInlineStart: `${virtualPadding}px`,
+            paddingInlineEnd: `${virtualPadding}px`,
+            marginInlineStart:
               !this.model.props.textAlign$.value ||
               this.model.props.textAlign$?.value === 'left'
                 ? undefined
                 : 'auto',
-            marginRight:
+            marginInlineEnd:
               !this.model.props.textAlign$.value ||
               this.model.props.textAlign$?.value === 'right'
                 ? undefined


### PR DESCRIPTION
## Problem
Several block components use hardcoded physical CSS properties, breaking RTL layout.

## Solution
Replace physical CSS with logical equivalents across 5 files (14 changes):
- page-root-block: editor side padding
- table-block: full-width bleed margins
- edgeless-page-block-title: note title margins
- callout-block: content padding
- embed-linked-doc-block: banner spacing

## Testing
Switch UI to Arabic → all block elements render correctly in RTL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved layout spacing across callout, embedded document, note, page, and table blocks by switching to writing-mode–aware logical spacing properties, yielding more consistent spacing and better RTL support without functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->