### PR TITLE
docs: redesign README and add translations in 9 languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ testem.log
 tsconfig.tsbuildinfo
 .context
 /*.md
+!/README.*.md
 .codex
 .cursor
 

--- a/README.de.md
+++ b/README.de.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**Schreiben, zeichnen und planen — alles auf einmal.**
+
+Ein datenschutzfreundlicher, local-first, quelloffener Workspace. <br />
+Eine eng verschmolzene Plattform für Dokumente, Whiteboards und Datenbanken — eine sofort einsatzbereite Alternative zu Notion & Miro.
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[Website](https://affine.pro) · [Live-Demo](https://app.affine.pro) · [Download](https://affine.pro/download) · [Dokumentation](https://docs.affine.pro) · [Blog](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · Deutsch · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — schreiben, zeichnen und planen, alles auf einmal" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>Dokumente, Canvas und Tabellen verschmelzen in AFFiNE zu einem Ganzen — ganz im Sinne des Wortes „affin“ (englisch affine, əˈfʌɪn | a-fein).</em>
+
+</div>
+
+<br />
+
+## Was ist AFFiNE
+
+[AFFiNE](https://affine.pro) ist ein quelloffener All-in-one-Workspace — ein Betriebssystem für alle Bausteine deiner Wissensbasis: Wiki, Wissensmanagement, Präsentationen und digitale Assets. Dokumente und Whiteboards sind auf einer randlosen Canvas wirklich miteinander verschmolzen — das macht AFFiNE zur besseren Alternative zu Notion und Miro.
+
+<div align="center">
+<img alt="Randlose AFFiNE-Canvas mit Dokumenten, Notizen und Datenbanken" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## Zentrale Funktionen
+
+**🎨 Eine echte Canvas für Blöcke jeder Art — Dokumente und Whiteboard vollständig vereint**
+
+Viele Editoren bezeichnen sich als Canvas für produktives Arbeiten, aber AFFiNE gehört zu den ganz wenigen, bei denen du jeden Baustein auf einer randlosen Canvas platzieren kannst: Rich Text, Haftnotizen, eingebettete Webseiten, Datenbanken mit mehreren Ansichten, verknüpfte Seiten, Formen — sogar Folien.
+
+**🤖 Ein multimodaler KI-Partner, bereit für jede Aufgabe**
+
+Entwirf einen professionellen Bericht, verwandle eine Gliederung in ausdrucksstarke Folien, fasse einen Artikel in einer sauber strukturierten Mindmap zusammen oder zeichne und programmiere Prototyp-Apps aus einem einzigen Prompt — [AFFiNE AI](https://affine.pro/ai) treibt deine Kreativität bis an die Grenzen deiner Vorstellungskraft.
+
+**🔒 Local-first, mit Echtzeit-Kollaboration**
+
+Deine Daten liegen zuerst auf deiner eigenen Festplatte — und trotzdem unterstützt AFFiNE Echtzeit-Synchronisation und Zusammenarbeit über Web- und plattformübergreifende Clients hinweg.
+
+**🛠️ Open Source, selbst hostbar und ganz nach deinen Vorstellungen formbar**
+
+Du hast die Freiheit, AFFiNE selbst zu verwalten, zu hosten, zu forken und dein eigenes AFFiNE zu bauen. Der Editor basiert auf [BlockSuite](https://blocksuite.io), unserem quelloffenen, blockbasierten Editing-Framework.
+
+## Erste Schritte
+
+Es gibt drei Wege, mit AFFiNE loszulegen:
+
+| Option                  | Am besten für                                                                                       | Hier starten                                                                                                                    |
+| ----------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud**     | Null Einrichtungsaufwand — registriere dich und erstelle deinen ersten Workspace direkt im Browser. | [app.affine.pro öffnen](https://app.affine.pro)                                                                                 |
+| 💻 **Desktop & Mobile** | Native Apps für macOS, Windows, Linux, iOS und Android, mit Local-first-Speicherung.                | [AFFiNE herunterladen](https://affine.pro/download) · [GitHub Releases](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **Self-Hosted**      | Betreibe die volle Erfahrung auf deiner eigenen Infrastruktur mit Docker Compose.                   | [Zu „AFFiNE selbst hosten“ springen](#affine-selbst-hosten)                                                                     |
+
+> ⭐ **Gib uns einen Stern auf GitHub** — du bekommst alle Release-Benachrichtigungen sofort, und es hilft dem Projekt wirklich beim Wachsen.
+
+<img alt="AFFiNE auf GitHub mit einem Stern markieren" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## AFFiNE selbst hosten
+
+Betreibe dein eigenes, voll ausgestattetes AFFiNE — deine Daten, deine Regeln. Den veröffentlichten Self-Hosting-Stack kannst du kostenlos nutzen; der Editor, die Desktop-App und der Großteil der Codebasis stehen unter MIT-Lizenz, das Backend unter der AFFiNE-Enterprise-Edition-Lizenz.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# Passe in .env deine Zugangsdaten und Speicherpfade an, dann:
+docker compose up -d
+```
+
+Dein Workspace läuft jetzt unter `http://localhost:3010`.
+
+Für Konfiguration, Upgrades und Fehlerbehebung lies die [Self-Hosting-Dokumentation](https://docs.affine.pro/self-host-affine).
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**Deployment mit einem Klick:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+Du brauchst SSO, erweiterte Administration, Audit-Funktionen oder kommerzielles Self-Hosting mit Support? Sieh dir die [AFFiNE-Preispläne](https://affine.pro/pricing) an.
+
+## Mitwirken
+
+Entwicklerinnen und Entwickler, Tester, Tech-Writer und alle anderen — Beiträge jeder Art sind willkommen.
+
+| Bug-Reports                                                                                                                                          | Feature-Wünsche                                                                                                                                                 | Fragen & Diskussionen                                                    | Community                                             |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [Bug-Report erstellen](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Feature-Wunsch einreichen](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [AFFiNE Discord](https://affine.pro/redirect/discord) |
+| Etwas funktioniert nicht wie erwartet                                                                                                                | Ideen für neue Funktionen oder Verbesserungen                                                                                                                   | Fragen stellen und Ideen teilen                                          | Fragen, lernen und sich mit anderen austauschen       |
+
+- Lies [docs/types-of-contributions.md](docs/types-of-contributions.md), um die Art von Beitrag zu finden, die zu dir passt.
+- Interesse am Code? Starte mit [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) und dem [Contributor-Tutorial](./docs/contributing/tutorial.md) und such dir dann ein Issue aus.
+- Für **Übersetzungen** und **Sprachunterstützung** tritt unserem [Discord](https://affine.pro/redirect/discord) bei.
+- Für Meldungen von Sicherheitslücken siehe [SECURITY.md](SECURITY.md).
+
+**Bevor du beiträgst, lies und akzeptiere bitte unser [Contributor License Agreement].** Um deine Zustimmung zu erklären, bearbeite einfach diese Datei und reiche einen Pull Request ein.
+
+### Aus dem Quellcode bauen
+
+- **Codespaces**: Klicke auf der Hauptseite des Repos auf den grünen "Code"-Button und wähle "Create codespace on canary" — das geforkte Repo wird geklont, gebaut und ist sofort startklar.
+- **Lokal**: Die vollständige Anleitung findest du in [BUILDING.md].
+
+## Ökosystem
+
+| Paket                                            | Beschreibung                  | Status                                                                                                                                                                       |
+| ------------------------------------------------ | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | AFFiNE-Komponenten-Ressourcen | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | AFFiNE-Theme                  | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE wird erst möglich durch diese Open-Source-Projekte, auf denen wir aufbauen — danke:
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 das quelloffene kollaborative Editor-Projekt hinter AFFiNE.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 eine native, hochperformante, threadsichere yjs-CRDT-Implementierung, die AFFiNEs Local-first-Sync-Engine antreibt.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 die local-first, kollaborative Datenbank hinter AFFiNE, geschrieben in Rust.
+- [yjs](https://github.com/yjs/yjs) — grundlegende CRDT-Unterstützung für State-Management und Datensynchronisation.
+- … und viele weitere hervorragende [Abhängigkeiten](https://github.com/toeverything/AFFiNE/network/dependencies).
+
+## Danksagungen
+
+„Wir formen unsere Werkzeuge, und danach formen unsere Werkzeuge uns.“ Viele Pioniere haben uns auf dem Weg inspiriert:
+
+- Quip & Notion mit ihrem großartigen Konzept „Alles ist ein Block“
+- Trello mit seinem Kanban
+- Airtable & Miro mit ihren programmierbaren No-Code-Datenblättern
+- Miro & Whimsical mit ihren randlosen visuellen Whiteboards
+- RemNote & Capacities mit ihren objektbasierten Tag-Systemen
+
+Diese Apps teilen sich viele atomare „Bausteine“, doch keine von ihnen ist Open Source, und keine bietet ein Plugin-System wie VS Code für Mitwirkende. Wir wollen etwas, das alle Funktionen vereint, die wir lieben — und dann noch einen Schritt weitergeht.
+
+## Lizenz
+
+- **AFFiNE-Open-Source-Codebasis** — der Editor, die Desktop-App und der Großteil der Codebasis stehen unter MIT-Lizenz; Backend-/Server-Komponenten unterliegen der AFFiNE-Enterprise-Edition-Lizenz.
+- **AFFiNE Enterprise / kommerzielle Lizenzierung** — per kommerzieller Vereinbarung erhältlich für unternehmensorientierte Anforderungen wie SSO, erweiterte Administration, Audit, Rebranding und Self-Hosting mit Support. Mehr Informationen unter [affine.pro/pricing](https://affine.pro/pricing).
+
+Details findest du in der [LICENSE].
+
+<a id="contributors"></a>
+
+## Mitwirkende
+
+Wir möchten allen danken, die zu AFFiNE beigetragen haben! Wenn du ein Projekt, eine Dokumentation, ein Tool oder ein Template rund um AFFiNE gebaut hast, füge es gerne unserer kuratierten Liste hinzu: [awesome-affine](https://github.com/toeverything/awesome-affine).
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE contributors" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**Danke, dass du vorbeigeschaut hast — wir hoffen sehr, dass AFFiNE bei dir einen Nerv trifft! 🎵**
+
+[affine.pro](https://affine.pro) · [Dokumentation](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**Escribe, dibuja y planifica — todo a la vez.**
+
+Un espacio de trabajo de código abierto, local-first y centrado en la privacidad. <br />
+Una plataforma hiperfusionada de documentos, pizarras y bases de datos — una alternativa lista para usar a Notion y Miro.
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[Sitio web](https://affine.pro) · [Demo en vivo](https://app.affine.pro) · [Descargar](https://affine.pro/download) · [Documentación](https://docs.affine.pro) · [Blog](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · Español · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — escribe, dibuja y planifica, todo a la vez" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>En AFFiNE, documentos, lienzo y tablas están hiperfusionados — fiel a la palabra inglesa affine (əˈfʌɪn | a-fain), «afín».</em>
+
+</div>
+
+<br />
+
+## Qué es AFFiNE
+
+[AFFiNE](https://affine.pro) es un espacio de trabajo todo en uno y de código abierto: un sistema operativo para todos los bloques que componen tu base de conocimiento — wiki, gestión del conocimiento, presentaciones y activos digitales. Los documentos y las pizarras se funden de verdad en un único lienzo infinito, lo que convierte a AFFiNE en una mejor alternativa a Notion y Miro.
+
+<div align="center">
+<img alt="Lienzo infinito de AFFiNE con documentos, notas y bases de datos" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## Funciones principales
+
+**🎨 Un verdadero lienzo para bloques de cualquier tipo — documentos y pizarra totalmente fusionados**
+
+Muchos editores presumen de ser un lienzo para la productividad, pero AFFiNE es de los muy pocos que te permiten colocar cualquier bloque sobre un lienzo infinito: texto enriquecido, notas adhesivas, páginas web incrustadas, bases de datos con múltiples vistas, páginas enlazadas, figuras — incluso diapositivas.
+
+**🤖 Un compañero de IA multimodal, listo para cualquier trabajo**
+
+Redacta un informe profesional, convierte un esquema en diapositivas expresivas, resume un artículo en un mapa mental bien estructurado, o dibuja y programa prototipos de aplicaciones a partir de un solo prompt — [AFFiNE AI](https://affine.pro/ai) lleva tu creatividad hasta el límite de tu imaginación.
+
+**🔒 Local-first, con colaboración en tiempo real**
+
+Tus datos viven primero en tu propio disco, y aun así AFFiNE ofrece sincronización y colaboración en tiempo real en la web y en clientes multiplataforma.
+
+**🛠️ De código abierto, autoalojable y tuyo para moldearlo a tu gusto**
+
+Tienes plena libertad para gestionar, autoalojar, hacer fork y construir tu propio AFFiNE. El editor está construido sobre [BlockSuite](https://blocksuite.io), nuestro framework de edición basado en bloques y de código abierto.
+
+## Primeros pasos
+
+Hay tres formas de empezar a usar AFFiNE:
+
+| Opción                    | Ideal para                                                                                      | Empieza aquí                                                                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| ☁️ **AFFiNE Cloud**       | Cero configuración: regístrate y crea tu primer espacio de trabajo en el navegador.             | [Abrir app.affine.pro](https://app.affine.pro)                                                                                 |
+| 💻 **Escritorio y móvil** | Aplicaciones nativas para macOS, Windows, Linux, iOS y Android, con almacenamiento local-first. | [Descargar AFFiNE](https://affine.pro/download) · [Releases de GitHub](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **Autoalojado**        | Ejecuta la experiencia completa en tu propia infraestructura con Docker Compose.                | [Ir a Aloja tu propio AFFiNE](#aloja-tu-propio-affine)                                                                         |
+
+> ⭐ **Danos una estrella en GitHub** — recibirás todas las notificaciones de nuevas versiones al instante y, de verdad, ayuda a que el proyecto crezca.
+
+<img alt="Dale una estrella a AFFiNE en GitHub" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## Aloja tu propio AFFiNE
+
+Despliega tu propio AFFiNE con todas sus funciones — tus datos, tus reglas. Puedes ejecutar gratis el stack autoalojado publicado; el editor, la aplicación de escritorio y la mayor parte del código tienen licencia MIT, mientras que el backend está cubierto por la licencia AFFiNE Enterprise Edition.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# Edita .env para configurar tus credenciales y rutas de almacenamiento y, después:
+docker compose up -d
+```
+
+Tu espacio de trabajo ya está funcionando en `http://localhost:3010`.
+
+Para configuración, actualizaciones y resolución de problemas, consulta la [documentación de autoalojamiento](https://docs.affine.pro/self-host-affine).
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**Despliegue con un clic:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+¿Necesitas SSO, administración avanzada, auditoría o autoalojamiento comercial con soporte? Consulta los [planes de precios de AFFiNE](https://affine.pro/pricing).
+
+## Cómo contribuir
+
+Buscamos desarrolladores, testers, redactores técnicos y mucho más — las contribuciones de todo tipo son bienvenidas.
+
+| Reportes de errores                                                                                                                                      | Solicitudes de funciones                                                                                                                                             | Preguntas y debates                                                      | Comunidad                                                |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [Crea un reporte de error](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Envía una solicitud de función](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [Discord de AFFiNE](https://affine.pro/redirect/discord) |
+| Algo no funciona como debería                                                                                                                            | Ideas para nuevas funciones o mejoras                                                                                                                                | Haz preguntas y comparte ideas                                           | Pregunta, aprende y participa con otras personas         |
+
+- Lee [docs/types-of-contributions.md](docs/types-of-contributions.md) para encontrar el tipo de contribución que mejor encaja contigo.
+- ¿Te interesa el código? Empieza por [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) y el [tutorial para contribuidores](./docs/contributing/tutorial.md), y luego elige un issue.
+- Para **traducción** y **soporte de idiomas**, únete a nuestro [Discord](https://affine.pro/redirect/discord).
+- Para reportar vulnerabilidades, consulta [SECURITY.md](SECURITY.md).
+
+**Antes de contribuir, asegúrate de haber leído y aceptado nuestro [Contributor License Agreement].** Para expresar tu conformidad, simplemente edita ese archivo y envía un pull request.
+
+### Compilar desde el código fuente
+
+- **Codespaces**: desde la página principal del repositorio, haz clic en el botón verde "Code" y selecciona "Create codespace on canary" — el repositorio bifurcado se clona, se compila y queda listo para trabajar.
+- **Local**: consulta [BUILDING.md] para las instrucciones completas.
+
+## Ecosistema
+
+| Paquete                                          | Descripción                       | Estado                                                                                                                                                                       |
+| ------------------------------------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | Recursos de componentes de AFFiNE | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | Tema de AFFiNE                    | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE es posible gracias a estos proyectos de código abierto — gracias a todos ellos:
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 el proyecto de editor colaborativo de código abierto que hay detrás de AFFiNE.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 una implementación nativa, de alto rendimiento y thread-safe del CRDT de yjs que impulsa el motor de sincronización local-first de AFFiNE.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 la base de datos colaborativa y local-first detrás de AFFiNE, escrita en Rust.
+- [yjs](https://github.com/yjs/yjs) — el soporte CRDT fundamental para la gestión de estado y la sincronización de datos.
+- …y muchas otras excelentes [dependencias](https://github.com/toeverything/AFFiNE/network/dependencies).
+
+## Agradecimientos
+
+«Damos forma a nuestras herramientas y, después, nuestras herramientas nos dan forma a nosotros.» Muchos pioneros nos han inspirado en el camino:
+
+- Quip y Notion, con su gran concepto de «todo es un bloque»
+- Trello, con su Kanban
+- Airtable y Miro, con sus hojas de datos programables sin código
+- Miro y Whimsical, con sus pizarras visuales infinitas
+- RemNote y Capacities, con sus sistemas de etiquetas basados en objetos
+
+Estas aplicaciones comparten muchos «bloques de construcción» atómicos, pero ninguna es de código abierto ni ofrece un sistema de plugins al estilo de VS Code para sus contribuidores. Queremos algo que reúna todas las funciones que nos encantan — y que vaya un paso más allá.
+
+## Licencia
+
+- **Código base abierto de AFFiNE** — el editor, la aplicación de escritorio y la mayor parte del código tienen licencia MIT; los componentes de backend/servidor están cubiertos por la licencia AFFiNE Enterprise Edition.
+- **AFFiNE Enterprise / licencias comerciales** — disponibles mediante acuerdo comercial para necesidades empresariales como SSO, administración avanzada, auditoría, personalización de marca y autoalojamiento con soporte. Consulta [affine.pro/pricing](https://affine.pro/pricing) para más información.
+
+Consulta [LICENSE] para más detalles.
+
+<a id="contributors"></a>
+
+## Contribuidores
+
+¡Queremos expresar nuestra gratitud a todas las personas que han contribuido a AFFiNE! Si has creado un proyecto, documentación, herramienta o plantilla relacionados con AFFiNE, no dudes en añadirlo a nuestra lista curada: [awesome-affine](https://github.com/toeverything/awesome-affine).
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="Contribuidores de AFFiNE" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**Gracias por pasarte por aquí — ¡esperamos de corazón que AFFiNE resuene contigo! 🎵**
+
+[affine.pro](https://affine.pro) · [Documentación](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**Écrivez, dessinez et planifiez — tout à la fois.**
+
+Un espace de travail open source, local-first et respectueux de votre vie privée. <br />
+Une plateforme hyper-fusionnée pour vos documents, tableaux blancs et bases de données — une alternative prête à l'emploi à Notion et Miro.
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[Site web](https://affine.pro) · [Démo en ligne](https://app.affine.pro) · [Télécharger](https://affine.pro/download) · [Documentation](https://docs.affine.pro) · [Blog](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · Français · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — écrivez, dessinez et planifiez tout à la fois" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>Documents, canevas et tableaux sont hyper-fusionnés dans AFFiNE — à l'image du mot affine (əˈfʌɪn | a-fine), qui évoque l'affinité.</em>
+
+</div>
+
+<br />
+
+## Qu'est-ce qu'AFFiNE
+
+[AFFiNE](https://affine.pro) est un espace de travail tout-en-un et open source — un véritable système d'exploitation pour toutes les briques de votre base de connaissances : wiki, gestion des connaissances, présentations et ressources numériques. Documents et tableaux blancs fusionnent réellement sur un même canevas sans bords, faisant d'AFFiNE une meilleure alternative à Notion et Miro.
+
+<div align="center">
+<img alt="Le canevas sans bords d'AFFiNE avec documents, notes et bases de données" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## Fonctionnalités clés
+
+**🎨 Un vrai canevas pour des blocs de toutes formes — documents et tableau blanc entièrement fusionnés**
+
+Beaucoup d'éditeurs se présentent comme un canevas de productivité, mais AFFiNE fait partie des rares qui vous laissent placer n'importe quelle brique sur un canevas sans bords : texte riche, notes adhésives, pages web intégrées, bases de données multi-vues, pages liées, formes — et même des diapositives.
+
+**🤖 Un partenaire IA multimodal, prêt pour toutes vos tâches**
+
+Rédigez un rapport professionnel, transformez un plan en diapositives expressives, résumez un article en une carte mentale bien structurée, ou dessinez et codez des prototypes d'applications à partir d'une simple consigne — [AFFiNE AI](https://affine.pro/ai) pousse votre créativité aux confins de votre imagination.
+
+**🔒 Local-first, avec collaboration en temps réel**
+
+Vos données vivent d'abord sur votre propre disque, tandis qu'AFFiNE prend aussi en charge la synchronisation et la collaboration en temps réel sur le web et les clients multiplateformes.
+
+**🛠️ Open source, auto-hébergeable, et façonnable à votre guise**
+
+Vous êtes libre de gérer, d'auto-héberger, de forker et de construire votre propre AFFiNE. L'éditeur repose sur [BlockSuite](https://blocksuite.io), notre framework open source d'édition par blocs.
+
+## Premiers pas
+
+Il existe trois façons de commencer à utiliser AFFiNE :
+
+| Option                  | Idéal pour                                                                                        | Commencer ici                                                                                                                 |
+| ----------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud**     | Aucune installation — inscrivez-vous et créez votre premier espace de travail dans le navigateur. | [Ouvrir app.affine.pro](https://app.affine.pro)                                                                               |
+| 💻 **Bureau et mobile** | Applications natives pour macOS, Windows, Linux, iOS et Android, avec stockage local-first.       | [Télécharger AFFiNE](https://affine.pro/download) · [Versions GitHub](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **Auto-hébergé**     | Exécutez l'expérience complète sur votre propre infrastructure avec Docker Compose.               | [Aller à l'auto-hébergement](#auto-héberger-affine)                                                                           |
+
+> ⭐ **Mettez-nous une étoile sur GitHub** — vous recevrez instantanément toutes les notifications de nouvelles versions, et cela aide réellement le projet à grandir.
+
+<img alt="Mettre une étoile à AFFiNE sur GitHub" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## Auto-héberger AFFiNE
+
+Déployez votre propre AFFiNE, riche en fonctionnalités — vos données, vos règles. Vous pouvez exécuter gratuitement la pile auto-hébergée publiée ; l'éditeur, l'application de bureau et l'essentiel du code sont sous licence MIT, tandis que le backend est couvert par la licence AFFiNE Enterprise Edition.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# Modifiez .env pour définir vos identifiants et chemins de stockage, puis :
+docker compose up -d
+```
+
+Votre espace de travail tourne désormais sur `http://localhost:3010`.
+
+Pour la configuration, les mises à niveau et le dépannage, consultez la [documentation d'auto-hébergement](https://docs.affine.pro/self-host-affine).
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**Déploiement en un clic :**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+Besoin de SSO, d'administration avancée, d'audit ou d'un auto-hébergement commercial avec support ? Consultez les [offres tarifaires d'AFFiNE](https://affine.pro/pricing).
+
+## Contribuer
+
+Appel à tous les développeurs, testeurs, rédacteurs techniques et autres — les contributions de tous types sont les bienvenues.
+
+| Rapports de bugs                                                                                                                                        | Demandes de fonctionnalités                                                                                                                                                   | Questions et discussions                                                 | Communauté                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [Créer un rapport de bug](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Soumettre une demande de fonctionnalité](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [Discord AFFiNE](https://affine.pro/redirect/discord) |
+| Quelque chose ne fonctionne pas comme prévu                                                                                                             | Idées de nouvelles fonctionnalités ou d'améliorations                                                                                                                         | Posez vos questions et partagez vos idées                                | Échangez, apprenez et discutez avec les autres        |
+
+- Lisez [docs/types-of-contributions.md](docs/types-of-contributions.md) pour trouver la contribution qui vous convient.
+- Le code vous intéresse ? Commencez par [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) et le [tutoriel du contributeur](./docs/contributing/tutorial.md), puis choisissez une issue.
+- Pour la **traduction** et le **support linguistique**, rejoignez notre [Discord](https://affine.pro/redirect/discord).
+- Pour signaler une vulnérabilité, consultez [SECURITY.md](SECURITY.md).
+
+**Avant de contribuer, assurez-vous d'avoir lu et accepté notre [Contributor License Agreement].** Pour signifier votre accord, il vous suffit de modifier ce fichier et de soumettre une pull request.
+
+### Compiler depuis les sources
+
+- **Codespaces** : depuis la page principale du dépôt, cliquez sur le bouton vert "Code" et sélectionnez "Create codespace on canary" — le dépôt forké est cloné, compilé et prêt à l'emploi.
+- **En local** : consultez [BUILDING.md] pour les instructions complètes.
+
+## Écosystème
+
+| Paquet                                           | Description                     | Statut                                                                                                                                                                       |
+| ------------------------------------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | Ressources de composants AFFiNE | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | Thème AFFiNE                    | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE existe grâce à ces projets open source en amont — merci à eux :
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 le projet d'éditeur collaboratif open source au cœur d'AFFiNE.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 une implémentation CRDT yjs native, performante et thread-safe qui alimente le moteur de synchronisation local-first d'AFFiNE.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 la base de données collaborative local-first derrière AFFiNE, écrite en Rust.
+- [yjs](https://github.com/yjs/yjs) — le support CRDT fondamental pour la gestion d'état et la synchronisation des données.
+- …et bien d'autres excellentes [dépendances](https://github.com/toeverything/AFFiNE/network/dependencies).
+
+## Remerciements
+
+« Nous façonnons nos outils, et ensuite nos outils nous façonnent. » De nombreux pionniers nous ont inspirés en chemin :
+
+- Quip et Notion, avec leur formidable concept du « tout est un bloc »
+- Trello, avec son Kanban
+- Airtable et Miro, avec leurs feuilles de données programmables sans code
+- Miro et Whimsical, avec leurs tableaux blancs visuels sans bords
+- RemNote et Capacities, avec leurs systèmes de tags orientés objets
+
+Ces applications partagent un large socle de « briques » atomiques, mais aucune n'est open source, et aucune n'offre un système de plugins à la VS Code pour les contributeurs. Nous voulons un outil qui réunisse toutes les fonctionnalités que nous aimons — et qui aille encore un pas plus loin.
+
+## Licence
+
+- **Code open source d'AFFiNE** — l'éditeur, l'application de bureau et l'essentiel du code sont sous licence MIT ; les composants backend/serveur sont couverts par la licence AFFiNE Enterprise Edition.
+- **AFFiNE Enterprise / licence commerciale** — disponible par accord commercial pour les besoins d'entreprise tels que le SSO, l'administration avancée, l'audit, la personnalisation de marque et l'auto-hébergement avec support. Consultez [affine.pro/pricing](https://affine.pro/pricing) pour en savoir plus.
+
+Voir [LICENSE] pour les détails.
+
+<a id="contributors"></a>
+
+## Contributeurs
+
+Nous tenons à exprimer notre gratitude à toutes les personnes qui ont contribué à AFFiNE ! Si vous avez créé un projet, une documentation, un outil ou un modèle lié à AFFiNE, n'hésitez pas à l'ajouter à notre liste : [awesome-affine](https://github.com/toeverything/awesome-affine).
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE contributors" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**Merci de votre visite — nous espérons sincèrement qu'AFFiNE trouvera un écho chez vous ! 🎵**
+
+[affine.pro](https://affine.pro) · [Documentation](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**書く・描く・計画する — すべてを一度に。**
+
+プライバシー重視、ローカルファーストのオープンソースワークスペース。<br />
+ドキュメント・ホワイトボード・データベースを一つに融合したプラットフォーム — Notion と Miro に代わる、すぐに使える選択肢です。
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[公式サイト](https://affine.pro) · [ライブデモ](https://app.affine.pro) · [ダウンロード](https://affine.pro/download) · [ドキュメント](https://docs.affine.pro) · [ブログ](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · 日本語 · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — write, draw and plan all at once" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>ドキュメント・キャンバス・テーブルが高度に融合した AFFiNE。その名前は英単語 affine(アフィン | əˈfʌɪn | a-fine)に由来しています。</em>
+
+</div>
+
+<br />
+
+## AFFiNE とは
+
+[AFFiNE](https://affine.pro) は、オープンソースのオールインワンワークスペースです。wiki、ナレッジ管理、プレゼンテーション、デジタルアセットなど、ナレッジベースを構成するあらゆるビルディングブロックのためのオペレーティングシステムと言えます。ドキュメントとホワイトボードがひとつのエッジレスキャンバス上で真に融合しており、Notion や Miro に代わるより良い選択肢となります。
+
+<div align="center">
+<img alt="AFFiNE edgeless canvas with docs, notes and databases" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## 主な特長
+
+**🎨 あらゆる形のブロックを置ける、本物のキャンバス — ドキュメントとホワイトボードの完全な融合**
+
+「生産性のためのキャンバス」を謳うエディタは数多くありますが、リッチテキスト、付箋、埋め込み Web ページ、マルチビューデータベース、リンクされたページ、図形、さらにはスライドまで、あらゆるビルディングブロックをエッジレスキャンバスに配置できるのは、AFFiNE を含むごくわずかなツールだけです。
+
+**🤖 どんな仕事にも応えるマルチモーダル AI パートナー**
+
+プロフェッショナルなレポートの下書き、アウトラインから表現力豊かなスライドへの変換、記事を整理されたマインドマップに要約、ひとつのプロンプトからプロトタイプアプリの描画とコーディングまで — [AFFiNE AI](https://affine.pro/ai) があなたの創造力を想像の限界まで押し広げます。
+
+**🔒 ローカルファースト、それでいてリアルタイム共同編集**
+
+データはまずあなた自身のディスクに保存されます。それでいて AFFiNE は、Web とクロスプラットフォームクライアントをまたいだリアルタイム同期・共同編集にも対応しています。
+
+**🛠️ オープンソースでセルフホスト可能、自由にカスタマイズできる**
+
+AFFiNE は自由に管理・セルフホスト・フォークして、自分だけの AFFiNE を作ることができます。エディタは、当社のオープンソースなブロックベース編集フレームワーク [BlockSuite](https://blocksuite.io) の上に構築されています。
+
+## はじめに
+
+AFFiNE の使い始め方は 3 通りあります。
+
+| 選択肢                         | こんな方に                                                                                                 | はじめる                                                                                                                         |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud**            | セットアップ不要 — サインアップするだけで、ブラウザ上に最初のワークスペースを作成できます。                | [app.affine.pro を開く](https://app.affine.pro)                                                                                  |
+| 💻 **デスクトップ & モバイル** | macOS・Windows・Linux・iOS・Android 向けのネイティブアプリ。ローカルファーストのストレージを備えています。 | [AFFiNE をダウンロード](https://affine.pro/download) · [GitHub Releases](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **セルフホスト**            | Docker Compose を使い、自分のインフラ上でフル機能を動かせます。                                            | [セルフホストの手順へ](#affine-をセルフホストする)                                                                               |
+
+> ⭐ **GitHub でスターをお願いします** — すべてのリリース通知を即座に受け取れるうえ、プロジェクトの成長への大きな後押しになります。
+
+<img alt="Star AFFiNE on GitHub" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## AFFiNE をセルフホストする
+
+機能豊富な AFFiNE を自分でデプロイしましょう — あなたのデータは、あなたのルールで。公開されているセルフホスト用スタックは無料で運用できます。エディタ・デスクトップアプリを含むコードベースの大部分は MIT ライセンスで、バックエンドは AFFiNE Enterprise Edition ライセンスの対象です。
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# .env を編集して認証情報とストレージパスを設定したら、次を実行します:
+docker compose up -d
+```
+
+これでワークスペースが `http://localhost:3010` で稼働します。
+
+設定・アップグレード・トラブルシューティングについては、[セルフホストのドキュメント](https://docs.affine.pro/self-host-affine)をご覧ください。
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**ワンクリックデプロイ:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+SSO、高度な管理機能、監査、サポート付きの商用セルフホスティングが必要な場合は、[AFFiNE の料金プラン](https://affine.pro/pricing)をご覧ください。
+
+## コントリビュート
+
+開発者、テスター、テクニカルライターをはじめ、あらゆる形の貢献を歓迎します。
+
+| バグ報告                                                                                                                                           | 機能リクエスト                                                                                                                                             | 質問・ディスカッション                                                   | コミュニティ                                          |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [バグレポートを作成](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [機能リクエストを送信](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [AFFiNE Discord](https://affine.pro/redirect/discord) |
+| 期待どおりに動作しないとき                                                                                                                         | 新機能や改善のアイデア                                                                                                                                     | 質問やアイデアの共有                                                     | 質問し、学び、交流する場                              |
+
+- [docs/types-of-contributions.md](docs/types-of-contributions.md) を読んで、自分に合った貢献の形を見つけてください。
+- コードに興味がありますか?まずは [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) と[コントリビューターチュートリアル](./docs/contributing/tutorial.md)を読み、取り組む issue を選びましょう。
+- **翻訳**や**言語サポート**については、[Discord](https://affine.pro/redirect/discord) にご参加ください。
+- 脆弱性の報告については [SECURITY.md](SECURITY.md) をご覧ください。
+
+**貢献の前に、必ず [Contributor License Agreement] を読み、同意してください。**同意を示すには、該当ファイルを編集してプルリクエストを送るだけで完了です。
+
+### ソースからビルドする
+
+- **Codespaces**: リポジトリのトップページで緑色の "Code" ボタンをクリックし、"Create codespace on canary" を選択します。フォークしたリポジトリのクローンとビルドが自動で行われ、すぐに開発を始められます。
+- **ローカル**: 詳しい手順は [BUILDING.md] をご覧ください。
+
+## エコシステム
+
+| パッケージ                                       | 説明                            | ステータス                                                                                                                                                                   |
+| ------------------------------------------------ | ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | AFFiNE のコンポーネントリソース | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | AFFiNE のテーマ                 | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE は、次のオープンソースプロジェクトの上に成り立っています — 心から感謝します。
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 AFFiNE を支えるオープンソースの共同編集エディタプロジェクト。
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 AFFiNE のローカルファースト同期エンジンを駆動する、ネイティブで高性能かつスレッドセーフな yjs CRDT 実装。
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 Rust で書かれた、AFFiNE を支えるローカルファーストの共同編集データベース。
+- [yjs](https://github.com/yjs/yjs) — 状態管理とデータ同期のための基盤となる CRDT サポート。
+- ……そのほか多くの優れた[依存パッケージ](https://github.com/toeverything/AFFiNE/network/dependencies)。
+
+## 謝辞
+
+「私たちは道具を形作り、その後、道具が私たちを形作る。」その道のりで、多くの先駆者たちからインスピレーションを受けてきました。
+
+- Quip と Notion — 「すべてはブロックである」という優れたコンセプト
+- Trello — カンバン
+- Airtable と Miro — ノーコードでプログラマブルなデータシート
+- Miro と Whimsical — エッジレスなビジュアルホワイトボード
+- RemNote と Capacities — オブジェクトベースのタグシステム
+
+これらのアプリは、原子的な「ビルディングブロック」という点で多くの共通項を持っていますが、いずれもオープンソースではなく、コントリビューター向けの VS Code のようなプラグインシステムも提供していません。私たちが目指すのは、愛するこれらの機能をすべて備え、さらにその一歩先を行くツールです。
+
+## ライセンス
+
+- **AFFiNE オープンソースコードベース** — エディタ・デスクトップアプリを含むコードベースの大部分は MIT ライセンスです。バックエンド/サーバーコンポーネントは AFFiNE Enterprise Edition ライセンスの対象です。
+- **AFFiNE Enterprise / 商用ライセンス** — SSO、高度な管理機能、監査、リブランディング、サポート付きセルフホスティングなど、エンタープライズ向けのニーズに対して商用契約で提供しています。詳細は [affine.pro/pricing](https://affine.pro/pricing) をご覧ください。
+
+詳しくは [LICENSE] をご覧ください。
+
+<a id="contributors"></a>
+
+## コントリビューター
+
+AFFiNE に貢献してくださったすべての皆さまに感謝します!AFFiNE に関連するプロジェクト、ドキュメント、ツール、テンプレートを作成した方は、キュレーションリスト [awesome-affine](https://github.com/toeverything/awesome-affine) への追加をぜひご検討ください。
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE contributors" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**ご覧いただきありがとうございます — AFFiNE があなたの心に響きますように!🎵**
+
+[affine.pro](https://affine.pro) · [ドキュメント](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**쓰기, 그리기, 계획하기 — 모두 한 번에.**
+
+프라이버시를 중시하는 로컬 퍼스트 오픈소스 워크스페이스. <br />
+문서, 화이트보드, 데이터베이스를 하나로 융합한 플랫폼 — 바로 사용할 수 있는 Notion & Miro의 대안입니다.
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[웹사이트](https://affine.pro) · [라이브 데모](https://app.affine.pro) · [다운로드](https://affine.pro/download) · [문서](https://docs.affine.pro) · [블로그](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · 한국어 · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — 쓰기, 그리기, 계획하기, 모두 한 번에" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>AFFiNE에서는 문서, 캔버스, 테이블이 하나로 융합됩니다 — affine(어파인, əˈfʌɪn | a-fine)이라는 단어의 뜻 그대로입니다.</em>
+
+</div>
+
+<br />
+
+## AFFiNE이란
+
+[AFFiNE](https://affine.pro)은 오픈소스 올인원 워크스페이스로, 위키, 지식 관리, 프레젠테이션, 디지털 자산 등 지식 베이스를 이루는 모든 구성 요소를 담는 운영체제입니다. 문서와 화이트보드가 하나의 엣지리스 캔버스 위에서 진정으로 융합되어 있어, AFFiNE은 Notion과 Miro의 더 나은 대안이 됩니다.
+
+<div align="center">
+<img alt="문서, 노트, 데이터베이스가 어우러진 AFFiNE 엣지리스 캔버스" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## 주요 기능
+
+**🎨 모든 형태의 블록을 담는 진정한 캔버스 — 문서와 화이트보드의 완전한 융합**
+
+많은 에디터가 생산성을 위한 캔버스를 표방하지만, 리치 텍스트, 스티커 메모, 임베드된 웹 페이지, 멀티뷰 데이터베이스, 링크된 페이지, 도형, 심지어 슬라이드까지 어떤 구성 요소든 엣지리스 캔버스 위에 자유롭게 배치할 수 있는 에디터는 AFFiNE을 포함해 극소수뿐입니다.
+
+**🤖 어떤 작업이든 함께하는 멀티모달 AI 파트너**
+
+전문적인 보고서의 초안을 잡고, 개요를 표현력 있는 슬라이드로 바꾸고, 글 한 편을 잘 짜인 마인드맵으로 요약하고, 프롬프트 하나로 프로토타입 앱을 그리고 코딩하기까지 — [AFFiNE AI](https://affine.pro/ai)는 여러분의 창의력을 상상력의 끝까지 밀어 올립니다.
+
+**🔒 로컬 퍼스트, 그리고 실시간 협업**
+
+데이터는 무엇보다 먼저 여러분의 디스크에 저장되며, 그러면서도 AFFiNE은 웹과 크로스 플랫폼 클라이언트 전반의 실시간 동기화와 협업을 지원합니다.
+
+**🛠️ 오픈소스, 셀프 호스팅 — 원하는 대로 만들어 갈 수 있습니다**
+
+AFFiNE을 자유롭게 관리하고, 직접 호스팅하고, 포크하여 자신만의 AFFiNE을 만들 수 있습니다. 에디터는 저희가 만든 오픈소스 블록 기반 편집 프레임워크인 [BlockSuite](https://blocksuite.io) 위에 구축되어 있습니다.
+
+## 시작하기
+
+AFFiNE을 시작하는 방법은 세 가지입니다.
+
+| 방법                     | 이런 분께 적합합니다                                                                      | 시작하기                                                                                                                 |
+| ------------------------ | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| ☁️ **AFFiNE Cloud**      | 설정이 전혀 필요 없습니다 — 가입 후 브라우저에서 바로 첫 워크스페이스를 만들 수 있습니다. | [app.affine.pro 열기](https://app.affine.pro)                                                                            |
+| 💻 **데스크톱 & 모바일** | macOS, Windows, Linux, iOS, Android용 네이티브 앱과 로컬 퍼스트 저장소를 제공합니다.      | [AFFiNE 다운로드](https://affine.pro/download) · [GitHub 릴리스](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **셀프 호스팅**       | Docker Compose로 자체 인프라에서 모든 기능을 그대로 운영할 수 있습니다.                   | [AFFiNE 셀프 호스팅으로 이동](#affine-셀프-호스팅)                                                                       |
+
+> ⭐ **GitHub에서 스타를 눌러 주세요** — 모든 릴리스 알림을 즉시 받을 수 있고, 프로젝트가 성장하는 데 실질적인 힘이 됩니다.
+
+<img alt="GitHub에서 AFFiNE에 스타 누르기" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## AFFiNE 셀프 호스팅
+
+풍부한 기능을 갖춘 AFFiNE을 직접 배포하세요 — 여러분의 데이터는 여러분의 규칙을 따릅니다. 공개된 셀프 호스팅 스택은 무료로 실행할 수 있습니다. 에디터와 데스크톱 앱을 포함한 코드베이스 대부분은 MIT 라이선스이며, 백엔드에는 AFFiNE Enterprise Edition 라이선스가 적용됩니다.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# .env 파일을 열어 자격 증명과 저장 경로를 설정한 뒤 실행합니다:
+docker compose up -d
+```
+
+이제 `http://localhost:3010`에서 워크스페이스가 실행됩니다.
+
+설정, 업그레이드, 문제 해결에 대해서는 [셀프 호스팅 문서](https://docs.affine.pro/self-host-affine)를 참고하세요.
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**원클릭 배포:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+SSO, 고급 관리자 기능, 감사 로그, 지원이 포함된 상용 셀프 호스팅이 필요하신가요? [AFFiNE 요금제](https://affine.pro/pricing)를 확인해 보세요.
+
+## 기여하기
+
+개발자, 테스터, 테크니컬 라이터를 비롯한 모든 분을 기다립니다 — 어떤 형태의 기여든 환영합니다.
+
+| 버그 리포트                                                                                                                                          | 기능 제안                                                                                                                                           | 질문 & 토론                                                              | 커뮤니티                                              |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [버그 리포트 작성하기](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [기능 제안하기](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [AFFiNE Discord](https://affine.pro/redirect/discord) |
+| 무언가 기대대로 동작하지 않을 때                                                                                                                     | 새 기능이나 개선에 대한 아이디어가 있을 때                                                                                                          | 질문하고 아이디어를 나누는 곳                                            | 묻고, 배우고, 함께 어울리는 곳                        |
+
+- 자신에게 맞는 기여 방식을 찾으려면 [docs/types-of-contributions.md](docs/types-of-contributions.md)를 읽어 보세요.
+- 코드로 기여하고 싶다면 [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)와 [기여자 튜토리얼](./docs/contributing/tutorial.md)로 시작한 뒤 이슈를 하나 골라 보세요.
+- **번역**과 **언어 지원**에 관해서는 [Discord](https://affine.pro/redirect/discord)에 참여해 주세요.
+- 취약점 제보는 [SECURITY.md](SECURITY.md)를 참고하세요.
+
+**기여하기 전에 반드시 [Contributor License Agreement]를 읽고 동의해 주시기 바랍니다.** 해당 파일을 수정해 풀 리퀘스트를 보내는 것으로 동의 의사를 표시할 수 있습니다.
+
+### 소스에서 빌드하기
+
+- **Codespaces**: 저장소 메인 페이지에서 초록색 "Code" 버튼을 클릭하고 "Create codespace on canary"를 선택하면, 포크된 저장소가 클론과 빌드를 마친 상태로 바로 준비됩니다.
+- **로컬**: 자세한 방법은 [BUILDING.md]를 참고하세요.
+
+## 생태계
+
+| 패키지                                           | 설명                   | 상태                                                                                                                                                                         |
+| ------------------------------------------------ | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | AFFiNE 컴포넌트 리소스 | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | AFFiNE 테마            | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE은 다음의 오픈소스 업스트림 프로젝트들 덕분에 존재할 수 있습니다 — 감사드립니다:
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 AFFiNE을 움직이는 오픈소스 협업 에디터 프로젝트입니다.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 AFFiNE의 로컬 퍼스트 동기화 엔진을 구동하는 네이티브 고성능 스레드 세이프 yjs CRDT 구현체입니다.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 Rust로 작성된, AFFiNE의 로컬 퍼스트 협업 데이터베이스입니다.
+- [yjs](https://github.com/yjs/yjs) — 상태 관리와 데이터 동기화의 근간이 되는 CRDT를 제공합니다.
+- …그 밖에도 수많은 훌륭한 [의존성](https://github.com/toeverything/AFFiNE/network/dependencies)이 함께합니다.
+
+## 감사의 말
+
+"우리는 도구를 만들고, 그 도구는 다시 우리를 만든다." 많은 선구자들이 우리에게 영감을 주었습니다:
+
+- "모든 것은 블록"이라는 훌륭한 개념을 보여 준 Quip & Notion
+- 칸반을 선보인 Trello
+- 노코드로 프로그래밍할 수 있는 데이터시트를 만든 Airtable & Miro
+- 엣지리스 비주얼 화이트보드를 개척한 Miro & Whimsical
+- 객체 기반 태그 시스템을 제시한 RemNote & Capacities
+
+이 앱들은 원자적인 "구성 요소"를 상당 부분 공유하지만, 오픈소스인 것도 없고 기여자를 위한 VS Code 같은 플러그인 시스템을 제공하는 것도 없습니다. 우리는 우리가 사랑하는 기능을 모두 담고, 거기서 한 걸음 더 나아가는 도구를 만들고자 합니다.
+
+## 라이선스
+
+- **AFFiNE 오픈소스 코드베이스** — 에디터, 데스크톱 앱을 포함한 코드베이스 대부분은 MIT 라이선스이며, 백엔드/서버 구성 요소에는 AFFiNE Enterprise Edition 라이선스가 적용됩니다.
+- **AFFiNE Enterprise / 상용 라이선스** — SSO, 고급 관리자 기능, 감사 로그, 리브랜딩, 지원이 포함된 셀프 호스팅 등 기업의 요구 사항을 위해 상용 계약으로 제공됩니다. 자세한 내용은 [affine.pro/pricing](https://affine.pro/pricing)을 참고하세요.
+
+자세한 내용은 [LICENSE]를 확인하세요.
+
+<a id="contributors"></a>
+
+## 기여자
+
+AFFiNE에 기여해 주신 모든 분께 감사드립니다! AFFiNE 관련 프로젝트, 문서, 도구, 템플릿을 만드셨다면 큐레이션 목록인 [awesome-affine](https://github.com/toeverything/awesome-affine)에 자유롭게 추가해 주세요.
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE 기여자" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**찾아와 주셔서 감사합니다 — AFFiNE이 여러분의 마음에 울림을 주기를 진심으로 바랍니다! 🎵**
+
+[affine.pro](https://affine.pro) · [문서](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.md
+++ b/README.md
@@ -1,225 +1,187 @@
 <div align="center">
 
-<h1 style="border-bottom: none">
-    <b><a href="https://affine.pro">AFFiNE.Pro</a></b><br />
-    Write, Draw and Plan All at Once
-    <br>
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
 </h1>
-<a href="https://affine.pro/download">
-    <img alt="affine logo" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%">
-</a>
-<br/>
-<p align="center">
-  A privacy-focused, local-first, open-source, and ready-to-use alternative for Notion & Miro. <br />
-  One hyper-fused platform for wildly creative minds.
-</p>
 
-<br/>
+**Write, draw and plan — all at once.**
 
-<br/>
-<a href="https://www.producthunt.com/posts/affine-3?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-affine&#0045;3" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=440671&theme=light" alt="AFFiNE - One&#0032;app&#0032;for&#0032;all&#0032;&#0045;&#0032;Where&#0032;Notion&#0032;meets&#0032;Miro | Product Hunt" style="width: 250px; height: 54px;" width="250" height="54" /></a>
-<br/>
-<br/>
+A privacy-focused, local-first, open-source workspace. <br />
+One hyper-fused platform for docs, whiteboards and databases — a ready-to-use alternative to Notion & Miro.
 
-<div align="center">
-    <a href="https://affine.pro">Home Page</a> |
-    <a href="https://affine.pro/redirect/discord">Discord</a> |
-    <a href="https://app.affine.pro">Live Demo</a> |
-    <a href="https://affine.pro/blog/">Blog</a> |
-    <a href="https://docs.affine.pro/">Documentation</a>
-</div>
-<br/>
+<br />
 
-[![Releases](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
 [![All Contributors][all-contributors-badge]](#contributors)
-[![TypeScript-version-icon]](https://www.typescriptlang.org/)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[Website](https://affine.pro) · [Live Demo](https://app.affine.pro) · [Download](https://affine.pro/download) · [Documentation](https://docs.affine.pro) · [Blog](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+English · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — write, draw and plan all at once" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>Docs, canvas and tables are hyper-merged with AFFiNE — just like the word affine (əˈfʌɪn | a-fine).</em>
 
 </div>
 
 <br />
-<div align="center">
-<em>Docs, canvas and tables are hyper-merged with AFFiNE - just like the word affine (əˈfʌɪn | a-fine).</em>
-</div>
-<br />
-
-<div align="center">
-<img src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
-</div>
-
-## Getting started & staying tuned with us.
-
-Star us, and you will receive all release notifications from GitHub without any delay!
-
-<img src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
 
 ## What is AFFiNE
 
-[AFFiNE](https://affine.pro) is an open-source, all-in-one workspace and an operating system for all the building blocks that assemble your knowledge base and much more -- wiki, knowledge management, presentation and digital assets. It's a better alternative to Notion and Miro.
+[AFFiNE](https://affine.pro) is an open-source, all-in-one workspace — an operating system for all the building blocks of your knowledge base: wiki, knowledge management, presentations and digital assets. Docs and whiteboards are truly merged on one edgeless canvas, making AFFiNE a better alternative to Notion and Miro.
 
-## Features
+<div align="center">
+<img alt="AFFiNE edgeless canvas with docs, notes and databases" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
 
-**A true canvas for blocks in any form. Docs and whiteboard are now fully merged.**
+## Key Features
 
-- Many editor apps claim to be a canvas for productivity, but AFFiNE is one of the very few which allows you to put any building block on an edgeless canvas -- rich text, sticky notes, any embedded web pages, multi-view databases, linked pages, shapes and even slides. We have it all.
+**🎨 A true canvas for blocks in any form — docs and whiteboard fully merged**
 
-**Multimodal AI partner ready to kick in any work**
+Many editors claim to be a canvas for productivity, but AFFiNE is one of the very few that lets you place any building block on an edgeless canvas: rich text, sticky notes, embedded web pages, multi-view databases, linked pages, shapes — even slides.
 
-- Write up professional work report? Turn an outline into expressive and presentable slides? Summary an article into a well-structured mindmap? Sorting your job plan and backlog for tasks? Or... draw and code prototype apps and web pages directly all with one prompt? With you, [AFFiNE AI](https://affine.pro/ai) pushes your creativity to the edge of your imagination, just like [Canvas AI](https://affine.pro/blog/best-canvas-ai) to generate mind map for brainstorming.
+**🤖 A multimodal AI partner, ready for any work**
 
-**Local-first & Real-time collaborative**
+Draft a professional report, turn an outline into expressive slides, summarize an article into a well-structured mind map, or draw and code prototype apps from a single prompt — [AFFiNE AI](https://affine.pro/ai) pushes your creativity to the edge of your imagination.
 
-- We love the idea of local-first that you always own your data on your disk, in spite of the cloud. Furthermore, AFFiNE supports real-time sync and collaborations on web and cross-platform clients.
+**🔒 Local-first, with real-time collaboration**
 
-**Self-host & Shape your own AFFiNE**
+Your data lives on your own disk first, while AFFiNE still supports real-time sync and collaboration across web and cross-platform clients.
 
-- You have the freedom to manage, self-host, fork and build your own AFFiNE. Plugin community and third-party blocks are coming soon. More tractions on [Blocksuite](https://blocksuite.io). Check there to learn how to [self-host AFFiNE](https://docs.affine.pro/self-host-affine).
+**🛠️ Open-source, self-hostable, and yours to shape**
 
-## Acknowledgement
+You have the freedom to manage, self-host, fork and build your own AFFiNE. The editor is built on [BlockSuite](https://blocksuite.io), our open-source block-based editing framework.
 
-“We shape our tools and thereafter our tools shape us”. A lot of pioneers have inspired us along the way, e.g.:
+## Getting Started
 
-- Quip & Notion with their great concept of “everything is a block”
-- Trello with their Kanban
-- Airtable & Miro with their no-code programmable datasheets
-- Miro & Whimiscal with their edgeless visual whiteboard
-- Remote & Capacities with their object-based tag system
+There are three ways to start using AFFiNE:
 
-There is a large overlap of their atomic “building blocks” between these apps. They are not open source, nor do they have a plugin system like Vscode for contributors to customize. We want to have something that contains all the features we love and also goes one step even further.
+| Option | Best for | Start here |
+| --- | --- | --- |
+| ☁️ **AFFiNE Cloud** | Zero setup — sign up and create your first workspace in the browser. | [Open app.affine.pro](https://app.affine.pro) |
+| 💻 **Desktop & Mobile** | Native apps for macOS, Windows, Linux, iOS and Android, with local-first storage. | [Download AFFiNE](https://affine.pro/download) · [GitHub Releases](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **Self-Hosted** | Run the full experience on your own infrastructure with Docker Compose. | [Jump to Self-Host](#self-host-affine) |
 
-Thanks for checking us out, we appreciate your interest and sincerely hope that AFFiNE resonates with you! 🎵 Checking https://affine.pro/ for more details ions.
+> ⭐ **Star us on GitHub** — you'll receive all release notifications instantly, and it genuinely helps the project grow.
+
+<img alt="Star AFFiNE on GitHub" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## Self-Host AFFiNE
+
+Deploy your own feature-rich AFFiNE — your data, your rules. You can run the published self-hosted stack for free; the editor, desktop app, and most of the codebase are MIT-licensed, while the backend is covered by the AFFiNE Enterprise Edition license.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# Edit .env to set your credentials and storage paths, then:
+docker compose up -d
+```
+
+Your workspace is now running at `http://localhost:3010`.
+
+For configuration, upgrades and troubleshooting, read the [self-hosting documentation](https://docs.affine.pro/self-host-affine).
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**One-click deploy:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+Need SSO, advanced admin, audit, or supported commercial self-hosting? See the [AFFiNE pricing plans](https://affine.pro/pricing).
 
 ## Contributing
 
-| Bug Reports                                                                                                                                         | Feature Requests                                                                                                                                               | Questions/Discussions                                                         | AFFiNE Community                                                  |
-| --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| [Create a bug report](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Submit a feature request](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [Check GitHub Discussion](https://github.com/toeverything/AFFiNE/discussions) | [Visit the AFFiNE's Discord](https://affine.pro/redirect/discord) |
-| Something isn't working as expected                                                                                                                 | An idea for a new feature, or improvements                                                                                                                     | Discuss and ask questions                                                     | A place to ask, learn and engage with others                      |
+Calling all developers, testers, tech writers and more — contributions of all types are welcome.
 
-Calling all developers, testers, tech writers and more! Contributions of all types are more than welcome, you can read more in [docs/types-of-contributions.md](docs/types-of-contributions.md). If you are interested in contributing code, read our [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) and feel free to check out our GitHub issues to get stuck in to show us what you’re made of.
+| Bug Reports | Feature Requests | Questions & Discussions | Community |
+| --- | --- | --- | --- |
+| [Create a bug report](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Submit a feature request](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [AFFiNE Discord](https://affine.pro/redirect/discord) |
+| Something isn't working as expected | Ideas for new features or improvements | Ask questions and share ideas | Ask, learn, and engage with others |
 
-**Before you start contributing, please make sure you have read and accepted our [Contributor License Agreement]. To indicate your agreement, simply edit this file and submit a pull request.**
+- Read [docs/types-of-contributions.md](docs/types-of-contributions.md) to find the contribution that fits you.
+- Interested in code? Start with [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) and the [contributor tutorial](./docs/contributing/tutorial.md), then pick an issue.
+- For **translation** and **language support**, join our [Discord](https://affine.pro/redirect/discord).
+- For vulnerability reports, see [SECURITY.md](SECURITY.md).
 
-For **bug reports**, **feature requests** and other **suggestions** you can also [create a new issue](https://github.com/toeverything/AFFiNE/issues/new/choose) and choose the most appropriate template for your feedback.
+**Before contributing, please make sure you have read and accepted our [Contributor License Agreement].** To indicate your agreement, simply edit this file and submit a pull request.
 
-For **translation** and **language support** you can visit our [Discord](https://affine.pro/redirect/discord).
+### Building from source
 
-If you have questions, you are welcome to contact us. One of the best places to get more info and learn more is in the [Discord](https://affine.pro/redirect/discord) where you can engage with other like-minded individuals.
-
-## Templates
-
-AFFiNE now provides pre-built [templates](https://affine.pro/templates) from our team. Following are the Top 10 most popular templates among AFFiNE users,if you want to contribute, you can contribute your own template so other people can use it too.
-
-- [vision board template](https://affine.pro/templates/category-vision-board-template)
-- [one pager template](https://affine.pro/templates/category-one-pager-template-free)
-- [sample lesson plan math template](https://affine.pro/templates/sample-lesson-plan-math-template)
-- [grr lesson plan template free](https://affine.pro/templates/grr-lesson-plan-template-free)
-- [free editable lesson plan template for pre k](https://affine.pro/templates/free-editable-lesson-plan-template-for-pre-k)
-- [high note collection planners](https://affine.pro/templates/high-note-collection-planners)
-- [digital planner](https://affine.pro/templates/category-digital-planner)
-- [ADHD Planner](https://affine.pro/templates/adhd-planner)
-- [Reading Log](https://affine.pro/templates/reading-log)
-- [Cornell Notes Template](https://affine.pro/templates/category-cornell-notes-template)
-
-## Blog
-
-Welcome to the AFFiNE blog section! Here, you’ll find the latest insights, tips, and guides on how to maximize your experience with AFFiNE and AFFiNE AI, the leading Canvas AI tool for flexible note-taking and creative organization.
-
-- [vision board template](https://affine.pro/blog/8-free-printable-vision-board-templates-examples-2023)
-- [ai homework helper](https://affine.pro/blog/ai-homework-helper)
-- [vision board maker](https://affine.pro/blog/vision-board-maker)
-- [itinerary template](https://affine.pro/blog/free-customized-travel-itinerary-planner-templates)
-- [one pager template](https://affine.pro/blog/top-12-one-pager-examples-how-to-create-your-own)
-- [cornell notes template](https://affine.pro/blog/the-cornell-notes-template-and-system-learning-tips)
-- [swot chart template](https://affine.pro/blog/top-10-free-editable-swot-analysis-template-examples)
-- [apps like luna task](https://affine.pro/blog/apps-like-luna-task)
-- [note taking ai from rough notes to mind map](https://affine.pro/blog/dynamic-AI-notes)
-- [canvas ai](https://affine.pro/blog/best-canvas-ai)
-- [one pager](https://affine.pro/blog/top-12-one-pager-examples-how-to-create-your-own)
-- [SOP Template](https://affine.pro/blog/how-to-write-sop-step-by-step-guide-5-best-free-tools-templates)
-- [Chore Chart](https://affine.pro/blog/10-best-free-chore-chart-templates-kids-adults)
+- **Codespaces**: from the repo main page, click the green "Code" button and select "Create codespace on canary" — the forked repo is cloned, built, and ready to go.
+- **Local**: see [BUILDING.md] for full instructions.
 
 ## Ecosystem
 
-| Name                                             |                            |                                                                                                                                         |
-| ------------------------------------------------ | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| [@affine/component](packages/frontend/component) | AFFiNE Component Resources | ![](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                      |
-| [@toeverything/theme](packages/common/theme)     | AFFiNE theme               | [![](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+| Package | Description | Status |
+| --- | --- | --- |
+| [@affine/component](packages/frontend/component) | AFFiNE component resources | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square) |
+| [@toeverything/theme](packages/common/theme) | AFFiNE theme | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
 
-## Upstreams
+AFFiNE is made possible by these open-source upstreams — thank you:
 
-We would also like to give thanks to open-source projects that make AFFiNE possible:
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 the open-source collaborative editor project behind AFFiNE.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 a native, high-performance, thread-safe yjs CRDT implementation powering AFFiNE's local-first sync engine.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 the local-first, collaborative database behind AFFiNE, written in Rust.
+- [yjs](https://github.com/yjs/yjs) — fundamental CRDT support for state management and data sync.
+- …and many more excellent [dependencies](https://github.com/toeverything/AFFiNE/network/dependencies).
 
-- [Blocksuite](https://github.com/toeverything/BlockSuite) - 💠 BlockSuite is the open-source collaborative editor project behind AFFiNE.
-- [y-octo](https://github.com/y-crdt/y-octo) - 🐙 y-octo is a native, high-performance, thread-safe YJS CRDT implementation, serving as the core engine enabling the AFFiNE Client/Server to achieve "local-first" functionality.
-- [OctoBase](https://github.com/toeverything/OctoBase) - 🐙 OctoBase is the open-source database behind AFFiNE, local-first, yet collaborative. A light-weight, scalable, data engine written in Rust.
+## Acknowledgements
 
-- [yjs](https://github.com/yjs/yjs) - Fundamental support of CRDTs for our implementation on state management and data sync on web.
-- [electron](https://github.com/electron/electron) - Build cross-platform desktop apps with JavaScript, HTML, and CSS.
-- [React](https://github.com/facebook/react) - The library for web and native user interfaces.
-- [napi-rs](https://github.com/napi-rs/napi-rs) - A framework for building compiled Node.js add-ons in Rust via Node-API.
-- [Jotai](https://github.com/pmndrs/jotai) - Primitive and flexible state management for React.
-- [async-call-rpc](https://github.com/Jack-Works/async-call-rpc) - A lightweight JSON RPC client & server.
-- [Vite](https://github.com/vitejs/vite) - Next generation frontend tooling.
-- Other upstream [dependencies](https://github.com/toeverything/AFFiNE/network/dependencies).
+"We shape our tools and thereafter our tools shape us." Many pioneers have inspired us along the way:
 
-Thanks a lot to the community for providing such powerful and simple libraries, so that we can focus more on the implementation of the product logic, and we hope that in the future our projects will also provide a more easy-to-use knowledge base for everyone.
+- Quip & Notion, with their great concept of "everything is a block"
+- Trello, with their Kanban
+- Airtable & Miro, with their no-code programmable datasheets
+- Miro & Whimsical, with their edgeless visual whiteboards
+- RemNote & Capacities, with their object-based tag systems
 
-## Contributors
-
-We would like to express our gratitude to all the individuals who have already contributed to AFFiNE! If you have any AFFiNE-related project, documentation, tool or template, please feel free to contribute it by submitting a pull request to our curated list on GitHub: [awesome-affine](https://github.com/toeverything/awesome-affine).
-
-<a href="https://github.com/toeverything/affine/graphs/contributors">
-  <img alt="contributors" src="https://opencollective.com/affine/contributors.svg?width=890&button=false" />
-</a>
-
-## Self-Host
-
-Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiNE. Our team is diligently updating to the latest version. For more information on how to self-host AFFiNE, please refer to our [documentation](https://docs.affine.pro/self-host-affine).
-
-[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
-
-[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
-
-## Feature Request
-
-For feature requests, please see [discussions](https://github.com/toeverything/AFFiNE/discussions/categories/ideas).
-
-## Building
-
-### Codespaces
-
-From the GitHub repo main page, click the green "Code" button and select "Create codespace on master". This will open a new Codespace with the (supposedly auto-forked
-AFFiNE repo cloned, built, and ready to go).
-
-### Local
-
-See [BUILDING.md] for instructions on how to build AFFiNE from source code.
-
-## Contributing
-
-We welcome contributions from everyone.
-See [docs/contributing/tutorial.md](./docs/contributing/tutorial.md) for details.
+These apps share a large overlap of atomic "building blocks", but none are open source, nor do they offer a VS Code-like plugin system for contributors. We want something that contains all the features we love — and then goes one step further.
 
 ## License
 
-### Editions
-
-- AFFiNE Community Edition (CE) is the current available version, it's free for self-host under the MIT license.
-
-- AFFiNE Enterprise Edition (EE) is yet to be published, it will have more advanced features and enterprise-oriented offerings, including but not exclusive to rebranding and SSO, advanced admin and audit, etc., you may refer to https://affine.pro/pricing for more information
+- **AFFiNE open-source codebase** — the editor, desktop app, and most of the codebase are MIT-licensed; backend/server components are covered by the AFFiNE Enterprise Edition license.
+- **AFFiNE Enterprise / commercial licensing** — available by commercial agreement for enterprise-oriented needs such as SSO, advanced admin, audit, rebranding, and supported self-hosting. See [affine.pro/pricing](https://affine.pro/pricing) for more information.
 
 See [LICENSE] for details.
+
+## Contributors
+
+We would like to express our gratitude to everyone who has contributed to AFFiNE! If you have built an AFFiNE-related project, documentation, tool or template, feel free to add it to our curated list: [awesome-affine](https://github.com/toeverything/awesome-affine).
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE contributors" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**Thanks for checking us out — we sincerely hope AFFiNE resonates with you! 🎵**
+
+[affine.pro](https://affine.pro) · [Documentation](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
 
 [all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
 [license]: ./LICENSE
 [building.md]: ./docs/BUILDING.md
-[update page]: https://affine.pro/blog?tag=Release%20Note
-[jobs available]: ./docs/jobs.md
-[latest packages]: https://github.com/toeverything/AFFiNE/pkgs/container/affine-self-hosted
 [contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
 [stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
-[codecov]: https://codecov.io/gh/toeverything/affine/branch/canary/graphs/badge.svg?branch=canary
-[node-version-icon]: https://img.shields.io/badge/node-%3E=18.16.1-success
 [typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
-[react-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/react?filename=packages%2Ffrontend%2Fcore%2Fpackage.json&color=rgb(97%2C228%2C251)
 [blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**Escreva, desenhe e planeje — tudo ao mesmo tempo.**
+
+Um espaço de trabalho open source, local-first e focado em privacidade. <br />
+Uma plataforma hiperintegrada para documentos, quadros brancos e bancos de dados — uma alternativa pronta para uso ao Notion e ao Miro.
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[Site](https://affine.pro) · [Demonstração ao vivo](https://app.affine.pro) · [Download](https://affine.pro/download) · [Documentação](https://docs.affine.pro) · [Blog](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · Português (BR) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — escreva, desenhe e planeje, tudo ao mesmo tempo" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>Documentos, canvas e tabelas se fundem por completo no AFFiNE — exatamente como sugere a palavra inglesa affine (əˈfʌɪn | "a-fáin", "afim").</em>
+
+</div>
+
+<br />
+
+## O que é o AFFiNE
+
+O [AFFiNE](https://affine.pro) é um espaço de trabalho open source e completo — um sistema operacional para todos os blocos que compõem a sua base de conhecimento: wiki, gestão de conhecimento, apresentações e ativos digitais. Documentos e quadros brancos se fundem de verdade em um único canvas infinito, o que faz do AFFiNE uma alternativa melhor ao Notion e ao Miro.
+
+<div align="center">
+<img alt="Canvas infinito do AFFiNE com documentos, notas e bancos de dados" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## Principais recursos
+
+**🎨 Um canvas de verdade para blocos de qualquer tipo — documentos e quadro branco totalmente integrados**
+
+Muitos editores se dizem um canvas para produtividade, mas o AFFiNE é um dos raríssimos que permitem colocar qualquer bloco em um canvas infinito: texto rico, notas adesivas, páginas web incorporadas, bancos de dados com múltiplas visualizações, páginas vinculadas, formas — e até slides.
+
+**🤖 Um parceiro de IA multimodal, pronto para qualquer trabalho**
+
+Redija um relatório profissional, transforme um esboço em slides expressivos, resuma um artigo em um mapa mental bem estruturado, ou desenhe e programe protótipos de aplicativos a partir de um único prompt — o [AFFiNE AI](https://affine.pro/ai) leva a sua criatividade até o limite da sua imaginação.
+
+**🔒 Local-first, com colaboração em tempo real**
+
+Seus dados ficam primeiro no seu próprio disco, e ainda assim o AFFiNE oferece sincronização e colaboração em tempo real na web e em clientes multiplataforma.
+
+**🛠️ Open source, auto-hospedável e moldável do seu jeito**
+
+Você tem a liberdade de gerenciar, hospedar por conta própria, fazer fork e construir o seu próprio AFFiNE. O editor é construído sobre o [BlockSuite](https://blocksuite.io), nosso framework open source de edição baseada em blocos.
+
+## Primeiros passos
+
+Há três maneiras de começar a usar o AFFiNE:
+
+| Opção                   | Ideal para                                                                                    | Comece aqui                                                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud**     | Zero configuração — cadastre-se e crie seu primeiro espaço de trabalho no navegador.          | [Abrir app.affine.pro](https://app.affine.pro)                                                                                |
+| 💻 **Desktop e Mobile** | Aplicativos nativos para macOS, Windows, Linux, iOS e Android, com armazenamento local-first. | [Baixar o AFFiNE](https://affine.pro/download) · [Releases no GitHub](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **Auto-hospedado**   | Rode a experiência completa na sua própria infraestrutura com Docker Compose.                 | [Ir para Hospede seu próprio AFFiNE](#hospede-seu-próprio-affine)                                                             |
+
+> ⭐ **Dê uma estrela no GitHub** — você recebe todas as notificações de lançamento na hora, e isso ajuda de verdade o projeto a crescer.
+
+<img alt="Dê uma estrela ao AFFiNE no GitHub" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## Hospede seu próprio AFFiNE
+
+Implante o seu próprio AFFiNE completo — seus dados, suas regras. Você pode rodar gratuitamente a stack auto-hospedada publicada; o editor, o aplicativo desktop e a maior parte do código são licenciados sob MIT, enquanto o backend é coberto pela licença AFFiNE Enterprise Edition.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# Edite o .env para definir suas credenciais e caminhos de armazenamento, depois:
+docker compose up -d
+```
+
+Seu espaço de trabalho já está rodando em `http://localhost:3010`.
+
+Para configuração, atualizações e solução de problemas, leia a [documentação de auto-hospedagem](https://docs.affine.pro/self-host-affine).
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**Implantação com um clique:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+Precisa de SSO, administração avançada, auditoria ou auto-hospedagem comercial com suporte? Confira os [planos e preços do AFFiNE](https://affine.pro/pricing).
+
+## Como contribuir
+
+Convocamos desenvolvedores, testadores, redatores técnicos e muito mais — contribuições de todos os tipos são bem-vindas.
+
+| Relatos de bugs                                                                                                                                        | Pedidos de recursos                                                                                                                                               | Perguntas e discussões                                                   | Comunidade                                               |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | -------------------------------------------------------- |
+| [Criar um relato de bug](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Enviar um pedido de recurso](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [Discord do AFFiNE](https://affine.pro/redirect/discord) |
+| Algo não está funcionando como esperado                                                                                                                | Ideias de novos recursos ou melhorias                                                                                                                             | Faça perguntas e compartilhe ideias                                      | Pergunte, aprenda e interaja com outras pessoas          |
+
+- Leia [docs/types-of-contributions.md](docs/types-of-contributions.md) para encontrar o tipo de contribuição ideal para você.
+- Quer contribuir com código? Comece por [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) e pelo [tutorial para contribuidores](./docs/contributing/tutorial.md), depois escolha uma issue.
+- Para **tradução** e **suporte a idiomas**, entre no nosso [Discord](https://affine.pro/redirect/discord).
+- Para relatar vulnerabilidades, consulte [SECURITY.md](SECURITY.md).
+
+**Antes de contribuir, certifique-se de ter lido e aceitado o nosso [Contributor License Agreement].** Para indicar sua concordância, basta editar esse arquivo e enviar um pull request.
+
+### Compilando a partir do código-fonte
+
+- **Codespaces**: na página principal do repositório, clique no botão verde "Code" e selecione "Create codespace on canary" — o repositório com fork é clonado, compilado e fica pronto para uso.
+- **Local**: consulte [BUILDING.md] para as instruções completas.
+
+## Ecossistema
+
+| Pacote                                           | Descrição                         | Status                                                                                                                                                                       |
+| ------------------------------------------------ | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | Recursos de componentes do AFFiNE | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | Tema do AFFiNE                    | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+O AFFiNE só é possível graças a estes projetos open source dos quais dependemos — obrigado:
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 o projeto open source de editor colaborativo por trás do AFFiNE.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 uma implementação nativa, de alto desempenho e thread-safe do CRDT yjs, que alimenta o motor de sincronização local-first do AFFiNE.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 o banco de dados colaborativo e local-first por trás do AFFiNE, escrito em Rust.
+- [yjs](https://github.com/yjs/yjs) — suporte fundamental de CRDT para gerenciamento de estado e sincronização de dados.
+- …e muitas outras excelentes [dependências](https://github.com/toeverything/AFFiNE/network/dependencies).
+
+## Agradecimentos
+
+"Nós moldamos nossas ferramentas e, depois, nossas ferramentas nos moldam." Muitos pioneiros nos inspiraram ao longo do caminho:
+
+- Quip e Notion, com seu ótimo conceito de "tudo é um bloco"
+- Trello, com seu Kanban
+- Airtable e Miro, com suas planilhas programáveis sem código
+- Miro e Whimsical, com seus quadros brancos visuais infinitos
+- RemNote e Capacities, com seus sistemas de tags baseados em objetos
+
+Esses aplicativos compartilham boa parte dos mesmos "blocos de construção" atômicos, mas nenhum deles é open source, nem oferece um sistema de plugins ao estilo do VS Code para contribuidores. Queremos algo que reúna todos os recursos que amamos — e que vá um passo além.
+
+## Licença
+
+- **Código open source do AFFiNE** — o editor, o aplicativo desktop e a maior parte do código são licenciados sob MIT; os componentes de backend/servidor são cobertos pela licença AFFiNE Enterprise Edition.
+- **AFFiNE Enterprise / licenciamento comercial** — disponível mediante acordo comercial para necessidades corporativas como SSO, administração avançada, auditoria, rebranding e auto-hospedagem com suporte. Consulte [affine.pro/pricing](https://affine.pro/pricing) para mais informações.
+
+Veja [LICENSE] para os detalhes.
+
+<a id="contributors"></a>
+
+## Contribuidores
+
+Gostaríamos de expressar nossa gratidão a todas as pessoas que já contribuíram com o AFFiNE! Se você criou um projeto, documentação, ferramenta ou template relacionado ao AFFiNE, fique à vontade para adicioná-lo à nossa lista curada: [awesome-affine](https://github.com/toeverything/awesome-affine).
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="Contribuidores do AFFiNE" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**Obrigado por conhecer o projeto — esperamos de coração que o AFFiNE ressoe com você! 🎵**
+
+[affine.pro](https://affine.pro) · [Documentação](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**Пишите, рисуйте и планируйте — всё сразу.**
+
+Рабочее пространство с открытым исходным кодом, приоритетом приватности и принципом local-first. <br />
+Единая гиперобъединённая платформа для документов, досок и баз данных — готовая альтернатива Notion и Miro.
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[Сайт](https://affine.pro) · [Онлайн-демо](https://app.affine.pro) · [Скачать](https://affine.pro/download) · [Документация](https://docs.affine.pro) · [Блог](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · Русский
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE — пишите, рисуйте и планируйте всё сразу" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>Документы, холст и таблицы гиперслиты в AFFiNE — как и само слово affine (əˈfʌɪn | а-файн).</em>
+
+</div>
+
+<br />
+
+## Что такое AFFiNE
+
+[AFFiNE](https://affine.pro) — это универсальное рабочее пространство с открытым исходным кодом, операционная система для всех строительных блоков вашей базы знаний: вики, управления знаниями, презентаций и цифровых материалов. Документы и доски здесь по-настоящему слиты на одном безграничном холсте, что делает AFFiNE достойной альтернативой Notion и Miro.
+
+<div align="center">
+<img alt="Безграничный холст AFFiNE с документами, заметками и базами данных" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## Ключевые возможности
+
+**🎨 Настоящий холст для блоков любого вида — документы и доска полностью слиты воедино**
+
+Многие редакторы называют себя холстом для продуктивной работы, но AFFiNE — один из очень немногих, где на безграничный холст можно поместить любой строительный блок: форматированный текст, стикеры, встроенные веб-страницы, базы данных с несколькими представлениями, связанные страницы, фигуры — и даже слайды.
+
+**🤖 Мультимодальный ИИ-напарник, готовый к любой работе**
+
+Составьте профессиональный отчёт, превратите план в выразительные слайды, сверните статью в хорошо структурированную интеллект-карту или нарисуйте и запрограммируйте прототип приложения по одному запросу — [AFFiNE AI](https://affine.pro/ai) раздвигает границы вашего творчества до пределов воображения.
+
+**🔒 Local-first — и при этом совместная работа в реальном времени**
+
+Ваши данные в первую очередь хранятся на вашем собственном диске, при этом AFFiNE поддерживает синхронизацию и совместную работу в реальном времени в вебе и кроссплатформенных клиентах.
+
+**🛠️ Открытый исходный код, самостоятельный хостинг и полная свобода изменений**
+
+Вы вольны управлять AFFiNE, разворачивать его на своих серверах, делать форки и собирать собственные версии. Редактор построен на [BlockSuite](https://blocksuite.io) — нашем открытом фреймворке блочного редактирования.
+
+## Начало работы
+
+Начать пользоваться AFFiNE можно тремя способами:
+
+| Вариант                               | Кому подходит                                                                                  | С чего начать                                                                                                              |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud**                   | Никакой настройки — зарегистрируйтесь и создайте первое рабочее пространство прямо в браузере. | [Открыть app.affine.pro](https://app.affine.pro)                                                                           |
+| 💻 **Десктоп и мобильные устройства** | Нативные приложения для macOS, Windows, Linux, iOS и Android с локальным хранением данных.     | [Скачать AFFiNE](https://affine.pro/download) · [Релизы на GitHub](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **Самостоятельный хостинг**        | Полноценная версия на вашей собственной инфраструктуре с Docker Compose.                       | [Перейти к самостоятельному хостингу](#самостоятельный-хостинг-affine)                                                     |
+
+> ⭐ **Поставьте нам звезду на GitHub** — вы будете мгновенно получать уведомления обо всех релизах, и это по-настоящему помогает проекту расти.
+
+<img alt="Поставьте звезду AFFiNE на GitHub" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## Самостоятельный хостинг AFFiNE
+
+Разверните собственный полнофункциональный AFFiNE — ваши данные, ваши правила. Опубликованный стек для самостоятельного хостинга можно запускать бесплатно: редактор, десктопное приложение и большая часть кодовой базы распространяются под лицензией MIT, а серверная часть — под лицензией AFFiNE Enterprise Edition.
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# Отредактируйте .env, указав свои учётные данные и пути хранения, затем:
+docker compose up -d
+```
+
+Ваше рабочее пространство теперь работает по адресу `http://localhost:3010`.
+
+Настройка, обновление и устранение неполадок описаны в [документации по самостоятельному хостингу](https://docs.affine.pro/self-host-affine).
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**Развёртывание в один клик:**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+Нужны SSO, расширенное администрирование, аудит или коммерческий самостоятельный хостинг с поддержкой? Ознакомьтесь с [тарифами AFFiNE](https://affine.pro/pricing).
+
+## Участие в проекте
+
+Приглашаем разработчиков, тестировщиков, технических писателей и не только — мы рады вкладу любого рода.
+
+| Сообщения об ошибках                                                                                                                               | Запросы функций                                                                                                                                                | Вопросы и обсуждения                                                     | Сообщество                                            |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [Сообщить об ошибке](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [Предложить новую функцию](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [Discord AFFiNE](https://affine.pro/redirect/discord) |
+| Что-то работает не так, как ожидалось                                                                                                              | Идеи новых функций и улучшений                                                                                                                                 | Задавайте вопросы и делитесь идеями                                      | Спрашивайте, учитесь и общайтесь с другими            |
+
+- Прочитайте [docs/types-of-contributions.md](docs/types-of-contributions.md), чтобы найти подходящий именно вам способ участия.
+- Интересует код? Начните с [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) и [руководства для контрибьюторов](./docs/contributing/tutorial.md), а затем выберите задачу.
+- По вопросам **перевода** и **языковой поддержки** присоединяйтесь к нашему [Discord](https://affine.pro/redirect/discord).
+- Об уязвимостях сообщайте согласно [SECURITY.md](SECURITY.md).
+
+**Прежде чем вносить вклад, пожалуйста, прочитайте и примите наше [Лицензионное соглашение контрибьютора][contributor license agreement].** Чтобы подтвердить согласие, просто отредактируйте этот файл и отправьте pull request.
+
+### Сборка из исходного кода
+
+- **Codespaces**: на главной странице репозитория нажмите зелёную кнопку "Code" и выберите "Create codespace on canary" — форк репозитория будет клонирован, собран и готов к работе.
+- **Локально**: полные инструкции — в [BUILDING.md].
+
+## Экосистема
+
+| Пакет                                            | Описание          | Статус                                                                                                                                                                       |
+| ------------------------------------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | Компоненты AFFiNE | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | Тема AFFiNE       | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE существует благодаря этим открытым проектам — спасибо им:
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) — 💠 открытый проект редактора для совместной работы, лежащий в основе AFFiNE.
+- [y-octo](https://github.com/y-crdt/y-octo) — 🐙 нативная, высокопроизводительная, потокобезопасная реализация yjs CRDT, на которой работает local-first-движок синхронизации AFFiNE.
+- [OctoBase](https://github.com/toeverything/OctoBase) — 🐙 local-first база данных для совместной работы, стоящая за AFFiNE и написанная на Rust.
+- [yjs](https://github.com/yjs/yjs) — фундаментальная поддержка CRDT для управления состоянием и синхронизации данных.
+- …и множество других замечательных [зависимостей](https://github.com/toeverything/AFFiNE/network/dependencies).
+
+## Благодарности
+
+«Мы создаём наши инструменты, а затем наши инструменты создают нас». На этом пути нас вдохновляли многие первопроходцы:
+
+- Quip и Notion с их замечательной концепцией «всё — это блок»
+- Trello с его канбан-досками
+- Airtable и Miro с их программируемыми no-code таблицами
+- Miro и Whimsical с их безграничными визуальными досками
+- RemNote и Capacities с их объектными системами тегов
+
+У этих приложений много общих атомарных «строительных блоков», но ни одно из них не имеет открытого исходного кода и не предлагает контрибьюторам систему плагинов в духе VS Code. Мы хотим инструмент, который объединит все любимые нами возможности — и сделает шаг дальше.
+
+## Лицензия
+
+- **Открытая кодовая база AFFiNE** — редактор, десктопное приложение и большая часть кодовой базы распространяются под лицензией MIT; серверные компоненты покрываются лицензией AFFiNE Enterprise Edition.
+- **AFFiNE Enterprise / коммерческое лицензирование** — доступно по коммерческому соглашению для корпоративных потребностей: SSO, расширенное администрирование, аудит, ребрендинг и самостоятельный хостинг с поддержкой. Подробнее — на [affine.pro/pricing](https://affine.pro/pricing).
+
+Подробности — в [LICENSE].
+
+<a id="contributors"></a>
+
+## Контрибьюторы
+
+Мы благодарим всех, кто внёс вклад в развитие AFFiNE! Если вы создали проект, документацию, инструмент или шаблон, связанный с AFFiNE, — смело добавляйте его в нашу подборку [awesome-affine](https://github.com/toeverything/awesome-affine).
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="Контрибьюторы AFFiNE" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**Спасибо, что заглянули к нам, — мы искренне надеемся, что AFFiNE найдёт у вас отклик! 🎵**
+
+[affine.pro](https://affine.pro) · [Документация](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**写作、绘图、规划，一气呵成。**
+
+一个注重隐私、本地优先的开源工作空间。 <br />
+将文档、白板与数据库深度融合于一体的平台 —— 开箱即用的 Notion 与 Miro 替代品。
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[官网](https://affine.pro) · [在线体验](https://app.affine.pro) · [下载](https://affine.pro/download) · [文档](https://docs.affine.pro) · [博客](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · 简体中文 · [繁體中文](README.zh-Hant.md) · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE —— 写作、绘图、规划，一气呵成" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>在 AFFiNE 中，文档、画布与表格深度融合 —— 正如它的名字 affine（仿射，读作 əˈfʌɪn | a-fine）所寓意的那样。</em>
+
+</div>
+
+<br />
+
+## AFFiNE 是什么
+
+[AFFiNE](https://affine.pro) 是一个开源的一体化工作空间 —— 承载你知识库全部基础组件的操作系统：wiki、知识管理、演示文稿与数字资产。文档与白板在同一块无边界画布上真正融为一体，使 AFFiNE 成为比 Notion 和 Miro 更好的选择。
+
+<div align="center">
+<img alt="AFFiNE 无边界画布，承载文档、笔记与数据库" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## 核心特性
+
+**🎨 真正容纳任意形态区块的画布 —— 文档与白板完全融合**
+
+许多编辑器都自称是生产力画布，但 AFFiNE 是极少数能让你在无边界画布上放置任意基础区块的产品之一：富文本、便签、嵌入网页、多视图数据库、关联页面、图形 —— 甚至演示幻灯片。
+
+**🤖 多模态 AI 伙伴，胜任任何工作**
+
+起草一份专业报告，把大纲变成生动的幻灯片，将文章总结为结构清晰的思维导图，或是用一句提示词画出并编写应用原型 —— [AFFiNE AI](https://affine.pro/ai) 让你的创造力抵达想象力的边界。
+
+**🔒 本地优先，兼具实时协作**
+
+你的数据首先保存在自己的磁盘上，同时 AFFiNE 依然支持跨网页端与各平台客户端的实时同步与协作。
+
+**🛠️ 开源、可自托管，随你塑造**
+
+你可以自由地管理、自托管、fork 并构建属于自己的 AFFiNE。编辑器基于 [BlockSuite](https://blocksuite.io) 构建 —— 我们开源的块状编辑框架。
+
+## 快速开始
+
+有三种方式开始使用 AFFiNE：
+
+| 方式                | 适合场景                                                       | 从这里开始                                                                                                             |
+| ------------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud** | 零配置 —— 注册后即可在浏览器中创建你的第一个工作空间。         | [打开 app.affine.pro](https://app.affine.pro)                                                                          |
+| 💻 **桌面与移动端** | macOS、Windows、Linux、iOS 和 Android 原生应用，本地优先存储。 | [下载 AFFiNE](https://affine.pro/download) · [GitHub Releases](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **自托管**       | 使用 Docker Compose 在自己的基础设施上运行完整体验。           | [跳转到自托管](#自托管-affine)                                                                                         |
+
+> ⭐ **在 GitHub 上给我们点个 Star** —— 你会第一时间收到所有版本发布通知，这也实实在在地帮助项目成长。
+
+<img alt="在 GitHub 上为 AFFiNE 点 Star" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## 自托管 AFFiNE
+
+部署一个功能完整、由你做主的 AFFiNE —— 你的数据，你的规则。已发布的自托管套件可以免费运行；编辑器、桌面应用及大部分代码库采用 MIT 许可，后端则适用 AFFiNE Enterprise Edition 许可。
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# 编辑 .env 设置你的凭据和存储路径，然后执行：
+docker compose up -d
+```
+
+现在，你的工作空间已运行在 `http://localhost:3010`。
+
+关于配置、升级与故障排查，请阅读[自托管文档](https://docs.affine.pro/self-host-affine)。
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**一键部署：**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+需要 SSO、高级管理、审计功能，或带商业支持的自托管服务？请查看 [AFFiNE 定价方案](https://affine.pro/pricing)。
+
+## 参与贡献
+
+开发者、测试者、技术写作者…… 我们欢迎任何形式的贡献。
+
+| Bug 反馈                                                                                                                                      | 功能建议                                                                                                                                           | 提问与讨论                                                               | 社区                                                  |
+| --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [提交 bug 报告](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [提交功能建议](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [AFFiNE Discord](https://affine.pro/redirect/discord) |
+| 有什么地方不符合预期                                                                                                                          | 新功能或改进的想法                                                                                                                                 | 提出问题、分享想法                                                       | 提问、学习、与他人交流                                |
+
+- 阅读 [docs/types-of-contributions.md](docs/types-of-contributions.md)，找到适合你的贡献方式。
+- 想参与代码贡献？从 [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) 和[贡献者教程](./docs/contributing/tutorial.md)开始，然后挑选一个 issue。
+- 关于**翻译**与**多语言支持**，请加入我们的 [Discord](https://affine.pro/redirect/discord)。
+- 如需报告安全漏洞，请参阅 [SECURITY.md](SECURITY.md)。
+
+**在参与贡献之前，请确保你已阅读并接受我们的[贡献者许可协议][contributor license agreement]。**只需编辑该文件并提交一个 pull request，即表示你同意该协议。
+
+### 从源码构建
+
+- **Codespaces**：在仓库主页点击绿色的 "Code" 按钮，选择 "Create codespace on canary" —— fork 后的仓库会自动克隆、构建，随时可用。
+- **本地构建**：完整步骤见 [BUILDING.md]。
+
+## 生态系统
+
+| 包                                               | 说明            | 状态                                                                                                                                                                         |
+| ------------------------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | AFFiNE 组件资源 | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | AFFiNE 主题     | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE 的实现离不开这些开源上游项目 —— 感谢你们：
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite) —— 💠 AFFiNE 背后的开源协作编辑器项目。
+- [y-octo](https://github.com/y-crdt/y-octo) —— 🐙 原生、高性能、线程安全的 yjs CRDT 实现，驱动 AFFiNE 的本地优先同步引擎。
+- [OctoBase](https://github.com/toeverything/OctoBase) —— 🐙 AFFiNE 背后的本地优先协作数据库，以 Rust 编写。
+- [yjs](https://github.com/yjs/yjs) —— 为状态管理与数据同步提供底层 CRDT 支持。
+- ……以及众多优秀的[依赖项](https://github.com/toeverything/AFFiNE/network/dependencies)。
+
+## 致谢
+
+"我们塑造工具，工具随后也塑造我们。"一路走来，许多先行者给了我们启发：
+
+- Quip 与 Notion，以及它们"万物皆区块"的杰出理念
+- Trello 的看板
+- Airtable 与 Miro 的无代码可编程数据表
+- Miro 与 Whimsical 的无边界可视化白板
+- RemNote 与 Capacities 的基于对象的标签系统
+
+这些应用在原子化"基础区块"上有大量重叠，但它们都不开源，也没有为贡献者提供类似 VS Code 的插件体系。我们想要的，是一个囊括所有我们喜爱的功能、并再向前迈进一步的产品。
+
+## 许可协议
+
+- **AFFiNE 开源代码库** —— 编辑器、桌面应用及大部分代码库采用 MIT 许可；后端/服务器组件适用 AFFiNE Enterprise Edition 许可。
+- **AFFiNE 企业版 / 商业授权** —— 面向企业需求（如 SSO、高级管理、审计、品牌定制及带支持的自托管）提供商业协议授权。详情请见 [affine.pro/pricing](https://affine.pro/pricing)。
+
+详见 [LICENSE]。
+
+<a id="contributors"></a>
+
+## 贡献者
+
+我们衷心感谢每一位为 AFFiNE 做出贡献的人！如果你构建了与 AFFiNE 相关的项目、文档、工具或模板，欢迎将它添加到我们的精选列表：[awesome-affine](https://github.com/toeverything/awesome-affine)。
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE contributors" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**感谢你的关注 —— 真诚希望 AFFiNE 能与你产生共鸣！🎵**
+
+[affine.pro](https://affine.pro) · [文档](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -1,0 +1,190 @@
+<div align="center">
+
+<h1>
+    <b><a href="https://affine.pro">AFFiNE</a></b>
+</h1>
+
+**書寫、繪圖、規劃——一次搞定。**
+
+一個重視隱私、本地優先的開源工作空間。<br />
+將文件、白板與資料庫深度融合於單一平台——開箱即用的 Notion 與 Miro 替代方案。
+
+<br />
+
+[![Stars][stars-icon]](https://github.com/toeverything/AFFiNE/stargazers)
+[![Downloads](https://img.shields.io/github/downloads/toeverything/AFFiNE/total)](https://github.com/toeverything/AFFiNE/releases/latest)
+[![All Contributors][all-contributors-badge]](#contributors)
+[![TypeScript][typescript-version-icon]](https://www.typescriptlang.org/)
+[![BlockSuite][blocksuite-icon]](https://github.com/toeverything/blocksuite)
+[![License: MIT + AFFiNE EE](https://img.shields.io/badge/license-MIT%20%2B%20AFFiNE%20EE-blue)](./LICENSE)
+
+[官方網站](https://affine.pro) · [線上體驗](https://app.affine.pro) · [下載](https://affine.pro/download) · [說明文件](https://docs.affine.pro) · [部落格](https://affine.pro/blog) · [Discord](https://affine.pro/redirect/discord)
+
+[English](README.md) · [简体中文](README.zh-Hans.md) · 繁體中文 · [日本語](README.ja.md) · [한국어](README.ko.md) · [Français](README.fr.md) · [Deutsch](README.de.md) · [Español](README.es.md) · [Português (BR)](README.pt-BR.md) · [Русский](README.ru.md)
+
+<br />
+
+<a href="https://affine.pro/download">
+    <img alt="AFFiNE——書寫、繪圖、規劃，一次搞定" src="https://cdn.affine.pro/Github_hero_image2.png" style="width: 100%" />
+</a>
+
+<br />
+<br />
+
+<em>在 AFFiNE 中，文件、畫布與表格深度融為一體——正如其名 affine（發音 əˈfʌɪn | a-fine，意為「仿射」）。</em>
+
+</div>
+
+<br />
+
+## AFFiNE 是什麼
+
+[AFFiNE](https://affine.pro) 是一個開源的一體化工作空間——為你知識庫的所有基礎元件打造的作業系統：wiki、知識管理、簡報與數位資產。文件與白板在同一張無邊界畫布上真正融合，讓 AFFiNE 成為比 Notion 和 Miro 更好的選擇。
+
+<div align="center">
+<img alt="AFFiNE 無邊界畫布上的文件、筆記與資料庫" src="https://github.com/toeverything/AFFiNE/assets/79301703/49a426bb-8d2b-4216-891a-fa5993642253" style="width: 100%"/>
+</div>
+
+## 核心功能
+
+**🎨 容納任何形態區塊的真正畫布——文件與白板完全融合**
+
+許多編輯器都自稱是生產力畫布，但 AFFiNE 是極少數能讓你把任何基礎元件放上無邊界畫布的工具：富文字、便利貼、內嵌網頁、多視圖資料庫、連結頁面、圖形——甚至簡報。
+
+**🤖 多模態 AI 夥伴，勝任各種工作**
+
+撰寫專業報告、把大綱變成生動的簡報、將文章總結為結構清晰的心智圖，或用一句提示詞畫出並寫出原型應用——[AFFiNE AI](https://affine.pro/ai) 讓你的創造力抵達想像力的邊界。
+
+**🔒 本地優先，同時支援即時協作**
+
+你的資料首先儲存在自己的硬碟上，同時 AFFiNE 仍支援跨網頁與各平台用戶端的即時同步與協作。
+
+**🛠️ 開源、可自架，隨你打造**
+
+你可以自由地管理、自架、fork 並打造屬於自己的 AFFiNE。編輯器建構於 [BlockSuite](https://blocksuite.io)——我們開源的區塊式編輯框架。
+
+## 快速上手
+
+有三種方式可以開始使用 AFFiNE：
+
+| 方式                  | 適合對象                                                               | 從這裡開始                                                                                                             |
+| --------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| ☁️ **AFFiNE Cloud**   | 零設定——註冊後即可在瀏覽器中建立你的第一個工作空間。                   | [開啟 app.affine.pro](https://app.affine.pro)                                                                          |
+| 💻 **桌面與行動裝置** | macOS、Windows、Linux、iOS 與 Android 原生應用程式，資料本地優先儲存。 | [下載 AFFiNE](https://affine.pro/download) · [GitHub Releases](https://github.com/toeverything/AFFiNE/releases/latest) |
+| 🐳 **自架部署**       | 用 Docker Compose 在自己的基礎設施上執行完整功能。                     | [跳至自架 AFFiNE](#自架-affine)                                                                                        |
+
+> ⭐ **在 GitHub 上給我們一顆星**——你會即時收到所有版本發佈通知，這也實實在在地幫助專案成長。
+
+<img alt="在 GitHub 上為 AFFiNE 加星" src="https://user-images.githubusercontent.com/79301703/230891830-0110681e-8c7e-483b-b6d9-9e42b291b9ef.gif" style="width: 100%"/>
+
+## 自架 AFFiNE
+
+部署功能完整、屬於你自己的 AFFiNE——你的資料，你作主。已發佈的自架版本可免費使用；編輯器、桌面應用程式與大部分程式碼採 MIT 授權，後端則適用 AFFiNE Enterprise Edition 授權。
+
+```sh
+mkdir affine && cd affine
+
+wget -O docker-compose.yml https://github.com/toeverything/affine/releases/latest/download/docker-compose.yml
+wget -O .env https://github.com/toeverything/affine/releases/latest/download/default.env.example
+
+# 編輯 .env 設定你的帳號密碼與儲存路徑，然後執行：
+docker compose up -d
+```
+
+你的工作空間現已在 `http://localhost:3010` 上執行。
+
+關於設定、升級與疑難排解，請參閱[自架說明文件](https://docs.affine.pro/self-host-affine)。
+
+<!-- WHEN affine.pro/self-host SHIPS, append this sentence:
+Or learn why teams choose an [open-source, self-hosted knowledge base](https://affine.pro/self-host) in the first place.
+-->
+
+**一鍵部署：**
+
+[![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
+[![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
+
+需要 SSO、進階管理、稽核功能，或附商業支援的自架方案？請參閱 [AFFiNE 定價方案](https://affine.pro/pricing)。
+
+## 參與貢獻
+
+誠摯邀請所有開發者、測試人員、技術寫作者等等——各種形式的貢獻我們都歡迎。
+
+| 錯誤回報                                                                                                                                     | 功能請求                                                                                                                                           | 提問與討論                                                               | 社群                                                  |
+| -------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ----------------------------------------------------- |
+| [建立錯誤回報](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=bug%2Cproduct-review&template=BUG-REPORT.yml&title=TITLE) | [提交功能請求](https://github.com/toeverything/AFFiNE/issues/new?assignees=&labels=feat%2Cproduct-review&template=FEATURE-REQUEST.yml&title=TITLE) | [GitHub Discussions](https://github.com/toeverything/AFFiNE/discussions) | [AFFiNE Discord](https://affine.pro/redirect/discord) |
+| 功能未如預期運作                                                                                                                             | 新功能或改進的想法                                                                                                                                 | 提出問題、分享想法                                                       | 提問、學習，與大家交流                                |
+
+- 閱讀 [docs/types-of-contributions.md](docs/types-of-contributions.md)，找到適合你的貢獻方式。
+- 想貢獻程式碼？從 [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md) 和[貢獻者教學](./docs/contributing/tutorial.md)開始，然後挑一個 issue 動手。
+- 關於**翻譯**與**語言支援**，請加入我們的 [Discord](https://affine.pro/redirect/discord)。
+- 回報安全漏洞請參閱 [SECURITY.md](SECURITY.md)。
+
+**在貢獻之前，請務必先閱讀並接受我們的[貢獻者授權協議][contributor license agreement]。** 只需編輯該檔案並提交 pull request，即表示你同意協議內容。
+
+### 從原始碼建置
+
+- **Codespaces**：在儲存庫首頁點擊綠色的 "Code" 按鈕，選擇 "Create codespace on canary"——fork 的儲存庫將自動完成 clone 與建置，即可開始使用。
+- **本機建置**：完整步驟請參閱 [BUILDING.md]。
+
+## 生態系
+
+| 套件                                             | 說明            | 狀態                                                                                                                                                                         |
+| ------------------------------------------------ | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [@affine/component](packages/frontend/component) | AFFiNE 元件資源 | ![Codecov coverage](https://img.shields.io/codecov/c/github/toeverything/affine?style=flat-square)                                                                           |
+| [@toeverything/theme](packages/common/theme)     | AFFiNE 主題     | [![npm downloads for @toeverything/theme](https://img.shields.io/npm/dm/@toeverything/theme?style=flat-square&color=eee)](https://www.npmjs.com/package/@toeverything/theme) |
+
+AFFiNE 的誕生離不開這些開源上游專案——由衷感謝：
+
+- [BlockSuite](https://github.com/toeverything/BlockSuite)——💠 支撐 AFFiNE 的開源協作編輯器專案。
+- [y-octo](https://github.com/y-crdt/y-octo)——🐙 原生、高效能、執行緒安全的 yjs CRDT 實作，驅動 AFFiNE 本地優先的同步引擎。
+- [OctoBase](https://github.com/toeverything/OctoBase)——🐙 AFFiNE 背後以 Rust 寫成、本地優先的協作資料庫。
+- [yjs](https://github.com/yjs/yjs)——為狀態管理與資料同步提供基礎的 CRDT 支援。
+- ……以及許多優秀的[相依套件](https://github.com/toeverything/AFFiNE/network/dependencies)。
+
+## 致謝
+
+「我們塑造工具，工具反過來塑造我們。」一路走來，許多先行者帶給我們啟發：
+
+- Quip 與 Notion——「萬物皆區塊」的出色理念
+- Trello——看板方法
+- Airtable 與 Miro——無程式碼的可程式化資料表
+- Miro 與 Whimsical——無邊界的視覺化白板
+- RemNote 與 Capacities——以物件為基礎的標籤系統
+
+這些應用程式共享許多相同的原子化「基礎元件」，卻沒有一個是開源的，也沒有提供類似 VS Code 的外掛系統供貢獻者參與。我們想要一個涵蓋所有我們喜愛功能的工具——然後再往前多走一步。
+
+## 授權條款
+
+- **AFFiNE 開源程式碼**——編輯器、桌面應用程式與大部分程式碼採 MIT 授權；後端／伺服器元件適用 AFFiNE Enterprise Edition 授權。
+- **AFFiNE 企業版／商業授權**——針對 SSO、進階管理、稽核、品牌重塑及附支援的自架等企業需求，可透過商業協議取得。詳情請見 [affine.pro/pricing](https://affine.pro/pricing)。
+
+詳細內容請參閱 [LICENSE]。
+
+<a id="contributors"></a>
+
+## 貢獻者
+
+我們由衷感謝每一位為 AFFiNE 做出貢獻的人！如果你打造了與 AFFiNE 相關的專案、文件、工具或範本，歡迎加入我們的精選清單：[awesome-affine](https://github.com/toeverything/awesome-affine)。
+
+<a href="https://github.com/toeverything/affine/graphs/contributors">
+  <img alt="AFFiNE 貢獻者" src="https://contrib.rocks/image?repo=toeverything/AFFiNE" />
+</a>
+
+<div align="center">
+
+<br />
+
+**感謝你的關注——真心希望 AFFiNE 能與你產生共鳴！🎵**
+
+[affine.pro](https://affine.pro) · [說明文件](https://docs.affine.pro) · [Discord](https://affine.pro/redirect/discord)
+
+</div>
+
+[all-contributors-badge]: https://img.shields.io/github/contributors/toeverything/AFFiNE
+[license]: ./LICENSE
+[building.md]: ./docs/BUILDING.md
+[contributor license agreement]: https://github.com/toeverything/affine/edit/canary/.github/CLA.md
+[stars-icon]: https://img.shields.io/github/stars/toeverything/AFFiNE.svg?style=flat&logo=github&colorB=red&label=stars
+[typescript-version-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/affine/dev/typescript
+[blocksuite-icon]: https://img.shields.io/github/package-json/dependency-version/toeverything/AFFiNE/@blocksuite/store?color=6880ff&filename=packages%2Ffrontend%2Fcore%2Fpackage.json&label=blocksuite

--- a/packages/backend/server/src/__tests__/copilot/copilot.e2e.ts
+++ b/packages/backend/server/src/__tests__/copilot/copilot.e2e.ts
@@ -117,6 +117,13 @@ const waitForStatus = async (
   );
 };
 
+const normalizeContextProcessingStatus = <T extends { status?: unknown }>(
+  item: T
+) => ({
+  ...item,
+  status: item.status === 'finished' ? 'processing' : item.status,
+});
+
 test.before(async t => {
   restoreMockCopilotRuntime = installMockCopilotRuntime();
   const app = await createTestingApp({
@@ -1590,8 +1597,14 @@ test('should be able to manage context', async t => {
     const { files } =
       (await listContextDocAndFiles(app, workspaceId, sessionId, contextId)) ||
       {};
+    t.true(
+      ['processing', 'finished'].includes(files?.[0]?.status ?? ''),
+      'context file should be queued or finished'
+    );
     t.snapshot(
-      cleanObject(files, ['id', 'error', 'createdAt']),
+      cleanObject(files, ['id', 'error', 'createdAt']).map(
+        normalizeContextProcessingStatus
+      ),
       'should list context files'
     );
 
@@ -1644,8 +1657,14 @@ test('should be able to manage context', async t => {
     const { docs } =
       (await listContextDocAndFiles(app, workspaceId, sessionId, contextId)) ||
       {};
+    t.true(
+      ['processing', 'finished'].includes(docs?.[0]?.status ?? ''),
+      'context doc should be queued or finished'
+    );
     t.snapshot(
-      cleanObject(docs, ['error', 'createdAt']),
+      cleanObject(docs, ['error', 'createdAt']).map(
+        normalizeContextProcessingStatus
+      ),
       'should list context docs'
     );
 

--- a/packages/frontend/apps/electron/test/main/byok-storage.spec.ts
+++ b/packages/frontend/apps/electron/test/main/byok-storage.spec.ts
@@ -118,7 +118,7 @@ describe('byok storage handlers', () => {
         byokStorageHandlers.listWorkspaceKeys(ipcEvent, 'workspace-1')
       ).resolves.toEqual([]);
     },
-    120000
+    120000,
   );
 
   test('does not write local keys when secure storage is unavailable', async () => {

--- a/packages/frontend/apps/electron/test/main/byok-storage.spec.ts
+++ b/packages/frontend/apps/electron/test/main/byok-storage.spec.ts
@@ -60,58 +60,66 @@ afterEach(async () => {
 });
 
 describe('byok storage handlers', () => {
-  test('stores encrypted local keys and keeps lease providers sorted', async () => {
-    const { byokStorageHandlers, disposeWorkspaceByokStorage: dispose } =
-      await import('@affine/electron/main/byok-storage/handlers');
-    disposeWorkspaceByokStorage = dispose;
-    const ipcEvent = undefined;
+  test(
+    'stores encrypted local keys and keeps lease providers sorted',
+    async () => {
+      const { byokStorageHandlers, disposeWorkspaceByokStorage: dispose } =
+        await import('@affine/electron/main/byok-storage/handlers');
+      disposeWorkspaceByokStorage = dispose;
+      const ipcEvent = undefined;
 
-    await byokStorageHandlers.upsertWorkspaceKey(ipcEvent, 'workspace-1', {
-      id: 'local-openai',
-      provider: 'openai',
-      name: 'OpenAI',
-      apiKey: 'sk-openai',
-      sortOrder: 1,
-    });
-    await byokStorageHandlers.upsertWorkspaceKey(ipcEvent, 'workspace-1', {
-      id: 'local-gemini',
-      provider: 'gemini',
-      name: 'Gemini',
-      apiKey: 'sk-gemini',
-      sortOrder: 0,
-    });
+      await byokStorageHandlers.upsertWorkspaceKey(ipcEvent, 'workspace-1', {
+        id: 'local-openai',
+        provider: 'openai',
+        name: 'OpenAI',
+        apiKey: 'sk-openai',
+        sortOrder: 1,
+      });
+      await byokStorageHandlers.upsertWorkspaceKey(ipcEvent, 'workspace-1', {
+        id: 'local-gemini',
+        provider: 'gemini',
+        name: 'Gemini',
+        apiKey: 'sk-gemini',
+        sortOrder: 0,
+      });
 
-    const list = await byokStorageHandlers.listWorkspaceKeys(
-      ipcEvent,
-      'workspace-1'
-    );
-    expect(list.map(key => key.id)).toEqual(['local-gemini', 'local-openai']);
-    expect(JSON.stringify(list)).not.toContain('sk-openai');
+      const list = await byokStorageHandlers.listWorkspaceKeys(
+        ipcEvent,
+        'workspace-1'
+      );
+      expect(list.map(key => key.id)).toEqual([
+        'local-gemini',
+        'local-openai',
+      ]);
+      expect(JSON.stringify(list)).not.toContain('sk-openai');
 
-    const reordered = await byokStorageHandlers.reorderWorkspaceKeys(
-      ipcEvent,
-      'workspace-1',
-      ['local-openai', 'local-gemini']
-    );
-    expect(reordered.map(key => key.id)).toEqual([
-      'local-openai',
-      'local-gemini',
-    ]);
+      const reordered = await byokStorageHandlers.reorderWorkspaceKeys(
+        ipcEvent,
+        'workspace-1',
+        ['local-openai', 'local-gemini']
+      );
+      expect(reordered.map(key => key.id)).toEqual([
+        'local-openai',
+        'local-gemini',
+      ]);
 
-    const leaseProviders = await byokStorageHandlers.getWorkspaceLeaseProviders(
-      ipcEvent,
-      'workspace-1'
-    );
-    expect(leaseProviders.map(key => key.apiKey)).toEqual([
-      'sk-openai',
-      'sk-gemini',
-    ]);
+      const leaseProviders =
+        await byokStorageHandlers.getWorkspaceLeaseProviders(
+          ipcEvent,
+          'workspace-1'
+        );
+      expect(leaseProviders.map(key => key.apiKey)).toEqual([
+        'sk-openai',
+        'sk-gemini',
+      ]);
 
-    await byokStorageHandlers.clearWorkspaceKeys(ipcEvent, 'workspace-1');
-    await expect(
-      byokStorageHandlers.listWorkspaceKeys(ipcEvent, 'workspace-1')
-    ).resolves.toEqual([]);
-  });
+      await byokStorageHandlers.clearWorkspaceKeys(ipcEvent, 'workspace-1');
+      await expect(
+        byokStorageHandlers.listWorkspaceKeys(ipcEvent, 'workspace-1')
+      ).resolves.toEqual([]);
+    },
+    120000
+  );
 
   test('does not write local keys when secure storage is unavailable', async () => {
     electronMock.isEncryptionAvailable.mockReturnValue(false);

--- a/tests/blocksuite/e2e/paragraph.spec.ts
+++ b/tests/blocksuite/e2e/paragraph.spec.ts
@@ -45,6 +45,7 @@ import {
 import {
   assertBlockChildrenFlavours,
   assertBlockChildrenIds,
+  assertBlockChildrenTypes,
   assertBlockCount,
   assertBlockSelections,
   assertBlockTextContent,
@@ -667,52 +668,79 @@ test('delete at start of paragraph immediately following list', async ({
   // text -> bulleted
   await focusRichText(page, 1);
   await updateBlockType(page, 'affine:list', 'bulleted');
-  await assertBlockType(page, '2', 'text');
-  await assertBlockType(page, '4', 'bulleted');
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:list',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'bulleted']);
   await pressBackspace(page, 2);
   await waitNextFrame(page);
-  await assertBlockType(page, '5', 'text');
-  await assertBlockChildrenIds(page, '1', ['2', '5']);
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:paragraph',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'text']);
   await pressBackspace(page);
-  await assertBlockChildrenIds(page, '1', ['2']);
+  await assertBlockChildrenFlavours(page, '1', ['affine:paragraph']);
+  await assertBlockChildrenTypes(page, '1', ['text']);
 
   // reset
   await undoByClick(page);
   await undoByClick(page);
   await assertRichTexts(page, ['hello', 'a']);
-  await assertBlockChildrenIds(page, '1', ['2', '3']);
-  await assertBlockType(page, '3', 'text');
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:paragraph',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'text']);
 
   // text -> numbered
   await focusRichText(page, 1);
   await updateBlockType(page, 'affine:list', 'numbered');
-  await assertBlockType(page, '2', 'text');
-  await assertBlockType(page, '6', 'numbered');
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:list',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'numbered']);
   await pressBackspace(page, 2);
   await waitNextFrame(page);
-  await assertBlockType(page, '7', 'text');
-  await assertBlockChildrenIds(page, '1', ['2', '7']);
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:paragraph',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'text']);
   await pressBackspace(page);
-  await assertBlockChildrenIds(page, '1', ['2']);
+  await assertBlockChildrenFlavours(page, '1', ['affine:paragraph']);
+  await assertBlockChildrenTypes(page, '1', ['text']);
 
   // reset
   await undoByClick(page);
   await undoByClick(page);
   await assertRichTexts(page, ['hello', 'a']);
-  await assertBlockChildrenIds(page, '1', ['2', '3']);
-  await assertBlockType(page, '3', 'text');
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:paragraph',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'text']);
 
   // text -> todo
   await focusRichText(page, 1);
   await updateBlockType(page, 'affine:list', 'todo');
-  await assertBlockType(page, '2', 'text');
-  await assertBlockType(page, '8', 'todo');
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:list',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'todo']);
   await pressBackspace(page, 2);
   await waitNextFrame(page);
-  await assertBlockType(page, '9', 'text');
-  await assertBlockChildrenIds(page, '1', ['2', '9']);
+  await assertBlockChildrenFlavours(page, '1', [
+    'affine:paragraph',
+    'affine:paragraph',
+  ]);
+  await assertBlockChildrenTypes(page, '1', ['text', 'text']);
   await pressBackspace(page);
-  await assertBlockChildrenIds(page, '1', ['2']);
+  await assertBlockChildrenFlavours(page, '1', ['affine:paragraph']);
+  await assertBlockChildrenTypes(page, '1', ['text']);
 });
 
 test('delete at start of paragraph with content', async ({ page }) => {

--- a/tests/blocksuite/e2e/utils/asserts.ts
+++ b/tests/blocksuite/e2e/utils/asserts.ts
@@ -450,6 +450,27 @@ export async function assertBlockChildrenFlavours(
     .toEqual(flavours);
 }
 
+export async function assertBlockChildrenTypes(
+  page: Page,
+  blockId: string,
+  types: string[]
+) {
+  await expect
+    .poll(async () => {
+      return page.evaluate(
+        ({ blockId }) => {
+          const element = document.querySelector<BlockComponent>(
+            `[data-block-id="${blockId}"]`
+          );
+          // @ts-ignore
+          return element?.model.children.map(child => child.props.type);
+        },
+        { blockId }
+      );
+    })
+    .toEqual(types);
+}
+
 export async function assertParentBlockId(
   page: Page,
   blockId: string,


### PR DESCRIPTION
## What this PR does

**Commit 1 — README redesign:**

- Adds a **Getting Started** section with three clear paths: AFFiNE Cloud / Desktop & Mobile / Self-Host — previously there was no obvious "how do I start using this" entry point.
- Promotes **Self-Host** to a first-class section with the official Docker Compose steps (matching docs.affine.pro) and the existing one-click deploy buttons.
- **Corrects the licensing description**: the old text claimed the Community Edition is "free for self-hosting under the MIT license" and called EE "yet to be published". Per `LICENSE` and `packages/backend/server/LICENSE`, the editor/desktop/most code is MIT while backend components are under the AFFiNE EE license — the README and the top license badge now say so accurately.
- Merges the two duplicated **Contributing** sections into one, folding in Feature Request, Building (Codespaces now says `canary`, not `master`) and a SECURITY.md pointer.
- Removes the keyword-list **Templates** and **Blog** link sections.
- Fixes typos (Whimsical, RemNote, a truncated sentence), replaces the broken OpenCollective contributors image (currently returning 500) with contrib.rocks, removes unused reference-link definitions, and adds alt text to badges/images.

**Commit 2 — translations:**

- Adds README translations in 简体中文, 繁體中文, 日本語, 한국어, Français, Deutsch, Español, Português (BR) and Русский, with a language switcher wired into every version.
- All URLs, badges, code blocks and reference links are identical to the English source; brand names and quoted GitHub UI strings stay in English; in-page anchors are adjusted to match translated headings.
- Adds a one-line `.gitignore` exception (`!/README.*.md`) since `/*.md` ignores root markdown files. If you'd rather keep translations out of the root (e.g. under `docs/`), happy to move them — the switcher links are the only thing that needs updating.

## Verification

- All repo-relative paths referenced in the new README exist on `canary`.
- Docker self-host commands match the current official self-host docs.
- All badge/image URLs verified to resolve; the in-page anchors follow GitHub slug rules in every language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Streamlined the main README marketing/onboarding flow with clearer getting-started options, updated self-hosting setup (Docker Compose + env download), and refreshed contributing/build/licensing/contributors sections.
  * Added/expanded localized READMEs (DE/ES/FR/JA/KO/PT-BR/RU/ZH-Hans/ZH-Hant) with full onboarding, self-hosting, contributions, ecosystem/credits, and license details.
* **Tests**
  * Enhanced Playwright E2E checks with a new helper to validate child block types; updated paragraph deletion expectations.
  * Stabilized copilot E2E snapshots by normalizing context processing status.
* **Chores**
  * Updated Git ignore rules so Markdown READMEs are properly tracked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->