### PR TITLE
fix(editor): note-edgeless-block loses edit state during shift-click range selection

### DIFF
--- a/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
+++ b/blocksuite/affine/blocks/note/src/note-edgeless-block.ts
@@ -516,6 +516,9 @@ export const EdgelessNoteInteraction =
                   }
                 })
                 .catch(console.error);
+            } else if (multiSelect && alreadySelected && editing) {
+              // range selection using Shift-click when editing
+              return;
             } else {
               context.default(context);
             }


### PR DESCRIPTION
### Problem
●In edgeless mode, when using Shift + click to perform range selection inside an editing `note-edgeless-block` (click at the starting point, then hold Shift and click at the end point), the block will unexpectedly lose its editing and selection state. As a result, subsequent operations on the selection - such as deleting and moving - no longer work.

●The following video demonstrates this issue:

https://github.com/user-attachments/assets/82c68683-e002-4a58-b011-fe59f7fc9f02

### Solution
●The reason is that this "Shift + click" behavior is being handled by the default multi-selection logic, which toggles selection mode and exits the editing state. So I added an `else-if` branch to match this case.

### After
●The video below shows the behavior after this fix.

https://github.com/user-attachments/assets/18d61108-2089-4def-b2dc-ae13fc5ac333

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection behavior during note editing in multi-select mode to provide more intuitive interaction when using range selection during active editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->