### PR TITLE
fix(editor): remove Notion import debug logs

### DIFF
--- a/blocksuite/affine/widgets/linked-doc/src/transformers/notion-html.ts
+++ b/blocksuite/affine/widgets/linked-doc/src/transformers/notion-html.ts
@@ -64,19 +64,10 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
   // Look for Notion page icon in the HTML
   // Notion export format: <div class="page-header-icon undefined"><span class="icon">✅</span></div>
 
-  console.log('=== Extracting page icon ===');
-
-  // Check if there's a head section with title for debugging
-  const headTitle = doc.querySelector('head title');
-  if (headTitle) {
-    console.log('Page title from head:', headTitle.textContent);
-  }
-
   // Look for the exact Notion export structure: .page-header-icon .icon
   const notionIconSpan = doc.querySelector('.page-header-icon .icon');
   if (notionIconSpan && notionIconSpan.textContent) {
     const iconContent = notionIconSpan.textContent.trim();
-    console.log('Found Notion icon (.page-header-icon .icon):', iconContent);
     if (/\p{Emoji}/u.test(iconContent)) {
       return {
         type: 'emoji',
@@ -85,22 +76,9 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
     }
   }
 
-  // Look for page header area for debugging
-  const pageHeader = doc.querySelector('.page-header-icon');
-  if (pageHeader) {
-    console.log(
-      'Found .page-header-icon:',
-      pageHeader.outerHTML.substring(0, 300) + '...'
-    );
-  }
-
   // Fallback: try to find emoji icons with older selectors
   const emojiIcon = doc.querySelector('.page-header-icon .notion-emoji');
   if (emojiIcon && emojiIcon.textContent) {
-    console.log(
-      'Found emoji icon (.page-header-icon .notion-emoji):',
-      emojiIcon.textContent
-    );
     return {
       type: 'emoji',
       content: emojiIcon.textContent.trim(),
@@ -114,10 +92,6 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
     altEmojiIcon.textContent &&
     /\p{Emoji}/u.test(altEmojiIcon.textContent)
   ) {
-    console.log(
-      'Found emoji icon ([role="img"][aria-label]):',
-      altEmojiIcon.textContent
-    );
     return {
       type: 'emoji',
       content: altEmojiIcon.textContent.trim(),
@@ -128,7 +102,6 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
   const imageIcon = doc.querySelector('.page-header-icon img');
   if (imageIcon) {
     const src = imageIcon.getAttribute('src');
-    console.log('Found image icon (.page-header-icon img):', src);
     if (src) {
       return {
         type: 'image',
@@ -142,22 +115,12 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
   for (const span of iconSpans) {
     if (span.textContent && /\p{Emoji}/u.test(span.textContent.trim())) {
       const parent = span.parentElement;
-      console.log(
-        'Found emoji in span.icon:',
-        span.textContent,
-        'parent classes:',
-        parent?.className
-      );
       // Check if this is in a page header context
       if (
         parent &&
         (parent.classList.contains('page-header-icon') ||
           parent.closest('.page-header-icon'))
       ) {
-        console.log(
-          'Using emoji from span.icon in page header:',
-          span.textContent
-        );
         return {
           type: 'emoji',
           content: span.textContent.trim(),
@@ -169,12 +132,10 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
   // Fallback: Try to find icons in the page title area that might contain emoji
   const pageTitle = doc.querySelector('.page-title, h1');
   if (pageTitle && pageTitle.textContent) {
-    console.log('Page title element found:', pageTitle.textContent);
     const text = pageTitle.textContent.trim();
     // Check if the title starts with an emoji
     const emojiMatch = text.match(/^(\p{Emoji}+)/u);
     if (emojiMatch) {
-      console.log('Found emoji in title:', emojiMatch[1]);
       return {
         type: 'emoji',
         content: emojiMatch[1],
@@ -182,7 +143,6 @@ function extractPageIcon(doc: Document): PageIcon | undefined {
     }
   }
 
-  console.log('No page icon found');
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

- Remove development-only `console.log` calls from Notion page icon extraction.
- Drop DOM lookups that only existed to print debugging information.
- Keep the existing page icon extraction fallback order unchanged.

## Why

Notion HTML/zip imports can currently write detailed page title, header, icon, and fallback information to the browser console. That output is noisy for users and does not affect import behavior.

## Validation

- `rg -n "console\.log\(" blocksuite/affine/widgets/linked-doc/src/transformers/notion-html.ts` returned no matches.
- `git diff --check -- blocksuite/affine/widgets/linked-doc/src/transformers/notion-html.ts`
- `npx --yes prettier@3.7.4 --check blocksuite/affine/widgets/linked-doc/src/transformers/notion-html.ts`

Note: the full repository install was not run because this checkout has no `node_modules`, and the repo-local Yarn command requires an installed node_modules state file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined Notion icon extraction logic
  * Removed debug console logging for a cleaner browser console experience while maintaining robust fallback icon detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toeverything/AFFiNE/pull/14986?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->