### PR TITLE
fix(shortcut): now user can increase the size of text using command +…

### DIFF
--- a/blocksuite/affine/blocks/note/src/note-keymap.ts
+++ b/blocksuite/affine/blocks/note/src/note-keymap.ts
@@ -191,6 +191,54 @@ class NoteKeymap {
     );
   };
 
+  private readonly _changeHeadingLevel = (direction: 'up' | 'down') => {
+    const selection = this._std.selection;
+    const textSelection = selection.find(TextSelection);
+    const blockSelections = selection.filter(BlockSelection);
+
+    let blockId: string | undefined;
+    if (textSelection) {
+      blockId = textSelection.from.blockId;
+    } else if (blockSelections.length > 0) {
+      blockId = blockSelections[0].blockId;
+    }
+
+    if (!blockId) return false;
+
+    const model = this._std.store.getBlock(blockId)?.model;
+    if (!model) return false;
+
+    let currentType = 'text';
+    if (model.flavour === 'affine:paragraph') {
+      currentType = (model as any).props?.type || (model as any).type || 'text';
+    }
+
+    const levels = ['text', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1'];
+    const currentIndex = levels.indexOf(currentType);
+    let nextType = 'text';
+    if (currentIndex === -1) {
+      nextType = direction === 'up' ? 'h6' : 'text';
+    } else {
+      const nextIndex =
+        direction === 'up'
+          ? Math.min(currentIndex + 1, levels.length - 1)
+          : Math.max(currentIndex - 1, 0);
+      nextType = levels[nextIndex];
+    }
+
+    const [result] = this._std.command
+      .chain()
+      .pipe(updateBlockType, {
+        flavour: 'affine:paragraph',
+        props: {
+          type: nextType,
+        },
+      })
+      .run();
+
+    return result;
+  };
+
   private _focusBlock: BlockComponent | null = null;
 
   private readonly _getClosestNoteByBlockId = (blockId: string) => {
@@ -603,6 +651,14 @@ class NoteKeymap {
       ...this._bindQuickActionHotKey(),
       ...this._bindTextConversionHotKey(),
       ...this._bindTextAlignHotKey(),
+      'Mod-Alt-[': ctx => {
+        ctx.get('defaultState').event.preventDefault();
+        return this._changeHeadingLevel('up');
+      },
+      'Mod-Alt-]': ctx => {
+        ctx.get('defaultState').event.preventDefault();
+        return this._changeHeadingLevel('down');
+      },
       Tab: ctx => {
         const [success] = this.std.command.exec(indentBlocks);
 

--- a/blocksuite/affine/blocks/note/src/note-keymap.ts
+++ b/blocksuite/affine/blocks/note/src/note-keymap.ts
@@ -193,46 +193,67 @@ class NoteKeymap {
 
   private readonly _changeHeadingLevel = (direction: 'up' | 'down') => {
     const selection = this._std.selection;
-    const textSelection = selection.find(TextSelection);
+    // Gather all selected blocks (multi-selection aware)
     const blockSelections = selection.filter(BlockSelection);
-
-    let blockId: string | undefined;
-    if (textSelection) {
-      blockId = textSelection.from.blockId;
-    } else if (blockSelections.length > 0) {
-      blockId = blockSelections[0].blockId;
+    let blockIds: string[] = [];
+    if (blockSelections.length > 0) {
+      blockIds = blockSelections.map(sel => sel.blockId);
+    } else {
+      const textSelection = selection.find(TextSelection);
+      if (textSelection) {
+        blockIds = [textSelection.from.blockId];
+      }
     }
 
-    if (!blockId) return false;
+    if (blockIds.length === 0) return false;
 
-    const model = this._std.store.getBlock(blockId)?.model;
-    if (!model) return false;
+    // Only adjust heading level for paragraph/heading blocks
+    const store = this._std.store;
+    // Get BlockComponent and model together
+    const eligibleBlocks = blockIds
+      .map(id => {
+        const blockComponent = this._std.view.getBlock(id);
+        const model = store.getBlock(id)?.model;
+        return blockComponent &&
+          model &&
+          model.flavour === 'affine:paragraph' &&
+          ['text', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(
+            (model as any).props?.type || (model as any).type || 'text'
+          )
+          ? { blockComponent, model }
+          : null;
+      })
+      .filter(Boolean) as { blockComponent: BlockComponent; model: any }[];
 
-    let currentType = 'text';
-    if (model.flavour === 'affine:paragraph') {
-      currentType = (model as any).props?.type || (model as any).type || 'text';
-    }
+    if (eligibleBlocks.length === 0) return false;
 
     const levels = ['text', 'h6', 'h5', 'h4', 'h3', 'h2', 'h1'];
-    const currentIndex = levels.indexOf(currentType);
-    let nextType = 'text';
-    if (currentIndex === -1) {
-      nextType = direction === 'up' ? 'h6' : 'text';
-    } else {
-      const nextIndex =
-        direction === 'up'
-          ? Math.min(currentIndex + 1, levels.length - 1)
-          : Math.max(currentIndex - 1, 0);
-      nextType = levels[nextIndex];
-    }
 
+    // Compute new type for each block
+    const updates = eligibleBlocks.map(({ blockComponent, model }) => {
+      const currentType =
+        (model as any).props?.type || (model as any).type || 'text';
+      const currentIndex = levels.indexOf(currentType);
+      let nextType = 'text';
+      if (currentIndex === -1) {
+        nextType = direction === 'up' ? 'h6' : 'text';
+      } else {
+        const nextIndex =
+          direction === 'up'
+            ? Math.min(currentIndex + 1, levels.length - 1)
+            : Math.max(currentIndex - 1, 0);
+        nextType = levels[nextIndex];
+      }
+      return { blockComponent, nextType };
+    });
+
+    // Update all eligible blocks in one command
     const [result] = this._std.command
       .chain()
       .pipe(updateBlockType, {
         flavour: 'affine:paragraph',
-        props: {
-          type: nextType,
-        },
+        props: updates[0] ? { type: updates[0].nextType } : {},
+        selectedBlocks: updates.map(u => u.blockComponent),
       })
       .run();
 


### PR DESCRIPTION
now user can increase the size of text using command +option +[, as well decrease.  #14838

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts to adjust heading levels: Ctrl/Cmd+Alt+[ to decrease and Ctrl/Cmd+Alt+] to increase. Works across single and multi-block selections, cycling between plain text and headings (h1–h6).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->