### PR TITLE
fix: insert table outside nested list context

### DIFF
--- a/blocksuite/affine/blocks/table/src/commands.ts
+++ b/blocksuite/affine/blocks/table/src/commands.ts
@@ -20,12 +20,17 @@ export const insertTableBlockCommand: Command<
   const { selectedModels, place, removeEmptyLine, std } = ctx;
   if (!selectedModels?.length) return;
 
-  const targetModel =
+  let targetModel =
     place === 'before'
       ? selectedModels[0]
       : selectedModels[selectedModels.length - 1];
-
   if (!targetModel) return;
+
+  let parent = std.store.getParent(targetModel);
+  while (parent && parent.flavour === 'affine:list') {
+    targetModel = parent;
+    parent = std.store.getParent(targetModel);
+  }
 
   const result = std.store.addSiblingBlocks(
     targetModel,


### PR DESCRIPTION
Fixes toeverything/AFFiNE#14741

### Issue
When attempting to insert a table inside a nested numbered list using
the slash menu, the table would fail to insert and nothing would happen.

### Fix
- `insertTableBlockCommand` uses `addSiblingBlocks` which tries to add
  the table as a child of the `affine:list` parent block — invalid for
  a table block
- Added a walk up the parent chain while the parent flavour is
  `affine:list`, so the table is inserted as a sibling of the outermost
  list block instead



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved handling of sibling block insertion positioning in tables to correctly traverse parent elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->