### PR TITLE
fix(widgets): use CSS logical properties for RTL-aware linked-doc and slash-menu styling

### DIFF
--- a/blocksuite/affine/widgets/linked-doc/src/import-doc/styles.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/import-doc/styles.ts
@@ -41,9 +41,9 @@ export const styles = css`
   }
 
   header icon-button {
-    margin-left: auto;
+    margin-inline-start: auto;
     position: relative;
-    left: 24px;
+    inset-inline-start: 24px;
   }
 
   .button-container {
@@ -74,7 +74,7 @@ export const styles = css`
 
   .button-suffix {
     display: flex;
-    margin-left: auto;
+    margin-inline-start: auto;
   }
 
   .overlay-mask {

--- a/blocksuite/affine/widgets/linked-doc/src/styles.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/styles.ts
@@ -64,7 +64,7 @@ export const linkedDocPopoverStyles = css`
   .linked-doc-popover .group-title .loading-icon {
     display: flex;
     align-items: center;
-    margin-left: 8px;
+    margin-inline-start: 8px;
   }
 
   .linked-doc-popover .group-title .loading-icon svg {

--- a/blocksuite/affine/widgets/slash-menu/src/styles.ts
+++ b/blocksuite/affine/widgets/slash-menu/src/styles.ts
@@ -97,7 +97,7 @@ export const slashItemToolTipStyle = css`
   }
 
   .tooltip-caption {
-    padding-left: 4px;
+    padding-inline-start: 4px;
     color: var(
       --light-textColor-textSecondaryColor,
       var(--textColor-textSecondaryColor, #8e8d91)


### PR DESCRIPTION
## Problem
Linked doc and slash menu widgets use hardcoded physical CSS properties.

## Solution
Replace physical CSS with logical equivalents across 3 files (5 changes):
- linked-doc/styles.ts: loading icon margin
- linked-doc/import-doc/styles.ts: button alignment
- slash-menu/styles.ts: tooltip padding

## Testing
Switch UI to Arabic → linked doc menu and slash menu render correctly in RTL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated widget styling to use writing-mode-aware (logical) CSS properties instead of directional ones, improving layout consistency and compatibility with different text directions. No change to functionality or public interfaces; visual behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->