### PR TITLE
fix(rtl): add DirectionProvider to AffineContext for Radix UI components

### DIFF
--- a/packages/frontend/core/src/components/context/index.tsx
+++ b/packages/frontend/core/src/components/context/index.tsx
@@ -1,12 +1,30 @@
 import { ConfirmModalProvider, PromptModalProvider } from '@affine/component';
 import { ProviderComposer } from '@affine/component/provider-composer';
 import { ThemeProvider } from '@affine/core/components/theme-provider';
+import { DirectionProvider } from '@radix-ui/react-direction';
 import type { createStore } from 'jotai';
 import { Provider } from 'jotai';
 import type { PropsWithChildren } from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useImageAntialiasing } from '../hooks/use-image-antialiasing';
+
+function useDocumentDir(): 'ltr' | 'rtl' {
+  const [dir, setDir] = useState<'ltr' | 'rtl'>(
+    () => (document.documentElement.dir as 'ltr' | 'rtl') || 'ltr'
+  );
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setDir((document.documentElement.dir as 'ltr' | 'rtl') || 'ltr');
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['dir'],
+    });
+    return () => observer.disconnect();
+  }, []);
+  return dir;
+}
 
 export type AffineContextProps = PropsWithChildren<{
   store?: ReturnType<typeof createStore>;
@@ -14,6 +32,7 @@ export type AffineContextProps = PropsWithChildren<{
 
 export function AffineContext(props: AffineContextProps) {
   useImageAntialiasing();
+  const dir = useDocumentDir();
   return (
     <ProviderComposer
       contexts={useMemo(
@@ -21,10 +40,11 @@ export function AffineContext(props: AffineContextProps) {
           [
             <Provider key="JotaiProvider" store={props.store} />,
             <ThemeProvider key="ThemeProvider" />,
+            <DirectionProvider key="DirectionProvider" dir={dir} />,
             <ConfirmModalProvider key="ConfirmModalProvider" />,
             <PromptModalProvider key="PromptModalProvider" />,
           ].filter(Boolean),
-        [props.store]
+        [props.store, dir]
       )}
     >
       {props.children}


### PR DESCRIPTION
## Root Cause

Radix UI's `useDirection()` defaults to `"ltr"` when no `DirectionProvider` exists in the React tree. Every Radix component (ScrollArea, Dialog, DropdownMenu, Popover, Tooltip, etc.) was rendering `dir="ltr"` on its DOM elements, overriding the `dir="rtl"` inherited from `<html>`. This caused:

- Sidebar scroll area misaligned in RTL
- Settings dialog content anchored to wrong side
- All dropdown menus opening in wrong direction

## Fix

Added `DirectionProvider` from `@radix-ui/react-direction` in `AffineContext` — the top-level context wrapper shared across all AFFiNE surfaces (desktop, web, mobile). A `useDocumentDir()` hook with `MutationObserver` watches for `dir` changes on `<html>` and propagates them to all Radix components automatically.

This is a single fix that repairs all Radix components at once without requiring per-component changes.

## Testing

1. Switch language to Arabic in Settings
2. Verify sidebar ScrollArea scrolls correctly
3. Verify Settings dialog content is RTL-aligned
4. Verify DropdownMenus open from the correct side

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic document direction detection so the app responds when the page switches between left-to-right and right-to-left.
  * UI context now updates dynamically when direction changes, improving correct layout and styling for RTL/LTR without requiring a reload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->