### PR TITLE
fix: Code Block syntax does not support "empty", "text", or "plaintext"

### DIFF
--- a/blocksuite/affine/blocks/code/src/code-block.ts
+++ b/blocksuite/affine/blocks/code/src/code-block.ts
@@ -59,7 +59,10 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
 
   languageName$: Signal<string> = computed(() => {
     const lang = this.model.props.language$.value;
-    if (lang === null) {
+    if (
+      lang === null ||
+      ['text', 'plaintext', 'empty'].includes(lang.toLowerCase())
+    ) {
       return 'Plain Text';
     }
 
@@ -108,7 +111,10 @@ export class CodeBlockComponent extends CaptionedBlockComponent<CodeBlockModel> 
 
   private _updateHighlightTokens() {
     const modelLang = this.model.props.language$.value;
-    if (modelLang === null) {
+    if (
+      modelLang === null ||
+      ['text', 'plaintext', 'empty'].includes(modelLang.toLowerCase())
+    ) {
       this.highlightTokens$.value = [];
       return;
     }


### PR DESCRIPTION
Code Block syntax does not support "empty", "text", or "plaintext"  #14932 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of plain text code blocks to properly recognize various text input formats (text, plaintext, empty) and prevent unnecessary syntax highlighting processing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toeverything/AFFiNE/pull/14949)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->