### PR TITLE
fix(editor): sorting of page emoji display toggle

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/general.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/general-setting/editor/general.tsx
@@ -487,20 +487,6 @@ export const NewDocDateTitleSettings = () => {
           onChange={onToggleAutoDateTitle}
         />
       </SettingRow>
-      <SettingRow
-        name={t.t(
-          'com.affine.settings.editorSettings.general.add-icon-option.title'
-        )}
-        desc={t.t(
-          'com.affine.settings.editorSettings.general.add-icon-option.description'
-        )}
-      >
-        <Switch
-          data-testid="display-add-icon-option-trigger"
-          checked={settings.displayAddIconOption}
-          onChange={onToggleDisplayAddIconOption}
-        />
-      </SettingRow>
       {settings.autoTitleNewDocWithCurrentDate ? (
         <SettingRow
           name={t[
@@ -535,6 +521,20 @@ export const NewDocDateTitleSettings = () => {
           </Menu>
         </SettingRow>
       ) : null}
+      <SettingRow
+        name={t.t(
+          'com.affine.settings.editorSettings.general.add-icon-option.title'
+        )}
+        desc={t.t(
+          'com.affine.settings.editorSettings.general.add-icon-option.description'
+        )}
+      >
+        <Switch
+          data-testid="display-add-icon-option-trigger"
+          checked={settings.displayAddIconOption}
+          onChange={onToggleDisplayAddIconOption}
+        />
+      </SettingRow>
     </>
   );
 };


### PR DESCRIPTION
Fixes the order of the new setting toggle introduced in #14999.
It appeared between "Auto-title new docs with current date" and "New doc date format" which both belong together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the "display add icon option" setting within General settings for improved interface organization and logical grouping.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toeverything/AFFiNE/pull/15020?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->