### PR TITLE
fix(edgeless): stabilize connector pan and canvas transforms

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-keyboard.ts
@@ -702,6 +702,10 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
     const currentTool = edgeless.gfx.tool.currentTool$.peek()!;
     const currentSel = selection.surfaceSelections;
     const isKeyDown = event.type === 'keydown';
+    const temporaryPanTool = currentTool as BaseTool & {
+      pauseForTemporaryPan?: () => void;
+      resumeFromTemporaryPan?: () => void;
+    };
 
     if (edgeless.gfx.tool.dragging$.peek()) {
       return; // Don't do anything if currently dragging
@@ -721,6 +725,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         }
 
         this._setEdgelessTool(toolConstructor, finalOptions);
+        temporaryPanTool.resumeFromTemporaryPan?.();
         selection.set(currentSel);
         document.removeEventListener('keyup', revertToPrevTool, false);
       }
@@ -741,6 +746,7 @@ export class EdgelessPageKeyboardManager extends PageKeyboardManager {
         });
       }
 
+      temporaryPanTool.pauseForTemporaryPan?.();
       this._setEdgelessTool(PanTool, { panning: false });
 
       this.std.event.disposables.addFromEvent(

--- a/blocksuite/affine/blocks/surface/src/renderer/canvas-renderer.ts
+++ b/blocksuite/affine/blocks/surface/src/renderer/canvas-renderer.ts
@@ -101,8 +101,12 @@ type MutableCanvasRendererDebugMetrics = Omit<
 
 type RenderPassStats = CanvasRenderPassMetrics;
 
-type StackingCanvasState = {
+type CanvasViewportState = {
   bound: Bound | null;
+  zoom: number;
+};
+
+type StackingCanvasState = CanvasViewportState & {
   layerId: string | null;
 };
 
@@ -144,6 +148,8 @@ export class CanvasRenderer {
   private _mainCanvasDirty = true;
 
   private _needsFullRender = true;
+
+  private _mainCanvasState: CanvasViewportState | null = null;
 
   private _debugMetrics: MutableCanvasRendererDebugMetrics = {
     refreshCount: 0,
@@ -243,6 +249,43 @@ export class CanvasRenderer {
     };
   }
 
+  private _getCanvasTransform(bound: Bound, renderedZoom: number) {
+    const { viewportBounds, zoom, viewScale } = this.viewport;
+    const left = (bound.x - viewportBounds.x) * zoom;
+    const top = (bound.y - viewportBounds.y) * zoom;
+    const scale = zoom / renderedZoom / viewScale;
+
+    return `translate(${left}px, ${top}px) scale(${scale})`;
+  }
+
+  private _syncCanvasTransform(
+    canvas: HTMLCanvasElement,
+    state: CanvasViewportState | null
+  ) {
+    if (!state?.bound) {
+      return;
+    }
+
+    const transform = this._getCanvasTransform(state.bound, state.zoom);
+
+    if (canvas.style.transform !== transform) {
+      canvas.style.transform = transform;
+    }
+    if (canvas.style.transformOrigin !== 'top left') {
+      canvas.style.transformOrigin = 'top left';
+    }
+  }
+
+  private _syncCanvasTransforms() {
+    // Keep bitmap layers visually locked to DOM blocks while redraw is deferred.
+    this._syncCanvasTransform(this.canvas, this._mainCanvasState);
+
+    for (const canvas of this._stackingCanvas) {
+      const state = this._stackingCanvasState.get(canvas) ?? null;
+      this._syncCanvasTransform(canvas, state);
+    }
+  }
+
   private _applyStackingCanvasLayout(
     canvas: HTMLCanvasElement,
     bound: Bound | null,
@@ -253,6 +296,7 @@ export class CanvasRenderer {
       ({
         bound: null,
         layerId: canvas.dataset.layerId ?? null,
+        zoom: this.viewport.zoom,
       } satisfies StackingCanvasState);
 
     if (!bound || bound.w <= 0 || bound.h <= 0) {
@@ -266,18 +310,17 @@ export class CanvasRenderer {
       canvas.height = 0;
       state.bound = null;
       state.layerId = canvas.dataset.layerId ?? null;
+      state.zoom = this.viewport.zoom;
       this._stackingCanvasState.set(canvas, state);
       return;
     }
 
-    const { viewportBounds, zoom, viewScale } = this.viewport;
+    const { zoom } = this.viewport;
     const width = bound.w * zoom;
     const height = bound.h * zoom;
-    const left = (bound.x - viewportBounds.x) * zoom;
-    const top = (bound.y - viewportBounds.y) * zoom;
     const actualWidth = Math.max(1, Math.ceil(width * dpr));
     const actualHeight = Math.max(1, Math.ceil(height * dpr));
-    const transform = `translate(${left}px, ${top}px) scale(${1 / viewScale})`;
+    const transform = this._getCanvasTransform(bound, zoom);
 
     if (canvas.style.display !== 'block') {
       canvas.style.display = 'block';
@@ -311,6 +354,7 @@ export class CanvasRenderer {
 
     state.bound = bound;
     state.layerId = canvas.dataset.layerId ?? null;
+    state.zoom = zoom;
     this._stackingCanvasState.set(canvas, state);
   }
 
@@ -505,6 +549,7 @@ export class CanvasRenderer {
 
     this._disposables.add(
       this.viewport.viewportUpdated.subscribe(() => {
+        this._syncCanvasTransforms();
         this.refresh({ type: 'all' });
       })
     );
@@ -656,6 +701,12 @@ export class CanvasRenderer {
         true,
         renderStats
       );
+
+      this._mainCanvasState = {
+        bound: viewportBound,
+        zoom,
+      };
+      this._syncCanvasTransform(this.canvas, this._mainCanvasState);
     }
 
     const canvasMemorySnapshots = this._getCanvasMemorySnapshots();

--- a/blocksuite/affine/gfx/connector/src/connector-tool.ts
+++ b/blocksuite/affine/gfx/connector/src/connector-tool.ts
@@ -53,6 +53,8 @@ export class ConnectorTool extends BaseTool<ConnectorToolOptions> {
 
   private _startPoint: IVec | null = null;
 
+  private _temporaryPan = false;
+
   private get _overlay() {
     return this.std.get(OverlayIdentifier('connection')) as ConnectionOverlay;
   }
@@ -110,11 +112,13 @@ export class ConnectorTool extends BaseTool<ConnectorToolOptions> {
   override deactivate() {
     const id = this._connector?.id;
 
-    if (this._allowCancel && id) {
+    if (this._allowCancel && id && !this._temporaryPan) {
       this.gfx.surface?.deleteElement(id);
     }
 
     this._overlay?.clear();
+    if (this._temporaryPan) return;
+
     this._mode = ConnectorToolMode.Dragging;
     this._connector = null;
     this._source = null;
@@ -233,5 +237,13 @@ export class ConnectorTool extends BaseTool<ConnectorToolOptions> {
     const currentIndex = modes.indexOf(this.activatedOption.mode);
     const nextIndex = (currentIndex + 1) % modes.length;
     return modes[nextIndex];
+  }
+
+  pauseForTemporaryPan() {
+    this._temporaryPan = this._mode === ConnectorToolMode.Quick;
+  }
+
+  resumeFromTemporaryPan() {
+    this._temporaryPan = false;
   }
 }

--- a/blocksuite/affine/gfx/pointer/src/__tests__/pan-tool.unit.spec.ts
+++ b/blocksuite/affine/gfx/pointer/src/__tests__/pan-tool.unit.spec.ts
@@ -36,6 +36,8 @@ const createToolFixture = (options?: {
   currentToolOptions?: Record<string, unknown>;
 }) => {
   const applyDeltaCenter = vi.fn();
+  const pauseForTemporaryPan = vi.fn();
+  const resumeFromTemporaryPan = vi.fn();
   const selectionSet = vi.fn();
   const setTool = vi.fn();
   const navigatorSettingUpdated = {
@@ -62,7 +64,10 @@ const createToolFixture = (options?: {
     },
     tool: {
       currentTool$: {
-        peek: () => null,
+        peek: () => ({
+          pauseForTemporaryPan,
+          resumeFromTemporaryPan,
+        }),
       },
       currentToolOption$: {
         peek: () => currentToolOption,
@@ -85,6 +90,8 @@ const createToolFixture = (options?: {
   return {
     applyDeltaCenter,
     navigatorSettingUpdated,
+    pauseForTemporaryPan,
+    resumeFromTemporaryPan,
     selectionSet,
     setTool,
     tool,
@@ -173,5 +180,52 @@ describe('PanTool', () => {
         restoredAfterPan: true,
       }
     );
+  });
+
+  test('middle click temporary pan suspends and restores the previous tool', () => {
+    const {
+      pauseForTemporaryPan,
+      resumeFromTemporaryPan,
+      selectionSet,
+      setTool,
+      tool,
+    } = createToolFixture({
+      currentToolName: 'connector',
+      currentToolOptions: { mode: 0 },
+    });
+
+    const hooks: Partial<Record<'pointerDown', PointerDownHandler>> = {};
+    (tool as any).eventTarget = {
+      addHook: (eventName: 'pointerDown', handler: PointerDownHandler) => {
+        hooks[eventName] = handler;
+      },
+    };
+
+    tool.mounted();
+
+    hooks.pointerDown!({
+      raw: {
+        button: MouseButton.MIDDLE,
+        preventDefault: vi.fn(),
+      },
+    });
+
+    document.dispatchEvent(
+      new PointerEvent('pointerup', { button: MouseButton.MIDDLE })
+    );
+
+    expect(setTool).toHaveBeenNthCalledWith(1, PanTool, {
+      panning: true,
+    });
+    expect(setTool).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        toolName: 'connector',
+      }),
+      { mode: 0 }
+    );
+    expect(pauseForTemporaryPan).toHaveBeenCalledTimes(1);
+    expect(resumeFromTemporaryPan).toHaveBeenCalledTimes(1);
+    expect(selectionSet).toHaveBeenLastCalledWith([{ elements: ['shape-1'] }]);
   });
 });

--- a/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
+++ b/blocksuite/affine/gfx/pointer/src/tools/pan-tool.ts
@@ -21,6 +21,11 @@ export type PanToolOption = {
   panning: boolean;
 };
 
+type TemporaryPanSuspendableTool = BaseTool & {
+  pauseForTemporaryPan?: () => void;
+  resumeFromTemporaryPan?: () => void;
+};
+
 export class PanTool extends BaseTool<PanToolOption> {
   static override toolName = 'pan';
 
@@ -94,14 +99,21 @@ export class PanTool extends BaseTool<PanToolOption> {
       evt.raw.preventDefault();
 
       const selectionToRestore = this.gfx.selection.surfaceSelections.slice();
+      const toolToRestore = this.controller.currentTool$.peek() as
+        | TemporaryPanSuspendableTool
+        | undefined;
+      toolToRestore?.pauseForTemporaryPan?.();
 
       const restoreToPrevious = () => {
-        this.gfx.selection.set(selectionToRestore);
+        if (!toolType) {
+          this.gfx.selection.set(selectionToRestore);
+          return;
+        }
 
-        if (!toolType) return;
         // restore to DefaultTool if previous tool is CopilotTool
         if (toolType.toolName === 'copilot') {
           this.controller.setTool(DefaultTool);
+          this.gfx.selection.set(selectionToRestore);
           return;
         }
 
@@ -120,6 +132,8 @@ export class PanTool extends BaseTool<PanToolOption> {
           } as RestorablePresentToolOptions;
         }
         this.controller.setTool(toolType, finalOptions);
+        toolToRestore?.resumeFromTemporaryPan?.();
+        this.gfx.selection.set(selectionToRestore);
       };
 
       // If in presentation mode, disable black background after middle mouse drag


### PR DESCRIPTION
## Summary

This PR improves edgeless canvas interaction stability around temporary panning and viewport updates.

## Changes

- Preserve connector quick-create state when temporarily switching to pan mode.
- Add suspend/resume hooks for `ConnectorTool` during temporary pan.
- Restore the previous tool, options, and selection after middle-click or keyboard-triggered temporary pan.
- Sync main and stacking canvas CSS transforms immediately on viewport updates to avoid visual misalignment before deferred redraw.
- Add unit coverage for restoring connector state after temporary pan.

## Test Plan

- Added coverage in `blocksuite/affine/gfx/pointer/src/__tests__/pan-tool.unit.spec.ts`.
- Verified affected changes from the latest two commits:
  - `feat(edgeless): add temporary pan support for connector tool`
  - `fix(surface): sync canvas transforms on viewport update`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Tool state is now preserved during temporary panning operations initiated with spacebar or middle-mouse button, allowing tools to pause and resume behavior instead of resetting.
  * Canvas viewport state tracking and transform synchronization enhanced for improved visual consistency during rendering.

* **Tests**
  * Added test coverage verifying tool pause and resume behavior during middle-click temporary panning operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->