### PR TITLE
chore: split i18n and bs-docs dirty checks in typecheck workflow

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -114,13 +114,20 @@ jobs:
           electron-install: false
           full-cache: true
       - name: Run i18n codegen
-        run: yarn affine @affine/i18n build
+        run: |
+          yarn affine @affine/i18n build
+          git checkout packages/frontend/i18n/src/i18n-completenesses.json
+          if git status --porcelain | grep -q .; then
+            echo "Run 'yarn affine @affine/i18n build' and make sure all generated i18n changes are submitted"
+            exit 1
+          else
+            echo "All generated i18n changes are submitted"
+          fi
       - name: Run Type Check
         run: yarn typecheck
       - name: Run BS Docs Build
         run: |
           yarn affine bs-docs build
-          git checkout packages/frontend/i18n/src/i18n-completenesses.json
           if git status --porcelain | grep -q .; then
             echo "Run 'yarn typecheck && yarn affine bs-docs build' and make sure all changes are submitted"
             exit 1


### PR DESCRIPTION
## Summary

Split generated-file validation in the `typecheck` workflow so i18n outputs and BS docs outputs are checked separately.

This fixes a misleading CI failure message: previously, CI could fail due to i18n-generated changes like `packages/frontend/i18n/src/i18n.gen.ts`, but only suggested running `yarn typecheck && yarn affine bs-docs build`, which does not regenerate those files.

## Changes

- validate i18n-generated changes immediately after `yarn affine @affine/i18n build`
- keep ignoring `packages/frontend/i18n/src/i18n-completenesses.json` in CI as before
- leave `yarn typecheck` as a separate step
- make the BS docs step only check for changes introduced by `yarn affine bs-docs build`

## Result

CI now gives the correct remediation command depending on which generated files are out of date:
- i18n issues: `yarn affine @affine/i18n build`
- docs/typecheck issues: `yarn typecheck && yarn affine bs-docs build`

## Testing

- verified the updated workflow YAML parses successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build validation for internationalization code generation to ensure generated changes are properly committed before proceeding. The validation now occurs immediately after code generation runs, providing faster feedback during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->