### PR TITLE
fix(server): workspace sub status

### DIFF
--- a/packages/backend/server/src/__tests__/e2e/workspace/team.spec.ts
+++ b/packages/backend/server/src/__tests__/e2e/workspace/team.spec.ts
@@ -145,6 +145,28 @@ e2e('should set new invited users to waiting-seat status', async t => {
   t.is(invitationInfo.status, WorkspaceMemberStatus.NeedMoreSeat);
 });
 
+e2e('should allocate existing team seats for new invited users', async t => {
+  const { owner, workspace } = await createTeamWorkspace(4);
+  await app.login(owner);
+
+  const u1 = await app.createUser();
+
+  const result = await app.gql({
+    query: inviteByEmailsMutation,
+    variables: {
+      workspaceId: workspace.id,
+      emails: [u1.email],
+    },
+  });
+
+  t.not(result.inviteMembers[0].inviteId, null);
+
+  const invitationInfo = await getInvitationInfo(
+    result.inviteMembers[0].inviteId!
+  );
+  t.is(invitationInfo.status, WorkspaceMemberStatus.Pending);
+});
+
 e2e('should allocate seats', async t => {
   const { owner, workspace } = await createTeamWorkspace();
   await app.login(owner);

--- a/packages/backend/server/src/__tests__/payment/service.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/service.spec.ts
@@ -1475,6 +1475,41 @@ test('should not be able to checkout for workspace if subscribed', async t => {
   );
 });
 
+test('should be able to checkout for workspace after canceled subscription', async t => {
+  const { service, u1, db, stripe } = t.context;
+
+  await db.subscription.create({
+    data: {
+      targetId: 'ws_1',
+      stripeSubscriptionId: 'sub_1',
+      plan: SubscriptionPlan.Team,
+      recurring: SubscriptionRecurring.Monthly,
+      status: SubscriptionStatus.Canceled,
+      start: new Date(Date.now() - 100000),
+      end: new Date(Date.now() - 1000),
+      quantity: 1,
+    },
+  });
+
+  await service.checkout(
+    {
+      plan: SubscriptionPlan.Team,
+      recurring: SubscriptionRecurring.Monthly,
+      variant: null,
+      successCallbackLink: '',
+    },
+    {
+      user: u1,
+      workspaceId: 'ws_1',
+    }
+  );
+
+  t.deepEqual(getLastCheckoutPrice(stripe.checkout.sessions.create), {
+    price: TEAM_MONTHLY,
+    coupon: undefined,
+  });
+});
+
 const teamSub: Stripe.Subscription = {
   ...sub,
   items: {

--- a/packages/backend/server/src/core/workspaces/resolvers/member.ts
+++ b/packages/backend/server/src/core/workspaces/resolvers/member.ts
@@ -243,10 +243,8 @@ export class WorkspaceMemberResolver {
               inviterId: me.id,
             }
           );
-          results.push({
-            email,
-            inviteId: role.id,
-          });
+          await this.allocateAvailableTeamSeats(workspaceId, quota.memberLimit);
+          results.push({ email, inviteId: role.id });
         } else {
           const needMoreSeat = quota.memberCount + idx + 1 > quota.memberLimit;
           if (needMoreSeat) {
@@ -404,6 +402,7 @@ export class WorkspaceMemberResolver {
               inviterId: me.id,
             }
           );
+          await this.allocateAvailableTeamSeats(workspaceId, quota.memberLimit);
         } else {
           if (quota.memberCount >= quota.memberLimit) {
             throw new NoMoreSeat({ spaceId: workspaceId });
@@ -716,5 +715,10 @@ export class WorkspaceMemberResolver {
     if (state.isReadonly) {
       throw new SpaceAccessDenied({ spaceId: workspaceId });
     }
+  }
+
+  private async allocateAvailableTeamSeats(workspaceId: string, limit: number) {
+    if (limit <= 0) return;
+    await this.workspaceService.allocateSeats(workspaceId, limit);
   }
 }

--- a/packages/backend/server/src/plugins/payment/manager/workspace.ts
+++ b/packages/backend/server/src/plugins/payment/manager/workspace.ts
@@ -72,7 +72,7 @@ export class WorkspaceSubscriptionManager extends SubscriptionManager {
     params: z.infer<typeof CheckoutParams>,
     args: z.infer<typeof WorkspaceSubscriptionCheckoutArgs>
   ) {
-    const subscription = await this.getSubscription({
+    const subscription = await this.getActiveSubscription({
       plan: SubscriptionPlan.Team,
       workspaceId: args.workspaceId,
     });


### PR DESCRIPTION



#### PR Dependency Tree


* **PR #15155** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team workspace invites now automatically allocate available seats when new members are added or approved.
  * Checkout for a team plan now works again when a previous subscription has been canceled.

* **Bug Fixes**
  * Improved handling of team member invite status so invited users are correctly marked as pending.
  * Team subscription checkout now checks for only active subscriptions, avoiding false “already exists” errors from canceled or historical records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->