### PR TITLE
fix(ios): authenticate native Intelligents GraphQL/SSE requests

### DIFF
--- a/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/ChatManager/ChatManager+Stream.swift
+++ b/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/ChatManager/ChatManager+Stream.swift
@@ -255,6 +255,9 @@ private extension ChatManager {
       timeoutInterval: 10
     )
     request.setValue("close", forHTTPHeaderField: "Connection")
+    // The SSE stream bypasses the Apollo client, so attach the Bearer token the
+    // same way QLService authorizes its GraphQL/REST traffic.
+    request = QLService.shared.authorized(request)
 
     let closable = ClosableTask(detachedTask: .detached(operation: {
       let eventSource = EventSource()

--- a/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/IntelligentContext/QLService+URLSessionCookieClient.swift
+++ b/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/IntelligentContext/QLService+URLSessionCookieClient.swift
@@ -52,9 +52,10 @@ extension QLService {
   /// External hosts (e.g. presigned blob-storage uploads) are left untouched.
   func authorized(_ request: URLRequest) -> URLRequest {
     guard request.value(forHTTPHeaderField: "Authorization") == nil,
-          let requestHost = request.url?.host?.lowercased(),
-          let serverHost = serverBaseURL.host?.lowercased(),
-          requestHost == serverHost,
+          let requestURL = request.url,
+          let requestOrigin = Self.canonicalOrigin(of: requestURL),
+          let serverOrigin = Self.canonicalOrigin(of: serverBaseURL),
+          requestOrigin == serverOrigin,
           let token = currentAuthToken()
     else {
       return request

--- a/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/IntelligentContext/QLService+URLSessionCookieClient.swift
+++ b/packages/frontend/apps/ios/App/Packages/Intelligents/Sources/Intelligents/IntelligentContext/QLService+URLSessionCookieClient.swift
@@ -7,6 +7,7 @@
 
 import Apollo
 import Foundation
+import Security
 
 extension QLService {
   final class URLSessionCookieClient: URLSessionClient {
@@ -17,5 +18,89 @@ extension QLService {
         self.session.configuration.httpCookieStorage?.setCookie(cookie)
       }
     }
+
+    // AFFiNE native auth is token-based: after sign-in the web layer stores a
+    // Bearer token in the Keychain and clears the session cookies (see
+    // AuthPlugin.exchangeSession). Every native GraphQL/REST call therefore has
+    // to attach `Authorization: Bearer <token>` the same way the web `fetch`
+    // shim does in `proxy.ts`; otherwise requests are anonymous and
+    // `currentUser` resolves to nil. All Apollo traffic and the raw
+    // `sendAuthenticatedRequest`/`put` helpers funnel through this method, so
+    // injecting here covers them in one place.
+    @discardableResult
+    override func sendRequest(
+      _ request: URLRequest,
+      taskDescription: String?,
+      rawTaskCompletionHandler: RawCompletion?,
+      completion: @escaping Completion
+    ) -> URLSessionTask {
+      super.sendRequest(
+        QLService.shared.authorized(request),
+        taskDescription: taskDescription,
+        rawTaskCompletionHandler: rawTaskCompletionHandler,
+        completion: completion
+      )
+    }
+  }
+}
+
+extension QLService {
+  private static let authTokenService = "app.affine.pro.auth-token"
+
+  /// Returns a copy of `request` with an `Authorization: Bearer` header when the
+  /// request targets the current AFFiNE server and a Keychain token exists.
+  /// External hosts (e.g. presigned blob-storage uploads) are left untouched.
+  func authorized(_ request: URLRequest) -> URLRequest {
+    guard request.value(forHTTPHeaderField: "Authorization") == nil,
+          let requestHost = request.url?.host?.lowercased(),
+          let serverHost = serverBaseURL.host?.lowercased(),
+          requestHost == serverHost,
+          let token = currentAuthToken()
+    else {
+      return request
+    }
+    var authorized = request
+    authorized.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+    return authorized
+  }
+
+  /// Reads the Bearer token the web layer persisted for the current server,
+  /// keyed by the canonical origin (matching `AuthPlugin.canonicalEndpoint` and
+  /// the JS `readEndpointToken`).
+  func currentAuthToken() -> String? {
+    guard let account = Self.canonicalOrigin(of: serverBaseURL) else { return nil }
+
+    let query: [String: Any] = [
+      kSecClass as String: kSecClassGenericPassword,
+      kSecAttrService as String: Self.authTokenService,
+      kSecAttrAccount as String: account,
+      kSecReturnData as String: true,
+      kSecMatchLimit as String: kSecMatchLimitOne,
+    ]
+
+    var item: CFTypeRef?
+    let status = SecItemCopyMatching(query as CFDictionary, &item)
+    guard status == errSecSuccess,
+          let data = item as? Data,
+          let token = String(data: data, encoding: .utf8),
+          !token.isEmpty
+    else {
+      return nil
+    }
+    return token
+  }
+
+  private static func canonicalOrigin(of url: URL) -> String? {
+    guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+          let scheme = components.scheme?.lowercased(),
+          let host = components.host?.lowercased()
+    else {
+      return nil
+    }
+    let defaultPort = scheme == "https" ? 443 : (scheme == "http" ? 80 : nil)
+    if let port = components.port, port != defaultPort {
+      return "\(scheme)://\(host):\(port)"
+    }
+    return "\(scheme)://\(host)"
   }
 }


### PR DESCRIPTION
## Summary

Split out from #15189 (closed). That PR bundled two unrelated changes; a maintainer closed it because the **subscription-gate bypass** was not acceptable ("permission checks should not be bypassed"). This PR keeps **only the legitimate native-auth bug fix** and drops the subscription bypass entirely — it does **not** bypass any permission check.

The native Intelligents `QLService` only copied the (now-empty) shared cookies and never attached the Bearer token that AFFiNE iOS actually authenticates with. After sign-in the web layer stores a Bearer token in the Keychain and clears the session cookies, and every web request attaches `Authorization: Bearer <token>` via the proxy fetch shim. Native requests were left anonymous, so `GetCurrentUser` resolved to nil and downstream chat session/context/stream calls were unauthenticated.

## Changes

- `QLService+URLSessionCookieClient.swift`: read the same Keychain token (service `app.affine.pro.auth-token`, keyed by the canonical server origin) and inject `Authorization: Bearer` by overriding the single `URLSessionClient.sendRequest` funnel (covers all Apollo GraphQL, the multipart message mutation, and blob-redirect calls). The token is gated on a **full canonical-origin match** (scheme + host + port), so it is never sent to external/presigned upload hosts or a different scheme/port.
- `ChatManager+Stream.swift`: the SSE `/stream` request bypasses Apollo, so it attaches the header explicitly via `QLService.shared.authorized(request)`.

## Test plan

- Native build of the Intelligents package
- Manual iOS check: signed-in native GraphQL/SSE requests now carry the Bearer token; external upload hosts untouched

Made with Cursor

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Native app requests now support secure token-based sign-in for authenticated server communication.
* **Bug Fixes**
  * Fixed streaming responses so they carry the same authentication as other app requests.
  * Improved request handling to avoid missing authorization on eligible connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->