### PR TITLE
feat(core): persist collection display preferences

### DIFF
--- a/packages/frontend/core/src/desktop/pages/workspace/collection/index.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/collection/index.tsx
@@ -8,6 +8,7 @@ import { DocsExplorer } from '@affine/core/components/explorer/docs-view/docs-li
 import type { ExplorerDisplayPreference } from '@affine/core/components/explorer/types';
 import {
   type Collection,
+  CollectionPropertiesService,
   CollectionService,
 } from '@affine/core/modules/collection';
 import { CollectionRulesService } from '@affine/core/modules/collection-rules';
@@ -17,7 +18,7 @@ import { WorkspaceService } from '@affine/core/modules/workspace';
 import { useI18n } from '@affine/i18n';
 import { ViewLayersIcon } from '@blocksuite/icons/rc';
 import { useLiveData, useService, useServices } from '@toeverything/infra';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { useNavigateHelper } from '../../../../components/hooks/use-navigate-helper';
@@ -39,7 +40,14 @@ export const CollectionDetail = ({
 }: {
   collection: Collection;
 }) => {
-  const [explorerContextValue] = useState(createDocExplorerContext);
+  const collectionPropertiesService = useService(CollectionPropertiesService);
+  const savedPrefs = useMemo(
+    () => collectionPropertiesService.getDisplayPreference(collection.id),
+    [collectionPropertiesService, collection.id]
+  );
+  const [explorerContextValue] = useState(() =>
+    createDocExplorerContext(savedPrefs)
+  );
   const collectionRulesService = useService(CollectionRulesService);
 
   const permissionService = useService(WorkspacePermissionService);
@@ -57,8 +65,12 @@ export const CollectionDetail = ({
   const handleDisplayPreferenceChange = useCallback(
     (displayPreference: ExplorerDisplayPreference) => {
       explorerContextValue.displayPreference$.next(displayPreference);
+      collectionPropertiesService.setDisplayPreference(
+        collection.id,
+        displayPreference
+      );
     },
-    [explorerContextValue]
+    [explorerContextValue, collectionPropertiesService, collection.id]
   );
 
   useEffect(() => {

--- a/packages/frontend/core/src/modules/collection/index.ts
+++ b/packages/frontend/core/src/modules/collection/index.ts
@@ -1,6 +1,7 @@
 export { Collection } from './entities/collection';
 export type { CollectionMeta } from './services/collection';
 export { CollectionService } from './services/collection';
+export { CollectionPropertiesService } from './services/collection-properties';
 export { PinnedCollectionService } from './services/pinned-collection';
 export type { CollectionInfo } from './stores/collection';
 export type { PinnedCollectionRecord } from './stores/pinned-collection';
@@ -12,16 +13,20 @@ import { WorkspaceDBService } from '../db';
 import { WorkspaceScope, WorkspaceService } from '../workspace';
 import { Collection } from './entities/collection';
 import { CollectionService } from './services/collection';
+import { CollectionPropertiesService } from './services/collection-properties';
 import { PinnedCollectionService } from './services/pinned-collection';
 import { CollectionStore } from './stores/collection';
+import { CollectionPropertiesStore } from './stores/collection-properties';
 import { PinnedCollectionStore } from './stores/pinned-collection';
 
 export function configureCollectionModule(framework: Framework) {
   framework
     .scope(WorkspaceScope)
-    .service(CollectionService, [CollectionStore])
+    .service(CollectionService, [CollectionStore, CollectionPropertiesStore])
     .store(CollectionStore, [WorkspaceService])
     .entity(Collection, [CollectionStore, CollectionRulesService])
+    .store(CollectionPropertiesStore, [WorkspaceDBService])
+    .service(CollectionPropertiesService, [CollectionPropertiesStore])
     .store(PinnedCollectionStore, [WorkspaceDBService])
     .service(PinnedCollectionService, [PinnedCollectionStore]);
 }

--- a/packages/frontend/core/src/modules/collection/services/collection-properties.ts
+++ b/packages/frontend/core/src/modules/collection/services/collection-properties.ts
@@ -1,0 +1,38 @@
+import { LiveData, Service } from '@toeverything/infra';
+
+import type { ExplorerDisplayPreference } from '../../../components/explorer/types';
+import type { CollectionPropertiesStore } from '../stores/collection-properties';
+
+export class CollectionPropertiesService extends Service {
+  constructor(
+    private readonly collectionPropertiesStore: CollectionPropertiesStore
+  ) {
+    super();
+  }
+
+  getDisplayPreference(
+    collectionId: string
+  ): ExplorerDisplayPreference | undefined {
+    return this.collectionPropertiesStore.getDisplayPreference(collectionId);
+  }
+
+  watchDisplayPreference$(
+    collectionId: string
+  ): LiveData<ExplorerDisplayPreference | undefined> {
+    return LiveData.from(
+      this.collectionPropertiesStore.watchDisplayPreference(collectionId),
+      this.collectionPropertiesStore.getDisplayPreference(collectionId)
+    );
+  }
+
+  setDisplayPreference(
+    collectionId: string,
+    pref: ExplorerDisplayPreference
+  ): void {
+    this.collectionPropertiesStore.setDisplayPreference(collectionId, pref);
+  }
+
+  deleteProperties(collectionId: string): void {
+    this.collectionPropertiesStore.deleteProperties(collectionId);
+  }
+}

--- a/packages/frontend/core/src/modules/collection/services/collection.ts
+++ b/packages/frontend/core/src/modules/collection/services/collection.ts
@@ -3,13 +3,17 @@ import { map } from 'rxjs';
 
 import { Collection } from '../entities/collection';
 import type { CollectionInfo, CollectionStore } from '../stores/collection';
+import type { CollectionPropertiesStore } from '../stores/collection-properties';
 
 export interface CollectionMeta extends Pick<CollectionInfo, 'id' | 'name'> {
   title: string;
 }
 
 export class CollectionService extends Service {
-  constructor(private readonly store: CollectionStore) {
+  constructor(
+    private readonly store: CollectionStore,
+    private readonly collectionPropertiesStore: CollectionPropertiesStore
+  ) {
     super();
   }
 
@@ -79,5 +83,6 @@ export class CollectionService extends Service {
 
   deleteCollection(id: string) {
     this.store.deleteCollection(id);
+    this.collectionPropertiesStore.deleteProperties(id);
   }
 }

--- a/packages/frontend/core/src/modules/collection/stores/collection-properties.ts
+++ b/packages/frontend/core/src/modules/collection/stores/collection-properties.ts
@@ -1,0 +1,54 @@
+import { Store } from '@toeverything/infra';
+import { map, type Observable } from 'rxjs';
+
+import type { ExplorerDisplayPreference } from '../../../components/explorer/types';
+import type { WorkspaceDBService } from '../../db';
+
+export class CollectionPropertiesStore extends Store {
+  constructor(private readonly workspaceDBService: WorkspaceDBService) {
+    super();
+  }
+
+  getDisplayPreference(
+    collectionId: string
+  ): ExplorerDisplayPreference | undefined {
+    const record =
+      this.workspaceDBService.db.collectionProperties.get(collectionId);
+    return record?.displayPreference as ExplorerDisplayPreference | undefined;
+  }
+
+  watchDisplayPreference(
+    collectionId: string
+  ): Observable<ExplorerDisplayPreference | undefined> {
+    return this.workspaceDBService.db.collectionProperties
+      .get$(collectionId)
+      .pipe(
+        map(
+          record =>
+            record?.displayPreference as ExplorerDisplayPreference | undefined
+        )
+      );
+  }
+
+  setDisplayPreference(
+    collectionId: string,
+    pref: ExplorerDisplayPreference
+  ): void {
+    const existing =
+      this.workspaceDBService.db.collectionProperties.get(collectionId);
+    if (existing) {
+      this.workspaceDBService.db.collectionProperties.update(collectionId, {
+        displayPreference: pref,
+      });
+    } else {
+      this.workspaceDBService.db.collectionProperties.create({
+        id: collectionId,
+        displayPreference: pref,
+      });
+    }
+  }
+
+  deleteProperties(collectionId: string): void {
+    this.workspaceDBService.db.collectionProperties.delete(collectionId);
+  }
+}

--- a/packages/frontend/core/src/modules/db/schema/schema.ts
+++ b/packages/frontend/core/src/modules/db/schema/schema.ts
@@ -47,6 +47,10 @@ export const AFFiNE_WORKSPACE_DB_SCHEMA = {
     collectionId: f.string().primaryKey(),
     index: f.string(),
   },
+  collectionProperties: {
+    id: f.string().primaryKey(), // collectionId
+    displayPreference: f.json().optional(),
+  },
   explorerIcon: {
     /**
      * ${doc|collection|folder|tag}:${id}


### PR DESCRIPTION
## Summary
- Add server-synced persistence for collection view settings (grouping, ordering, display properties, view mode)
- Settings are stored in a new `collectionProperties` table in the workspace DB (Yjs-backed, auto-synced to server)
- Records are only created when a user explicitly changes display preferences — no writes on passive visits
- Collection deletion automatically cleans up associated view settings

## Test plan
- [ ] Navigate to a Collection, change groupBy and orderBy in Display menu
- [ ] Navigate away, then return — settings should be restored
- [ ] Open the same collection on another device — settings should sync
- [ ] Delete a collection — verify no orphaned `collectionProperties` records

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Collections now persist display preferences (e.g., layout settings) per collection, allowing preferences to be restored on subsequent visits.
  
* **Bug Fixes & Improvements**
  * Collection preferences are automatically cleaned up when a collection is deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->