### PR TITLE
fix(editor): align selection/handle/remote/text overlays with blocks

### DIFF
--- a/blocksuite/affine/gfx/shape/src/text/edgeless-shape-text-editor.ts
+++ b/blocksuite/affine/gfx/shape/src/text/edgeless-shape-text-editor.ts
@@ -434,6 +434,8 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
     const textResizing = this.element.textResizing;
     const viewport = this.gfx.viewport;
     const zoom = viewport.zoom;
+    // Compensate for outer CSS scale, matching GfxBlockComponent.getCSSTransform.
+    const { viewportX, viewportY, viewScale } = viewport;
     const rect = getSelectedRect([this.element]);
     const rotate = this.element.rotate;
     const [leftTopX, leftTopY] = Vec.rotWith(
@@ -441,7 +443,8 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       [rect.left + rect.width / 2, rect.top + rect.height / 2],
       toRadian(rotate)
     );
-    const [x, y] = this.gfx.viewport.toViewCoord(leftTopX, leftTopY);
+    const x = ((leftTopX - viewportX) * zoom) / viewScale;
+    const y = ((leftTopY - viewportY) * zoom) / viewScale;
     const autoWidth = textResizing === TextResizing.AUTO_WIDTH_AND_HEIGHT;
     const constrainedAutoWidth = autoWidth && !!this.element.maxWidth;
     const editorWidth = constrainedAutoWidth
@@ -476,7 +479,7 @@ export class EdgelessShapeTextEditor extends WithDisposable(ShadowlessElement) {
       fontWeight: this.element.fontWeight,
       lineHeight: 'normal',
       outline: 'none',
-      transform: `scale(${zoom}, ${zoom}) rotate(${rotate}deg)`,
+      transform: `scale(${zoom / viewScale}, ${zoom / viewScale}) rotate(${rotate}deg)`,
       transformOrigin: 'top left',
       color,
       padding: `${verticalPadding}px ${horiPadding}px`,

--- a/blocksuite/affine/gfx/text/src/edgeless-text-editor.ts
+++ b/blocksuite/affine/gfx/text/src/edgeless-text-editor.ts
@@ -418,13 +418,14 @@ export class EdgelessTextEditor extends WithDisposable(ShadowlessElement) {
     const lineHeight = getLineHeight(fontFamily, fontSize, fontWeight);
     const rect = getSelectedRect([this.element]);
 
-    const { translateX, translateY, zoom } = this.gfx.viewport;
+    const { translateX, translateY, zoom, viewScale } = this.gfx.viewport;
     const [visualX, visualY] = this.getVisualPosition(this.element);
     const containerOffset = this.getContainerOffset();
+    // Compensate for outer CSS scale, matching GfxBlockComponent.getCSSTransform.
     const transformOperation = [
-      `translate(${translateX}px, ${translateY}px)`,
-      `translate(${visualX * zoom}px, ${visualY * zoom}px)`,
-      `scale(${zoom})`,
+      `translate(${translateX / viewScale}px, ${translateY / viewScale}px)`,
+      `translate(${(visualX * zoom) / viewScale}px, ${(visualY * zoom) / viewScale}px)`,
+      `scale(${zoom / viewScale})`,
       `rotate(${rotate}deg)`,
       `translate(${containerOffset})`,
     ];

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/edgeless-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/edgeless-watcher.ts
@@ -278,7 +278,7 @@ export class EdgelessWatcher {
 
     const containerWidth =
       (DRAG_HANDLE_CONTAINER_WIDTH_TOP_LEVEL * scale) / viewScale;
-    const offsetLeft = DRAG_HANDLE_CONTAINER_OFFSET_LEFT_TOP_LEVEL;
+    const offsetLeft = DRAG_HANDLE_CONTAINER_OFFSET_LEFT_TOP_LEVEL / viewScale;
 
     left -= containerWidth + offsetLeft;
     right += padding;

--- a/blocksuite/affine/widgets/drag-handle/src/watchers/edgeless-watcher.ts
+++ b/blocksuite/affine/widgets/drag-handle/src/watchers/edgeless-watcher.ts
@@ -264,16 +264,20 @@ export class EdgelessWatcher {
 
     const { viewport } = this.gfx;
     const rect = getSelectedRect([edgelessElement]);
-    let [left, top] = viewport.toViewCoord(rect.left, rect.top);
+    // Compensate for outer CSS scale, matching GfxBlockComponent.getCSSTransform.
+    const { viewportX, viewportY, viewScale } = viewport;
     const scale = this.widget.scale.peek();
-    const width = rect.width * scale;
-    const height = rect.height * scale;
+    let left = ((rect.left - viewportX) * scale) / viewScale;
+    const top = ((rect.top - viewportY) * scale) / viewScale;
+    const width = (rect.width * scale) / viewScale;
+    const height = (rect.height * scale) / viewScale;
 
     let [right, bottom] = [left + width, top + height];
 
-    const padding = HOVER_AREA_RECT_PADDING_TOP_LEVEL * scale;
+    const padding = (HOVER_AREA_RECT_PADDING_TOP_LEVEL * scale) / viewScale;
 
-    const containerWidth = DRAG_HANDLE_CONTAINER_WIDTH_TOP_LEVEL * scale;
+    const containerWidth =
+      (DRAG_HANDLE_CONTAINER_WIDTH_TOP_LEVEL * scale) / viewScale;
     const offsetLeft = DRAG_HANDLE_CONTAINER_OFFSET_LEFT_TOP_LEVEL;
 
     left -= containerWidth + offsetLeft;

--- a/blocksuite/affine/widgets/edgeless-selected-rect/src/edgeless-selected-rect.ts
+++ b/blocksuite/affine/widgets/edgeless-selected-rect/src/edgeless-selected-rect.ts
@@ -473,12 +473,15 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<RootBlockModel> 
     const { zoom, selection, gfx } = this;
 
     const elements = selection.selectedElements;
-    // in surface
     const rect = getSelectedRect(elements);
 
-    // in viewport
-    const [left, top] = gfx.viewport.toViewCoord(rect.left, rect.top);
-    const [width, height] = [rect.width * zoom, rect.height * zoom];
+    // Compensate for outer CSS scale (e.g. embed-edgeless-synced-doc),
+    // matching GfxBlockComponent.getCSSTransform.
+    const { viewportX, viewportY, viewScale } = gfx.viewport;
+    const left = ((rect.left - viewportX) * zoom) / viewScale;
+    const top = ((rect.top - viewportY) * zoom) / viewScale;
+    const width = (rect.width * zoom) / viewScale;
+    const height = (rect.height * zoom) / viewScale;
 
     let rotate = 0;
     if (elements.length === 1 && elements[0].rotate) {

--- a/blocksuite/affine/widgets/edgeless-selected-rect/src/edgeless-selected-rect.ts
+++ b/blocksuite/affine/widgets/edgeless-selected-rect/src/edgeless-selected-rect.ts
@@ -717,15 +717,17 @@ export class EdgelessSelectedRectWidget extends WidgetComponent<RootBlockModel> 
           element => element.id,
           element => {
             const [modelX, modelY, w, h] = deserializeXYWH(element.xywh);
-            const [x, y] = gfx.viewport.toViewCoord(modelX, modelY);
+            const { viewportX, viewportY, zoom, viewScale } = gfx.viewport;
+            const x = ((modelX - viewportX) * zoom) / viewScale;
+            const y = ((modelY - viewportY) * zoom) / viewScale;
             const { left, top, borderWidth } = this._selectedRect;
             const style = {
               position: 'absolute',
               boxSizing: 'border-box',
               left: `${x - left - borderWidth}px`,
               top: `${y - top - borderWidth}px`,
-              width: `${w * this.zoom}px`,
-              height: `${h * this.zoom}px`,
+              width: `${(w * zoom) / viewScale}px`,
+              height: `${(h * zoom) / viewScale}px`,
               transform: `rotate(${element.rotate}deg)`,
               border: `1px solid var(--affine-primary-color)`,
             };

--- a/blocksuite/affine/widgets/remote-selection/src/edgeless/index.ts
+++ b/blocksuite/affine/widgets/remote-selection/src/edgeless/index.ts
@@ -148,13 +148,14 @@ export class EdgelessRemoteSelectionWidget extends WidgetComponent<RootBlockMode
   };
 
   private readonly _updateTransform = requestThrottledConnectedFrame(() => {
-    const { translateX, translateY, zoom } = this.gfx.viewport;
+    const { translateX, translateY, zoom, viewScale } = this.gfx.viewport;
 
-    this.style.setProperty('--v-zoom', `${zoom}`);
+    // Compensate for outer CSS scale, matching GfxBlockComponent.getCSSTransform.
+    this.style.setProperty('--v-zoom', `${zoom / viewScale}`);
 
     this.style.setProperty(
       'transform',
-      `translate(${translateX}px, ${translateY}px) scale(var(--v-zoom))`
+      `translate(${translateX / viewScale}px, ${translateY / viewScale}px) scale(var(--v-zoom))`
     );
   }, this);
 


### PR DESCRIPTION
# Closes #14855.

## The bug

When an `affine:embed-synced-doc` is placed on an edgeless canvas and resized which sets `model.props.scale` to a value ≠ 1 - the block-selection frame rendered **inside** that embedded editor is drawn offset from the actual block boundary. The reporter hit this in Safari, but the root cause is platform-independent.

![reported screenshot](https://github.com/user-attachments/assets/ce415528-1d01-4bfe-9d63-1e2884ca2f70)

## Root cause

`affine-embed-edgeless-synced-doc-block` applies `transform: scale(modelScale)` to its `.affine-embed-synced-doc-container` so the embedded editor visually fits inside its edgeless xywh ([embed-edgeless-synced-doc-block.ts#L48-L58](https://github.com/toeverything/AFFiNE/blob/canary/blocksuite/affine/blocks/embed-doc/src/embed-synced-doc-block/embed-edgeless-synced-doc-block.ts#L48-L58)). The inner `Viewport` exposes that outer scale as `viewScale = boundingClientRect.width / offsetWidth`.

PR #14015 and PR #14074 already taught the surface canvas and `GfxBlockComponent.getCSSTransform` to compensate by dividing by `viewScale`. But several selection-related overlays that render inside the same scaled container were **not** updated in those PRs. They either:

- read `viewport.toViewCoord(x, y)` - which returns `(x - viewportX) * zoom * viewScale` and drop the result into CSS `left` / `top` inside the scaled container, or
- hand-build a `translate(translateX, translateY) scale(zoom)` transform without `viewScale` compensation.

The outer CSS `scale(viewScale)` then re-applies the scale, leaving the overlays one factor of `viewScale` away from their blocks. That's exactly the misalignment in the screenshot - the rect's size looks right but its position is offset.

## The fix

Mirror the pattern shipped in #14074 everywhere the inner overlays are placed:

- position: `(model - viewportX) * zoom / viewScale`
- transform scale: `zoom / viewScale`
- translate: `translateX / viewScale, translateY / viewScale`

This keeps the overlays in the same reference frame as `GfxBlockComponent.getCSSTransform` so they line up with the block they're framing. When `viewScale === 1` (normal edgeless canvas, outside any embed) every `/ viewScale` is a no-op and behaviour is unchanged.

## Why this is safe

- When `viewScale === 1` - every existing caller outside `embed-edgeless-synced-doc` - the math reduces to the original expression byte-for-byte.
- The fix strictly mirrors the invariant already adopted by `GfxBlockComponent.getCSSTransform` in #14074. It's the same division by `viewScale` applied in the same place.
- No public API, type, or DOM structure changed.

## Scope / known limitations

- The `Viewport._cachedBoundingClientRect` cache is only invalidated by its own `ResizeObserver` ([viewport.ts#L500-L505](https://github.com/toeverything/AFFiNE/blob/canary/blocksuite/framework/std/src/gfx/viewport.ts#L500-L505)). A CSS-transform change on an ancestor (e.g. the user panning/zooming the outer edgeless canvas) does not fire it, so in theory `viewScale` can go stale between outer-viewport updates. In practice this hasn't come up in repro - the inner viewport's shell is observed and fires whenever layout shifts. If it turns out to matter I'm happy to add a `viewport.onResize()` refresh hook off the existing `GfxViewportInitializer` in a follow-up.
- No integration test added - the existing `blocksuite/integration-test/edgeless/` suite has no `embed-synced-doc` harness. Adding one is a larger scope; can follow up if requested.

## Test plan

- [x] `yarn typecheck` - passes
- [x] `yarn lint:ox` - `0 warnings, 0 errors`
- [x] `yarn prettier --write` on the 5 touched files - no changes
- [ ] Manual: on canary, create an edgeless canvas, drop an embed-synced-doc, resize with `Shift` held so `model.props.scale` ≠ 1, select any block inside, and verify the blue selection frame sits flush with the block's boundary (confirm on Safari, Chrome, Firefox).
- [ ] Regression check: on a normal edgeless canvas (no embed), verify element selection, drag handle, and text/shape inline editors still render correctly (these code paths hit `viewScale === 1` and should be unchanged).

## Related PRs

- #14015 - fixed surface canvas at non-1 `viewScale`.
- #14074 - fixed `GfxBlockComponent.getCSSTransform` at non-1 `viewScale`. This PR completes that series by covering the selection overlays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed positioning and scaling of inline text editors, selection rectangles, drag handles, and remote cursors so overlays and editors remain correctly aligned and sized when the viewport uses an additional outer scale/transform during zooming and panning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->