### PR TITLE
fix(editor): allow hyperlink clicks in locked text blocks

### DIFF
--- a/blocksuite/affine/blocks/edgeless-text/src/edgeless-text-block.ts
+++ b/blocksuite/affine/blocks/edgeless-text/src/edgeless-text-block.ts
@@ -43,6 +43,11 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
       font-weight: var(--edgeless-text-font-weight);
       text-align: var(--edgeless-text-text-align);
     }
+
+    .edgeless-text-block-container .locked-content a[href] {
+      pointer-events: auto;
+      cursor: pointer;
+    }
   `;
 
   private readonly _resizeObserver = new ResizeObserver(() => {
@@ -304,6 +309,7 @@ export class EdgelessTextBlockComponent extends GfxBlockComponent<EdgelessTextBl
         style=${styleMap(containerStyle)}
       >
         <div
+          class=${!editing && this.model.isLocked() ? 'locked-content' : ''}
           style=${styleMap({
             pointerEvents: editing ? 'auto' : 'none',
             userSelect: editing ? 'auto' : 'none',


### PR DESCRIPTION
When a text block is locked on the edgeless canvas, `pointer-events: none` on the inner content div prevents all mouse interaction — including clicking hyperlinks. Since locking is meant to prevent accidental edits rather than block navigation, links should remain clickable.

Added a `locked-content` CSS class applied when the block is locked and not in editing mode. A targeted CSS rule restores `pointer-events: auto` on anchor elements within locked content so hyperlinks work as expected.

Closes #14673

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Links within locked edgeless text blocks are now properly interactive and display a clickable cursor indicator when hovered, improving usability when interacting with locked content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->