### PR TITLE
feat: add Helm chart for self-hosted k8s deployment

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -1,0 +1,70 @@
+name: Release Helm Chart
+
+permissions: {}
+
+on:
+  push:
+    branches:
+      - main
+      - canary
+    paths:
+      - charts/affine/**
+
+jobs:
+  release:
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Lint Chart
+        run: helm lint charts/affine
+
+      - name: Package Chart
+        run: |
+          helm package charts/affine
+          ls -la affine-*.tgz
+
+      - name: Get Chart Version
+        id: chart_version
+        run: |
+          VERSION=$(helm show chart charts/affine | awk '/^version:/ {print $2}')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: affine-${{ steps.chart_version.outputs.version }}
+          name: AFFiNE Helm Chart ${{ steps.chart_version.outputs.version }}
+          files: affine-*.tgz
+          body: |
+            Helm chart for AFFiNE self-hosted server.
+
+            ## Installation
+
+            ```bash
+            helm install affine oci://ghcr.io/${{ github.repository_owner }}/charts/affine --version ${{ steps.chart_version.outputs.version }}
+            ```
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
+        run: |
+          helm push affine-${{ steps.chart_version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -53,7 +53,7 @@ jobs:
             ## Installation
 
             ```bash
-            helm install affine oci://ghcr.io/${{ github.repository_owner }}/charts/affine --version ${{ steps.chart_version.outputs.version }}
+            helm install affine oci://ghcr.io/toeverything/charts/affine --version ${{ steps.chart_version.outputs.version }}
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,4 +67,4 @@ jobs:
 
       - name: Push chart to GHCR
         run: |
-          helm push affine-${{ steps.chart_version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push affine-${{ steps.chart_version.outputs.version }}.tgz oci://ghcr.io/toeverything/charts

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -30,16 +30,31 @@ jobs:
       - name: Lint Chart
         run: helm lint charts/affine
 
+      - name: Prepare chart version
+        id: chart_version
+        run: |
+          VERSION=$(helm show chart charts/affine | awk '/^version:/ {print $2}')
+          if [ "${{ github.ref_name }}" = "canary" ]; then
+            VERSION="${VERSION}-canary.${GITHUB_RUN_NUMBER}"
+            sed -i "s/^version:.*/version: ${VERSION}/" charts/affine/Chart.yaml
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Package Chart
         run: |
           helm package charts/affine
           ls -la affine-*.tgz
 
-      - name: Get Chart Version
-        id: chart_version
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push chart to GHCR
         run: |
-          VERSION=$(helm show chart charts/affine | awk '/^version:/ {print $2}')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          helm push affine-${{ steps.chart_version.outputs.version }}.tgz oci://ghcr.io/toeverything/charts
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -57,14 +72,3 @@ jobs:
             ```
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Push chart to GHCR
-        run: |
-          helm push affine-${{ steps.chart_version.outputs.version }}.tgz oci://ghcr.io/toeverything/charts

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 **/node_modules
 .yarn
 .github/helm
+charts
 .git
 .vscode
 .context

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,7 @@
 **/node_modules
 .yarn
 .github/helm
-charts
+charts/**/templates/**
 .git
 .vscode
 .context

--- a/charts/affine/.helmignore
+++ b/charts/affine/.helmignore
@@ -1,0 +1,17 @@
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/affine/Chart.yaml
+++ b/charts/affine/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: affine
+description: AFFiNE self-hosted server
+type: application
+version: 0.1.0
+appVersion: "stable"

--- a/charts/affine/README.md
+++ b/charts/affine/README.md
@@ -61,6 +61,22 @@ config:
 | `migration.enabled` | `true` | Run DB migrations on install/upgrade |
 | `service.port` | `3010` | Service port |
 | `replicaCount` | `1` | Replicas (use `1` with RWO volume) |
+| `service.type` | `ClusterIP` | Kubernetes Service type |
+| `resources` | see `values.yaml` | CPU/memory requests and limits |
+| `podSecurityContext` / `securityContext` | `{}` | Optional pod/container hardening |
+| `nodeSelector` / `tolerations` / `affinity` | `{}` / `[]` / `{}` | Scheduling constraints |
+
+_See `values.yaml` for the complete list of configurable parameters._
+
+## Migration
+
+On every `helm install` and `helm upgrade`, a pre-install/pre-upgrade Job runs `self-host-predeploy.js` to apply database migrations. The release completes only when this Job succeeds.
+
+The hook deletes itself on success. If it fails, inspect the retained pod:
+
+```bash
+kubectl logs -n affine -l app.kubernetes.io/component=migration
+```
 
 ## Verify
 
@@ -72,7 +88,7 @@ kubectl port-forward -n affine svc/affine 3010:3010
 
 ## Upgrade
 
-Bump `version` in `Chart.yaml` before merging chart changes — CI publishes a new release on push to `main` or `canary`.
+Bump `version` in `Chart.yaml` before merging chart changes — CI publishes a new release on push to `main` or `canary`. Reusing the same version fails because the GitHub tag `affine-${version}` already exists.
 
 Pushes to `canary` publish prerelease chart versions (`0.1.0-canary.<run>`) so they do not collide with stable releases from `main`.
 

--- a/charts/affine/README.md
+++ b/charts/affine/README.md
@@ -1,0 +1,87 @@
+# AFFiNE Helm Chart
+
+Kubernetes deployment for [self-hosted AFFiNE](https://docs.affine.pro/self-host-affine).
+
+Postgres and Redis are **not** included — provide connection settings via `env` (same variables as [`.docker/selfhost/compose.yml`](../../.docker/selfhost/compose.yml)).
+
+## Quick Start
+
+```bash
+helm install affine oci://ghcr.io/masterbpro/charts/affine \
+  --namespace affine --create-namespace \
+  --set env.DATABASE_URL="postgresql://affine:secret@pg.example.com:5432/affine" \
+  --set env.REDIS_SERVER_HOST="redis.example.com"
+```
+
+Or from this repository:
+
+```bash
+helm install affine ./charts/affine -f my-values.yaml
+```
+
+## Prerequisites
+
+- PostgreSQL 16+ with [pgvector](https://github.com/pgvector/pgvector)
+- Redis
+- Persistent volume for uploads (`/root/.affine/storage`)
+
+## Configuration
+
+All runtime settings go into a single `env` map — no separate chart keys for database or redis:
+
+```yaml
+env:
+  DATABASE_URL: postgresql://affine:secret@pg.example.com:5432/affine
+  REDIS_SERVER_HOST: redis.example.com
+  AFFINE_INDEXER_ENABLED: "false"
+  AFFINE_SERVER_EXTERNAL_URL: https://affine.example.com
+```
+
+Sensitive values can be stored in a Kubernetes Secret and referenced with `existingSecret` (keys must match `env` names).
+
+Optional `config.json` (see [configuration docs](https://docs.affine.pro/self-host-affine/install/configuration)):
+
+```yaml
+config:
+  server:
+    name: AFFiNE Self Hosted Server
+```
+
+## Common Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `image.repository` | `ghcr.io/toeverything/affine` | Container image |
+| `image.tag` | `stable` | Image tag |
+| `env` | see `values.yaml` | Environment variables |
+| `existingSecret` | `""` | Secret with env keys |
+| `config` | `{}` | `config.json` content |
+| `persistence.enabled` | `true` | PVC for uploads |
+| `persistence.size` | `10Gi` | PVC size |
+| `migration.enabled` | `true` | Run DB migrations on install/upgrade |
+| `service.port` | `3010` | Service port |
+| `replicaCount` | `1` | Replicas (use `1` with RWO volume) |
+
+## Verify
+
+```bash
+kubectl get pods -n affine
+kubectl port-forward -n affine svc/affine 3010:3010
+# open http://localhost:3010 and create the first admin account
+```
+
+## Upgrade
+
+Bump `version` in `Chart.yaml` before merging chart changes — CI publishes a new release on push to `main`/`canary`.
+
+```bash
+helm upgrade affine oci://ghcr.io/masterbpro/charts/affine --version 0.1.1 -f my-values.yaml
+```
+
+## Uninstall
+
+```bash
+helm uninstall affine -n affine
+```
+
+PVC is not removed automatically — delete it manually if uploads are no longer needed.

--- a/charts/affine/README.md
+++ b/charts/affine/README.md
@@ -72,7 +72,9 @@ kubectl port-forward -n affine svc/affine 3010:3010
 
 ## Upgrade
 
-Bump `version` in `Chart.yaml` before merging chart changes — CI publishes a new release on push to `main`/`canary`.
+Bump `version` in `Chart.yaml` before merging chart changes — CI publishes a new release on push to `main` or `canary`.
+
+Pushes to `canary` publish prerelease chart versions (`0.1.0-canary.<run>`) so they do not collide with stable releases from `main`.
 
 ```bash
 helm upgrade affine oci://ghcr.io/toeverything/charts/affine --version 0.1.1 -f my-values.yaml

--- a/charts/affine/README.md
+++ b/charts/affine/README.md
@@ -7,7 +7,7 @@ Postgres and Redis are **not** included — provide connection settings via `env
 ## Quick Start
 
 ```bash
-helm install affine oci://ghcr.io/masterbpro/charts/affine \
+helm install affine oci://ghcr.io/toeverything/charts/affine \
   --namespace affine --create-namespace \
   --set env.DATABASE_URL="postgresql://affine:secret@pg.example.com:5432/affine" \
   --set env.REDIS_SERVER_HOST="redis.example.com"
@@ -75,7 +75,7 @@ kubectl port-forward -n affine svc/affine 3010:3010
 Bump `version` in `Chart.yaml` before merging chart changes — CI publishes a new release on push to `main`/`canary`.
 
 ```bash
-helm upgrade affine oci://ghcr.io/masterbpro/charts/affine --version 0.1.1 -f my-values.yaml
+helm upgrade affine oci://ghcr.io/toeverything/charts/affine --version 0.1.1 -f my-values.yaml
 ```
 
 ## Uninstall

--- a/charts/affine/templates/NOTES.txt
+++ b/charts/affine/templates/NOTES.txt
@@ -1,0 +1,13 @@
+1. Set external Postgres and Redis in values.env (or existingSecret):
+
+   DATABASE_URL, REDIS_SERVER_HOST, AFFINE_INDEXER_ENABLED=false
+
+2. Open AFFiNE:
+
+   kubectl port-forward svc/{{ include "affine.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+
+   http://127.0.0.1:{{ .Values.service.port }}
+
+3. Create the first admin account in the browser.
+
+Docs: https://docs.affine.pro/self-host-affine

--- a/charts/affine/templates/_helpers.tpl
+++ b/charts/affine/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{- define "affine.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "affine.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "affine.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "affine.labels" -}}
+helm.sh/chart: {{ include "affine.chart" . }}
+{{ include "affine.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{- define "affine.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "affine.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "affine.env" -}}
+{{- if .Values.existingSecret }}
+envFrom:
+  - secretRef:
+      name: {{ .Values.existingSecret }}
+{{- else }}
+env:
+  {{- range $key, $value := .Values.env }}
+  - name: {{ $key }}
+    value: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "affine.volumes" -}}
+{{- if .Values.persistence.enabled }}
+- name: storage
+  persistentVolumeClaim:
+    claimName: {{ include "affine.fullname" . }}
+{{- end }}
+{{- if .Values.config }}
+- name: config
+  configMap:
+    name: {{ include "affine.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{- define "affine.volumeMounts" -}}
+{{- if .Values.persistence.enabled }}
+- name: storage
+  mountPath: /root/.affine/storage
+{{- end }}
+{{- if .Values.config }}
+- name: config
+  mountPath: /root/.affine/config
+  readOnly: true
+{{- end }}
+{{- end }}

--- a/charts/affine/templates/_helpers.tpl
+++ b/charts/affine/templates/_helpers.tpl
@@ -45,13 +45,17 @@ env:
 {{- end }}
 {{- end }}
 
+{{- define "affine.hasConfig" -}}
+{{- if and .Values.config (gt (len .Values.config) 0) -}}true{{- end -}}
+{{- end }}
+
 {{- define "affine.volumes" -}}
 {{- if .Values.persistence.enabled }}
 - name: storage
   persistentVolumeClaim:
     claimName: {{ include "affine.fullname" . }}
 {{- end }}
-{{- if .Values.config }}
+{{- if include "affine.hasConfig" . }}
 - name: config
   configMap:
     name: {{ include "affine.fullname" . }}
@@ -63,9 +67,33 @@ env:
 - name: storage
   mountPath: /root/.affine/storage
 {{- end }}
-{{- if .Values.config }}
+{{- if include "affine.hasConfig" . }}
 - name: config
   mountPath: /root/.affine/config
   readOnly: true
 {{- end }}
+{{- end }}
+
+{{- define "affine.migrationVolumes" -}}
+{{- if include "affine.hasConfig" . }}
+- name: config
+  configMap:
+    name: {{ include "affine.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{- define "affine.migrationVolumeMounts" -}}
+{{- if include "affine.hasConfig" . }}
+- name: config
+  mountPath: /root/.affine/config
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{- define "affine.hasVolumes" -}}
+{{- if or .Values.persistence.enabled (include "affine.hasConfig" .) -}}true{{- end -}}
+{{- end }}
+
+{{- define "affine.hasMigrationVolumes" -}}
+{{- include "affine.hasConfig" . -}}
 {{- end }}

--- a/charts/affine/templates/configmap.yaml
+++ b/charts/affine/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "affine.fullname" . }}
+  labels:
+    {{- include "affine.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {{- $config := dict "$schema" "https://github.com/toeverything/affine/releases/latest/download/config.schema.json" }}
+    {{- $config = merge $config .Values.config }}
+    {{- $config | toJson | nindent 4 }}
+{{- end }}

--- a/charts/affine/templates/configmap.yaml
+++ b/charts/affine/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config }}
+{{- if include "affine.hasConfig" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/affine/templates/deployment.yaml
+++ b/charts/affine/templates/deployment.yaml
@@ -29,10 +29,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: affine
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/charts/affine/templates/deployment.yaml
+++ b/charts/affine/templates/deployment.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "affine.fullname" . }}
+  labels:
+    {{- include "affine.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "affine.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "affine.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: affine
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- include "affine.env" . | nindent 10 }}
+          {{- with .Values.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            {{- include "affine.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "affine.volumes" . | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/affine/templates/deployment.yaml
+++ b/charts/affine/templates/deployment.yaml
@@ -54,10 +54,14 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- if include "affine.hasVolumes" . }}
           volumeMounts:
             {{- include "affine.volumeMounts" . | nindent 12 }}
+          {{- end }}
+      {{- if include "affine.hasVolumes" . }}
       volumes:
         {{- include "affine.volumes" . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/affine/templates/job.yaml
+++ b/charts/affine/templates/job.yaml
@@ -11,6 +11,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: {{ .Values.migration.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:
@@ -22,12 +23,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: migration
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
           {{- include "affine.env" . | nindent 10 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.migration.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if include "affine.hasMigrationVolumes" . }}
           volumeMounts:
             {{- include "affine.migrationVolumeMounts" . | nindent 12 }}

--- a/charts/affine/templates/job.yaml
+++ b/charts/affine/templates/job.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "affine.fullname" . }}-migration
+  labels:
+    {{- include "affine.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "affine.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: migration
+    spec:
+      restartPolicy: Never
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: migration
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
+          {{- include "affine.env" . | nindent 10 }}
+          volumeMounts:
+            {{- include "affine.volumeMounts" . | nindent 12 }}
+      volumes:
+        {{- include "affine.volumes" . | nindent 8 }}
+{{- end }}

--- a/charts/affine/templates/job.yaml
+++ b/charts/affine/templates/job.yaml
@@ -28,8 +28,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-c", "node ./scripts/self-host-predeploy.js"]
           {{- include "affine.env" . | nindent 10 }}
+          {{- if include "affine.hasMigrationVolumes" . }}
           volumeMounts:
-            {{- include "affine.volumeMounts" . | nindent 12 }}
+            {{- include "affine.migrationVolumeMounts" . | nindent 12 }}
+          {{- end }}
+      {{- if include "affine.hasMigrationVolumes" . }}
       volumes:
-        {{- include "affine.volumes" . | nindent 8 }}
+        {{- include "affine.migrationVolumes" . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/affine/templates/pvc.yaml
+++ b/charts/affine/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "affine.fullname" . }}
+  labels:
+    {{- include "affine.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/affine/templates/service.yaml
+++ b/charts/affine/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "affine.fullname" . }}
+  labels:
+    {{- include "affine.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "affine.selectorLabels" . | nindent 4 }}

--- a/charts/affine/values.yaml
+++ b/charts/affine/values.yaml
@@ -1,0 +1,72 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/toeverything/affine
+  tag: stable
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+# All runtime configuration as plain env vars (see .docker/selfhost/compose.yml).
+# External Postgres and Redis are not deployed by this chart — set connection strings here.
+env:
+  DATABASE_URL: postgresql://affine:change-me@postgres.example.com:5432/affine
+  REDIS_SERVER_HOST: redis.example.com
+  AFFINE_INDEXER_ENABLED: "false"
+  # AFFINE_SERVER_EXTERNAL_URL: https://affine.example.com
+
+# Optional config.json mounted to /root/.affine/config/config.json
+# https://docs.affine.pro/self-host-affine/install/configuration
+config: {}
+# config:
+#   server:
+#     name: AFFiNE Self Hosted Server
+
+# Use an existing Secret with the same keys as env instead of values.env
+existingSecret: ""
+
+persistence:
+  enabled: true
+  size: 10Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+migration:
+  enabled: true
+
+service:
+  type: ClusterIP
+  port: 3010
+
+resources:
+  limits:
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+
+livenessProbe:
+  tcpSocket:
+    port: http
+  periodSeconds: 30
+
+readinessProbe:
+  tcpSocket:
+    port: http
+  periodSeconds: 10
+
+startupProbe:
+  tcpSocket:
+    port: http
+  failureThreshold: 30
+  periodSeconds: 10
+
+podAnnotations: {}
+podLabels: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+strategy:
+  type: Recreate

--- a/charts/affine/values.yaml
+++ b/charts/affine/values.yaml
@@ -34,6 +34,13 @@ persistence:
 
 migration:
   enabled: true
+  ttlSecondsAfterFinished: 86400
+  resources:
+    requests:
+      cpu: 50m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
 
 service:
   type: ClusterIP
@@ -61,6 +68,19 @@ startupProbe:
     port: http
   failureThreshold: 30
   periodSeconds: 10
+
+# The image writes to /root/.affine — keep runAsNonRoot disabled unless you adjust paths.
+podSecurityContext: {}
+# podSecurityContext:
+#   seccompProfile:
+#     type: RuntimeDefault
+
+securityContext: {}
+# securityContext:
+#   allowPrivilegeEscalation: false
+#   capabilities:
+#     drop:
+#       - ALL
 
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
Adds an official Helm chart for deploying self-hosted AFFiNE on Kubernetes.

**What's included:**
- Chart at `charts/affine/` — Deployment, Service, PVC, optional ConfigMap, migration Job (pre-install/upgrade)
- External Postgres and Redis are not bundled; connection settings go through a single `env` map (same vars as Docker Compose)
- CI workflow: `helm lint` → package → GitHub Release → push to `oci://ghcr.io/toeverything/charts/affine`
- `charts/` excluded from Prettier (Helm templates are not plain YAML)

**Prerequisites:** PostgreSQL 16+ with pgvector, Redis, persistent storage for uploads. (can be installed via cnpg)

```bash
helm install affine oci://ghcr.io/toeverything/charts/affine \
  --set env.DATABASE_URL="postgresql://..." \
  --set env.REDIS_SERVER_HOST="redis.example.com"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Helm chart for self-hosting AFFiNE on Kubernetes, including Deployment, Service, PVC support, configuration via `config.json`, and a migration pre-install/pre-upgrade job.
  * Added end-user installation, upgrade, verification, and uninstall documentation for the chart.
  * Added automated Helm chart releases (packaging, GitHub Releases, and pushing to an OCI registry), including canary versioning.
* **Bug Fixes**
  * Improved Helm chart packaging by excluding generated/unneeded files and ignoring chart templates in formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->