### PR TITLE
feat(blocksuite): add password encrypted blocks

### DIFF
--- a/blocksuite/affine/blocks/root/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/root/src/configs/toolbar.ts
@@ -43,6 +43,13 @@ import {
   getSelectedModelsCommand,
   getTextSelectionCommand,
 } from '@blocksuite/affine-shared/commands';
+import {
+  canEncryptBlock,
+  encryptBlockWithPassword,
+  isBlockEncrypted,
+  isBlockLocallyUnlocked,
+  lockBlockWithEncryptedEdits,
+} from '@blocksuite/affine-shared/encryption';
 import type {
   ToolbarAction,
   ToolbarActionGenerator,
@@ -52,6 +59,7 @@ import type {
 import {
   ActionPlacement,
   blockCommentToolbarButton,
+  NotificationProvider,
 } from '@blocksuite/affine-shared/services';
 import { getMostCommonValue } from '@blocksuite/affine-shared/utils';
 import { tableViewMeta } from '@blocksuite/data-view/view-presets';
@@ -61,6 +69,7 @@ import {
   DeleteIcon,
   DuplicateIcon,
   LinkedPageIcon,
+  LockIcon,
 } from '@blocksuite/icons/lit';
 import {
   type BlockComponent,
@@ -420,6 +429,121 @@ export const builtinToolbarConfig = {
               })
               .pipe(duplicateSelectedModelsCommand)
               .run();
+          },
+        },
+        {
+          id: 'encrypt',
+          label: 'Encrypt',
+          icon: LockIcon(),
+          when({ chain }) {
+            const [ok, { selectedModels = [] }] = chain
+              .tryAll(chain => [
+                chain.pipe(getTextSelectionCommand),
+                chain.pipe(getBlockSelectionsCommand),
+                chain.pipe(getImageSelectionsCommand),
+              ])
+              .pipe(getSelectedModelsCommand, {
+                types: ['text', 'block', 'image'],
+                mode: 'highest',
+              })
+              .run();
+
+            return ok && selectedModels.some(canEncryptBlock);
+          },
+          run({ chain, host, std, store }) {
+            (async () => {
+              const notification = std.getOptional(NotificationProvider);
+              const password = await notification?.prompt({
+                title: 'Encrypt block',
+                message:
+                  'Use a block password. This is not your account password and will not be stored.',
+                placeholder: 'Password',
+                confirmText: 'Encrypt',
+              });
+
+              if (!password) return;
+
+              const [ok, { selectedModels = [] }] = chain
+                .tryAll(chain => [
+                  chain.pipe(getTextSelectionCommand),
+                  chain.pipe(getBlockSelectionsCommand),
+                  chain.pipe(getImageSelectionsCommand),
+                ])
+                .pipe(getSelectedModelsCommand, {
+                  types: ['text', 'block', 'image'],
+                  mode: 'highest',
+                })
+                .run();
+
+              if (!ok || selectedModels.length === 0) return;
+
+              const targets = selectedModels.filter(canEncryptBlock);
+
+              if (targets.length === 0) {
+                toast(host, 'Selected blocks cannot be encrypted');
+                return;
+              }
+
+              await Promise.all(
+                targets.map(model =>
+                  encryptBlockWithPassword(store, model, password)
+                )
+              );
+              toast(host, 'Encrypted');
+            })().catch(error => {
+              console.error(error);
+              toast(host, 'Encryption failed');
+            });
+          },
+        },
+        {
+          id: 'lock-encrypted',
+          label: 'Lock',
+          icon: LockIcon(),
+          when({ chain }) {
+            const [ok, { selectedModels = [] }] = chain
+              .tryAll(chain => [
+                chain.pipe(getTextSelectionCommand),
+                chain.pipe(getBlockSelectionsCommand),
+                chain.pipe(getImageSelectionsCommand),
+              ])
+              .pipe(getSelectedModelsCommand, {
+                types: ['text', 'block', 'image'],
+                mode: 'highest',
+              })
+              .run();
+
+            return (
+              ok &&
+              selectedModels.some(
+                model =>
+                  isBlockEncrypted(model) && isBlockLocallyUnlocked(model)
+              )
+            );
+          },
+          run({ chain, store }) {
+            const [ok, { selectedModels = [] }] = chain
+              .tryAll(chain => [
+                chain.pipe(getTextSelectionCommand),
+                chain.pipe(getBlockSelectionsCommand),
+                chain.pipe(getImageSelectionsCommand),
+              ])
+              .pipe(getSelectedModelsCommand, {
+                types: ['text', 'block', 'image'],
+                mode: 'highest',
+              })
+              .run();
+
+            if (!ok || selectedModels.length === 0) return;
+
+            void Promise.all(
+              selectedModels
+                .filter(
+                  model =>
+                    isBlockEncrypted(model) && isBlockLocallyUnlocked(model)
+                )
+                .map(model => lockBlockWithEncryptedEdits(store, model))
+            ).catch(console.error);
           },
         },
       ],

--- a/blocksuite/affine/blocks/root/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/root/src/configs/toolbar.ts
@@ -452,17 +452,6 @@ export const builtinToolbarConfig = {
           },
           run({ chain, host, std, store }) {
             (async () => {
-              const notification = std.getOptional(NotificationProvider);
-              const password = await notification?.prompt({
-                title: 'Encrypt block',
-                message:
-                  'Use a block password. This is not your account password and will not be stored.',
-                placeholder: 'Password',
-                confirmText: 'Encrypt',
-              });
-
-              if (!password) return;
-
               const [ok, { selectedModels = [] }] = chain
                 .tryAll(chain => [
                   chain.pipe(getTextSelectionCommand),
@@ -477,6 +466,17 @@ export const builtinToolbarConfig = {
 
               if (!ok || selectedModels.length === 0) return;
 
+              const notification = std.getOptional(NotificationProvider);
+              const password = await notification?.prompt({
+                title: 'Encrypt block',
+                message:
+                  'Use a block password. This is not your account password and will not be stored.',
+                placeholder: 'Password',
+                confirmText: 'Encrypt',
+              });
+
+              if (!password) return;
+
               const targets = selectedModels.filter(canEncryptBlock);
 
               if (targets.length === 0) {
@@ -484,12 +484,29 @@ export const builtinToolbarConfig = {
                 return;
               }
 
-              await Promise.all(
+              const results = await Promise.allSettled(
                 targets.map(model =>
                   encryptBlockWithPassword(store, model, password)
                 )
               );
-              toast(host, 'Encrypted');
+              const failed = results.filter(
+                result => result.status === 'rejected'
+              );
+              failed.forEach(result => {
+                console.error(result.reason);
+              });
+
+              const succeeded = results.length - failed.length;
+              if (failed.length === 0) {
+                toast(host, 'Encrypted');
+              } else if (succeeded === 0) {
+                toast(host, 'Encryption failed');
+              } else {
+                toast(
+                  host,
+                  `Encrypted ${succeeded} blocks, ${failed.length} failed`
+                );
+              }
             })().catch(error => {
               console.error(error);
               toast(host, 'Encryption failed');
@@ -521,7 +538,7 @@ export const builtinToolbarConfig = {
               )
             );
           },
-          run({ chain, store }) {
+          run({ chain, host, store }) {
             const [ok, { selectedModels = [] }] = chain
               .tryAll(chain => [
                 chain.pipe(getTextSelectionCommand),
@@ -536,14 +553,29 @@ export const builtinToolbarConfig = {
 
             if (!ok || selectedModels.length === 0) return;
 
-            void Promise.all(
-              selectedModels
-                .filter(
-                  model =>
-                    isBlockEncrypted(model) && isBlockLocallyUnlocked(model)
-                )
-                .map(model => lockBlockWithEncryptedEdits(store, model))
-            ).catch(console.error);
+            const targets = selectedModels.filter(
+              model => isBlockEncrypted(model) && isBlockLocallyUnlocked(model)
+            );
+
+            void Promise.allSettled(
+              targets.map(model => lockBlockWithEncryptedEdits(store, model))
+            )
+              .then(results => {
+                const failed = results.filter(
+                  result => result.status === 'rejected'
+                );
+                failed.forEach(result => {
+                  console.error(result.reason);
+                });
+
+                if (failed.length > 0) {
+                  toast(host, 'Some encrypted blocks failed to lock');
+                }
+              })
+              .catch(error => {
+                console.error(error);
+                toast(host, 'Some encrypted blocks failed to lock');
+              });
           },
         },
       ],

--- a/blocksuite/affine/blocks/root/src/effects.ts
+++ b/blocksuite/affine/blocks/root/src/effects.ts
@@ -1,4 +1,8 @@
 import {
+  AFFINE_ENCRYPTED_BLOCKS_WIDGET,
+  AffineEncryptedBlocksWidget,
+} from './encryption/index.js';
+import {
   EdgelessRootBlockComponent,
   EdgelessRootPreviewBlockComponent,
   PageRootBlockComponent,
@@ -11,6 +15,10 @@ export function effects() {
 }
 
 function registerRootComponents() {
+  customElements.define(
+    AFFINE_ENCRYPTED_BLOCKS_WIDGET,
+    AffineEncryptedBlocksWidget
+  );
   customElements.define('affine-page-root', PageRootBlockComponent);
   customElements.define('affine-preview-root', PreviewRootBlockComponent);
   customElements.define('affine-edgeless-root', EdgelessRootBlockComponent);

--- a/blocksuite/affine/blocks/root/src/encryption/encrypted-blocks-widget.ts
+++ b/blocksuite/affine/blocks/root/src/encryption/encrypted-blocks-widget.ts
@@ -33,7 +33,6 @@ type EncryptedBlockOverlay = {
   left: number;
   width: number;
   height: number;
-  unlocked: boolean;
 };
 
 const LOCKED_MIN_HEIGHT = 104;
@@ -183,6 +182,9 @@ export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel>
     if (blockElement.dataset.affineEncryptedLocked === 'true') {
       blockElement.style.removeProperty('visibility');
       blockElement.style.removeProperty('min-height');
+      blockElement.style.removeProperty('pointer-events');
+      blockElement.removeAttribute('aria-hidden');
+      blockElement.removeAttribute('inert');
       delete blockElement.dataset.affineEncryptedLocked;
     }
   }
@@ -238,17 +240,22 @@ export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel>
       .filter(model => model.role === 'content' && isBlockEncrypted(model));
   }
 
+  private _flushPendingAutoEncrypt(model: BlockModel) {
+    const timer = this._pendingEncryptTimers.get(model.id);
+    if (!timer) return;
+
+    window.clearTimeout(timer);
+    this._pendingEncryptTimers.delete(model.id);
+    persistUnlockedBlockEdits(this.store, model).catch(console.error);
+  }
+
   private _clearAutoEncrypt(model: BlockModel) {
+    this._flushPendingAutoEncrypt(model);
+
     this._autoEncryptDisposables.get(model.id)?.forEach(dispose => {
       dispose();
     });
     this._autoEncryptDisposables.delete(model.id);
-
-    const timer = this._pendingEncryptTimers.get(model.id);
-    if (timer) {
-      window.clearTimeout(timer);
-      this._pendingEncryptTimers.delete(model.id);
-    }
   }
 
   private _ensureAutoEncrypt(model: BlockModel) {
@@ -321,21 +328,25 @@ export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel>
         blockElement.dataset.affineEncryptedLocked = 'true';
         blockElement.style.visibility = 'hidden';
         blockElement.style.minHeight = `${LOCKED_MIN_HEIGHT}px`;
+        blockElement.style.pointerEvents = 'none';
+        blockElement.setAttribute('aria-hidden', 'true');
+        blockElement.setAttribute('inert', '');
       }
 
       const rect = blockElement.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return;
 
-      overlays.push({
-        id: model.id,
-        flavour: model.flavour,
-        preview: getBlockEncryptedPreview(model),
-        top: rect.top - containerRect.top,
-        left: rect.left - containerRect.left,
-        width: rect.width,
-        height: Math.max(rect.height, LOCKED_MIN_HEIGHT),
-        unlocked,
-      });
+      if (!unlocked) {
+        overlays.push({
+          id: model.id,
+          flavour: model.flavour,
+          preview: getBlockEncryptedPreview(model),
+          top: rect.top - containerRect.top,
+          left: rect.left - containerRect.left,
+          width: rect.width,
+          height: Math.max(rect.height, LOCKED_MIN_HEIGHT),
+        });
+      }
     });
 
     this._styledBlockIds.forEach(blockId => {
@@ -356,22 +367,22 @@ export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel>
   private async _unlock(model: BlockModel) {
     if (this._unlockingBlockId) return;
 
-    const notification = this.std.getOptional(NotificationProvider);
-    const password = await notification?.prompt({
-      title: 'Decrypt block',
-      message: 'Use the block password. This password is not stored.',
-      placeholder: 'Password',
-      confirmText: 'Decrypt',
-    });
-
-    if (!password) return;
-
     this._unlockingBlockId = model.id;
     this._error = '';
     this._errorBlockId = null;
     this.requestUpdate();
 
     try {
+      const notification = this.std.getOptional(NotificationProvider);
+      const password = await notification?.prompt({
+        title: 'Decrypt block',
+        message: 'Use the block password. This password is not stored.',
+        placeholder: 'Password',
+        confirmText: 'Decrypt',
+      });
+
+      if (!password) return;
+
       await unlockBlockWithPassword(model, password);
       this._scheduleRefresh();
     } catch (error) {
@@ -408,6 +419,14 @@ export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel>
         @paste=${stopPropagation}
         @keydown=${stopPropagation}
         @keyup=${stopPropagation}
+        @beforeinput=${stopPropagation}
+        @compositionstart=${stopPropagation}
+        @compositionupdate=${stopPropagation}
+        @compositionend=${stopPropagation}
+        @dragstart=${stopPropagation}
+        @drop=${stopPropagation}
+        @focusin=${stopPropagation}
+        @focusout=${stopPropagation}
       >
         <div class="affine-encrypted-block-overlay-header">
           <span class="affine-encrypted-block-overlay-title">
@@ -485,9 +504,8 @@ export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel>
     return html`
       ${repeat(
         this._overlays,
-        overlay => `${overlay.id}:${overlay.unlocked ? 'u' : 'l'}`,
-        overlay =>
-          overlay.unlocked ? nothing : this._renderLockedOverlay(overlay)
+        overlay => overlay.id,
+        overlay => this._renderLockedOverlay(overlay)
       )}
     `;
   }

--- a/blocksuite/affine/blocks/root/src/encryption/encrypted-blocks-widget.ts
+++ b/blocksuite/affine/blocks/root/src/encryption/encrypted-blocks-widget.ts
@@ -1,0 +1,515 @@
+import type { RootBlockModel } from '@blocksuite/affine-model';
+import {
+  getBlockEncryptedPreview,
+  getBlockEncryptionState,
+  getUnlockedBlockTexts,
+  isBlockEncrypted,
+  isBlockLocallyUnlocked,
+  persistUnlockedBlockEdits,
+  unlockBlockWithPassword,
+} from '@blocksuite/affine-shared/encryption';
+import { NotificationProvider } from '@blocksuite/affine-shared/services';
+import { stopPropagation } from '@blocksuite/affine-shared/utils';
+import {
+  BLOCK_ID_ATTR,
+  WidgetComponent,
+  WidgetViewExtension,
+} from '@blocksuite/std';
+import type { BlockModel } from '@blocksuite/store';
+import { effect } from '@preact/signals-core';
+import { css, html, nothing } from 'lit';
+import { state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { styleMap } from 'lit/directives/style-map.js';
+import { literal, unsafeStatic } from 'lit/static-html.js';
+
+export const AFFINE_ENCRYPTED_BLOCKS_WIDGET = 'affine-encrypted-blocks-widget';
+
+type EncryptedBlockOverlay = {
+  id: string;
+  flavour: string;
+  preview: string;
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+  unlocked: boolean;
+};
+
+const LOCKED_MIN_HEIGHT = 104;
+const UNLOCKED_MARKER_HEIGHT = 18;
+const UNLOCKED_MARKER_STYLE_ID = 'affine-encrypted-block-unlocked-marker-style';
+
+export class AffineEncryptedBlocksWidget extends WidgetComponent<RootBlockModel> {
+  static override styles = css`
+    :host {
+      position: absolute;
+      inset: 0;
+      z-index: var(--affine-z-index-popover);
+      pointer-events: none;
+    }
+
+    .affine-encrypted-block-overlay {
+      box-sizing: border-box;
+      position: absolute;
+      border: 1px solid var(--affine-border-color);
+      border-radius: 8px;
+      background: var(--affine-background-secondary-color);
+      color: var(--affine-text-primary-color);
+      padding: 12px;
+      pointer-events: auto;
+    }
+
+    .affine-encrypted-block-overlay-header {
+      align-items: center;
+      display: flex;
+      gap: 8px;
+      justify-content: space-between;
+      margin-bottom: 8px;
+    }
+
+    .affine-encrypted-block-overlay-title {
+      font-weight: 600;
+      line-height: 22px;
+    }
+
+    .affine-encrypted-block-overlay-flavour {
+      color: var(--affine-text-secondary-color);
+      font-family: var(--affine-font-code-family);
+      font-size: 12px;
+    }
+
+    .affine-encrypted-block-preview {
+      overflow: hidden;
+      border: 1px solid var(--affine-border-color);
+      border-radius: 6px;
+      background: var(--affine-code-block-background);
+      color: var(--affine-text-secondary-color);
+      font-family: var(--affine-font-code-family);
+      font-size: 12px;
+      line-height: 18px;
+      margin-bottom: 10px;
+      max-height: 38px;
+      padding: 8px;
+      text-overflow: ellipsis;
+      word-break: break-all;
+    }
+
+    .affine-encrypted-block-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .affine-encrypted-block-overlay button {
+      border: 1px solid var(--affine-border-color);
+      border-radius: 6px;
+      background: var(--affine-background-primary-color);
+      color: var(--affine-text-primary-color);
+      cursor: pointer;
+      font: inherit;
+      height: 32px;
+      padding: 0 12px;
+      white-space: nowrap;
+    }
+
+    .affine-encrypted-block-overlay button:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+
+    .affine-encrypted-block-error {
+      color: var(--affine-error-color);
+      font-size: 13px;
+      line-height: 20px;
+      margin-top: 8px;
+    }
+  `;
+
+  private _raf = 0;
+
+  private readonly _styledBlockIds = new Set<string>();
+
+  private readonly _autoEncryptDisposables = new Map<string, (() => void)[]>();
+
+  private readonly _pendingEncryptTimers = new Map<string, number>();
+
+  private _unlockingBlockId: string | null = null;
+
+  private _setParentPositioned() {
+    const parent = this.parentElement;
+    if (!parent || parent.dataset.affineEncryptedLayerParent === 'true') {
+      return;
+    }
+
+    const style = getComputedStyle(parent);
+    if (style.position === 'static') {
+      parent.dataset.affineEncryptedLayerParent = 'true';
+      parent.style.position = 'relative';
+    }
+  }
+
+  private _installUnlockedMarkerStyle() {
+    if (document.getElementById(UNLOCKED_MARKER_STYLE_ID)) return;
+
+    const style = document.createElement('style');
+    style.id = UNLOCKED_MARKER_STYLE_ID;
+    style.textContent = `
+      [${BLOCK_ID_ATTR}][data-affine-encrypted-unlocked="true"] {
+        margin-bottom: ${UNLOCKED_MARKER_HEIGHT}px;
+        position: relative;
+      }
+
+      [${BLOCK_ID_ATTR}][data-affine-encrypted-unlocked="true"]::after {
+        bottom: -${UNLOCKED_MARKER_HEIGHT}px;
+        box-sizing: border-box;
+        color: var(--affine-text-secondary-color);
+        content: 'Encrypted';
+        font-size: 12px;
+        left: 0;
+        line-height: ${UNLOCKED_MARKER_HEIGHT}px;
+        pointer-events: none;
+        position: absolute;
+        right: 0;
+        text-align: center;
+      }
+    `;
+    document.head.append(style);
+  }
+
+  private _clearLockedBlockStyles(blockId: string) {
+    const blockElement = this._getBlockElement(blockId);
+    if (!blockElement) return;
+
+    if (blockElement.dataset.affineEncryptedLocked === 'true') {
+      blockElement.style.removeProperty('visibility');
+      blockElement.style.removeProperty('min-height');
+      delete blockElement.dataset.affineEncryptedLocked;
+    }
+  }
+
+  private _clearUnlockedBlockStyles(blockId: string) {
+    const blockElement = this._getBlockElement(blockId);
+    if (!blockElement) return;
+
+    if (blockElement.dataset.affineEncryptedUnlocked === 'true') {
+      delete blockElement.dataset.affineEncryptedUnlocked;
+    }
+  }
+
+  private _clearBlockEncryptionStyles(blockId: string) {
+    this._clearLockedBlockStyles(blockId);
+    this._clearUnlockedBlockStyles(blockId);
+  }
+
+  private _syncLockedHeights() {
+    let needsRefresh = false;
+
+    this.renderRoot
+      .querySelectorAll<HTMLElement>('[data-encrypted-overlay-id]')
+      .forEach(overlay => {
+        const blockId = overlay.dataset.encryptedOverlayId;
+        if (!blockId) return;
+
+        const blockElement = this._getBlockElement(blockId);
+        if (!blockElement) return;
+
+        const height = Math.ceil(overlay.getBoundingClientRect().height);
+        const nextMinHeight = `${height}px`;
+        if (blockElement.style.minHeight !== nextMinHeight) {
+          blockElement.style.minHeight = nextMinHeight;
+          needsRefresh = true;
+        }
+      });
+
+    if (needsRefresh) {
+      this._scheduleRefresh();
+    }
+  }
+
+  private _getBlockElement(blockId: string) {
+    return this.std.host.querySelector<HTMLElement>(
+      `[${BLOCK_ID_ATTR}="${blockId}"]`
+    );
+  }
+
+  private _getEncryptedModels() {
+    return this.store
+      .getAllModels()
+      .filter(model => model.role === 'content' && isBlockEncrypted(model));
+  }
+
+  private _clearAutoEncrypt(model: BlockModel) {
+    this._autoEncryptDisposables.get(model.id)?.forEach(dispose => {
+      dispose();
+    });
+    this._autoEncryptDisposables.delete(model.id);
+
+    const timer = this._pendingEncryptTimers.get(model.id);
+    if (timer) {
+      window.clearTimeout(timer);
+      this._pendingEncryptTimers.delete(model.id);
+    }
+  }
+
+  private _ensureAutoEncrypt(model: BlockModel) {
+    if (this._autoEncryptDisposables.has(model.id)) return;
+
+    const disposables = getUnlockedBlockTexts(model).map(text =>
+      effect(() => {
+        const deltas = text.deltas$.value;
+        if (deltas) {
+          this._schedulePersistUnlockedEdits(model);
+        }
+      })
+    );
+    const encryptedKeys = new Set(
+      getBlockEncryptionState(model)?.encryptedKeys ?? []
+    );
+    const subscription = model.propsUpdated.subscribe(({ key }) => {
+      if (encryptedKeys.has(key)) {
+        this._schedulePersistUnlockedEdits(model);
+      }
+    });
+    disposables.push(() => {
+      subscription.unsubscribe();
+    });
+
+    this._autoEncryptDisposables.set(model.id, disposables);
+  }
+
+  private _schedulePersistUnlockedEdits(model: BlockModel) {
+    const existingTimer = this._pendingEncryptTimers.get(model.id);
+    if (existingTimer) {
+      window.clearTimeout(existingTimer);
+    }
+
+    const timer = window.setTimeout(() => {
+      this._pendingEncryptTimers.delete(model.id);
+      persistUnlockedBlockEdits(this.store, model).catch(console.error);
+    }, 600);
+    this._pendingEncryptTimers.set(model.id, timer);
+  }
+
+  private readonly _scheduleRefresh = () => {
+    if (this._raf) return;
+
+    this._raf = requestAnimationFrame(() => {
+      this._raf = 0;
+      this._refresh();
+    });
+  };
+
+  private _refresh() {
+    const overlays: EncryptedBlockOverlay[] = [];
+    const encryptedIds = new Set<string>();
+    const containerRect = this.parentElement?.getBoundingClientRect();
+    if (!containerRect) return;
+
+    this._getEncryptedModels().forEach(model => {
+      encryptedIds.add(model.id);
+      const blockElement = this._getBlockElement(model.id);
+      if (!blockElement) return;
+
+      const unlocked = isBlockLocallyUnlocked(model);
+      if (unlocked) {
+        this._clearLockedBlockStyles(model.id);
+        blockElement.dataset.affineEncryptedUnlocked = 'true';
+        this._ensureAutoEncrypt(model);
+      } else {
+        this._clearAutoEncrypt(model);
+        this._clearUnlockedBlockStyles(model.id);
+        blockElement.dataset.affineEncryptedLocked = 'true';
+        blockElement.style.visibility = 'hidden';
+        blockElement.style.minHeight = `${LOCKED_MIN_HEIGHT}px`;
+      }
+
+      const rect = blockElement.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+
+      overlays.push({
+        id: model.id,
+        flavour: model.flavour,
+        preview: getBlockEncryptedPreview(model),
+        top: rect.top - containerRect.top,
+        left: rect.left - containerRect.left,
+        width: rect.width,
+        height: Math.max(rect.height, LOCKED_MIN_HEIGHT),
+        unlocked,
+      });
+    });
+
+    this._styledBlockIds.forEach(blockId => {
+      if (!encryptedIds.has(blockId)) {
+        this._clearBlockEncryptionStyles(blockId);
+        const model = this.store.getModelById(blockId);
+        if (model) {
+          this._clearAutoEncrypt(model);
+        }
+      }
+    });
+    this._styledBlockIds.clear();
+    encryptedIds.forEach(id => this._styledBlockIds.add(id));
+
+    this._overlays = overlays;
+  }
+
+  private async _unlock(model: BlockModel) {
+    if (this._unlockingBlockId) return;
+
+    const notification = this.std.getOptional(NotificationProvider);
+    const password = await notification?.prompt({
+      title: 'Decrypt block',
+      message: 'Use the block password. This password is not stored.',
+      placeholder: 'Password',
+      confirmText: 'Decrypt',
+    });
+
+    if (!password) return;
+
+    this._unlockingBlockId = model.id;
+    this._error = '';
+    this._errorBlockId = null;
+    this.requestUpdate();
+
+    try {
+      await unlockBlockWithPassword(model, password);
+      this._scheduleRefresh();
+    } catch (error) {
+      console.error(error);
+      this._error = 'Unable to decrypt with this password.';
+      this._errorBlockId = model.id;
+    } finally {
+      this._unlockingBlockId = null;
+      this.requestUpdate();
+    }
+  }
+
+  private _renderLockedOverlay(overlay: EncryptedBlockOverlay) {
+    const model = this.store.getModelById(overlay.id);
+    if (!model) return nothing;
+
+    return html`
+      <div
+        class="affine-encrypted-block-overlay"
+        data-encrypted-overlay-id=${overlay.id}
+        data-range-sync-exclude="true"
+        contenteditable="false"
+        style=${styleMap({
+          top: `${overlay.top}px`,
+          left: `${overlay.left}px`,
+          width: `${overlay.width}px`,
+          minHeight: `${overlay.height}px`,
+        })}
+        @pointerdown=${stopPropagation}
+        @click=${stopPropagation}
+        @dblclick=${stopPropagation}
+        @cut=${stopPropagation}
+        @copy=${stopPropagation}
+        @paste=${stopPropagation}
+        @keydown=${stopPropagation}
+        @keyup=${stopPropagation}
+      >
+        <div class="affine-encrypted-block-overlay-header">
+          <span class="affine-encrypted-block-overlay-title">
+            Encrypted block
+          </span>
+          <code class="affine-encrypted-block-overlay-flavour">
+            ${overlay.flavour}
+          </code>
+        </div>
+        <div class="affine-encrypted-block-preview">${overlay.preview}</div>
+        <div class="affine-encrypted-block-actions">
+          <button
+            ?disabled=${this._unlockingBlockId === overlay.id}
+            @click=${(event: Event) => {
+              event.stopPropagation();
+              void this._unlock(model).catch(console.error);
+            }}
+          >
+            Decrypt
+          </button>
+        </div>
+        ${this._error && this._errorBlockId === overlay.id
+          ? html`<div class="affine-encrypted-block-error">${this._error}</div>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.contentEditable = 'false';
+    this._setParentPositioned();
+    this._installUnlockedMarkerStyle();
+
+    this.disposables.add(
+      this.store.slots.blockUpdated.subscribe(() => {
+        this._scheduleRefresh();
+      })
+    );
+
+    window.addEventListener('resize', this._scheduleRefresh);
+    window.addEventListener('scroll', this._scheduleRefresh, true);
+    this.disposables.add(() => {
+      window.removeEventListener('resize', this._scheduleRefresh);
+      window.removeEventListener('scroll', this._scheduleRefresh, true);
+      if (this._raf) {
+        cancelAnimationFrame(this._raf);
+      }
+      this._styledBlockIds.forEach(blockId => {
+        this._clearBlockEncryptionStyles(blockId);
+        const model = this.store.getModelById(blockId);
+        if (model) {
+          this._clearAutoEncrypt(model);
+        }
+      });
+      this._styledBlockIds.clear();
+      if (this.parentElement?.dataset.affineEncryptedLayerParent === 'true') {
+        this.parentElement.style.removeProperty('position');
+        delete this.parentElement.dataset.affineEncryptedLayerParent;
+      }
+    });
+
+    this.updateComplete
+      .then(() => {
+        this._scheduleRefresh();
+      })
+      .catch(console.error);
+  }
+
+  override updated() {
+    this._syncLockedHeights();
+  }
+
+  override render() {
+    return html`
+      ${repeat(
+        this._overlays,
+        overlay => `${overlay.id}:${overlay.unlocked ? 'u' : 'l'}`,
+        overlay =>
+          overlay.unlocked ? nothing : this._renderLockedOverlay(overlay)
+      )}
+    `;
+  }
+
+  @state()
+  private accessor _error = '';
+
+  @state()
+  private accessor _errorBlockId: string | null = null;
+
+  @state()
+  private accessor _overlays: EncryptedBlockOverlay[] = [];
+}
+
+export const encryptedBlocksWidget = WidgetViewExtension(
+  'affine:page',
+  AFFINE_ENCRYPTED_BLOCKS_WIDGET,
+  literal`${unsafeStatic(AFFINE_ENCRYPTED_BLOCKS_WIDGET)}`
+);
+
+declare global {
+  interface HTMLElementTagNameMap {
+    [AFFINE_ENCRYPTED_BLOCKS_WIDGET]: AffineEncryptedBlocksWidget;
+  }
+}

--- a/blocksuite/affine/blocks/root/src/encryption/index.ts
+++ b/blocksuite/affine/blocks/root/src/encryption/index.ts
@@ -1,0 +1,1 @@
+export * from './encrypted-blocks-widget.js';

--- a/blocksuite/affine/blocks/root/src/view.ts
+++ b/blocksuite/affine/blocks/root/src/view.ts
@@ -21,6 +21,7 @@ import { EdgelessElementToolbarExtension } from './edgeless/configs/toolbar';
 import { EdgelessLocker } from './edgeless/edgeless-root-spec';
 import { AltCloneExtension } from './edgeless/interact-extensions/clone-ext';
 import { effects } from './effects';
+import { encryptedBlocksWidget } from './encryption';
 import { fallbackKeymap } from './keyboard/keymap';
 
 export class RootViewExtension extends ViewExtensionProvider {
@@ -65,7 +66,7 @@ export class RootViewExtension extends ViewExtensionProvider {
     context.register(
       BlockViewExtension('affine:page', literal`affine-page-root`)
     );
-    context.register(PageClipboard);
+    context.register([PageClipboard, encryptedBlocksWidget]);
   };
 
   private readonly _setupEdgeless = (context: ViewExtensionContext) => {

--- a/blocksuite/affine/shared/package.json
+++ b/blocksuite/affine/shared/package.json
@@ -59,6 +59,7 @@
     "./consts": "./src/consts/index.ts",
     "./types": "./src/types/index.ts",
     "./commands": "./src/commands/index.ts",
+    "./encryption": "./src/encryption/index.ts",
     "./theme": "./src/theme/index.ts",
     "./styles": "./src/styles/index.ts",
     "./services": "./src/services/index.ts",

--- a/blocksuite/affine/shared/src/__tests__/encryption/password-aes.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/encryption/password-aes.unit.spec.ts
@@ -30,6 +30,20 @@ describe('password AES encryption', () => {
     );
   });
 
+  test('rejects unsupported payload iterations', async () => {
+    const payload = await encryptStringWithPassword('secret', 'p');
+
+    await expect(
+      decryptStringWithPassword(
+        {
+          ...payload,
+          iterations: Number.MAX_SAFE_INTEGER,
+        },
+        'p'
+      )
+    ).rejects.toThrow('Unsupported encrypted payload iterations.');
+  });
+
   test('re-encrypts updated content with an unlocked session', async () => {
     const payload = await encryptStringWithPassword('first version', 'p');
     const session = await createPasswordAesSession(payload, 'p');

--- a/blocksuite/affine/shared/src/__tests__/encryption/password-aes.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/encryption/password-aes.unit.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  base64ToBytes,
+  bytesToBase64,
+  createPasswordAesSession,
+  decryptStringWithPassword,
+  decryptStringWithSession,
+  encryptStringWithPassword,
+  encryptStringWithSession,
+} from '../../encryption/password-aes.js';
+
+describe('password AES encryption', () => {
+  test('encrypts and decrypts a string with a password', async () => {
+    const payload = await encryptStringWithPassword(
+      'hello encrypted world',
+      'p'
+    );
+
+    await expect(decryptStringWithPassword(payload, 'p')).resolves.toBe(
+      'hello encrypted world'
+    );
+  });
+
+  test('rejects a wrong password', async () => {
+    const payload = await encryptStringWithPassword('secret', 'right');
+
+    await expect(decryptStringWithPassword(payload, 'wrong')).rejects.toThrow(
+      'Unable to decrypt payload with the provided password.'
+    );
+  });
+
+  test('re-encrypts updated content with an unlocked session', async () => {
+    const payload = await encryptStringWithPassword('first version', 'p');
+    const session = await createPasswordAesSession(payload, 'p');
+    const updatedPayload = await encryptStringWithSession(
+      'second version',
+      session
+    );
+
+    await expect(
+      decryptStringWithSession(updatedPayload, session)
+    ).resolves.toBe('second version');
+  });
+
+  test('round-trips base64 bytes', () => {
+    const bytes = new Uint8Array([0, 1, 2, 127, 128, 255]);
+
+    expect(Array.from(base64ToBytes(bytesToBase64(bytes)))).toEqual(
+      Array.from(bytes)
+    );
+  });
+});

--- a/blocksuite/affine/shared/src/encryption/block-encryption.ts
+++ b/blocksuite/affine/shared/src/encryption/block-encryption.ts
@@ -1,0 +1,267 @@
+import type { BlockModel, Store } from '@blocksuite/store';
+import { fromJSON, internalPrimitives, Text, toJSON } from '@blocksuite/store';
+import { signal } from '@preact/signals-core';
+import * as Y from 'yjs';
+
+import {
+  createPasswordAesSession,
+  decryptStringWithSession,
+  encryptStringWithPassword,
+  encryptStringWithSession,
+  type PasswordAesSession,
+  type PasswordEncryptedPayload,
+} from './password-aes.js';
+
+export const BLOCK_ENCRYPTION_PROP = 'affineBlockEncryption';
+
+export type EncryptedBlockSnapshot = {
+  version: 1;
+  props: Record<string, unknown>;
+};
+
+export type BlockEncryptionState = {
+  version: 1;
+  type: 'affine:block-encryption';
+  payload: PasswordEncryptedPayload;
+  encryptedKeys: string[];
+  placeholderProps: Record<string, unknown>;
+};
+
+const localUnlockedBlocks = new WeakSet<BlockModel>();
+
+const localEncryptionSessions = new WeakMap<BlockModel, PasswordAesSession>();
+
+function getProps(model: BlockModel) {
+  return model.props as Record<string, unknown>;
+}
+
+function getRecordModel(model: BlockModel) {
+  return model as BlockModel<Record<string, unknown>>;
+}
+
+function ensurePropKey(model: BlockModel, key: string) {
+  if (!model.keys.includes(key)) {
+    model.keys.push(key);
+  }
+
+  const props = getProps(model);
+  const signalKey = `${key}$`;
+  if (!(signalKey in props)) {
+    props[signalKey] = signal(undefined);
+  }
+}
+
+function getSchemaDefaultProps(model: BlockModel) {
+  return model.schema.model.props?.(internalPrimitives) ?? {};
+}
+
+function serializeProps(props: Record<string, unknown>, keys: string[]) {
+  return Object.fromEntries(
+    keys
+      .map(key => [key, toJSON(props[key])] as const)
+      .filter(([, value]) => value !== undefined)
+  );
+}
+
+function deserializeProps(props: Record<string, unknown>, keys: string[]) {
+  return Object.fromEntries(
+    keys.map(key => [key, fromJSON(props[key])] as const)
+  );
+}
+
+function attachLocalTexts(value: unknown): unknown {
+  if (value instanceof Text) {
+    if (!value.yText.doc) {
+      const localDoc = new Y.Doc();
+      localDoc.getMap('props').set('text', value.yText);
+    }
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(attachLocalTexts);
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    Object.values(value).forEach(attachLocalTexts);
+  }
+
+  return value;
+}
+
+function collectTexts(value: unknown, texts: Text[] = []) {
+  if (value instanceof Text) {
+    texts.push(value);
+    return texts;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach(item => collectTexts(item, texts));
+    return texts;
+  }
+
+  if (typeof value === 'object' && value !== null) {
+    Object.values(value).forEach(item => collectTexts(item, texts));
+  }
+
+  return texts;
+}
+
+function getEncryptedSnapshot(model: BlockModel, keys: string[]) {
+  return {
+    version: 1,
+    props: serializeProps(getProps(model), keys),
+  } satisfies EncryptedBlockSnapshot;
+}
+
+function getEncryptableKeys(model: BlockModel) {
+  return model.keys.filter(key => key !== BLOCK_ENCRYPTION_PROP);
+}
+
+export function getBlockEncryptionState(
+  model: BlockModel
+): BlockEncryptionState | null {
+  const state = getProps(model)[BLOCK_ENCRYPTION_PROP];
+  if (
+    typeof state !== 'object' ||
+    state === null ||
+    (state as BlockEncryptionState).type !== 'affine:block-encryption'
+  ) {
+    return null;
+  }
+
+  return state as BlockEncryptionState;
+}
+
+export function isBlockEncrypted(model: BlockModel) {
+  return getBlockEncryptionState(model) !== null;
+}
+
+export function isBlockLocallyUnlocked(model: BlockModel) {
+  return localUnlockedBlocks.has(model);
+}
+
+export function canEncryptBlock(model: BlockModel) {
+  return model.role === 'content' && !isBlockEncrypted(model);
+}
+
+export async function encryptBlockWithPassword(
+  store: Store,
+  model: BlockModel,
+  password: string
+) {
+  if (!password) {
+    throw new Error('Password is required.');
+  }
+
+  if (!canEncryptBlock(model)) {
+    throw new Error('Block cannot be encrypted.');
+  }
+
+  const keys = getEncryptableKeys(model);
+  const snapshot = getEncryptedSnapshot(model, keys);
+  const payload = await encryptStringWithPassword(
+    JSON.stringify(snapshot),
+    password
+  );
+  const defaults = getSchemaDefaultProps(model);
+  const placeholderProps = serializeProps(defaults, keys);
+  const state: BlockEncryptionState = {
+    version: 1,
+    type: 'affine:block-encryption',
+    payload,
+    encryptedKeys: keys,
+    placeholderProps,
+  };
+
+  ensurePropKey(model, BLOCK_ENCRYPTION_PROP);
+  store.updateBlock(model, {
+    ...deserializeProps(placeholderProps, keys),
+    [BLOCK_ENCRYPTION_PROP]: state,
+  });
+}
+
+export async function unlockBlockWithPassword(
+  model: BlockModel,
+  password: string
+) {
+  const state = getBlockEncryptionState(model);
+  if (!state) return;
+
+  const session = await createPasswordAesSession(state.payload, password);
+  const snapshot = JSON.parse(
+    await decryptStringWithSession(state.payload, session)
+  ) as EncryptedBlockSnapshot;
+
+  state.encryptedKeys.forEach(key => {
+    getRecordModel(model).stash(key);
+  });
+
+  const decryptedProps = deserializeProps(snapshot.props, state.encryptedKeys);
+  Object.entries(decryptedProps).forEach(([key, value]) => {
+    getProps(model)[key] = attachLocalTexts(value);
+  });
+  localEncryptionSessions.set(model, session);
+  localUnlockedBlocks.add(model);
+}
+
+export function getUnlockedBlockTexts(model: BlockModel) {
+  const state = getBlockEncryptionState(model);
+  if (!state || !isBlockLocallyUnlocked(model)) return [];
+
+  return state.encryptedKeys.flatMap(key => collectTexts(getProps(model)[key]));
+}
+
+export async function persistUnlockedBlockEdits(
+  store: Store,
+  model: BlockModel
+) {
+  const state = getBlockEncryptionState(model);
+  const session = localEncryptionSessions.get(model);
+  if (!state || !session || !isBlockLocallyUnlocked(model)) return;
+
+  const payload = await encryptStringWithSession(
+    JSON.stringify(getEncryptedSnapshot(model, state.encryptedKeys)),
+    session
+  );
+
+  const nextState: BlockEncryptionState = {
+    ...state,
+    payload,
+  };
+
+  store.updateBlock(model, {
+    [BLOCK_ENCRYPTION_PROP]: nextState,
+  });
+}
+
+export function lockBlock(model: BlockModel) {
+  const state = getBlockEncryptionState(model);
+  if (!state) return;
+
+  const placeholderProps = deserializeProps(
+    state.placeholderProps,
+    state.encryptedKeys
+  );
+
+  state.encryptedKeys.forEach(key => {
+    getProps(model)[key] = placeholderProps[key];
+    getRecordModel(model).pop(key);
+  });
+
+  localUnlockedBlocks.delete(model);
+  localEncryptionSessions.delete(model);
+}
+
+export async function lockBlockWithEncryptedEdits(
+  store: Store,
+  model: BlockModel
+) {
+  await persistUnlockedBlockEdits(store, model);
+  lockBlock(model);
+}
+
+export function getBlockEncryptedPreview(model: BlockModel) {
+  return getBlockEncryptionState(model)?.payload.ciphertext ?? '';
+}

--- a/blocksuite/affine/shared/src/encryption/block-encryption.ts
+++ b/blocksuite/affine/shared/src/encryption/block-encryption.ts
@@ -226,6 +226,13 @@ export async function persistUnlockedBlockEdits(
     session
   );
 
+  if (
+    localEncryptionSessions.get(model) !== session ||
+    !isBlockLocallyUnlocked(model)
+  ) {
+    return;
+  }
+
   const nextState: BlockEncryptionState = {
     ...state,
     payload,

--- a/blocksuite/affine/shared/src/encryption/index.ts
+++ b/blocksuite/affine/shared/src/encryption/index.ts
@@ -1,0 +1,2 @@
+export * from './block-encryption.js';
+export * from './password-aes.js';

--- a/blocksuite/affine/shared/src/encryption/password-aes.ts
+++ b/blocksuite/affine/shared/src/encryption/password-aes.ts
@@ -1,0 +1,279 @@
+export type PasswordEncryptedPayload = {
+  version: 1;
+  type: 'affine:password-encrypted';
+  algorithm: 'AES-GCM';
+  kdf: 'PBKDF2';
+  hash: 'SHA-256';
+  iterations: number;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+  encoding: 'base64';
+};
+
+export type PasswordEncryptOptions = {
+  iterations?: number;
+};
+
+export type PasswordAesSession = {
+  key: CryptoKey;
+  iterations: number;
+  salt: string;
+};
+
+const AES_KEY_LENGTH = 256;
+const DEFAULT_ITERATIONS = 210_000;
+const IV_LENGTH = 12;
+const SALT_LENGTH = 16;
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+function getWebCrypto(): Crypto {
+  const crypto = globalThis.crypto;
+
+  if (!crypto?.subtle) {
+    throw new Error('Web Crypto API is not available.');
+  }
+
+  return crypto;
+}
+
+function randomBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  getWebCrypto().getRandomValues(bytes);
+  return bytes;
+}
+
+function toArrayBuffer(data: Uint8Array | ArrayBuffer): ArrayBuffer {
+  if (data instanceof ArrayBuffer) {
+    return data;
+  }
+
+  return data.buffer.slice(
+    data.byteOffset,
+    data.byteOffset + data.byteLength
+  ) as ArrayBuffer;
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+
+  for (let i = 0; i < bytes.length; i += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+  }
+
+  return btoa(binary);
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return bytes;
+}
+
+async function deriveAesKey(
+  password: string,
+  salt: Uint8Array,
+  iterations: number,
+  usages: KeyUsage[]
+): Promise<CryptoKey> {
+  if (!password) {
+    throw new Error('Password is required.');
+  }
+
+  const crypto = getWebCrypto();
+  const baseKey = await crypto.subtle.importKey(
+    'raw',
+    encoder.encode(password),
+    'PBKDF2',
+    false,
+    ['deriveKey']
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      hash: 'SHA-256',
+      salt: toArrayBuffer(salt),
+      iterations,
+    },
+    baseKey,
+    {
+      name: 'AES-GCM',
+      length: AES_KEY_LENGTH,
+    },
+    false,
+    usages
+  );
+}
+
+function assertSupportedPayload(payload: PasswordEncryptedPayload) {
+  if (
+    payload.version !== 1 ||
+    payload.algorithm !== 'AES-GCM' ||
+    payload.kdf !== 'PBKDF2' ||
+    payload.hash !== 'SHA-256' ||
+    payload.encoding !== 'base64'
+  ) {
+    throw new Error('Unsupported encrypted payload.');
+  }
+}
+
+async function decryptBytesWithKey(
+  payload: PasswordEncryptedPayload,
+  key: CryptoKey
+): Promise<Uint8Array> {
+  const crypto = getWebCrypto();
+  const iv = base64ToBytes(payload.iv);
+  const ciphertext = base64ToBytes(payload.ciphertext);
+
+  try {
+    const plaintext = await crypto.subtle.decrypt(
+      {
+        name: 'AES-GCM',
+        iv: toArrayBuffer(iv),
+      },
+      key,
+      toArrayBuffer(ciphertext)
+    );
+
+    return new Uint8Array(plaintext);
+  } catch {
+    throw new Error('Unable to decrypt payload with the provided password.');
+  }
+}
+
+export async function createPasswordAesSession(
+  payload: PasswordEncryptedPayload,
+  password: string
+): Promise<PasswordAesSession> {
+  assertSupportedPayload(payload);
+
+  return {
+    key: await deriveAesKey(
+      password,
+      base64ToBytes(payload.salt),
+      payload.iterations,
+      ['decrypt', 'encrypt']
+    ),
+    iterations: payload.iterations,
+    salt: payload.salt,
+  };
+}
+
+export async function encryptBytesWithSession(
+  data: Uint8Array | ArrayBuffer,
+  session: PasswordAesSession
+): Promise<PasswordEncryptedPayload> {
+  const crypto = getWebCrypto();
+  const iv = randomBytes(IV_LENGTH);
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(iv),
+    },
+    session.key,
+    toArrayBuffer(data)
+  );
+
+  return {
+    version: 1,
+    type: 'affine:password-encrypted',
+    algorithm: 'AES-GCM',
+    kdf: 'PBKDF2',
+    hash: 'SHA-256',
+    iterations: session.iterations,
+    salt: session.salt,
+    iv: bytesToBase64(iv),
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+    encoding: 'base64',
+  };
+}
+
+export async function encryptBytesWithPassword(
+  data: Uint8Array | ArrayBuffer,
+  password: string,
+  options: PasswordEncryptOptions = {}
+): Promise<PasswordEncryptedPayload> {
+  const crypto = getWebCrypto();
+  const salt = randomBytes(SALT_LENGTH);
+  const iv = randomBytes(IV_LENGTH);
+  const iterations = options.iterations ?? DEFAULT_ITERATIONS;
+  const key = await deriveAesKey(password, salt, iterations, ['encrypt']);
+  const ciphertext = await crypto.subtle.encrypt(
+    {
+      name: 'AES-GCM',
+      iv: toArrayBuffer(iv),
+    },
+    key,
+    toArrayBuffer(data)
+  );
+
+  return {
+    version: 1,
+    type: 'affine:password-encrypted',
+    algorithm: 'AES-GCM',
+    kdf: 'PBKDF2',
+    hash: 'SHA-256',
+    iterations,
+    salt: bytesToBase64(salt),
+    iv: bytesToBase64(iv),
+    ciphertext: bytesToBase64(new Uint8Array(ciphertext)),
+    encoding: 'base64',
+  };
+}
+
+export async function decryptBytesWithPassword(
+  payload: PasswordEncryptedPayload,
+  password: string
+): Promise<Uint8Array> {
+  assertSupportedPayload(payload);
+
+  const key = await deriveAesKey(
+    password,
+    base64ToBytes(payload.salt),
+    payload.iterations,
+    ['decrypt']
+  );
+
+  return decryptBytesWithKey(payload, key);
+}
+
+export async function encryptStringWithPassword(
+  plaintext: string,
+  password: string,
+  options?: PasswordEncryptOptions
+): Promise<PasswordEncryptedPayload> {
+  return encryptBytesWithPassword(encoder.encode(plaintext), password, options);
+}
+
+export async function decryptStringWithPassword(
+  payload: PasswordEncryptedPayload,
+  password: string
+): Promise<string> {
+  const bytes = await decryptBytesWithPassword(payload, password);
+  return decoder.decode(bytes);
+}
+
+export async function decryptStringWithSession(
+  payload: PasswordEncryptedPayload,
+  session: PasswordAesSession
+): Promise<string> {
+  assertSupportedPayload(payload);
+
+  const bytes = await decryptBytesWithKey(payload, session.key);
+  return decoder.decode(bytes);
+}
+
+export async function encryptStringWithSession(
+  plaintext: string,
+  session: PasswordAesSession
+): Promise<PasswordEncryptedPayload> {
+  return encryptBytesWithSession(encoder.encode(plaintext), session);
+}

--- a/blocksuite/affine/shared/src/encryption/password-aes.ts
+++ b/blocksuite/affine/shared/src/encryption/password-aes.ts
@@ -24,6 +24,7 @@ export type PasswordAesSession = {
 const AES_KEY_LENGTH = 256;
 const DEFAULT_ITERATIONS = 210_000;
 const IV_LENGTH = 12;
+const MAX_ITERATIONS = 5_000_000;
 const SALT_LENGTH = 16;
 
 const decoder = new TextDecoder();
@@ -45,15 +46,23 @@ function randomBytes(length: number): Uint8Array {
   return bytes;
 }
 
-function toArrayBuffer(data: Uint8Array | ArrayBuffer): ArrayBuffer {
-  if (data instanceof ArrayBuffer) {
-    return data;
+function toArrayBuffer(data: ArrayBuffer | ArrayBufferView): ArrayBuffer {
+  if (ArrayBuffer.isView(data)) {
+    const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    return bytes.slice().buffer;
   }
 
-  return data.buffer.slice(
-    data.byteOffset,
-    data.byteOffset + data.byteLength
-  ) as ArrayBuffer;
+  return data;
+}
+
+function assertSupportedIterations(iterations: number) {
+  if (
+    !Number.isInteger(iterations) ||
+    iterations <= 0 ||
+    iterations > MAX_ITERATIONS
+  ) {
+    throw new Error('Unsupported encrypted payload iterations.');
+  }
 }
 
 export function bytesToBase64(bytes: Uint8Array): string {
@@ -123,6 +132,8 @@ function assertSupportedPayload(payload: PasswordEncryptedPayload) {
   ) {
     throw new Error('Unsupported encrypted payload.');
   }
+
+  assertSupportedIterations(payload.iterations);
 }
 
 async function decryptBytesWithKey(
@@ -205,6 +216,7 @@ export async function encryptBytesWithPassword(
   const salt = randomBytes(SALT_LENGTH);
   const iv = randomBytes(IV_LENGTH);
   const iterations = options.iterations ?? DEFAULT_ITERATIONS;
+  assertSupportedIterations(iterations);
   const key = await deriveAesKey(password, salt, iterations, ['encrypt']);
   const ciphertext = await crypto.subtle.encrypt(
     {


### PR DESCRIPTION
## Summary
- add password-based AES-GCM helpers and encrypted block metadata support
- add Encrypt/Lock toolbar actions for content blocks without storing the password
- render locked blocks through a root widget overlay, and show unlocked encrypted blocks with an inline marker while edits are re-encrypted from an in-memory session key

## Verification
- yarn tsc -b blocksuite/affine/shared blocksuite/affine/blocks/root blocksuite/affine/all --pretty false
- yarn eslint blocksuite/affine/blocks/root/src/view.ts blocksuite/affine/blocks/root/src/effects.ts blocksuite/affine/blocks/root/src/encryption/encrypted-blocks-widget.ts blocksuite/affine/blocks/root/src/configs/toolbar.ts blocksuite/affine/shared/src/encryption/password-aes.ts blocksuite/affine/shared/src/encryption/block-encryption.ts blocksuite/affine/shared/src/__tests__/encryption/password-aes.unit.spec.ts
- yarn vitest run blocksuite/affine/shared/src/__tests__/encryption/password-aes.unit.spec.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-protected block encryption and decryption via new toolbar actions (Encrypt, Lock).
  * Block locking/unlocking for encrypted content with editable unlocked state and auto-persist of edits.
  * Visual encrypted-block overlays showing previews and a Decrypt action.

* **Tests**
  * Added unit tests covering password-AES encryption/decryption and helper utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->