### PR TITLE
fix: save column header edits when pressing Enter

### DIFF
--- a/blocksuite/affine/components/src/context-menu/input.ts
+++ b/blocksuite/affine/components/src/context-menu/input.ts
@@ -71,6 +71,7 @@ export class MenuInput extends MenuFocusable {
     }
     if (e.key === 'Enter') {
       this.complete();
+      this.inputRef.blur();
       this.menu.close();
       return;
     }


### PR DESCRIPTION
## The Fix

Fixes #14744.

Updated the menu input Enter key behavior so that pressing Enter now saves the edited database column header name and closes the menu immediately.

This reuses the existing `blur()` save flow, keeping the behavior consistent with clicking outside the input.

The Tab key behavior remains unchanged and still saves through the existing blur flow.

## Video Demonstration

### After

https://github.com/user-attachments/assets/820a7c41-cae5-477c-8b65-b0667e0ce82b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling in context menu input to properly blur the input field when pressing Enter, ensuring cleaner interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->