### PR TITLE
fix: allow PDF preview on readonly public pages

### DIFF
--- a/blocksuite/affine/blocks/attachment/src/attachment-block.ts
+++ b/blocksuite/affine/blocks/attachment/src/attachment-block.ts
@@ -54,7 +54,7 @@ type AttachmentResolvedStateInfo = ResolvedStateInfo & {
 
 @Peekable({
   enableOn: ({ model }: AttachmentBlockComponent) => {
-    return !model.store.readonly && model.props.type.endsWith('pdf');
+    return model.props.type.endsWith('pdf');
   },
 })
 export class AttachmentBlockComponent extends CaptionedBlockComponent<AttachmentBlockModel> {


### PR DESCRIPTION
fixes https://github.com/toeverything/AFFiNE/issues/14727

https://www.loom.com/share/dfcd558332404896b3e02aad97b18f02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PDF attachments can now be previewed in read-only documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->