### PR TITLE
feat(android): add network security configuration to allow user CA trust

### DIFF
--- a/packages/frontend/apps/android/App/app/src/main/AndroidManifest.xml
+++ b/packages/frontend/apps/android/App/app/src/main/AndroidManifest.xml
@@ -15,7 +15,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:usesCleartextTraffic="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config">
+        
 
         <activity
             android:name=".MainActivity"

--- a/packages/frontend/apps/android/App/app/src/main/res/xml/network_security_config.xml
+++ b/packages/frontend/apps/android/App/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true">
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>


### PR DESCRIPTION
Resolution for https://github.com/toeverything/AFFiNE/issues/14335 and alike troubles.

**PR Summary**
This PR updates Android network security settings so the app can work in environments that use user-installed CA certificates (for local/self-hosted TLS interception) while also allowing cleartext HTTP traffic where needed.

**What Changed**
1. Updated the Android application manifest to enable custom network security config and cleartext traffic:
AndroidManifest.xml
2. Added Android network security config to trust both system and user certificate stores, with cleartext permitted:
network_security_config.xml

**Behavior Impact**
1. HTTPS connections can now validate certificates from user-installed CAs in addition to system CAs.
2. HTTP (cleartext) traffic is explicitly allowed for the app.
3. This is scoped to Android app networking policy and does not change backend behavior.

**Why**
This resolves connectivity issues in proxy/dev setups where custom root CAs are installed on device, and supports mixed HTTP/HTTPS environments required during testing or local deployments.

**Validation**
1. Rebuilt Android web assets and synced Capacitor assets.
2. Built stable release artifact and installed release APK on device.
3. App launched + authenticated successfully with updated network policy against a custom PKI internal endpoint and user installed root CA on android.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android network security configuration to support cleartext HTTP connections and improved certificate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->