### PR TITLE
fix: update guide panel immediately after language switch

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/appearance/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/appearance/index.tsx
@@ -11,7 +11,7 @@ import { FeatureFlagService } from '@affine/core/modules/feature-flag';
 import { useI18n } from '@affine/i18n';
 import { useLiveData, useService } from '@toeverything/infra';
 import { useTheme } from 'next-themes';
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 
 import { useAppSettingHelper } from '../../../../../components/hooks/affine/use-app-setting-helper';
 import { OpenInAppLinksMenu } from './links';
@@ -41,7 +41,7 @@ export const ThemeSettings = () => {
   const t = useI18n();
   const { setTheme, theme } = useTheme();
 
-  const radioItems = useMemo<RadioItem[]>(() => getThemeOptions(t), [t]);
+  const radioItems: RadioItem[] = getThemeOptions(t);
 
   return (
     <RadioGroup

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/appearance/links.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/appearance/links.tsx
@@ -5,7 +5,6 @@ import {
 } from '@affine/core/modules/open-in-app';
 import { useI18n } from '@affine/i18n';
 import { useLiveData, useService } from '@toeverything/infra';
-import { useMemo } from 'react';
 
 import * as styles from './links.css';
 
@@ -14,16 +13,12 @@ export const OpenInAppLinksMenu = () => {
   const openInAppService = useService(OpenInAppService);
   const currentOpenInAppMode = useLiveData(openInAppService.openLinkMode$);
 
-  const options = useMemo(
-    () =>
-      Object.values(OpenLinkMode).map(mode => ({
-        label:
-          t.t(`com.affine.setting.appearance.open-in-app.${mode}`) ||
-          `com.affine.setting.appearance.open-in-app.${mode}`,
-        value: mode,
-      })),
-    [t]
-  );
+  const options = Object.values(OpenLinkMode).map(mode => ({
+    label:
+      t.t(`com.affine.setting.appearance.open-in-app.${mode}`) ||
+      `com.affine.setting.appearance.open-in-app.${mode}`,
+    value: mode,
+  }));
 
   return (
     <Menu

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/index.tsx
@@ -14,7 +14,7 @@ import {
   PenIcon,
 } from '@blocksuite/icons/rc';
 import { useLiveData, useServices } from '@toeverything/infra';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 
 import { AuthService, ServerService } from '../../../../modules/cloud';
 import type { SettingSidebarItem, SettingState } from '../types';
@@ -62,100 +62,92 @@ export const useGeneralSettingList = (): GeneralSettingList => {
 
   const meetingSettings = useLiveData(meetingSettingsService.settings$);
 
-  return useMemo(() => {
-    const settings: GeneralSettingList = [
-      {
-        key: 'appearance',
-        title: t['com.affine.settings.appearance'](),
-        icon: <AppearanceIcon />,
-        testId: 'appearance-panel-trigger',
-      },
-      {
-        key: 'shortcuts',
-        title: t['com.affine.keyboardShortcuts.title'](),
-        icon: <KeyboardIcon />,
-        testId: 'shortcuts-panel-trigger',
-      },
-    ];
+  const settings: GeneralSettingList = [
+    {
+      key: 'appearance',
+      title: t['com.affine.settings.appearance'](),
+      icon: <AppearanceIcon />,
+      testId: 'appearance-panel-trigger',
+    },
+    {
+      key: 'shortcuts',
+      title: t['com.affine.keyboardShortcuts.title'](),
+      icon: <KeyboardIcon />,
+      testId: 'shortcuts-panel-trigger',
+    },
+  ];
+  if (loggedIn) {
+    settings.push({
+      key: 'notifications',
+      title: t['com.affine.setting.notifications'](),
+      icon: <NotificationIcon />,
+      testId: 'notifications-panel-trigger',
+    });
+  }
+  if (enableEditorSettings) {
+    // add editor settings to second position
+    settings.splice(1, 0, {
+      key: 'editor',
+      title: t['com.affine.settings.editorSettings'](),
+      icon: <PenIcon />,
+      testId: 'editor-panel-trigger',
+    });
+  }
+
+  if (
+    (environment.isMacOs || environment.isWindows) &&
+    BUILD_CONFIG.isElectron
+  ) {
+    settings.push({
+      key: 'meetings',
+      title: t['com.affine.settings.meetings'](),
+      icon: <MeetingIcon />,
+      testId: 'meetings-panel-trigger',
+      beta: !meetingSettings?.enabled,
+    });
+  }
+
+  if (hasPaymentFeature) {
+    settings.splice(4, 0, {
+      key: 'plans',
+      title: t['com.affine.payment.title'](),
+      icon: <UpgradeIcon />,
+      testId: 'plans-panel-trigger',
+    });
     if (loggedIn) {
-      settings.push({
-        key: 'notifications',
-        title: t['com.affine.setting.notifications'](),
-        icon: <NotificationIcon />,
-        testId: 'notifications-panel-trigger',
-      });
-    }
-    if (enableEditorSettings) {
-      // add editor settings to second position
-      settings.splice(1, 0, {
-        key: 'editor',
-        title: t['com.affine.settings.editorSettings'](),
-        icon: <PenIcon />,
-        testId: 'editor-panel-trigger',
-      });
-    }
-
-    if (
-      (environment.isMacOs || environment.isWindows) &&
-      BUILD_CONFIG.isElectron
-    ) {
-      settings.push({
-        key: 'meetings',
-        title: t['com.affine.settings.meetings'](),
-        icon: <MeetingIcon />,
-        testId: 'meetings-panel-trigger',
-        beta: !meetingSettings?.enabled,
-      });
-    }
-
-    if (hasPaymentFeature) {
       settings.splice(4, 0, {
-        key: 'plans',
-        title: t['com.affine.payment.title'](),
-        icon: <UpgradeIcon />,
-        testId: 'plans-panel-trigger',
-      });
-      if (loggedIn) {
-        settings.splice(4, 0, {
-          key: 'billing',
-          title: t['com.affine.payment.billing-setting.title'](),
-          icon: <PaymentIcon />,
-          testId: 'billing-panel-trigger',
-        });
-      }
-    }
-
-    if (BUILD_CONFIG.isElectron) {
-      settings.push({
-        key: 'backup',
-        title: t['com.affine.settings.workspace.backup'](),
-        icon: <FolderIcon />,
-        testId: 'backup-panel-trigger',
+        key: 'billing',
+        title: t['com.affine.payment.billing-setting.title'](),
+        icon: <PaymentIcon />,
+        testId: 'billing-panel-trigger',
       });
     }
+  }
 
-    settings.push(
-      {
-        key: 'experimental-features',
-        title: t['com.affine.settings.workspace.experimental-features'](),
-        icon: <ExperimentIcon />,
-        testId: 'experimental-features-trigger',
-      },
-      {
-        key: 'about',
-        title: t['com.affine.aboutAFFiNE.title'](),
-        icon: <InformationIcon />,
-        testId: 'about-panel-trigger',
-      }
-    );
-    return settings;
-  }, [
-    t,
-    loggedIn,
-    enableEditorSettings,
-    meetingSettings?.enabled,
-    hasPaymentFeature,
-  ]);
+  if (BUILD_CONFIG.isElectron) {
+    settings.push({
+      key: 'backup',
+      title: t['com.affine.settings.workspace.backup'](),
+      icon: <FolderIcon />,
+      testId: 'backup-panel-trigger',
+    });
+  }
+
+  settings.push(
+    {
+      key: 'experimental-features',
+      title: t['com.affine.settings.workspace.experimental-features'](),
+      icon: <ExperimentIcon />,
+      testId: 'experimental-features-trigger',
+    },
+    {
+      key: 'about',
+      title: t['com.affine.aboutAFFiNE.title'](),
+      icon: <InformationIcon />,
+      testId: 'about-panel-trigger',
+    }
+  );
+  return settings;
 };
 
 interface GeneralSettingProps {

--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/index.tsx
@@ -15,7 +15,6 @@ import {
   SettingsIcon,
 } from '@blocksuite/icons/rc';
 import { useLiveData, useService } from '@toeverything/infra';
-import { useMemo } from 'react';
 
 import type { SettingSidebarItem, SettingState } from '../types';
 import { WorkspaceSettingBilling } from './billing';
@@ -78,61 +77,57 @@ export const useWorkspaceSettingList = (): SettingSidebarItem[] => {
   const showBilling =
     !isSelfhosted && information?.isTeam && information?.isOwner;
   const showLicense = information?.isOwner && isSelfhosted;
-  const items = useMemo<SettingSidebarItem[]>(() => {
-    return [
-      {
-        key: 'workspace:preference',
-        title: t['com.affine.settings.workspace.preferences'](),
-        icon: <SettingsIcon />,
-        testId: 'workspace-setting:preference',
-      },
-      {
-        key: 'workspace:properties',
-        title: t['com.affine.settings.workspace.properties'](),
-        icon: <PropertyIcon />,
-        testId: 'workspace-setting:properties',
-      },
-      {
-        key: 'workspace:members',
-        title: t['Members'](),
-        icon: <CollaborationIcon />,
-        testId: 'workspace-setting:members',
-      },
-      {
-        key: 'workspace:integrations',
-        title: t['com.affine.integration.integrations'](),
-        icon: <IntegrationsIcon />,
-        testId: 'workspace-setting:integrations',
-      },
-      {
-        key: 'workspace:storage',
-        title: t['Storage'](),
-        icon: <SaveIcon />,
-        testId: 'workspace-setting:storage',
-      },
-      {
-        key: 'workspace:embedding',
-        title:
-          t[
-            'com.affine.settings.workspace.indexer-embedding.embedding.title'
-          ](),
-        icon: <AiEmbeddingIcon />,
-        testId: 'workspace-setting:embedding',
-      },
-      showBilling && {
-        key: 'workspace:billing' as SettingTab,
-        title: t['com.affine.settings.workspace.billing'](),
-        icon: <PaymentIcon />,
-        testId: 'workspace-setting:billing',
-      },
-      showLicense && {
-        key: 'workspace:license' as SettingTab,
-        title: t['com.affine.settings.workspace.license'](),
-        icon: <PaymentIcon />,
-        testId: 'workspace-setting:license',
-      },
-    ].filter((item): item is SettingSidebarItem => !!item);
-  }, [showBilling, showLicense, t]);
+  const items: SettingSidebarItem[] = [
+    {
+      key: 'workspace:preference',
+      title: t['com.affine.settings.workspace.preferences'](),
+      icon: <SettingsIcon />,
+      testId: 'workspace-setting:preference',
+    },
+    {
+      key: 'workspace:properties',
+      title: t['com.affine.settings.workspace.properties'](),
+      icon: <PropertyIcon />,
+      testId: 'workspace-setting:properties',
+    },
+    {
+      key: 'workspace:members',
+      title: t['Members'](),
+      icon: <CollaborationIcon />,
+      testId: 'workspace-setting:members',
+    },
+    {
+      key: 'workspace:integrations',
+      title: t['com.affine.integration.integrations'](),
+      icon: <IntegrationsIcon />,
+      testId: 'workspace-setting:integrations',
+    },
+    {
+      key: 'workspace:storage',
+      title: t['Storage'](),
+      icon: <SaveIcon />,
+      testId: 'workspace-setting:storage',
+    },
+    {
+      key: 'workspace:embedding',
+      title:
+        t['com.affine.settings.workspace.indexer-embedding.embedding.title'](),
+      icon: <AiEmbeddingIcon />,
+      testId: 'workspace-setting:embedding',
+    },
+    showBilling && {
+      key: 'workspace:billing' as SettingTab,
+      title: t['com.affine.settings.workspace.billing'](),
+      icon: <PaymentIcon />,
+      testId: 'workspace-setting:billing',
+    },
+    showLicense && {
+      key: 'workspace:license' as SettingTab,
+      title: t['com.affine.settings.workspace.license'](),
+      icon: <PaymentIcon />,
+      testId: 'workspace-setting:license',
+    },
+  ].filter((item): item is SettingSidebarItem => !!item);
 
   return items;
 };


### PR DESCRIPTION
## Summary
Fixes the issue where the left guide panel does not update immediately after switching display language.

## Changes
- removed stale memoized options in appearance settings
- updated the guide panel and settings sections to re-render on language switch
- cleaned unused React imports

## Testing
- switched between English and Chinese locally
- confirmed the left guide panel updates immediately
- confirmed theme and open-in-app options also update correctly
- verified no page refresh is needed
- tested switching back to English

## Demo
Attached a short before/after video showing the fix.

https://github.com/user-attachments/assets/12225e1f-1918-4fd0-9748-5fa6fe74fa5b


https://github.com/user-attachments/assets/75c89b8d-848b-4809-90dd-2f68df38a027


Closes #13291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code structure in appearance, general, and workspace settings dialogs for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->