### PR TITLE
fix(core): ai island hidden when ai is disabled

### DIFF
--- a/packages/frontend/core/src/desktop/components/ai-island/index.tsx
+++ b/packages/frontend/core/src/desktop/components/ai-island/index.tsx
@@ -1,3 +1,4 @@
+import { useEnableAI } from '@affine/core/components/hooks/affine/use-enable-ai';
 import { WorkbenchService } from '@affine/core/modules/workbench';
 import { useLiveData, useService } from '@toeverything/infra';
 import clsx from 'clsx';
@@ -25,9 +26,13 @@ export const AIIsland = () => {
   const activeTab = useLiveData(activeView.activeSidebarTab$);
   const sidebarOpen = useLiveData(workbench.sidebarOpen$);
 
+  const enableAI = useEnableAI();
+
   useEffect(() => {
     let hide = true;
-    if (haveChatTab) {
+    if (!enableAI) {
+      hide = true;
+    } else if (haveChatTab) {
       hide = !!sidebarOpen && activeTab?.id === 'chat';
     } else {
       const path = activeLocation.pathname;
@@ -36,7 +41,7 @@ export const AIIsland = () => {
       );
     }
     setHide(hide);
-  }, [activeLocation.pathname, activeTab, haveChatTab, sidebarOpen]);
+  }, [activeLocation.pathname, activeTab, enableAI, haveChatTab, sidebarOpen]);
 
   const onOpenChat = useCallback(() => {
     if (hide) return;

--- a/tests/affine-local/e2e/ai-land.spec.ts
+++ b/tests/affine-local/e2e/ai-land.spec.ts
@@ -15,3 +15,28 @@ test('Click ai-land icon', async ({ page }) => {
 
   await expect(page.getByTestId('chat-panel-input-container')).toBeVisible();
 });
+
+test('AI island is hidden when AI is disabled', async ({ page }) => {
+  test.skip(process.env.CI !== undefined, 'Skip test in CI');
+  await openHomePage(page);
+  await waitForEditorLoad(page);
+  await clickNewPageButton(page);
+
+  // Verify AI island is visible before disabling
+  await expect(page.getByTestId('ai-island')).toBeVisible();
+
+  // Disable AI via the feature flag in localStorage
+  await page.evaluate(() => {
+    localStorage.setItem(
+      'global-state:affine-flag:enable_ai',
+      JSON.stringify(false)
+    );
+  });
+
+  // Reload to pick up the flag change
+  await page.reload();
+  await waitForEditorLoad(page);
+
+  // AI island should not be visible
+  await expect(page.getByTestId('ai-island')).toBeHidden();
+});


### PR DESCRIPTION
Fixes #13276 

There is a bug where the AI Island component renders on the desktop app on Mac when AI is disabled in settings.

### What Changed
- Added check for AI enabled in AI Island component
- Always hide component when AI is not enabled
- E2E test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the AI assistant interface to properly hide when the AI feature is disabled through system configuration settings.
  * Enhanced feature flag detection to ensure the AI interface visibility state updates correctly when toggling the AI feature or reloading the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->