### PR TITLE
docs: fix workspace module link

### DIFF
--- a/docs/contributing/tutorial.md
+++ b/docs/contributing/tutorial.md
@@ -34,7 +34,7 @@ This package should be imported at the very beginning of the entry point.
 - Each workspace plugin has its state and is isolated from other workspace plugins.
 - The workspace plugin is responsible for its own state management, data persistence, synchronization, data backup and recovery.
 
-For the workspace API, see [types.ts](../../packages/frontend/workspace/src/type.ts).
+For the current workspace module exports and setup, see [workspace/index.ts](../../packages/frontend/core/src/modules/workspace/index.ts).
 
 ### `@affine/component`
 


### PR DESCRIPTION
## Summary

- Replace the stale workspace API link in the contributor tutorial.
- Point contributors to the current workspace module entry point under `packages/frontend/core/src/modules/workspace/index.ts`.

## Why

The previous link targeted `packages/frontend/workspace/src/type.ts`, which no longer exists. New contributors following the tutorial would hit a dead path when looking for workspace APIs.

## Validation

- `test -f packages/frontend/core/src/modules/workspace/index.ts`
- `git diff --check -- docs/contributing/tutorial.md`
- `npx --yes prettier@3.7.4 --check docs/contributing/tutorial.md`

Note: the full repository install was not run because this checkout has no `node_modules`, and the repo-local Yarn command requires an installed node_modules state file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated codebase overview tutorial with current workspace module reference guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toeverything/AFFiNE/pull/14988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->