### PR TITLE
[codex] improve tablet drawing interactions

### DIFF
--- a/blocksuite/affine/gfx/brush/src/toolbar/components/eraser/eraser-tool-button.ts
+++ b/blocksuite/affine/gfx/brush/src/toolbar/components/eraser/eraser-tool-button.ts
@@ -66,7 +66,10 @@ export class EdgelessEraserToolButton extends EdgelessToolbarToolMixin(
         ></affine-tooltip-content-with-shortcut>`}
         .tooltipOffset=${4}
         .active=${type === EraserTool}
-        @click=${() => this.setEdgelessTool(EraserTool)}
+        @click=${() => {
+          (this.ownerDocument.activeElement as HTMLElement | null)?.blur?.();
+          this.setEdgelessTool(EraserTool);
+        }}
       >
         <div class="eraser-button">${icon}</div>
       </edgeless-toolbar-button>

--- a/blocksuite/affine/gfx/brush/src/toolbar/components/pen/pen-tool-button.ts
+++ b/blocksuite/affine/gfx/brush/src/toolbar/components/pen/pen-tool-button.ts
@@ -144,6 +144,7 @@ export class EdgelessPenToolButton extends EdgelessToolbarToolMixin(
       }
     };
     if (!this.active) {
+      (this.ownerDocument.activeElement as HTMLElement | null)?.blur?.();
       const pen = this.pen$.peek();
       setPenByType(pen);
     }

--- a/blocksuite/affine/gfx/pointer/src/effects.ts
+++ b/blocksuite/affine/gfx/pointer/src/effects.ts
@@ -1,8 +1,13 @@
 import { EdgelessDefaultToolButton } from './quick-tool/default-tool-button';
+import { EdgelessHistoryToolGroup } from './quick-tool/history-tool-group';
 
 export function effects() {
   customElements.define(
     'edgeless-default-tool-button',
     EdgelessDefaultToolButton
+  );
+  customElements.define(
+    'edgeless-history-tool-group',
+    EdgelessHistoryToolGroup
   );
 }

--- a/blocksuite/affine/gfx/pointer/src/quick-tool/history-senior-tool.ts
+++ b/blocksuite/affine/gfx/pointer/src/quick-tool/history-senior-tool.ts
@@ -1,0 +1,24 @@
+import { SeniorToolExtension } from '@blocksuite/affine-widget-edgeless-toolbar';
+import { html } from 'lit';
+
+const isTouchPreferredDevice = () => {
+  if (typeof navigator !== 'undefined' && navigator.maxTouchPoints > 0) {
+    return true;
+  }
+
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(pointer: coarse)').matches
+  );
+};
+
+export const historySeniorTool = SeniorToolExtension('history', ({ block }) => {
+  return {
+    name: 'History',
+    enable: isTouchPreferredDevice(),
+    content: html`<edgeless-history-tool-group
+      .edgeless=${block}
+    ></edgeless-history-tool-group>`,
+  };
+});

--- a/blocksuite/affine/gfx/pointer/src/quick-tool/history-tool-group.ts
+++ b/blocksuite/affine/gfx/pointer/src/quick-tool/history-tool-group.ts
@@ -1,0 +1,88 @@
+import { SignalWatcher, WithDisposable } from '@blocksuite/global/lit';
+import { RedoIcon, UndoIcon } from '@blocksuite/icons/lit';
+import type { BlockComponent } from '@blocksuite/std';
+import { effect } from '@preact/signals-core';
+import { css, html, LitElement } from 'lit';
+import { property, state } from 'lit/decorators.js';
+
+export class EdgelessHistoryToolGroup extends SignalWatcher(
+  WithDisposable(LitElement)
+) {
+  static override styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 4px;
+      height: 100%;
+    }
+
+    edgeless-tool-icon-button {
+      flex: 0 0 auto;
+    }
+  `;
+
+  private readonly _handleUndo = () => {
+    if (!this.edgeless?.std.store.canUndo) return;
+    this.edgeless.std.store.undo();
+  };
+
+  private readonly _handleRedo = () => {
+    if (!this.edgeless?.std.store.canRedo) return;
+    this.edgeless.std.store.redo();
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    if (!this.edgeless) {
+      return;
+    }
+
+    this._disposables.add(
+      effect(() => {
+        this._canUndo = this.edgeless.std.store.history.canUndo$.value;
+        this._canRedo = this.edgeless.std.store.history.canRedo$.value;
+      })
+    );
+  }
+
+  override render() {
+    return html`
+      <edgeless-tool-icon-button
+        .tooltip=${'Undo'}
+        .disabled=${!this._canUndo}
+        .activeMode=${'background'}
+        .iconContainerPadding=${8}
+        .iconSize=${'20px'}
+        @click=${this._handleUndo}
+      >
+        ${UndoIcon()}
+      </edgeless-tool-icon-button>
+      <edgeless-tool-icon-button
+        .tooltip=${'Redo'}
+        .disabled=${!this._canRedo}
+        .activeMode=${'background'}
+        .iconContainerPadding=${8}
+        .iconSize=${'20px'}
+        @click=${this._handleRedo}
+      >
+        ${RedoIcon()}
+      </edgeless-tool-icon-button>
+    `;
+  }
+
+  @property({ attribute: false })
+  accessor edgeless!: BlockComponent;
+
+  @state()
+  private accessor _canRedo = false;
+
+  @state()
+  private accessor _canUndo = false;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'edgeless-history-tool-group': EdgelessHistoryToolGroup;
+  }
+}

--- a/blocksuite/affine/gfx/pointer/src/view.ts
+++ b/blocksuite/affine/gfx/pointer/src/view.ts
@@ -4,6 +4,7 @@ import {
 } from '@blocksuite/affine-ext-loader';
 
 import { effects } from './effects';
+import { historySeniorTool } from './quick-tool/history-senior-tool';
 import { defaultQuickTool } from './quick-tool/quick-tool';
 import { SnapExtension } from './snap/snap-manager';
 import { SnapOverlay } from './snap/snap-overlay';
@@ -23,6 +24,7 @@ export class PointerViewExtension extends ViewExtensionProvider {
     context.register(PanTool);
     if (this.isEdgeless(context.scope)) {
       context.register(defaultQuickTool);
+      context.register(historySeniorTool);
       context.register(SnapExtension);
       context.register(SnapOverlay);
     }

--- a/blocksuite/affine/gfx/turbo-renderer/src/turbo-renderer.ts
+++ b/blocksuite/affine/gfx/turbo-renderer/src/turbo-renderer.ts
@@ -140,12 +140,19 @@ export class ViewportTurboRendererExtension extends GfxExtension {
   }
 
   override mounted() {
-    const mountPoint = document.querySelector('.affine-edgeless-viewport');
-    if (mountPoint) {
-      mountPoint.append(this.canvas);
-    }
-
     this.viewport.elementReady.pipe(take(1)).subscribe(element => {
+      const mountPoint =
+        element.closest<HTMLElement>(
+          '.affine-edgeless-viewport, .affine-page-viewport'
+        ) ??
+        this.std.host.closest<HTMLElement>(
+          '.affine-edgeless-viewport, .affine-page-viewport'
+        );
+
+      if (mountPoint) {
+        mountPoint.append(this.canvas);
+      }
+
       this.viewportElement = element;
       syncCanvasSize(this.canvas, this.std.host);
       this.state$.next('pending');

--- a/blocksuite/affine/widgets/edgeless-toolbar/src/edgeless-toolbar.ts
+++ b/blocksuite/affine/widgets/edgeless-toolbar/src/edgeless-toolbar.ts
@@ -69,7 +69,10 @@ export class EdgelessToolbarWidget extends WidgetComponent<RootBlockModel> {
       z-index: 1;
       left: calc(50%);
       transform: translateX(-50%);
-      bottom: 0;
+      bottom: calc(
+        var(--affine-edgeless-toolbar-bottom-offset, 0px) +
+          var(--affine-edgeless-toolbar-keyboard-offset, 0px)
+      );
       -webkit-user-select: none;
       user-select: none;
       width: 100%;
@@ -271,6 +274,24 @@ export class EdgelessToolbarWidget extends WidgetComponent<RootBlockModel> {
   );
 
   private _resizeObserver: ResizeObserver | null = null;
+
+  private readonly _updateKeyboardOffset = () => {
+    const vv = window.visualViewport;
+
+    if (!vv) {
+      this.style.removeProperty('--affine-edgeless-toolbar-keyboard-offset');
+      return;
+    }
+
+    const keyboardHeight = Math.max(
+      0,
+      window.innerHeight - vv.height - vv.offsetTop
+    );
+    this.style.setProperty(
+      '--affine-edgeless-toolbar-keyboard-offset',
+      `${keyboardHeight}px`
+    );
+  };
 
   private readonly _slotsProvider = new ContextProvider(this, {
     context: edgelessToolbarSlotsContext,
@@ -591,6 +612,19 @@ export class EdgelessToolbarWidget extends WidgetComponent<RootBlockModel> {
       }
     });
     this._resizeObserver.observe(this);
+    this._updateKeyboardOffset();
+    if (window.visualViewport) {
+      this.disposables.addFromEvent(
+        window.visualViewport,
+        'resize',
+        this._updateKeyboardOffset
+      );
+      this.disposables.addFromEvent(
+        window.visualViewport,
+        'scroll',
+        this._updateKeyboardOffset
+      );
+    }
     this.disposables.add(
       this.std
         .get(ThemeProvider)
@@ -625,6 +659,7 @@ export class EdgelessToolbarWidget extends WidgetComponent<RootBlockModel> {
     if (this._resizeObserver) {
       this._resizeObserver.disconnect();
     }
+    this.style.removeProperty('--affine-edgeless-toolbar-keyboard-offset');
   }
 
   override firstUpdated() {

--- a/blocksuite/affine/widgets/keyboard-toolbar/src/keyboard-toolbar.ts
+++ b/blocksuite/affine/widgets/keyboard-toolbar/src/keyboard-toolbar.ts
@@ -127,14 +127,27 @@ export class AffineKeyboardToolbar extends SignalWatcher(
         const block = this.std.view.getBlock(selectedModels[0].id);
         if (!block) return;
 
-        const { y: y1 } = this.getBoundingClientRect();
-        const { bottom: y2 } = block.getBoundingClientRect();
+        const { top: toolbarTop } = this.getBoundingClientRect();
+        const { bottom: blockBottom } = block.getBoundingClientRect();
         const gap = 8;
+        const delta = blockBottom - toolbarTop + gap;
 
-        if (y2 < y1 + gap) return;
+        if (delta <= 0) return;
 
-        scrollTo({
-          top: window.scrollY + y2 - y1 + gap,
+        const scrollViewport = this.rootComponent.closest<HTMLElement>(
+          '.affine-page-viewport, .affine-edgeless-viewport'
+        );
+
+        if (scrollViewport) {
+          scrollViewport.scrollBy({
+            top: delta,
+            behavior: 'instant',
+          });
+          return;
+        }
+
+        window.scrollBy({
+          top: delta,
           behavior: 'instant',
         });
       })

--- a/packages/frontend/core/src/mobile/styles/mobile.css.ts
+++ b/packages/frontend/core/src/mobile/styles/mobile.css.ts
@@ -24,7 +24,10 @@ globalStyle('body:has(affine-keyboard-toolbar)', {
   paddingBottom: `calc(${globalVars.appKeyboardStaticHeight} + 46px)`,
 });
 globalStyle('body:has(>#app-tabs) edgeless-toolbar-widget', {
-  bottom: globalVars.appTabSafeArea,
+  vars: {
+    ['--affine-edgeless-toolbar-bottom-offset' as string]:
+      globalVars.appTabSafeArea,
+  },
 });
 
 globalStyle('html', {


### PR DESCRIPTION
## What changed

This PR improves mobile and tablet drawing interactions in edgeless mode.

It adds touch-first undo/redo controls to the edgeless toolbar, moves the edgeless toolbar above the virtual keyboard on mobile, blurs active text inputs before switching to pen or eraser tools, and changes the mobile keyboard toolbar to scroll the current editor viewport instead of lurching the window.

It also tightens the turbo renderer canvas mount logic so the canvas is attached to the current editor's viewport instead of the first matching viewport in the document.

## Why

Tablet web editing had a cluster of interaction problems:

- the virtual keyboard bar could overlap the pen toolbar
- stylus input could end up typing into an active text field while the user was trying to draw
- opening keyboard tool panels could overscroll the canvas downward
- touch surfaces lacked obvious undo/redo affordances
- turbo renderer canvas mounting was too global, which made viewport behavior more fragile than it needed to be

## User impact

On mobile web and tablet surfaces, drawing tools should behave more like drawing tools and less like a haunted text editor. The pen toolbar should stay usable when the keyboard is up, pen/eraser selection should stop competing with active text focus, and mobile viewport scrolling should be calmer when selecting or editing blocks.

## Root cause

The issues were split across a few layers:

- mobile toolbar positioning did not account for `visualViewport` keyboard offsets
- tool switching left the currently focused text input alive
- keyboard-toolbar scroll recovery used window scrolling instead of the nearest editor viewport
- touch-first undo/redo controls were missing from the edgeless toolbar
- turbo renderer canvas mounting relied on a global viewport query instead of the active editor context

## Validation

- `yarn eslint --no-warn-ignored` on the touched mobile/BlockSuite files
- cherry-pick conflict resolved onto `canary` in a clean worktree
- isolated branch pushed as `codex/mobile-drawing-interactions`

## Notes

A narrow TypeScript check in the isolated worktree is still noisy because of an existing ambient `VirtualKeyboard` type issue in `blocksuite/framework/global/src/disposable/index.ts`, which is outside this change.
