### PR TITLE
fix(android): route OAuth deep link to correct server's AuthService

### DIFF
--- a/packages/frontend/apps/android/src/app.tsx
+++ b/packages/frontend/apps/android/src/app.tsx
@@ -304,6 +304,7 @@ CapacitorApp.addListener('appUrlOpen', ({ url }) => {
   if (urlObj.hostname === 'authentication') {
     const method = urlObj.searchParams.get('method');
     const payload = JSON.parse(urlObj.searchParams.get('payload') ?? 'false');
+    const serverBaseUrl = urlObj.searchParams.get('server');
 
     if (
       !method ||
@@ -314,9 +315,18 @@ CapacitorApp.addListener('appUrlOpen', ({ url }) => {
       return;
     }
 
-    const authService = frameworkProvider
+    let authService = frameworkProvider
       .get(DefaultServerService)
       .server.scope.get(AuthService);
+
+    if (serverBaseUrl) {
+      const serversService = frameworkProvider.get(ServersService);
+      const server = serversService.getServerByBaseUrl(serverBaseUrl);
+      if (server) {
+        authService = server.scope.get(AuthService);
+      }
+    }
+
     if (method === 'oauth') {
       authService
         .signInOauth(payload.code, payload.state, payload.provider)

--- a/packages/frontend/apps/android/src/app.tsx
+++ b/packages/frontend/apps/android/src/app.tsx
@@ -322,9 +322,11 @@ CapacitorApp.addListener('appUrlOpen', ({ url }) => {
     if (serverBaseUrl) {
       const serversService = frameworkProvider.get(ServersService);
       const server = serversService.getServerByBaseUrl(serverBaseUrl);
-      if (server) {
-        authService = server.scope.get(AuthService);
+      if (!server) {
+        console.error('Authentication callback server not found', serverBaseUrl);
+        return;
       }
+      authService = server.scope.get(AuthService);
     }
 
     if (method === 'oauth') {


### PR DESCRIPTION
Porting over iOS fix for self-hosted SSO to Android from #11563.

Fixes #12819

Tested on own instance using Authentik.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android authentication now supports an optional server parameter in the callback URL, enabling sign-in against different server instances.
  * If the specified server cannot be found, the authentication attempt is halted and an error is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->