### PR TITLE
[Bug]:Fixes Can not scroll in chat window #14612

### DIFF
--- a/packages/frontend/core/src/blocksuite/ai/components/ai-scrollable-text-renderer.ts
+++ b/packages/frontend/core/src/blocksuite/ai/components/ai-scrollable-text-renderer.ts
@@ -45,7 +45,6 @@ export class AIScrollableTextRenderer extends WithDisposable(
   private readonly _throttledScrollToEnd = throttle(this._scrollToEnd, 300);
 
   private readonly _onWheel = (e: WheelEvent) => {
-    e.stopPropagation();
     if (this.state === 'generating') {
       e.preventDefault();
     }


### PR DESCRIPTION
Fixes #14612 

**fix(ai-panel): restore scroll in copilot chat window**

## Problem

The copilot chat panel was completely unscrollable. Users could not scroll up to view previous messages or scroll down to see the latest output when it exceeded the panel height. This affected both the AI chat interface and the right sidebar within documents.

## Root Cause

In `AIScrollableTextRenderer`, the `_onWheel` handler was unconditionally calling `e.stopPropagation()` on every wheel event. This silently swallowed all scroll events whenever the cursor was positioned over any AI response block, preventing them from reaching the parent chat panel's scroll container.

## Fix

Removed the unconditional `e.stopPropagation()` call from the `_onWheel` handler.

`e.preventDefault()` during the `generating` state is intentionally kept — it prevents the user from interrupting auto-scroll while a response is actively streaming.

```diff
- private readonly _onWheel = (e: WheelEvent) => {
-   e.stopPropagation();
-   if (this.state === 'generating') {
-     e.preventDefault();
-   }
- };
+ private readonly _onWheel = (e: WheelEvent) => {
+   if (this.state === 'generating') {
+     e.preventDefault();
+   }
+ };
```

## Files Changed

- `packages/frontend/core/src/blocksuite/ai/messages/ai-scrollable-text-renderer.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll event handling in AI text rendering, allowing scroll events to propagate to parent elements properly when not actively generating content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->