### PR TITLE
fix: resolve renovate configuration validation error

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -31,7 +31,8 @@
       "groupSlug": "all-minor-patch",
       "matchUpdateTypes": ["minor", "patch"],
       "matchManagers": ["npm"],
-      "matchPackageNames": ["*", "!/^@blocksuite//", "!/oxlint/"]
+      "matchPackageNames": ["*"],
+      "excludePackagePatterns": ["^@blocksuite/", "oxlint"]
     },
     {
       "groupName": "all non-major dependencies",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "matchManagers": ["npm"],
       "matchPackageNames": ["*"],
-      "excludePackagePatterns": ["^@blocksuite/", "oxlint"]
+      "excludePackagePatterns": ["^@blocksuite/", "^oxlint$"]
     },
     {
       "groupName": "all non-major dependencies",


### PR DESCRIPTION
Fixes #15101 

### What this PR does
Resolves a Renovate configuration error where the bot stopped processing PRs due to invalid settings in `.github/renovate.json`. 

### The Bug
The 4th rule in the `packageRules` array was combining the `*` wildcard with negated regex patterns (`!/^@blocksuite//`, `!/oxlint/`) inside the `matchPackageNames` field, which violates Renovate's current validation schema.

### The Fix
* Kept the `*` wildcard isolated inside `matchPackageNames`.
* Extracted the negative lookaheads and moved them to their dedicated `excludePackagePatterns` array.
* Cleaned up the regex formatting for the exclusion patterns.

*Note: This configuration was successfully verified locally using `npx renovate-config-validator`.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined dependency update configuration: broadened the non-major npm package rule to apply to all packages while explicitly excluding selected packages from automated updates.
  * Adjusted exclusion patterns to replace prior negation-based logic with clearer exclusion entries for specific packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->