### PR TITLE
Add markdown-only export and MCP doc editing

### DIFF
--- a/packages/backend/server/src/plugins/copilot/mcp/provider.ts
+++ b/packages/backend/server/src/plugins/copilot/mcp/provider.ts
@@ -239,190 +239,193 @@ export class WorkspaceMcpProvider {
       },
     });
 
-    const tools = [readDocument, semanticSearch, keywordSearch];
-
-    if (env.dev || env.namespaces.canary) {
-      const createDocument = defineTool({
-        name: 'create_document',
-        title: 'Create Document',
-        description:
-          'Create a new document in the workspace with the given title and markdown content. Returns the ID of the created document. This tool not support insert or update database block and image yet.',
-        parser: z.object({
-          title: z.string().min(1),
-          content: z.string(),
-        }),
-        inputSchema: {
-          type: 'object',
-          properties: {
-            title: {
-              type: 'string',
-              description: 'The title of the new document',
-            },
-            content: {
-              type: 'string',
-              description: 'The markdown content for the document body',
-            },
+    const createDocument = defineTool({
+      name: 'create_document',
+      title: 'Create Document',
+      description:
+        'Create a new document in the workspace with the given title and markdown content. Returns the ID of the created document. This tool not support insert or update database block and image yet.',
+      parser: z.object({
+        title: z.string().min(1),
+        content: z.string(),
+      }),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            description: 'The title of the new document',
           },
-          required: ['title', 'content'],
-          additionalProperties: false,
-        },
-        execute: async ({ title, content }, options) => {
-          try {
-            await this.ac
-              .user(userId)
-              .workspace(workspaceId)
-              .assert('Workspace.CreateDoc');
-
-            const abortedAfterPermission = abortIfNeeded(options.signal);
-            if (abortedAfterPermission) return abortedAfterPermission;
-
-            const sanitizedTitle = title.replace(/[\r\n]+/g, ' ').trim();
-            if (!sanitizedTitle) throw new Error('Title cannot be empty');
-            const strippedContent = content.replace(
-              /^[ \t]{0,3}#\s+[^\n]*#*\s*\n*/,
-              ''
-            );
-            const result = await this.writer.createDoc(
-              workspaceId,
-              sanitizedTitle,
-              strippedContent,
-              userId
-            );
-
-            return toolText(
-              JSON.stringify({
-                success: true,
-                docId: result.docId,
-                message: `Document "${title}" created successfully`,
-              })
-            );
-          } catch (error) {
-            return toolError(
-              `Failed to create document: ${error instanceof Error ? error.message : 'Unknown error'}`
-            );
-          }
-        },
-      });
-
-      const updateDocument = defineTool({
-        name: 'update_document',
-        title: 'Update Document',
-        description:
-          'Update an existing document with new markdown content (body only). Uses structural diffing to apply minimal changes, preserving document history and enabling real-time collaboration. This does NOT update the document title. This tool not support insert or update database block and image yet.',
-        parser: z.object({
-          docId: z.string(),
-          content: z.string(),
-        }),
-        inputSchema: {
-          type: 'object',
-          properties: {
-            docId: {
-              type: 'string',
-              description: 'The ID of the document to update',
-            },
-            content: {
-              type: 'string',
-              description:
-                'The complete new markdown content for the document body (do NOT include a title H1)',
-            },
+          content: {
+            type: 'string',
+            description: 'The markdown content for the document body',
           },
-          required: ['docId', 'content'],
-          additionalProperties: false,
         },
-        execute: async ({ docId, content }, options) => {
-          const notFoundError = toolError(`Doc with id ${docId} not found.`);
-
-          const accessible = await this.ac
+        required: ['title', 'content'],
+        additionalProperties: false,
+      },
+      execute: async ({ title, content }, options) => {
+        try {
+          await this.ac
             .user(userId)
             .workspace(workspaceId)
-            .doc(docId)
-            .can('Doc.Update');
-          if (!accessible) return notFoundError;
-
-          const abortedBeforeWrite = abortIfNeeded(options.signal);
-          if (abortedBeforeWrite) return abortedBeforeWrite;
-
-          try {
-            await this.writer.updateDoc(workspaceId, docId, content, userId);
-            return toolText(
-              JSON.stringify({
-                success: true,
-                docId,
-                message: 'Document updated successfully',
-              })
-            );
-          } catch (error) {
-            return toolError(
-              `Failed to update document: ${error instanceof Error ? error.message : 'Unknown error'}`
-            );
-          }
-        },
-      });
-
-      const updateDocumentMeta = defineTool({
-        name: 'update_document_meta',
-        title: 'Update Document Metadata',
-        description: 'Update document metadata (currently title only).',
-        parser: z.object({
-          docId: z.string(),
-          title: z.string().min(1),
-        }),
-        inputSchema: {
-          type: 'object',
-          properties: {
-            docId: {
-              type: 'string',
-              description: 'The ID of the document to update',
-            },
-            title: {
-              type: 'string',
-              description: 'The new document title',
-            },
-          },
-          required: ['docId', 'title'],
-          additionalProperties: false,
-        },
-        execute: async ({ docId, title }, options) => {
-          const notFoundError = toolError(`Doc with id ${docId} not found.`);
-
-          const accessible = await this.ac
-            .user(userId)
-            .workspace(workspaceId)
-            .doc(docId)
-            .can('Doc.Update');
-          if (!accessible) return notFoundError;
+            .assert('Workspace.CreateDoc');
 
           const abortedAfterPermission = abortIfNeeded(options.signal);
           if (abortedAfterPermission) return abortedAfterPermission;
 
-          try {
-            const sanitizedTitle = title.replace(/[\r\n]+/g, ' ').trim();
-            if (!sanitizedTitle) throw new Error('Title cannot be empty');
+          const sanitizedTitle = title.replace(/[\r\n]+/g, ' ').trim();
+          if (!sanitizedTitle) throw new Error('Title cannot be empty');
+          const strippedContent = content.replace(
+            /^[ \t]{0,3}#\s+[^\n]*#*\s*\n*/,
+            ''
+          );
+          const result = await this.writer.createDoc(
+            workspaceId,
+            sanitizedTitle,
+            strippedContent,
+            userId
+          );
 
-            await this.writer.updateDocMeta(
-              workspaceId,
-              docId,
-              { title: sanitizedTitle },
-              userId
-            );
+          return toolText(
+            JSON.stringify({
+              success: true,
+              docId: result.docId,
+              message: `Document "${title}" created successfully`,
+            })
+          );
+        } catch (error) {
+          return toolError(
+            `Failed to create document: ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      },
+    });
 
-            return toolText(
-              JSON.stringify({
-                success: true,
-                docId,
-                message: 'Document title updated successfully',
-              })
-            );
-          } catch (error) {
-            return toolError(
-              `Failed to update document metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
-            );
-          }
+    const updateDocument = defineTool({
+      name: 'update_document',
+      title: 'Update Document',
+      description:
+        'Update an existing document with new markdown content (body only). Uses structural diffing to apply minimal changes, preserving document history and enabling real-time collaboration. This does NOT update the document title. This tool not support insert or update database block and image yet.',
+      parser: z.object({
+        docId: z.string(),
+        content: z.string(),
+      }),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          docId: {
+            type: 'string',
+            description: 'The ID of the document to update',
+          },
+          content: {
+            type: 'string',
+            description:
+              'The complete new markdown content for the document body (do NOT include a title H1)',
+          },
         },
-      });
+        required: ['docId', 'content'],
+        additionalProperties: false,
+      },
+      execute: async ({ docId, content }, options) => {
+        const notFoundError = toolError(`Doc with id ${docId} not found.`);
 
-      tools.push(createDocument, updateDocument, updateDocumentMeta);
-    }
+        const accessible = await this.ac
+          .user(userId)
+          .workspace(workspaceId)
+          .doc(docId)
+          .can('Doc.Update');
+        if (!accessible) return notFoundError;
+
+        const abortedBeforeWrite = abortIfNeeded(options.signal);
+        if (abortedBeforeWrite) return abortedBeforeWrite;
+
+        try {
+          await this.writer.updateDoc(workspaceId, docId, content, userId);
+          return toolText(
+            JSON.stringify({
+              success: true,
+              docId,
+              message: 'Document updated successfully',
+            })
+          );
+        } catch (error) {
+          return toolError(
+            `Failed to update document: ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      },
+    });
+
+    const updateDocumentMeta = defineTool({
+      name: 'update_document_meta',
+      title: 'Update Document Metadata',
+      description: 'Update document metadata (currently title only).',
+      parser: z.object({
+        docId: z.string(),
+        title: z.string().min(1),
+      }),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          docId: {
+            type: 'string',
+            description: 'The ID of the document to update',
+          },
+          title: {
+            type: 'string',
+            description: 'The new document title',
+          },
+        },
+        required: ['docId', 'title'],
+        additionalProperties: false,
+      },
+      execute: async ({ docId, title }, options) => {
+        const notFoundError = toolError(`Doc with id ${docId} not found.`);
+
+        const accessible = await this.ac
+          .user(userId)
+          .workspace(workspaceId)
+          .doc(docId)
+          .can('Doc.Update');
+        if (!accessible) return notFoundError;
+
+        const abortedAfterPermission = abortIfNeeded(options.signal);
+        if (abortedAfterPermission) return abortedAfterPermission;
+
+        try {
+          const sanitizedTitle = title.replace(/[\r\n]+/g, ' ').trim();
+          if (!sanitizedTitle) throw new Error('Title cannot be empty');
+
+          await this.writer.updateDocMeta(
+            workspaceId,
+            docId,
+            { title: sanitizedTitle },
+            userId
+          );
+
+          return toolText(
+            JSON.stringify({
+              success: true,
+              docId,
+              message: 'Document title updated successfully',
+            })
+          );
+        } catch (error) {
+          return toolError(
+            `Failed to update document metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
+          );
+        }
+      },
+    });
+
+    const tools = [
+      readDocument,
+      semanticSearch,
+      keywordSearch,
+      createDocument,
+      updateDocument,
+      updateDocumentMeta,
+    ];
 
     return {
       name: `AFFiNE MCP Server for Workspace ${workspaceId}`,

--- a/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
+++ b/packages/frontend/core/src/components/page-list/operation-menu-items/export.tsx
@@ -1,16 +1,7 @@
-import { MenuItem, MenuSeparator, MenuSub } from '@affine/component';
-import { FeatureFlagService } from '@affine/core/modules/feature-flag';
+import { MenuItem, MenuSub } from '@affine/component';
 import { useI18n } from '@affine/i18n';
 import { track } from '@affine/track';
-import {
-  ExportIcon,
-  ExportToHtmlIcon,
-  ExportToMarkdownIcon,
-  ExportToPngIcon,
-  PageIcon,
-  PrinterIcon,
-} from '@blocksuite/icons/rc';
-import { useLiveData, useService } from '@toeverything/infra';
+import { ExportIcon, ExportToMarkdownIcon } from '@blocksuite/icons/rc';
 import type { ReactNode } from 'react';
 import { useCallback } from 'react';
 
@@ -59,51 +50,14 @@ export function ExportMenuItem<T>({
   );
 }
 
-export const PrintMenuItems = ({
-  exportHandler,
-  className = transitionStyle,
-}: ExportProps) => {
-  const t = useI18n();
-  return (
-    <ExportMenuItem
-      onSelect={() => exportHandler('pdf')}
-      className={className}
-      type="pdf"
-      icon={<PrinterIcon />}
-      label={t['com.affine.export.print']()}
-    />
-  );
-};
-
 export const ExportMenuItems = ({
   exportHandler,
   className = transitionStyle,
-  pageMode = 'page',
 }: ExportProps) => {
   const t = useI18n();
-  const featureFlags = useService(FeatureFlagService).flags;
-  const enable_pdfmake_export = useLiveData(
-    featureFlags.enable_pdfmake_export.$
-  );
 
   return (
     <>
-      <ExportMenuItem
-        onSelect={() => exportHandler('html')}
-        className={className}
-        type="html"
-        icon={<ExportToHtmlIcon />}
-        label={t['Export to HTML']()}
-      />
-      {pageMode !== 'edgeless' && (
-        <ExportMenuItem
-          onSelect={() => exportHandler('png')}
-          className={className}
-          type="png"
-          icon={<ExportToPngIcon />}
-          label={t['Export to PNG']()}
-        />
-      )}
       <ExportMenuItem
         onSelect={() => exportHandler('markdown')}
         className={className}
@@ -111,49 +65,14 @@ export const ExportMenuItems = ({
         icon={<ExportToMarkdownIcon />}
         label={t['Export to Markdown']()}
       />
-      <ExportMenuItem
-        onSelect={() => exportHandler('copy-markdown')}
-        className={className}
-        type="copy-markdown"
-        icon={<ExportToMarkdownIcon />}
-        label={t['com.affine.export.copy-markdown']()}
-      />
-      {pageMode !== 'edgeless' && enable_pdfmake_export && (
-        <ExportMenuItem
-          onSelect={() => exportHandler('pdf-export')}
-          className={className}
-          type="pdf-export"
-          icon={<PrinterIcon />}
-          label={t['Export to PDF']()}
-        />
-      )}
-      <ExportMenuItem
-        onSelect={() => exportHandler('snapshot')}
-        className={className}
-        type="snapshot"
-        icon={<PageIcon />}
-        label={t['Export to Snapshot']()}
-      />
     </>
   );
 };
 
-export const Export = ({ exportHandler, className, pageMode }: ExportProps) => {
+export const Export = ({ exportHandler, className }: ExportProps) => {
   const t = useI18n();
   const items = (
-    <>
-      <ExportMenuItems
-        exportHandler={exportHandler}
-        className={className}
-        pageMode={pageMode}
-      />
-      {pageMode !== 'edgeless' && (
-        <>
-          <MenuSeparator />
-          <PrintMenuItems exportHandler={exportHandler} className={className} />
-        </>
-      )}
-    </>
+    <ExportMenuItems exportHandler={exportHandler} className={className} />
   );
   const handleExportMenuOpenChange = useCallback((open: boolean) => {
     if (open) {

--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/index.tsx
@@ -1,7 +1,5 @@
-import { UserFeatureService } from '@affine/core/modules/cloud/services/user-feature';
 import type { SettingTab } from '@affine/core/modules/dialogs/constant';
 import { FeatureFlagService } from '@affine/core/modules/feature-flag';
-import { MeetingSettingsService } from '@affine/core/modules/media/services/meeting-settings';
 import { useI18n } from '@affine/i18n';
 import {
   AppearanceIcon,
@@ -9,58 +7,35 @@ import {
   FolderIcon,
   InformationIcon,
   KeyboardIcon,
-  MeetingIcon,
   NotificationIcon,
   PenIcon,
 } from '@blocksuite/icons/rc';
 import { useLiveData, useServices } from '@toeverything/infra';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 
-import { AuthService, ServerService } from '../../../../modules/cloud';
+import { AuthService } from '../../../../modules/cloud';
 import type { SettingSidebarItem, SettingState } from '../types';
 import { AboutAffine } from './about';
 import { AppearanceSettings } from './appearance';
 import { BackupSettingPanel } from './backup';
-import { BillingSettings } from './billing';
 import { EditorSettings } from './editor';
 import { ExperimentalFeatures } from './experimental-features';
-import { PaymentIcon, UpgradeIcon } from './icons';
-import { MeetingsSettings } from './meetings';
 import { NotificationSettings } from './notifications';
-import { AFFiNEPricingPlans } from './plans';
 import { Shortcuts } from './shortcuts';
 
 export type GeneralSettingList = SettingSidebarItem[];
 
 export const useGeneralSettingList = (): GeneralSettingList => {
   const t = useI18n();
-  const {
-    authService,
-    serverService,
-    userFeatureService,
-    featureFlagService,
-    meetingSettingsService,
-  } = useServices({
+  const { authService, featureFlagService } = useServices({
     AuthService,
-    ServerService,
-    UserFeatureService,
     FeatureFlagService,
-    MeetingSettingsService,
   });
   const status = useLiveData(authService.session.status$);
   const loggedIn = status === 'authenticated';
-  const hasPaymentFeature = useLiveData(
-    serverService.server.features$.map(f => f?.payment)
-  );
   const enableEditorSettings = useLiveData(
     featureFlagService.flags.enable_editor_settings.$
   );
-
-  useEffect(() => {
-    userFeatureService.userFeature.revalidate();
-  }, [userFeatureService]);
-
-  const meetingSettings = useLiveData(meetingSettingsService.settings$);
 
   return useMemo(() => {
     const settings: GeneralSettingList = [
@@ -95,36 +70,6 @@ export const useGeneralSettingList = (): GeneralSettingList => {
       });
     }
 
-    if (
-      (environment.isMacOs || environment.isWindows) &&
-      BUILD_CONFIG.isElectron
-    ) {
-      settings.push({
-        key: 'meetings',
-        title: t['com.affine.settings.meetings'](),
-        icon: <MeetingIcon />,
-        testId: 'meetings-panel-trigger',
-        beta: !meetingSettings?.enabled,
-      });
-    }
-
-    if (hasPaymentFeature) {
-      settings.splice(4, 0, {
-        key: 'plans',
-        title: t['com.affine.payment.title'](),
-        icon: <UpgradeIcon />,
-        testId: 'plans-panel-trigger',
-      });
-      if (loggedIn) {
-        settings.splice(4, 0, {
-          key: 'billing',
-          title: t['com.affine.payment.billing-setting.title'](),
-          icon: <PaymentIcon />,
-          testId: 'billing-panel-trigger',
-        });
-      }
-    }
-
     if (BUILD_CONFIG.isElectron) {
       settings.push({
         key: 'backup',
@@ -149,13 +94,7 @@ export const useGeneralSettingList = (): GeneralSettingList => {
       }
     );
     return settings;
-  }, [
-    t,
-    loggedIn,
-    enableEditorSettings,
-    meetingSettings?.enabled,
-    hasPaymentFeature,
-  ]);
+  }, [t, loggedIn, enableEditorSettings]);
 };
 
 interface GeneralSettingProps {
@@ -163,10 +102,7 @@ interface GeneralSettingProps {
   onChangeSettingState: (settingState: SettingState) => void;
 }
 
-export const GeneralSetting = ({
-  activeTab,
-  onChangeSettingState,
-}: GeneralSettingProps) => {
+export const GeneralSetting = ({ activeTab }: GeneralSettingProps) => {
   switch (activeTab) {
     case 'shortcuts':
       return <Shortcuts />;
@@ -176,14 +112,8 @@ export const GeneralSetting = ({
       return <EditorSettings />;
     case 'appearance':
       return <AppearanceSettings />;
-    case 'meetings':
-      return <MeetingsSettings />;
     case 'about':
       return <AboutAffine />;
-    case 'plans':
-      return <AFFiNEPricingPlans />;
-    case 'billing':
-      return <BillingSettings onChangeSettingState={onChangeSettingState} />;
     case 'experimental-features':
       return <ExperimentalFeatures />;
     case 'backup':

--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/index.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/index.tsx
@@ -7,7 +7,6 @@ import { ServerDeploymentType } from '@affine/graphql';
 import { useI18n } from '@affine/i18n';
 import {
   AiEmbeddingIcon,
-  CollaborationIcon,
   IntegrationsIcon,
   PaymentIcon,
   PropertyIcon,
@@ -21,7 +20,6 @@ import type { SettingSidebarItem, SettingState } from '../types';
 import { WorkspaceSettingBilling } from './billing';
 import { IntegrationSetting } from './integration';
 import { WorkspaceSettingLicense } from './license';
-import { MembersPanel } from './members';
 import { WorkspaceSettingDetail } from './preference';
 import { WorkspaceSettingProperties } from './properties';
 import { WorkspaceSettingStorage } from './storage';
@@ -30,7 +28,6 @@ export const WorkspaceSetting = ({
   activeTab,
   scrollAnchor,
   onCloseSetting,
-  onChangeSettingState,
 }: {
   activeTab: SettingTab;
   scrollAnchor?: string;
@@ -42,13 +39,6 @@ export const WorkspaceSetting = ({
       return <WorkspaceSettingDetail onCloseSetting={onCloseSetting} />;
     case 'workspace:properties':
       return <WorkspaceSettingProperties />;
-    case 'workspace:members':
-      return (
-        <MembersPanel
-          onCloseSetting={onCloseSetting}
-          onChangeSettingState={onChangeSettingState}
-        />
-      );
     case 'workspace:billing':
       return <WorkspaceSettingBilling />;
     case 'workspace:storage':
@@ -93,12 +83,6 @@ export const useWorkspaceSettingList = (): SettingSidebarItem[] => {
         title: t['com.affine.settings.workspace.properties'](),
         icon: <PropertyIcon />,
         testId: 'workspace-setting:properties',
-      },
-      {
-        key: 'workspace:members',
-        title: t['Members'](),
-        icon: <CollaborationIcon />,
-        testId: 'workspace-setting:members',
       },
       {
         key: 'workspace:integrations',

--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/integration/mcp-server/setting-panel.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/integration/mcp-server/setting-panel.tsx
@@ -59,7 +59,7 @@ const McpServerSetting = () => {
               [`affine_workspace_${workspaceService.workspace.id}`]: {
                 type: 'streamable-http',
                 url: `${serverService.server.baseUrl}/api/workspaces/${workspaceService.workspace.id}/mcp`,
-                note: `Read docs from AFFiNE workspace "${workspaceName}"`,
+                note: `Read and edit docs from AFFiNE workspace "${workspaceName}"`,
                 headers: {
                   Authorization: `Bearer ${displayedToken.token}`,
                 },
@@ -206,18 +206,16 @@ const McpServerSetting = () => {
 
         <div className={styles.section}>
           <div className={styles.sectionHeader}>
-            <div className={styles.sectionTitle}>doc-read</div>
+            <div className={styles.sectionTitle}>read_document</div>
           </div>
           <div className={styles.sectionDescription}>
-            Return the complete text and basic metadata of a single document
-            identified by docId; use this when the user needs the full content
-            of a specific file rather than a search result.
+            Read a document identified by docId and return its markdown content.
           </div>
         </div>
 
         <div className={styles.section}>
           <div className={styles.sectionHeader}>
-            <div className={styles.sectionTitle}>doc-semantic-search</div>
+            <div className={styles.sectionTitle}>semantic_search</div>
           </div>
           <div className={styles.sectionDescription}>
             Retrieve conceptually related passages by performing vector-based
@@ -230,13 +228,42 @@ const McpServerSetting = () => {
 
         <div className={styles.section}>
           <div className={styles.sectionHeader}>
-            <div className={styles.sectionTitle}>doc-keyword-search</div>
+            <div className={styles.sectionTitle}>keyword_search</div>
           </div>
           <div className={styles.sectionDescription}>
             Fuzzy search all workspace documents for the exact keyword or phrase
             supplied and return passages ranked by textual match. Use this tool
             by default whenever a straightforward term-based or keyword-base
             lookup is sufficient.
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <div className={styles.sectionTitle}>create_document</div>
+          </div>
+          <div className={styles.sectionDescription}>
+            Create a new document in the workspace from a title and markdown
+            body.
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <div className={styles.sectionTitle}>update_document</div>
+          </div>
+          <div className={styles.sectionDescription}>
+            Replace an existing document body with markdown content while
+            preserving document history.
+          </div>
+        </div>
+
+        <div className={styles.section}>
+          <div className={styles.sectionHeader}>
+            <div className={styles.sectionTitle}>update_document_meta</div>
+          </div>
+          <div className={styles.sectionDescription}>
+            Update document metadata, including the document title.
           </div>
         </div>
       </div>

--- a/packages/frontend/core/src/modules/share-menu/view/share-menu/share-export.tsx
+++ b/packages/frontend/core/src/modules/share-menu/view/share-menu/share-export.tsx
@@ -1,19 +1,12 @@
 import { useExportPage } from '@affine/core/components/hooks/affine/use-export-page';
-import {
-  ExportMenuItems,
-  PrintMenuItems,
-} from '@affine/core/components/page-list';
-import { EditorService } from '@affine/core/modules/editor';
+import { ExportMenuItems } from '@affine/core/components/page-list';
 import { useI18n } from '@affine/i18n';
-import { useLiveData, useService } from '@toeverything/infra';
 
 import * as styles from './index.css';
 
 export const ShareExport = () => {
   const t = useI18n();
-  const editor = useService(EditorService).editor;
   const exportHandler = useExportPage();
-  const currentMode = useLiveData(editor.mode$);
 
   return (
     <div className={styles.exportContainerStyle}>
@@ -24,22 +17,8 @@ export const ShareExport = () => {
         <ExportMenuItems
           exportHandler={exportHandler}
           className={styles.exportItemStyle}
-          pageMode={currentMode}
         />
       </div>
-      {currentMode === 'page' && (
-        <>
-          <div className={styles.descriptionStyle}>
-            {t['com.affine.share-menu.ShareViaPrintDescription']()}
-          </div>
-          <div>
-            <PrintMenuItems
-              exportHandler={exportHandler}
-              className={styles.exportItemStyle}
-            />
-          </div>
-        </>
-      )}
     </div>
   );
 };

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -8860,7 +8860,7 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.integration.mcp-server.name"](): string;
     /**
-      * `Enable other MCP Client to search and read the doc of AFFiNE.`
+      * `Enable other MCP clients to search, read, and edit AFFiNE docs.`
       */
     ["com.affine.integration.mcp-server.desc"](): string;
     /**

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -2218,7 +2218,7 @@
   "com.affine.integration.calendar.no-journal": "No journal page found for {{date}}. Please create a journal page first.",
   "com.affine.integration.calendar.no-calendar": "No subscribed calendars yet.",
   "com.affine.integration.mcp-server.name": "MCP Server",
-  "com.affine.integration.mcp-server.desc": "Enable other MCP Client to search and read the doc of AFFiNE.",
+  "com.affine.integration.mcp-server.desc": "Enable other MCP clients to search, read, and edit AFFiNE docs.",
   "com.affine.integration.mcp-server.copy-json.disabled-hint": "The MCP token is shown only once. Delete and recreate it to copy the JSON configuration.",
   "com.affine.audio.notes": "Notes",
   "com.affine.audio.transcribing": "Transcribing",

--- a/packages/frontend/i18n/src/resources/zh-Hans.json
+++ b/packages/frontend/i18n/src/resources/zh-Hans.json
@@ -2151,7 +2151,7 @@
   "com.affine.integration.calendar.show-all-day-events": "显示全天事件",
   "com.affine.integration.calendar.unsubscribe-content": "您确定要取消订阅“{{name}}”吗？取消订阅此帐户将从 Journal 中删除其数据。",
   "com.affine.integration.mcp-server.name": "MCP服务器",
-  "com.affine.integration.mcp-server.desc": "允许其他 MCP 客户端搜索和 AFFiNE 的文档。",
+  "com.affine.integration.mcp-server.desc": "允许其他 MCP 客户端搜索、读取和编辑 AFFiNE 文档。",
   "com.affine.audio.notes": "笔记",
   "com.affine.audio.transcribing": "转录",
   "com.affine.audio.transcribe.non-owner.confirm.title": "无法检索他人的 AI 结果",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * MCP server tools now support document creation and editing, allowing external clients to create, read, and edit workspace documents

* **Improvements**
  * Streamlined settings interface by removing unused tabs and features
  * Simplified export and sharing functionality

* **Documentation**
  * Updated integration descriptions and localization strings to reflect expanded document management capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->