### PR TITLE
fix(core): nested numbered list order

### DIFF
--- a/blocksuite/affine/blocks/list/src/commands/utils.ts
+++ b/blocksuite/affine/blocks/list/src/commands/utils.ts
@@ -30,7 +30,11 @@ export function correctNumberedListsOrderToPrev(
 
   const fn = () => {
     // step 1
-    const previousSibling = doc.getPrev(model);
+    const parent = doc.getParent(model);
+    if (!parent) return;
+    const index = parent.children.indexOf(model);
+    const previousSibling = index > 0 ? parent.children[index - 1] : null;
+
     if (
       previousSibling &&
       matchModels(previousSibling, [ListBlockModel]) &&

--- a/packages/backend/server/.env.example
+++ b/packages/backend/server/.env.example
@@ -1,15 +1,15 @@
-# DATABASE_URL="postgres://affine:affine@localhost:5432/affine"
-# REDIS_SERVER_HOST=localhost
-# COPILOT_FAL_API_KEY=YOUR_KEY
-# COPILOT_OPENAI_API_KEY=YOUR_KEY
-# COPILOT_PERPLEXITY_API_KEY=YOUR_KEY
+ DATABASE_URL="postgres://affine:affine@localhost:5432/affine"
+ REDIS_SERVER_HOST=localhost
+ COPILOT_FAL_API_KEY=YOUR_KEY
+ COPILOT_OPENAI_API_KEY=YOUR_KEY
+ COPILOT_PERPLEXITY_API_KEY=YOUR_KEY
 
-# MAILER_HOST=127.0.0.1
-# MAILER_PORT=1025
-# MAILER_SERVERNAME="mail.example.com"
-# MAILER_SENDER="noreply@toeverything.info"
-# MAILER_USER="noreply@toeverything.info"
-# MAILER_PASSWORD="affine"
-# MAILER_SECURE=false
+ MAILER_HOST=127.0.0.1
+ MAILER_PORT=1025
+ MAILER_SERVERNAME="mail.example.com"
+ MAILER_SENDER="noreply@toeverything.info"
+ MAILER_USER="noreply@toeverything.info"
+ MAILER_PASSWORD="affine"
+ MAILER_SECURE=false
 
-# AFFINE_INDEXER_ENABLED=true
+ AFFINE_INDEXER_ENABLED=true

--- a/packages/backend/server/.env.example
+++ b/packages/backend/server/.env.example
@@ -1,15 +1,15 @@
- DATABASE_URL="postgres://affine:affine@localhost:5432/affine"
- REDIS_SERVER_HOST=localhost
- COPILOT_FAL_API_KEY=YOUR_KEY
- COPILOT_OPENAI_API_KEY=YOUR_KEY
- COPILOT_PERPLEXITY_API_KEY=YOUR_KEY
+# DATABASE_URL="postgres://affine:affine@localhost:5432/affine"
+# REDIS_SERVER_HOST=localhost
+# COPILOT_FAL_API_KEY=YOUR_KEY
+# COPILOT_OPENAI_API_KEY=YOUR_KEY
+# COPILOT_PERPLEXITY_API_KEY=YOUR_KEY
 
- MAILER_HOST=127.0.0.1
- MAILER_PORT=1025
- MAILER_SERVERNAME="mail.example.com"
- MAILER_SENDER="noreply@toeverything.info"
- MAILER_USER="noreply@toeverything.info"
- MAILER_PASSWORD="affine"
- MAILER_SECURE=false
+# MAILER_HOST=127.0.0.1
+# MAILER_PORT=1025
+# MAILER_SERVERNAME="mail.example.com"
+# MAILER_SENDER="noreply@toeverything.info"
+# MAILER_USER="noreply@toeverything.info"
+# MAILER_PASSWORD="affine"
+# MAILER_SECURE=false
 
- AFFINE_INDEXER_ENABLED=true
+# AFFINE_INDEXER_ENABLED=true


### PR DESCRIPTION
## The Fix ##
Fixes #13396. The issue happened because 'doc.getPrev(model)' returns previous node based in document order instead of previous sibling within list level. This caused nested list items to inherit the numbering from their parent rather than restarting. The fix ensures that numbering is calculated relative to correct list context. 

## Video Demonstration ##
### Before ###
https://github.com/user-attachments/assets/9523209a-93d9-4984-aa9e-149ac1941036

### After ###
https://github.com/user-attachments/assets/ff28b166-3572-4536-9893-0ab5c05c8d9f






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numbered list ordering logic for improved list handling.

* **Chores**
  * Updated environment configuration template with active sample values for database connectivity, caching services, AI integrations, and email delivery settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->