### PR TITLE
fix(i18n): replace hardcoded "Download App" text with translation key

### DIFF
--- a/packages/frontend/core/src/modules/app-sidebar/views/app-download-button/index.tsx
+++ b/packages/frontend/core/src/modules/app-sidebar/views/app-download-button/index.tsx
@@ -1,4 +1,5 @@
 import { useCatchEventCallback } from '@affine/core/components/hooks/use-catch-event-hook';
+import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import { CloseIcon, DownloadIcon } from '@blocksuite/icons/rc';
 import clsx from 'clsx';
@@ -13,6 +14,7 @@ export function AppDownloadButton({
   className?: string;
   style?: React.CSSProperties;
 }) {
+  const t = useI18n();
   const [show, setShow] = useState(true);
 
   const handleClose = useCatchEventCallback(() => {
@@ -37,7 +39,9 @@ export function AppDownloadButton({
     >
       <div className={clsx([styles.label])}>
         <DownloadIcon className={styles.icon} />
-        <span className={styles.ellipsisTextOverflow}>Download App</span>
+        <span className={styles.ellipsisTextOverflow}>
+          {t['com.affine.auth.open.affine.download-app']()}
+        </span>
       </div>
       <div className={styles.closeIcon} onClick={handleClose}>
         <CloseIcon />


### PR DESCRIPTION
## Problem
The app sidebar download button renders hardcoded English "Download App" text instead of using the i18n translation function, breaking localization for all non-English users.

## Solution
Replace literal string with `{t['com.affine.auth.open.affine.download-app']()}` — the translation key already exists in all locale files.

## Testing
Switch UI to Arabic → button shows "تنزيل التطبيق"
Switch UI to any other language → button shows correct translation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app's download button now supports multiple languages, showing a localized label instead of a fixed English string so users see the appropriate text for their locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->