### PR TITLE
fix: resolve remaining untranslated doc title case in detail page header

### DIFF
--- a/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page-header.tsx
+++ b/packages/frontend/core/src/desktop/pages/workspace/detail-page/detail-page-header.tsx
@@ -97,8 +97,7 @@ export function JournalPageHeader({ page, workspace }: PageHeaderProps) {
     useDetailPageHeaderResponsive(containerWidth);
 
   const docDisplayMetaService = useService(DocDisplayMetaService);
-  const i18n = useI18n();
-  const title = i18n.t(useLiveData(docDisplayMetaService.title$(page.id)));
+  const title = useLiveData(docDisplayMetaService.title$(page.id));
 
   return (
     <Header className={styles.header} ref={containerRef}>
@@ -147,8 +146,7 @@ export function NormalPageHeader({ page, workspace }: PageHeaderProps) {
   }, []);
 
   const docDisplayMetaService = useService(DocDisplayMetaService);
-  const i18n = useI18n();
-  const title = i18n.t(useLiveData(docDisplayMetaService.title$(page.id)));
+  const title = useLiveData(docDisplayMetaService.title$(page.id));
 
   const editor = useService(EditorService).editor;
   const currentMode = useLiveData(editor.mode$);


### PR DESCRIPTION
fix #14735

This PR fixes a remaining desktop case related to #14467.

The previous fix resolved incorrect translation in navigation panels, but the detail page header tab title was still passing custom document titles through `i18n.t()`, causing user-defined titles to be unexpectedly translated.

### Results

https://github.com/user-attachments/assets/4abad3b9-d5d7-442f-b643-6d9ea63fa741

After:
<img width="2100" height="1722" alt="After" src="https://github.com/user-attachments/assets/0770eae2-e5c5-4816-8d53-e40a4b52800c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated page title retrieval mechanism in workspace detail page headers. The title is now sourced directly from the document display metadata service instead of using the previous derivation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->