### PR TITLE
fix: guard IME composition state before early returns in RangeBinding

### DIFF
--- a/blocksuite/affine/blocks/table/src/commands.ts
+++ b/blocksuite/affine/blocks/table/src/commands.ts
@@ -20,12 +20,17 @@ export const insertTableBlockCommand: Command<
   const { selectedModels, place, removeEmptyLine, std } = ctx;
   if (!selectedModels?.length) return;
 
-  const targetModel =
+  let targetModel =
     place === 'before'
       ? selectedModels[0]
       : selectedModels[selectedModels.length - 1];
-
   if (!targetModel) return;
+
+  let parent = std.store.getParent(targetModel);
+  while (parent && parent.flavour === 'affine:list') {
+    targetModel = parent;
+    parent = std.store.getParent(targetModel);
+  }
 
   const result = std.store.addSiblingBlocks(
     targetModel,

--- a/blocksuite/framework/std/src/inline/range/range-binding.ts
+++ b/blocksuite/framework/std/src/inline/range/range-binding.ts
@@ -85,6 +85,7 @@ export class RangeBinding {
   };
 
   private readonly _onCompositionEnd = (event: CompositionEvent) => {
+    this.isComposing = false;
     if (this._compositionStartCallback) {
       event.preventDefault();
       event.stopPropagation();
@@ -94,13 +95,12 @@ export class RangeBinding {
   };
 
   private readonly _onCompositionStart = () => {
+    this.isComposing = true;
     const selection = this.selectionManager.find(TextSelection);
     if (!selection) return;
 
     const { from, to } = selection;
     if (!to) return;
-
-    this.isComposing = true;
 
     const range = this.rangeManager?.value;
     if (!range) return;


### PR DESCRIPTION
Fixes toeverything/AFFiNE#14533

### Issue
After inserting a hyperlink and typing Chinese (or any IME language) 
directly after it, the line would freeze and become unselectable. The 
cursor would appear briefly then disappear on click. English input was 
unaffected, and adding a space after the hyperlink before typing would 
avoid the bug.

### Fix
- `isComposing` was only set to `true` after the `if (!to) return` early 
  return in `_onCompositionStart`, so single-block cursor positions (e.g. 
  typing right after a hyperlink) never set the flag which left
  `_onNativeSelectionChanged` firing and reconciling the DOM mid-IME composition
- Moved `this.isComposing = true` to the top of `_onCompositionStart` before 
  any early returns
- Added `this.isComposing = false` unconditionally at the top of 
  `_onCompositionEnd` so the flag is always cleared
  
 ### Screenshot Verification
 
<img width="178" height="65" alt="image" src="https://github.com/user-attachments/assets/73736465-23e1-4159-93cd-c9da2a559181" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed table command insertion when operating within nested lists.
  * Improved composition state handling for more consistent text input behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->