### PR TITLE
fix: hide experimental settings for doc and folder icons

### DIFF
--- a/packages/frontend/core/src/modules/feature-flag/constant.ts
+++ b/packages/frontend/core/src/modules/feature-flag/constant.ts
@@ -107,7 +107,7 @@ export const AFFINE_FLAGS = {
     feedbackType: 'discord',
     feedbackLink:
       'https://discord.com/channels/959027316334407691/1280014319865696351/1280014319865696351',
-    configurable: true,
+    configurable: false,
     defaultState: true,
   },
   enable_emoji_doc_icon: {
@@ -119,7 +119,7 @@ export const AFFINE_FLAGS = {
     feedbackType: 'discord',
     feedbackLink:
       'https://discord.com/channels/959027316334407691/1280014319865696351',
-    configurable: true,
+    configurable: false,
     defaultState: true,
   },
   enable_editor_settings: {


### PR DESCRIPTION
should fix #13955
The emoji doc and folder icons have been officially released with v0.25 but the experimental settings were still available with no effect if switched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Feature flags for emoji folder and document icons are no longer user-configurable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toeverything/AFFiNE/pull/15021?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->