### PR TITLE
fix(i18n): correct Japanese "property" mistranslation in page properties

### DIFF
--- a/packages/frontend/i18n/src/resources/ja.json
+++ b/packages/frontend/i18n/src/resources/ja.json
@@ -724,7 +724,7 @@
   "com.affine.other-page.nav.official-website": "公式サイト",
   "com.affine.other-page.nav.open-affine": "AFFiNEを開く",
   "com.affine.page-operation.add-linked-page": "リンクされたドキュメントを追加",
-  "com.affine.page-properties.more-property.more": "{{ count }} その他の物件",
+  "com.affine.page-properties.more-property.more": "{{ count }} その他のプロパティ",
   "com.affine.page-properties.more-property.one": "{{ count }} その他のプロパティ",
   "com.affine.page-properties.hide-property.one": "{{ count }} プロパティを非表示",
   "com.affine.page-properties.hide-property.more": "{{ count }} プロパティを非表示",


### PR DESCRIPTION
The plural form of the "more properties" string in the Japanese locale is mistranslated.

`com.affine.page-properties.more-property.more` renders as `{{ count }} その他の物件`, but 物件 means a real-estate listing or a physical item, not a data property. The singular key right next to it (`more-property.one`, "more property") already uses プロパティ, and every other property string in this file uses プロパティ too (`add-property`, `remove-property`, the property sidebar, workspace properties, and so on). For the same key, zh-Hans uses 属性 and ko uses 속성, both meaning attribute/property.

This aligns the one value with its singular sibling:

`{{ count }} その他の物件` -> `{{ count }} その他のプロパティ`

Single value change, no keys added or removed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Updated the Japanese label for the “more properties” count to use more natural wording in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->