### PR TITLE
fix(server): canary may missing changelog

### DIFF
--- a/packages/backend/server/src/core/config/resolver.ts
+++ b/packages/backend/server/src/core/config/resolver.ts
@@ -138,7 +138,7 @@ export class ServerConfigResolver {
       const releases = (await response.json()) as Array<{
         name: string;
         url: string;
-        body: string;
+        body: string | null;
         published_at: string;
       }>;
 
@@ -150,7 +150,7 @@ export class ServerConfigResolver {
       return {
         version: latest.name,
         url: latest.url,
-        changelog: latest.body,
+        changelog: latest.body ?? '',
         publishedAt: new Date(latest.published_at),
       };
     } catch (e) {


### PR DESCRIPTION
fix #15027 


#### PR Dependency Tree


* **PR #15061** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing release notes during upgrade checks. The changelog field now defaults to an empty value when release information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->