### PR TITLE
fix: harden revenuecat webhook handling

### DIFF
--- a/packages/backend/server/src/__tests__/payment/revenuecat.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/revenuecat.spec.ts
@@ -1,4 +1,5 @@
-import { PrismaClient, type User } from '@prisma/client';
+import { UnauthorizedException } from '@nestjs/common';
+import { PrismaClient, Provider, type User } from '@prisma/client';
 import ava, { TestFn } from 'ava';
 import { omit } from 'lodash-es';
 import Sinon from 'sinon';
@@ -948,13 +949,51 @@ test('should map via entitlement+duration when productId not whitelisted (P1M/P1
   );
 });
 
-test('should not dispatch webhook event when authorization header is missing or mismatched', async t => {
+test('should reject webhook event when authorization header is missing or mismatched', async t => {
   const { controller, event } = t.context;
-  const before = event.emitAsync.getCalls()?.length || 0;
-  const e = { id: '42', type: 'INITIAL_PURCHASE', app_user_id: user.id };
-  await controller.handleWebhook({ body: { event: e } } as any, undefined);
-  const after = event.emitAsync.getCalls()?.length || 0;
-  t.is(after - before, 0, 'should not emit event');
+  const e = {
+    id: '42',
+    type: 'INITIAL_PURCHASE',
+    app_id: 'app.affine.pro',
+    environment: 'PRODUCTION',
+    app_user_id: user.id,
+  };
+
+  await t.throwsAsync(() => controller.handleWebhook({ event: e } as any), {
+    instanceOf: UnauthorizedException,
+  });
+  await t.throwsAsync(
+    () => controller.handleWebhook({ event: e } as any, 'x'),
+    {
+      instanceOf: UnauthorizedException,
+    }
+  );
+  t.is(event.emitAsync.getCalls()?.length || 0, 0, 'should not emit event');
+});
+
+test('should deduplicate RevenueCat webhook events by event id', async t => {
+  const { controller, db, event } = t.context;
+  event.emitAsync.resolves([]);
+
+  const e = {
+    id: 'evt_duplicate',
+    type: 'INITIAL_PURCHASE',
+    app_id: 'app.affine.pro',
+    environment: 'PRODUCTION',
+    app_user_id: user.id,
+  };
+
+  await controller.handleWebhook({ event: e } as any, '42');
+  await controller.handleWebhook({ event: e } as any, '42');
+
+  t.is(event.emitAsync.getCalls()?.length || 0, 1, 'should emit once');
+  t.is(
+    await db.paymentEvent.count({
+      where: { provider: Provider.revenuecat, externalEventId: e.id },
+    }),
+    1,
+    'should persist one deduplication record'
+  );
 });
 
 test('should refresh user subscriptions (empty / revenuecat / stripe-only)', async t => {

--- a/packages/backend/server/src/plugins/payment/revenuecat/controller.ts
+++ b/packages/backend/server/src/plugins/payment/revenuecat/controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Headers, Logger, Post } from '@nestjs/common';
+import { timingSafeEqual } from 'node:crypto';
+
+import {
+  BadRequestException,
+  Body,
+  Controller,
+  Headers,
+  Logger,
+  Post,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Prisma, PrismaClient, Provider } from '@prisma/client';
 import { z } from 'zod';
 
 import { Config, EventBus, JobQueue } from '../../../base';
@@ -56,9 +67,62 @@ export class RevenueCatWebhookController {
     private readonly config: Config,
     private readonly event: EventBus,
     private readonly queue: JobQueue,
+    private readonly db: PrismaClient,
     private readonly models: Models,
     private readonly feature: FeatureService
   ) {}
+
+  private authorized(authorization: string | undefined, webhookAuth: string) {
+    if (!authorization || !webhookAuth) {
+      return false;
+    }
+
+    const actual = Buffer.from(authorization);
+    const expected = Buffer.from(webhookAuth);
+
+    return (
+      actual.length === expected.length && timingSafeEqual(actual, expected)
+    );
+  }
+
+  private async markEventReceived(event: RcEvent, appUserId?: string) {
+    const existing = await this.db.paymentEvent.findUnique({
+      where: {
+        provider_externalEventId: {
+          provider: Provider.revenuecat,
+          externalEventId: event.id,
+        },
+      },
+    });
+    if (existing) {
+      return false;
+    }
+
+    try {
+      await this.db.paymentEvent.create({
+        data: {
+          provider: Provider.revenuecat,
+          eventType: event.type,
+          externalEventId: event.id,
+          targetType: appUserId ? 'user' : undefined,
+          targetId: appUserId,
+          externalPaymentId: event.transaction_id || undefined,
+          metadata: event as unknown as Prisma.InputJsonValue,
+          processingStatus: 'processed',
+          processedAt: new Date(),
+        },
+      });
+      return true;
+    } catch (e) {
+      if (
+        e instanceof Prisma.PrismaClientKnownRequestError &&
+        e.code === 'P2002'
+      ) {
+        return false;
+      }
+      throw e;
+    }
+  }
 
   @Public()
   @Post('/webhook')
@@ -68,83 +132,96 @@ export class RevenueCatWebhookController {
   ) {
     const { enabled, webhookAuth, environment } =
       this.config.payment.revenuecat || {};
-    if (enabled) {
-      if (webhookAuth && authorization === webhookAuth) {
-        try {
-          const parsed = RcWebhookPayloadSchema.safeParse(body);
-          if (parsed.success) {
-            const event = parsed.data.event;
-            const { id, app_user_id: appUserId, type } = event;
+    if (!enabled) {
+      return { ok: true };
+    }
 
-            if (
-              event.environment.toLowerCase() === environment?.toLowerCase()
-            ) {
-              const logParams = {
-                appUserId,
-                familyShare: event.is_family_share,
-                environment: event.environment,
-                transactionId: event.transaction_id,
-              };
-              this.logger.log(
-                `[${id}] RevenueCat Webhook {${type}} received for appUserId=${appUserId}.`
-              );
-              if (appUserId && !appUserId.startsWith('$RCAnonymousID:')) {
-                const user = await this.models.user.get(appUserId);
-                if (user) {
-                  if (
-                    (typeof event.is_family_share !== 'boolean' ||
-                      !event.is_family_share) &&
-                    (environment.toLowerCase() === 'production' ||
-                      this.feature.isStaff(user.email))
-                  ) {
-                    // immediately ack and process asynchronously
-                    this.event
-                      .emitAsync('revenuecat.webhook', { appUserId, event })
-                      .catch((e: Error) => {
-                        this.logger.error(
-                          'Failed to handle RevenueCat Webhook event.',
-                          e
-                        );
-                      });
-                    return;
-                  } else {
-                    this.logger.warn(
-                      `[${id}] RevenueCat Webhook received for non-acceptable params.`,
-                      logParams
-                    );
-                  }
-                }
-              } else if (event.transaction_id) {
-                await this.queue
-                  .add('nightly.revenuecat.subscription.refresh.anonymous', {
-                    externalRef: event.transaction_id,
-                    startTime: Date.now(),
-                  })
-                  .catch((e: Error) => {
-                    this.logger.error(
-                      'Failed to handle RevenueCat Webhook event.',
-                      e
-                    );
-                  });
-                return;
-              }
-              this.logger.warn(
-                `RevenueCat Webhook received for unknown user`,
-                logParams
-              );
+    if (!this.authorized(authorization, webhookAuth || '')) {
+      this.logger.warn('RevenueCat webhook unauthorized.');
+      throw new UnauthorizedException('RevenueCat webhook unauthorized.');
+    }
+
+    try {
+      const parsed = RcWebhookPayloadSchema.safeParse(body);
+      if (!parsed.success) {
+        this.logger.warn(
+          'RevenueCat webhook invalid payload received.',
+          parsed.error
+        );
+        throw new BadRequestException('Invalid RevenueCat webhook payload.');
+      }
+
+      const event = parsed.data.event;
+      const { id, app_user_id: appUserId, type } = event;
+
+      if (event.environment.toLowerCase() !== environment?.toLowerCase()) {
+        return { ok: true };
+      }
+
+      const logParams = {
+        appUserId,
+        familyShare: event.is_family_share,
+        environment: event.environment,
+        transactionId: event.transaction_id,
+      };
+      this.logger.log(
+        `[${id}] RevenueCat Webhook {${type}} received for appUserId=${appUserId}.`
+      );
+      if (appUserId && !appUserId.startsWith('$RCAnonymousID:')) {
+        const user = await this.models.user.get(appUserId);
+        if (user) {
+          if (
+            (typeof event.is_family_share !== 'boolean' ||
+              !event.is_family_share) &&
+            (environment.toLowerCase() === 'production' ||
+              this.feature.isStaff(user.email))
+          ) {
+            if (!(await this.markEventReceived(event, appUserId))) {
+              return;
             }
+
+            // immediately ack and process asynchronously
+            this.event
+              .emitAsync('revenuecat.webhook', { appUserId, event })
+              .catch((e: Error) => {
+                this.logger.error(
+                  'Failed to handle RevenueCat Webhook event.',
+                  e
+                );
+              });
+            return;
           } else {
             this.logger.warn(
-              'RevenueCat webhook invalid payload received.',
-              parsed.error
+              `[${id}] RevenueCat Webhook received for non-acceptable params.`,
+              logParams
             );
           }
-        } catch (e) {
-          this.logger.error('RevenueCat webhook error', e as Error);
         }
-      } else {
-        this.logger.warn('RevenueCat webhook unauthorized.');
+      } else if (event.transaction_id) {
+        if (!(await this.markEventReceived(event))) {
+          return;
+        }
+
+        await this.queue
+          .add('nightly.revenuecat.subscription.refresh.anonymous', {
+            externalRef: event.transaction_id,
+            startTime: Date.now(),
+          })
+          .catch((e: Error) => {
+            this.logger.error('Failed to handle RevenueCat Webhook event.', e);
+          });
+        return;
       }
+      this.logger.warn(
+        `RevenueCat Webhook received for unknown user`,
+        logParams
+      );
+    } catch (e) {
+      if (e instanceof BadRequestException) {
+        throw e;
+      }
+      this.logger.error('RevenueCat webhook error', e as Error);
+      throw e;
     }
 
     return { ok: true };


### PR DESCRIPTION
## Summary

Harden the RevenueCat webhook endpoint against replayed events and silent delivery failures:

- compare the configured `Authorization` webhook secret with `timingSafeEqual`
- return `401 Unauthorized` for missing/mismatched webhook authorization
- return `400 Bad Request` for invalid RevenueCat webhook payloads
- persist RevenueCat event IDs in the existing `paymentEvent` table and skip duplicate events
- add regression coverage for unauthorized requests and duplicate event IDs

## Notes

RevenueCat's webhook configuration currently documents an `Authorization` header secret rather than a request-body HMAC signature header, so this keeps the existing integration model while making it fail closed and idempotent.

## Tests

- `corepack yarn prettier --check packages/backend/server/src/plugins/payment/revenuecat/controller.ts packages/backend/server/src/__tests__/payment/revenuecat.spec.ts`
- `corepack yarn eslint packages/backend/server/src/plugins/payment/revenuecat/controller.ts packages/backend/server/src/__tests__/payment/revenuecat.spec.ts --no-error-on-unmatched-pattern`
- `git diff --check`

Targeted AVA run was attempted but blocked by the local AVA prelude loader resolving `./src/prelude.ts` under `node_modules/.cache/ava` in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RevenueCat webhook processing is now idempotent, preventing duplicate handling for the same event.
  * Added timing-safe webhook authorization and early responses for disabled handling or environment mismatches.

* **Bug Fixes**
  * Missing or incorrect webhook authorization now returns an unauthorized error.
  * Duplicate webhook deliveries no longer trigger repeated downstream actions.
  * Invalid webhook payloads are rejected with clearer bad-request responses.
  * Events with mismatched environments are safely ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->