### PR TITLE
docs(README): add zenith hosting badge to self-host in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ We would like to express our gratitude to all the individuals who have already c
 
 Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiNE. Our team is diligently updating to the latest version. For more information on how to self-host AFFiNE, please refer to our [documentation](https://docs.affine.pro/self-host-affine).
 
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/affine?ref=gh)
+
 [![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
 
 [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)


### PR DESCRIPTION
Adds a Zenith Hosting badge to the README self-hosting section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Deploy with Zenith" deployment option to the Self-Host section, providing an additional hosting choice for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->