### PR TITLE
fix(editor): keyboard shortcuts in table cells

### DIFF
--- a/blocksuite/affine/blocks/table/src/table-cell.ts
+++ b/blocksuite/affine/blocks/table/src/table-cell.ts
@@ -649,12 +649,9 @@ export class TableCell extends SignalWatcher(
   }
 
   private readonly _handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key !== 'Escape') {
-      if (e.key === 'Tab') {
-        e.preventDefault();
-        return;
-      }
-      e.stopPropagation();
+    if (e.key !== 'Escape' && e.key === 'Tab') {
+      e.preventDefault();
+      return;
     }
   };
 

--- a/blocksuite/affine/blocks/table/src/table-keymap.ts
+++ b/blocksuite/affine/blocks/table/src/table-keymap.ts
@@ -1,0 +1,7 @@
+import { textKeymap } from '@blocksuite/affine-inline-preset';
+import { TableBlockSchema } from '@blocksuite/affine-model';
+import { KeymapExtension } from '@blocksuite/std';
+
+export const TableKeymapExtension = KeymapExtension(textKeymap, {
+  flavour: TableBlockSchema.model.flavour,
+});

--- a/blocksuite/affine/blocks/table/src/view.ts
+++ b/blocksuite/affine/blocks/table/src/view.ts
@@ -9,6 +9,7 @@ import { literal } from 'lit/static-html.js';
 
 import { tableSlashMenuConfig } from './configs/slash-menu';
 import { effects } from './effects';
+import { TableKeymapExtension } from './table-keymap.js';
 
 export class TableViewExtension extends ViewExtensionProvider {
   override name = 'affine-table-block';
@@ -22,6 +23,7 @@ export class TableViewExtension extends ViewExtensionProvider {
     super.setup(context);
     context.register([
       FlavourExtension(TableModelFlavour),
+      TableKeymapExtension,
       BlockViewExtension(TableModelFlavour, literal`affine-table`),
       SlashMenuConfigExtension(TableModelFlavour, tableSlashMenuConfig),
     ]);

--- a/blocksuite/affine/inlines/preset/src/keymap/format.ts
+++ b/blocksuite/affine/inlines/preset/src/keymap/format.ts
@@ -1,8 +1,4 @@
-import {
-  type BlockStdScope,
-  TextSelection,
-  type UIEventHandler,
-} from '@blocksuite/std';
+import { type BlockStdScope, type UIEventHandler } from '@blocksuite/std';
 
 import { textFormatConfigs } from '../command/index.js';
 
@@ -14,11 +10,8 @@ export const textFormatKeymap = (std: BlockStdScope) =>
         return {
           ...acc,
           [config.hotkey as string]: ctx => {
-            const { store: doc, selection } = std;
+            const { store: doc } = std;
             if (doc.readonly) return;
-
-            const textSelection = selection.find(TextSelection);
-            if (!textSelection) return;
 
             const allowed = config.textChecker?.(std.host) ?? true;
             if (!allowed) return;


### PR DESCRIPTION
## Description
Fixes keyboard shortcuts for text formatting (Ctrl+B, Ctrl+I, Ctrl+U, etc.) not working inside table cells.
## Changes
- **Modified `table-cell.ts`**: Updated the `_handleKeyDown` method to only prevent default behavior for Tab key and allow other keyboard events to propagate, enabling text formatting shortcuts to work properly
- **Created `table-keymap.ts`**: New module that registers the `textKeymap` for table blocks, ensuring text formatting shortcuts are available in table cells
- **Updated `view.ts`**: Registered the `TableKeymapExtension` in the table view extension setup
- **Cleaned up `format.ts`**: Removed unnecessary `TextSelection` check that was preventing shortcuts from working in table contexts
## Closes
Closes #13916 #12127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Tab key handling within table cells for more consistent keyboard navigation.
  * Simplified read-only detection for keyboard shortcuts to avoid unexpected behavior.

* **Refactor**
  * Reworked table keyboard mapping and registration to streamline shortcut handling and event flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->