### PR TITLE
feat: add native HTML Page support alongside Page/Edgeless modes

### DIFF
--- a/packages/frontend/core/src/blocksuite/block-suite-page-list/utils.tsx
+++ b/packages/frontend/core/src/blocksuite/block-suite-page-list/utils.tsx
@@ -134,6 +134,49 @@ export const usePageHelper = (docCollection: Workspace) => {
     [docCollection, workbench]
   );
 
+  const createHtmlPageAndOpen = useCallback(
+    (
+      options: {
+        at?: 'new-tab' | 'tail' | 'active';
+        show?: boolean;
+        sandboxMode?: 'restricted' | 'unrestricted';
+      } = {
+        at: 'active',
+        show: true,
+        sandboxMode: 'restricted',
+      }
+    ) => {
+      appSidebar.setHovering(false);
+      const title = resolveNewDocTitle({
+        autoTitleEnabled: settings.autoTitleNewDocWithCurrentDate,
+        existingTitles: allDocTitles.map(doc => doc.title).filter(Boolean),
+        format: settings.newDocDateTitleFormat,
+      });
+
+      const page = docsService.createDoc({
+        ...(title ? { title } : undefined),
+        isHtmlPage: true,
+        htmlSandboxMode: options.sandboxMode ?? 'restricted',
+      });
+
+      if (options.show !== false) {
+        workbench.openDoc(page.id, {
+          at: options.at,
+          show: options.show,
+        });
+      }
+      return page;
+    },
+    [
+      appSidebar,
+      allDocTitles,
+      docsService,
+      settings.autoTitleNewDocWithCurrentDate,
+      settings.newDocDateTitleFormat,
+      workbench,
+    ]
+  );
+
   return useMemo(() => {
     return {
       createPage: (
@@ -144,7 +187,13 @@ export const usePageHelper = (docCollection: Workspace) => {
         }
       ) => createPageAndOpen(mode, options),
       createEdgeless: createEdgelessAndOpen,
+      createHtmlPage: createHtmlPageAndOpen,
       importFile: importFileAndOpen,
     };
-  }, [createEdgelessAndOpen, createPageAndOpen, importFileAndOpen]);
+  }, [
+    createEdgelessAndOpen,
+    createHtmlPageAndOpen,
+    createPageAndOpen,
+    importFileAndOpen,
+  ]);
 };

--- a/packages/frontend/core/src/components/html-page-editor/html-page-editor.css.ts
+++ b/packages/frontend/core/src/components/html-page-editor/html-page-editor.css.ts
@@ -1,0 +1,141 @@
+import { cssVarV2 } from '@toeverything/theme/v2';
+import { globalStyle,style } from '@vanilla-extract/css';
+
+export const htmlPageEditorRoot = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  height: '100%',
+  minHeight: 'calc(100vh - 120px)',
+});
+
+export const toolbar = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '8px 16px',
+  borderBottom: `1px solid ${cssVarV2('layer/border')}`,
+  background: cssVarV2('layer/background/primary'),
+  position: 'sticky',
+  top: 0,
+  zIndex: 10,
+  flexShrink: 0,
+});
+
+export const toolbarGroup = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 4,
+});
+
+export const toolbarSeparator = style({
+  width: 1,
+  height: 20,
+  background: cssVarV2('layer/border'),
+  margin: '0 8px',
+});
+
+export const modeToggle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 0,
+  borderRadius: 8,
+  overflow: 'hidden',
+  border: `1px solid ${cssVarV2('layer/border')}`,
+});
+
+export const modeButton = style({
+  padding: '4px 12px',
+  fontSize: 13,
+  fontWeight: 500,
+  cursor: 'pointer',
+  border: 'none',
+  background: 'transparent',
+  color: cssVarV2('text/secondary'),
+  transition: 'all 0.15s ease',
+  selectors: {
+    '&[data-active="true"]': {
+      background: cssVarV2('button/primary'),
+      color: '#fff',
+    },
+  },
+});
+
+export const sandboxToggle = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '4px 10px',
+  borderRadius: 6,
+  fontSize: 12,
+  fontWeight: 500,
+  cursor: 'pointer',
+  border: `1px solid ${cssVarV2('layer/border')}`,
+  background: 'transparent',
+  color: cssVarV2('text/secondary'),
+  transition: 'all 0.15s ease',
+  selectors: {
+    '&:hover': {
+      background: cssVarV2('layer/background/hoverOverlay'),
+    },
+  },
+});
+
+export const sandboxDot = style({
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  transition: 'background 0.15s ease',
+});
+
+export const sandboxRestricted = style({
+  background: '#22c55e',
+});
+
+export const sandboxUnrestricted = style({
+  background: '#f59e0b',
+});
+
+export const editorArea = style({
+  flex: 1,
+  display: 'flex',
+  flexDirection: 'column',
+  overflow: 'hidden',
+  position: 'relative',
+});
+
+export const codeEditor = style({
+  width: '100%',
+  height: '100%',
+  border: 'none',
+  outline: 'none',
+  resize: 'none',
+  padding: '20px 24px',
+  fontFamily:
+    "'JetBrains Mono', 'Fira Code', 'Cascadia Code', Consolas, monospace",
+  fontSize: 13,
+  lineHeight: 1.6,
+  tabSize: 2,
+  background: cssVarV2('layer/background/primary'),
+  color: cssVarV2('text/primary'),
+  boxSizing: 'border-box',
+});
+
+export const previewFrame = style({
+  width: '100%',
+  height: '100%',
+  border: 'none',
+  background: '#fff',
+});
+
+export const statusBar = style({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '4px 16px',
+  borderTop: `1px solid ${cssVarV2('layer/border')}`,
+  background: cssVarV2('layer/background/secondary'),
+  fontSize: 11,
+  color: cssVarV2('text/tertiary'),
+  flexShrink: 0,
+});

--- a/packages/frontend/core/src/components/html-page-editor/html-page-editor.tsx
+++ b/packages/frontend/core/src/components/html-page-editor/html-page-editor.tsx
@@ -1,0 +1,231 @@
+import { useLiveData, useService } from '@toeverything/infra';
+import clsx from 'clsx';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { DocService } from '../../modules/doc';
+import * as styles from './html-page-editor.css';
+
+export interface HtmlPageEditorProps {
+  readonly?: boolean;
+}
+
+type ViewMode = 'edit' | 'preview' | 'split';
+type SandboxMode = 'restricted' | 'unrestricted';
+
+/**
+ * HtmlPageEditor — renders an HTML doc with source editing + live preview.
+ *
+ * - **Edit** mode: monospace textarea for raw HTML editing.
+ * - **Preview** mode: sandboxed iframe rendering the HTML.
+ * - **Split** mode: side-by-side editor + preview.
+ *
+ * The sandbox toggle controls whether scripts can run inside the preview:
+ *   • restricted  → `sandbox=""` (no scripts)
+ *   • unrestricted → `sandbox="allow-scripts"` (scripts enabled)
+ */
+export const HtmlPageEditor = ({ readonly }: HtmlPageEditorProps) => {
+  const doc = useService(DocService).doc;
+  const properties = useLiveData(doc.properties$);
+
+  const htmlContent = (properties.htmlContent as string) ?? '';
+  const sandboxMode: SandboxMode = ((properties.htmlSandboxMode as string) ??
+    'restricted') as SandboxMode;
+
+  const [viewMode, setViewMode] = useState<ViewMode>('split');
+  const [localContent, setLocalContent] = useState(htmlContent);
+  const [charCount, setCharCount] = useState(htmlContent.length);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Sync from external changes (e.g. sync engine updates)
+  useEffect(() => {
+    setLocalContent(htmlContent);
+    setCharCount(htmlContent.length);
+  }, [htmlContent]);
+
+  // Debounced save to doc property
+  const saveContent = useCallback(
+    (content: string) => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+      saveTimerRef.current = setTimeout(() => {
+        doc.record.setProperty('htmlContent', content);
+      }, 500);
+    },
+    [doc]
+  );
+
+  // Cleanup timer on unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleContentChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newContent = e.target.value;
+      setLocalContent(newContent);
+      setCharCount(newContent.length);
+      saveContent(newContent);
+    },
+    [saveContent]
+  );
+
+  const toggleSandboxMode = useCallback(() => {
+    const newMode: SandboxMode =
+      sandboxMode === 'restricted' ? 'unrestricted' : 'restricted';
+    doc.record.setProperty('htmlSandboxMode', newMode);
+  }, [doc, sandboxMode]);
+
+  // Build the sandbox attribute for the iframe
+  const sandboxAttr = useMemo(() => {
+    return sandboxMode === 'unrestricted' ? 'allow-scripts' : '';
+  }, [sandboxMode]);
+
+  // Build the srcDoc, wrapping in a basic HTML shell if needed
+  const previewSrcDoc = useMemo(() => {
+    return localContent || '<!DOCTYPE html><html><body></body></html>';
+  }, [localContent]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Tab key inserts two spaces instead of moving focus
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const target = e.currentTarget;
+        const start = target.selectionStart;
+        const end = target.selectionEnd;
+        const value = target.value;
+        const newValue =
+          value.substring(0, start) + '  ' + value.substring(end);
+        setLocalContent(newValue);
+        setCharCount(newValue.length);
+        saveContent(newValue);
+        // Restore cursor position after React re-render
+        requestAnimationFrame(() => {
+          target.selectionStart = start + 2;
+          target.selectionEnd = start + 2;
+        });
+      }
+    },
+    [saveContent]
+  );
+
+  const lineCount = useMemo(() => {
+    return localContent.split('\n').length;
+  }, [localContent]);
+
+  return (
+    <div className={styles.htmlPageEditorRoot}>
+      {/* ─── Toolbar ─── */}
+      <div className={styles.toolbar}>
+        {/* View mode toggle */}
+        <div className={styles.modeToggle}>
+          <button
+            className={styles.modeButton}
+            data-active={viewMode === 'edit'}
+            onClick={() => setViewMode('edit')}
+          >
+            Edit
+          </button>
+          <button
+            className={styles.modeButton}
+            data-active={viewMode === 'split'}
+            onClick={() => setViewMode('split')}
+          >
+            Split
+          </button>
+          <button
+            className={styles.modeButton}
+            data-active={viewMode === 'preview'}
+            onClick={() => setViewMode('preview')}
+          >
+            Preview
+          </button>
+        </div>
+
+        <div className={styles.toolbarSeparator} />
+
+        {/* Sandbox mode toggle */}
+        <button
+          className={styles.sandboxToggle}
+          onClick={toggleSandboxMode}
+          title={
+            sandboxMode === 'restricted'
+              ? 'Restricted mode: Scripts are disabled'
+              : 'Unrestricted mode: Scripts are enabled'
+          }
+        >
+          <span
+            className={clsx(
+              styles.sandboxDot,
+              sandboxMode === 'restricted'
+                ? styles.sandboxRestricted
+                : styles.sandboxUnrestricted
+            )}
+          />
+          {sandboxMode === 'restricted' ? 'Restricted' : 'Unrestricted'}
+        </button>
+      </div>
+
+      {/* ─── Editor / Preview area ─── */}
+      <div
+        className={styles.editorArea}
+        style={{
+          flexDirection: viewMode === 'split' ? 'row' : 'column',
+          display: 'flex',
+        }}
+      >
+        {/* Code editor */}
+        {(viewMode === 'edit' || viewMode === 'split') && (
+          <textarea
+            className={styles.codeEditor}
+            style={{
+              width: viewMode === 'split' ? '50%' : '100%',
+              borderRight:
+                viewMode === 'split'
+                  ? '1px solid var(--affine-border-color, #e3e2e4)'
+                  : 'none',
+            }}
+            value={localContent}
+            onChange={handleContentChange}
+            onKeyDown={handleKeyDown}
+            readOnly={readonly}
+            spellCheck={false}
+            placeholder="Write your HTML here..."
+          />
+        )}
+
+        {/* Live preview */}
+        {(viewMode === 'preview' || viewMode === 'split') && (
+          <iframe
+            ref={iframeRef}
+            className={styles.previewFrame}
+            style={{
+              width: viewMode === 'split' ? '50%' : '100%',
+            }}
+            sandbox={sandboxAttr}
+            srcDoc={previewSrcDoc}
+            title="HTML Page Preview"
+          />
+        )}
+      </div>
+
+      {/* ─── Status bar ─── */}
+      <div className={styles.statusBar}>
+        <span>
+          {lineCount} line{lineCount !== 1 ? 's' : ''} · {charCount} char
+          {charCount !== 1 ? 's' : ''}
+        </span>
+        <span>
+          HTML Page ·{' '}
+          {sandboxMode === 'restricted' ? '🔒 Restricted' : '⚠️ Unrestricted'}
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/packages/frontend/core/src/components/html-page-editor/html-page-editor.tsx
+++ b/packages/frontend/core/src/components/html-page-editor/html-page-editor.tsx
@@ -33,6 +33,7 @@ export const HtmlPageEditor = ({ readonly }: HtmlPageEditorProps) => {
     'restricted') as SandboxMode;
 
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
+  const { openConfirmModal } = useConfirmModal();
   const [localContent, setLocalContent] = useState(htmlContent);
   const [charCount, setCharCount] = useState(htmlContent.length);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -94,7 +95,7 @@ export const HtmlPageEditor = ({ readonly }: HtmlPageEditorProps) => {
     } else {
       doc.record.setProperty('htmlSandboxMode', 'restricted');
     }
-  }, [doc, sandboxMode]);
+  }, [doc, sandboxMode, openConfirmModal]);
 
   // Build the sandbox attribute for the iframe
   const sandboxAttr = useMemo(() => {

--- a/packages/frontend/core/src/components/html-page-editor/html-page-editor.tsx
+++ b/packages/frontend/core/src/components/html-page-editor/html-page-editor.tsx
@@ -1,3 +1,4 @@
+import { useConfirmModal } from '@affine/component';
 import { useLiveData, useService } from '@toeverything/infra';
 import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -31,7 +32,7 @@ export const HtmlPageEditor = ({ readonly }: HtmlPageEditorProps) => {
   const sandboxMode: SandboxMode = ((properties.htmlSandboxMode as string) ??
     'restricted') as SandboxMode;
 
-  const [viewMode, setViewMode] = useState<ViewMode>('split');
+  const [viewMode, setViewMode] = useState<ViewMode>('preview');
   const [localContent, setLocalContent] = useState(htmlContent);
   const [charCount, setCharCount] = useState(htmlContent.length);
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -76,9 +77,23 @@ export const HtmlPageEditor = ({ readonly }: HtmlPageEditorProps) => {
   );
 
   const toggleSandboxMode = useCallback(() => {
-    const newMode: SandboxMode =
-      sandboxMode === 'restricted' ? 'unrestricted' : 'restricted';
-    doc.record.setProperty('htmlSandboxMode', newMode);
+    if (sandboxMode === 'restricted') {
+      openConfirmModal({
+        title: 'Security Warning',
+        description:
+          'Enabling unrestricted mode will allow JavaScript execution within this HTML page. This can be dangerous if the HTML content is from an untrusted source. Are you sure you want to proceed?',
+        cancelText: 'Cancel',
+        confirmText: 'Enable Unrestricted Mode',
+        confirmButtonOptions: {
+          variant: 'error',
+        },
+        onConfirm: () => {
+          doc.record.setProperty('htmlSandboxMode', 'unrestricted');
+        },
+      });
+    } else {
+      doc.record.setProperty('htmlSandboxMode', 'restricted');
+    }
   }, [doc, sandboxMode]);
 
   // Build the sandbox attribute for the iframe

--- a/packages/frontend/core/src/components/html-page-editor/index.ts
+++ b/packages/frontend/core/src/components/html-page-editor/index.ts
@@ -1,0 +1,1 @@
+export { HtmlPageEditor } from './html-page-editor';

--- a/packages/frontend/core/src/components/page-detail-editor.tsx
+++ b/packages/frontend/core/src/components/page-detail-editor.tsx
@@ -60,8 +60,9 @@ export const PageDetailEditor = ({
     editor.doc.blockSuiteDoc.readonly = readonly ?? false;
   }, [editor, readonly]);
 
-  // If the doc is an HTML page, render the HTML editor instead of BlockSuite
-  if (isHtmlPage) {
+  // If the doc is an HTML page and we are in 'page' mode, render the HTML editor.
+  // In 'edgeless' mode, we fall back to the standard BlockSuite editor (canvas).
+  if (isHtmlPage && mode === 'page') {
     return <HtmlPageEditor readonly={readonly} />;
   }
 

--- a/packages/frontend/core/src/components/page-detail-editor.tsx
+++ b/packages/frontend/core/src/components/page-detail-editor.tsx
@@ -9,6 +9,7 @@ import { BlockSuiteEditor } from '../blocksuite/block-suite-editor';
 import { DocService } from '../modules/doc';
 import { EditorService } from '../modules/editor';
 import { EditorSettingService } from '../modules/editor-setting';
+import { HtmlPageEditor } from './html-page-editor';
 import * as styles from './page-detail-editor.css';
 
 declare global {
@@ -40,6 +41,7 @@ export const PageDetailEditor = ({
   const doc = useService(DocService).doc;
   const docMeta = useLiveData(doc.meta$) as DocMetaWithHeaderImage | null;
   const pageWidth = useLiveData(doc.properties$.selector(p => p.pageWidth));
+  const isHtmlPage = useLiveData(doc.properties$.selector(p => p.isHtmlPage));
 
   const isSharedMode = editor.isSharedMode;
   const editorSetting = useService(EditorSettingService).editorSetting;
@@ -57,6 +59,11 @@ export const PageDetailEditor = ({
   useEffect(() => {
     editor.doc.blockSuiteDoc.readonly = readonly ?? false;
   }, [editor, readonly]);
+
+  // If the doc is an HTML page, render the HTML editor instead of BlockSuite
+  if (isHtmlPage) {
+    return <HtmlPageEditor readonly={readonly} />;
+  }
 
   return (
     <>

--- a/packages/frontend/core/src/desktop/components/navigation-panel/nodes/folder/index.tsx
+++ b/packages/frontend/core/src/desktop/components/navigation-panel/nodes/folder/index.tsx
@@ -24,6 +24,7 @@ import { Unreachable } from '@affine/env/constant';
 import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
 import {
+  CodeBlockIcon,
   DeleteIcon,
   FolderIcon,
   PageIcon,
@@ -214,7 +215,7 @@ const NavigationPanelFolderNodeFolder = ({
   );
   const [newFolderId, setNewFolderId] = useState<string | null>(null);
 
-  const { createPage } = usePageHelper(
+  const { createPage, createHtmlPage } = usePageHelper(
     workspaceService.workspace.docCollection
   );
   const handleDelete = useCallback(() => {
@@ -595,6 +596,17 @@ const NavigationPanelFolderNodeFolder = ({
     setCollapsed(false);
   }, [createPage, node, setCollapsed]);
 
+  const handleNewHtmlDoc = useCallback(() => {
+    const newDoc = createHtmlPage();
+    node.createLink('doc', newDoc.id, node.indexAt('before'));
+    track.$.navigationPanel.folders.createDoc();
+    track.$.navigationPanel.organize.createOrganizeItem({
+      type: 'link',
+      target: 'doc',
+    });
+    setCollapsed(false);
+  }, [createHtmlPage, node, setCollapsed]);
+
   const handleCreateSubfolder = useCallback(() => {
     const newFolderId = node.createFolder(
       t['com.affine.rootAppSidebar.organize.new-folders'](),
@@ -686,6 +698,14 @@ const NavigationPanelFolderNodeFolder = ({
         ),
       },
       {
+        index: 101.5,
+        view: (
+          <MenuItem prefixIcon={<CodeBlockIcon />} onClick={handleNewHtmlDoc}>
+            {'Create HTML Page'}
+          </MenuItem>
+        ),
+      },
+      {
         index: 102,
         view: (
           <MenuSub
@@ -743,6 +763,7 @@ const NavigationPanelFolderNodeFolder = ({
     handleCreateSubfolder,
     handleDelete,
     handleNewDoc,
+    handleNewHtmlDoc,
     node,
     t,
   ]);

--- a/packages/frontend/core/src/modules/app-sidebar/views/add-page-button/index.tsx
+++ b/packages/frontend/core/src/modules/app-sidebar/views/add-page-button/index.tsx
@@ -13,6 +13,7 @@ import track from '@affine/track';
 import type { DocMode } from '@blocksuite/affine/model';
 import {
   ArrowDownSmallIcon,
+  CodeBlockIcon,
   EdgelessIcon,
   PageIcon,
   PlusIcon,
@@ -57,7 +58,14 @@ const useNewDoc = () => {
     [docsService, enablePageTemplate, pageHelper, pageTemplateDocId, workbench]
   );
 
-  return createPage;
+  const createHtmlPage = useAsyncCallback(
+    async (e?: MouseEvent) => {
+      pageHelper.createHtmlPage({ at: inferOpenMode(e) });
+    },
+    [pageHelper]
+  );
+
+  return { createPage, createHtmlPage };
 };
 
 interface AddPageButtonProps {
@@ -87,7 +95,7 @@ function AddPageWithAsk({ className, style }: AddPageButtonProps) {
 
   const createPage = useCallback(
     (e?: MouseEvent) => {
-      createDoc(e, 'page');
+      createDoc.createPage(e, 'page');
       track.$.navigationPanel.$.createDoc();
       track.$.sidebar.newDoc.quickStart({ with: 'page' });
     },
@@ -95,9 +103,17 @@ function AddPageWithAsk({ className, style }: AddPageButtonProps) {
   );
   const createEdgeless = useCallback(
     (e?: MouseEvent) => {
-      createDoc(e, 'edgeless');
+      createDoc.createPage(e, 'edgeless');
       track.$.navigationPanel.$.createDoc();
       track.$.sidebar.newDoc.quickStart({ with: 'edgeless' });
+    },
+    [createDoc]
+  );
+  const createHtmlPage = useCallback(
+    (e?: MouseEvent) => {
+      createDoc.createHtmlPage(e);
+      track.$.navigationPanel.$.createDoc();
+      track.$.sidebar.newDoc.quickStart({ with: 'html-page' as any });
     },
     [createDoc]
   );
@@ -128,6 +144,13 @@ function AddPageWithAsk({ className, style }: AddPageButtonProps) {
             onAuxClick={createEdgeless}
           >
             {t['Edgeless']()}
+          </MenuItem>
+          <MenuItem
+            prefixIcon={<CodeBlockIcon />}
+            onClick={createHtmlPage}
+            onAuxClick={createHtmlPage}
+          >
+            {'HTML Page'}
           </MenuItem>
           <MenuSub
             triggerOptions={{
@@ -169,7 +192,7 @@ function AddPageWithoutAsk({ className, style }: AddPageButtonProps) {
 
   const onClickNewPage = useCallback(
     (e?: MouseEvent) => {
-      createDoc(e);
+      createDoc.createPage(e);
       track.$.navigationPanel.$.createDoc();
     },
     [createDoc]

--- a/packages/frontend/core/src/modules/at-menu-config/services/index.ts
+++ b/packages/frontend/core/src/modules/at-menu-config/services/index.ts
@@ -59,6 +59,7 @@ function resolveSignal<T>(data: T | Signal<T>): T {
 const RESERVED_ITEM_KEYS = {
   createPage: 'create:page',
   createEdgeless: 'create:edgeless',
+  createHtmlPage: 'create:html-page',
   datePicker: 'date-picker',
 };
 
@@ -177,6 +178,23 @@ export class AtMenuConfigService extends Service {
           this.insertDoc(inlineEditor, page.id);
           track.doc.editor.atMenu.createDoc({
             mode: 'edgeless',
+          });
+        },
+      },
+      {
+        key: RESERVED_ITEM_KEYS.createHtmlPage,
+        icon: NewXxxPageIcon(), // Reuse icon or change to something HTML specific later
+        name: 'Create HTML Page',
+        action: () => {
+          close();
+          const page = this.docsService.createDoc({
+            title: query,
+            isHtmlPage: true,
+            htmlSandboxMode: 'restricted',
+          });
+          this.insertDoc(inlineEditor, page.id);
+          track.doc.editor.atMenu.createDoc({
+            mode: 'html-page' as any,
           });
         },
       },

--- a/packages/frontend/core/src/modules/db/schema/schema.ts
+++ b/packages/frontend/core/src/modules/db/schema/schema.ts
@@ -31,6 +31,9 @@ export const AFFiNE_WORKSPACE_DB_SCHEMA = {
     integrationType: integrationType.optional(),
     createdBy: f.string().optional(),
     updatedBy: f.string().optional(),
+    isHtmlPage: f.boolean().optional(),
+    htmlContent: f.string().optional(),
+    htmlSandboxMode: f.enum('restricted', 'unrestricted').optional(),
   }),
   docCustomPropertyInfo: {
     id: f.string().primaryKey().optional().default(nanoid),

--- a/packages/frontend/core/src/modules/doc/services/docs.ts
+++ b/packages/frontend/core/src/modules/doc/services/docs.ts
@@ -165,6 +165,17 @@ export class DocsService extends Service {
     if (options.isTemplate) {
       docRecord.setProperty('isTemplate', true);
     }
+    if (options.isHtmlPage) {
+      docRecord.setProperty('isHtmlPage', true);
+      docRecord.setProperty(
+        'htmlSandboxMode',
+        options.htmlSandboxMode ?? 'restricted'
+      );
+      docRecord.setProperty(
+        'htmlContent',
+        '<!DOCTYPE html>\n<html>\n<head>\n  <meta charset="UTF-8">\n  <style>\n    body { font-family: sans-serif; padding: 20px; }\n  </style>\n</head>\n<body>\n  <h1>Hello HTML Page</h1>\n  <p>Edit this content to get started.</p>\n</body>\n</html>'
+      );
+    }
     for (const middleware of this.docCreateMiddlewares) {
       middleware.afterCreate?.(docRecord, options);
     }

--- a/packages/frontend/core/src/modules/doc/types.ts
+++ b/packages/frontend/core/src/modules/doc/types.ts
@@ -8,4 +8,6 @@ export interface DocCreateOptions {
   skipInit?: boolean;
   docProps?: DocProps;
   isTemplate?: boolean;
+  isHtmlPage?: boolean;
+  htmlSandboxMode?: 'restricted' | 'unrestricted';
 }


### PR DESCRIPTION
## What type of PR is this?
- Feature

## What this PR does / why we need it:
This PR introduces a new **HTML Page** mode as a complementary addition to the standard 'Page' and 'Edgeless' modes. It allows users to create pages where the body is fully rendered HTML instead of Markdown/BlockSuite elements.

**Key Features:**
- Added `isHtmlPage` and `htmlSandboxMode` to the `DocProperties` schema to persist the new page type.
- Implemented `HtmlPageEditor` component with three togglable views: **Edit** (source code), **Preview** (rendered page, defaults to this view), and **Split** (side-by-side).
- Added a security toggle directly in the editor to switch between **Restricted** (sandboxed iframe without script execution) and **Unrestricted** modes. Moving to Unrestricted mode displays a standard confirmation modal warning about security risks.
- Integrated the creation flow into the Sidebar `+` button, the `@` slash menu, and the folder context menus.

## How to test:
1. Open the sidebar and click the `+` button or right-click a folder.
2. Select **Create HTML Page** (or **HTML Page**).
3. The new editor will open. Type any valid HTML/CSS in the Edit or Split view.
4. Toggle the sandbox mode to see script execution behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Create and edit HTML pages directly within the app
- Switch between edit, preview, and split-view modes for flexible workflow
- Toggle sandbox security mode with confirmation prompt for unrestricted access
- View line and character counts in the editor status bar
- Access HTML page creation from folders and the add-page menu

<!-- end of auto-generated comment: release notes by coderabbit.ai -->