### PR TITLE
fix(core): filters emojipicker on label in addition to tags

### DIFF
--- a/packages/frontend/component/src/ui/icon-picker/picker/emoji/groups.tsx
+++ b/packages/frontend/component/src/ui/icon-picker/picker/emoji/groups.tsx
@@ -123,8 +123,10 @@ export const EmojiGroups = memo(function EmojiGroups({
         emojiGroupList
           .map(group => ({
             ...group,
-            emojis: group.emojis.filter(emoji =>
-              emoji.tags?.some(tag => tag.includes(keyword.toLowerCase()))
+            emojis: group.emojis.filter(
+              (emoji) =>
+                emoji.label.toLowerCase().includes(keyword.toLowerCase()) ||
+                emoji.tags?.some((tag) => tag.includes(keyword.toLowerCase())),
             ),
           }))
           .filter(group => group.emojis.length > 0)

--- a/packages/frontend/component/src/ui/icon-picker/picker/emoji/groups.tsx
+++ b/packages/frontend/component/src/ui/icon-picker/picker/emoji/groups.tsx
@@ -124,9 +124,11 @@ export const EmojiGroups = memo(function EmojiGroups({
           .map(group => ({
             ...group,
             emojis: group.emojis.filter(
-              (emoji) =>
+              emoji =>
                 emoji.label.toLowerCase().includes(keyword.toLowerCase()) ||
-                emoji.tags?.some((tag) => tag.toLowerCase().includes(keyword.toLowerCase())),
+                emoji.tags?.some(tag =>
+                  tag.toLowerCase().includes(keyword.toLowerCase())
+                )
             ),
           }))
           .filter(group => group.emojis.length > 0)

--- a/packages/frontend/component/src/ui/icon-picker/picker/emoji/groups.tsx
+++ b/packages/frontend/component/src/ui/icon-picker/picker/emoji/groups.tsx
@@ -126,7 +126,7 @@ export const EmojiGroups = memo(function EmojiGroups({
             emojis: group.emojis.filter(
               (emoji) =>
                 emoji.label.toLowerCase().includes(keyword.toLowerCase()) ||
-                emoji.tags?.some((tag) => tag.includes(keyword.toLowerCase())),
+                emoji.tags?.some((tag) => tag.toLowerCase().includes(keyword.toLowerCase())),
             ),
           }))
           .filter(group => group.emojis.length > 0)


### PR DESCRIPTION
Fixes #15116 
# Issue
Emojipicker keyword filtering only filtered on `tags`, and not `label`. So searching for an emoji's name would not result in said emoji ending up in the result. E.G. searching "sunflower" does not make 🌻 appear

# Solution
Adding an extra condition to the filter function to check if the keyword is a substring of an emoji's label

# Result
Search results now include emojis with that `label`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved emoji picker search to include matches on both emoji labels and tags (case-insensitive), enabling broader search results for better discoverability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->