### PR TITLE
fix(editor): font weight dropdown empty on Chrome/Safari in edgeless mode

### DIFF
--- a/blocksuite/affine/blocks/surface/src/utils/font.ts
+++ b/blocksuite/affine/blocks/surface/src/utils/font.ts
@@ -1,5 +1,5 @@
 import type { FontFamily } from '@blocksuite/affine-model';
-import { IS_FIREFOX } from '@blocksuite/global/env';
+import { IS_FIREFOX, IS_SAFARI } from '@blocksuite/global/env';
 
 export function wrapFontFamily(fontFamily: FontFamily | string): string {
   return `"${fontFamily}"`;
@@ -21,9 +21,11 @@ export const getFontFaces = IS_FIREFOX
     }
   : () => [...document.fonts.keys()];
 
-export const isSameFontFamily =
-  (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
-    fontFace.family === `"${fontFamily}"`;
+export const isSameFontFamily = IS_SAFARI
+  ? (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
+      fontFace.family === fontFamily
+  : (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
+      fontFace.family === `"${fontFamily}"`;
 
 export function getFontFacesByFontFamily(
   fontFamily: FontFamily | string

--- a/blocksuite/affine/blocks/surface/src/utils/font.ts
+++ b/blocksuite/affine/blocks/surface/src/utils/font.ts
@@ -21,11 +21,9 @@ export const getFontFaces = IS_FIREFOX
     }
   : () => [...document.fonts.keys()];
 
-export const isSameFontFamily = IS_FIREFOX
-  ? (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
-      fontFace.family === `"${fontFamily}"`
-  : (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
-      fontFace.family === fontFamily;
+export const isSameFontFamily =
+  (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
+    fontFace.family === `"${fontFamily}"`;
 
 export function getFontFacesByFontFamily(
   fontFamily: FontFamily | string

--- a/blocksuite/affine/blocks/surface/src/utils/font.ts
+++ b/blocksuite/affine/blocks/surface/src/utils/font.ts
@@ -1,5 +1,16 @@
 import type { FontFamily } from '@blocksuite/affine-model';
-import { IS_FIREFOX, IS_SAFARI } from '@blocksuite/global/env';
+import { IS_FIREFOX } from '@blocksuite/global/env';
+
+function normalizeFontFamily(fontFamily: FontFamily | string): string {
+  let s = fontFamily.trim();
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    s = s.slice(1, -1);
+  }
+  return s.toLowerCase();
+}
 
 export function wrapFontFamily(fontFamily: FontFamily | string): string {
   return `"${fontFamily}"`;
@@ -21,11 +32,9 @@ export const getFontFaces = IS_FIREFOX
     }
   : () => [...document.fonts.keys()];
 
-export const isSameFontFamily = IS_SAFARI
-  ? (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
-      fontFace.family === fontFamily
-  : (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
-      fontFace.family === `"${fontFamily}"`;
+export const isSameFontFamily =
+  (fontFamily: FontFamily | string) => (fontFace: FontFace) =>
+    normalizeFontFamily(fontFace.family) === normalizeFontFamily(fontFamily);
 
 export function getFontFacesByFontFamily(
   fontFamily: FontFamily | string


### PR DESCRIPTION
### Summary
Resolves #14528. Normalizes font family string before comparison. Removes browser dependency.

### What Changed
On Edgeless mode, font dropdown was not appearing for shapes on Chrome. Now, it appears on Chrome, Safari, and Firefox.

### Screenshot Verification
**Google Chrome**
<img width="623" height="322" alt="Screenshot 2026-03-25 at 1 24 51 PM" src="https://github.com/user-attachments/assets/fb05790d-6842-43ce-a014-2b24d15bc80d" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved font matching to be more tolerant of whitespace, quotes, and casing so font family comparisons are consistent across browsers, reducing incorrect font fallbacks and visual mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->