### PR TITLE
fix(editor): prevent popMenu overflow on constrained viewports

### DIFF
--- a/blocksuite/affine/components/src/context-menu/menu-renderer.ts
+++ b/blocksuite/affine/components/src/context-menu/menu-renderer.ts
@@ -555,6 +555,7 @@ export const popMenu = (
         ],
       }),
       offset(4),
+      shift({ padding: 8 }),
     ],
     container: props.container,
     placement: props.placement,


### PR DESCRIPTION
Fixes #14722

## Summary

`popMenu()` in `blocksuite/affine/components/src/context-menu/menu-renderer.ts` uses `autoPlacement` + `offset` in its default middleware, but no `shift()` — so when `autoPlacement` picks a placement that would overflow the viewport (e.g. database column menu opening near the top of a short viewport), the menu stays overflowing and top items get clipped above the viewport.

## Fix

Add `shift({ padding: 8 })` to the default middleware chain.

This matches the behavior of the sibling helper `createPopup()` in the same file, which already includes `shift()` in its defaults.

## Reproducing (as reported in #14722)

Viewport ~879×461 (Chrome, macOS). Create a database block near the top of the viewport → click a column name → menu opens upward and the top items ("Rename", "Filter") get clipped above the viewport.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced context menu positioning on desktop to provide better alignment and spacing adjustments near screen boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->