### PR TITLE
fix(editor): restore horizontal scrolling in kanban board full-width layout

### DIFF
--- a/blocksuite/affine/data-view/src/__tests__/kanban.unit.spec.ts
+++ b/blocksuite/affine/data-view/src/__tests__/kanban.unit.spec.ts
@@ -25,6 +25,7 @@ import {
 import type { KanbanCard } from '../view-presets/kanban/pc/card.js';
 import { KanbanDragController } from '../view-presets/kanban/pc/controller/drag.js';
 import type { KanbanGroup } from '../view-presets/kanban/pc/group.js';
+import { KanbanViewUI } from '../view-presets/kanban/pc/kanban-view-ui-logic.js';
 
 type Column = {
   id: string;
@@ -527,6 +528,36 @@ describe('kanban', () => {
       expect(next?.columnId).toBe('checkbox');
       expect(next?.name).toBe('boolean');
       expect(next?.hideEmpty).toBe(true);
+    });
+  });
+
+  describe('scroll containment', () => {
+    it('sets inline-size containment so the board scrolls horizontally', () => {
+      if (!customElements.get('dv-kanban-view-ui')) {
+        customElements.define('dv-kanban-view-ui', KanbanViewUI);
+      }
+      const el = document.createElement('dv-kanban-view-ui') as KanbanViewUI;
+
+      const noopController = {
+        hostConnected: () => {},
+      };
+
+      el.logic = {
+        ui$: signal(undefined),
+        clipboardController: noopController,
+        dragController: noopController,
+        hotkeysController: noopController,
+        selectionController: noopController,
+      } as any;
+
+      document.body.append(el);
+      try {
+        expect(el.style.contain).toBe('inline-size');
+        expect(el.style.display).toBe('flex');
+        expect(el.style.flexDirection).toBe('column');
+      } finally {
+        el.remove();
+      }
     });
   });
 

--- a/blocksuite/affine/data-view/src/core/group-by/trait.ts
+++ b/blocksuite/affine/data-view/src/core/group-by/trait.ts
@@ -19,7 +19,6 @@ import type { SingleView } from '../view-manager/single-view.js';
 import { compareDateKeys } from './compare-date-keys.js';
 import { defaultGroupBy } from './default.js';
 import { findGroupByConfigByName, getGroupByService } from './matcher.js';
-// Test
 import type { GroupByConfig } from './types.js';
 
 export type GroupInfo<

--- a/blocksuite/affine/data-view/src/view-presets/kanban/pc/kanban-view-ui-logic.ts
+++ b/blocksuite/affine/data-view/src/view-presets/kanban/pc/kanban-view-ui-logic.ts
@@ -227,6 +227,7 @@ export class KanbanViewUI extends DataViewUIBase<KanbanViewUILogic> {
     this.style.userSelect = 'none';
     this.style.display = 'flex';
     this.style.flexDirection = 'column';
+    this.style.contain = 'inline-size';
   }
 
   override render(): TemplateResult {
@@ -244,8 +245,6 @@ export class KanbanViewUI extends DataViewUIBase<KanbanViewUILogic> {
     const wrapperStyle = styleMap({
       marginLeft: `-${vPadding}px`,
       marginRight: `-${vPadding}px`,
-      paddingLeft: `${vPadding}px`,
-      paddingRight: `${vPadding}px`,
     });
 
     const groupTrait = this.logic.groupTrait$.value;
@@ -260,8 +259,10 @@ export class KanbanViewUI extends DataViewUIBase<KanbanViewUILogic> {
         style="${wrapperStyle}"
         @wheel="${this.logic.onWheel}"
       >
+        <div style="flex-shrink:0;width:${Math.max(36, vPadding)}px;"></div>
         ${this.renderGroups()}
         ${groupTrait ? this.logic.renderAddGroup(groupTrait) : ''}
+        <div style="flex-shrink:0;width:${Math.max(36, vPadding)}px;"></div>
       </div>
     `;
   }


### PR DESCRIPTION
## Summary

Fixes the horizontal scrolling issue in the kanban board when using full-width page layout. The scrollbar wasn't showing up because the kanban container was expanding to match its content width instead of staying constrained to the viewport.

Closes #14531

## Problem

In full-width mode, `virtualPadding` is `0`, which meant the negative-margin/padding technique used for scroll alignment was essentially a no-op. Without any width constraint, the `KanbanViewUI` element would grow to fit all its child groups, so `scrollWidth === clientWidth` and no scrollbar appeared.

## Fix

- Added `contain: inline-size` to the kanban view element so its width comes from the parent, not its children
- Swapped out inline padding on the scroll container for spacer divs, since padding inflates `clientWidth` while spacer divs only add to `scrollWidth`

## Files changed

- `blocksuite/affine/data-view/src/view-presets/kanban/pc/kanban-view-ui-logic.ts` — the actual fix
- `blocksuite/affine/data-view/src/core/group-by/trait.ts` — removed stray comment
- `blocksuite/affine/data-view/src/__tests__/kanban.unit.spec.ts` — added test for scroll containment

## Testing

- Added a unit test that checks `KanbanViewUI` applies `contain: inline-size` on connect
- All 41 tests pass (40 existing + 1 new)

**To verify manually:**
1. Create a database with kanban view
2. Set page to full-width layout
3. Add groups until they go past the viewport
4. Confirm horizontal scrollbar shows up and works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite validating Kanban view UI styling, containment behavior, and layout properties with mock setup and DOM assertions

* **Style**
  * Enhanced horizontal spacing implementation in Kanban view component with improved layout approach

* **Chores**
  * Cleaned up test comments from internal utility code

<!-- end of auto-generated comment: release notes by coderabbit.ai -->