### PR TITLE
fix(server): align native JWT session TTL with auth session TTL

### DIFF
--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -204,21 +204,6 @@ test.serial(
   }
 );
 
-test.serial('should reject jwt when issued-at is in the future', async t => {
-  const issuedAt = Math.floor(Date.now() / 1000) + 60;
-  const token = signJwtSessionWithIssuedAt(
-    t.context.crypto,
-    t.context.user.id,
-    t.context.sessionId,
-    issuedAt,
-    DEFAULT_SESSION_TTL
-  );
-
-  await t.throwsAsync(() => t.context.jwtSession.verify(token), {
-    message: 'You must sign in first to access this resource.',
-  });
-});
-
 test.serial('should reject invalid jwt cases', async t => {
   const cases: Array<{ name: string; token: string }> = [
     {

--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from '@prisma/client';
-import ava, { TestFn } from 'ava';
+import ava, { ExecutionContext, TestFn } from 'ava';
 import jwt from 'jsonwebtoken';
 
 import { ConfigFactory } from '../../base';
@@ -54,7 +54,6 @@ test.after.always(async t => {
 
 const DEFAULT_SESSION_TTL = 60 * 60 * 24 * 15;
 const DEFAULT_SESSION_TTR = 60 * 60 * 24 * 7;
-const LEGACY_JWT_SESSION_TTL = 15 * 60;
 
 function resetAuthSessionConfig(config: ConfigFactory) {
   config.override({
@@ -74,24 +73,25 @@ function currentJwtKey(crypto: CryptoHelper) {
   ]);
 }
 
-function signJwtSessionWithIssuedAt(
-  crypto: CryptoHelper,
-  userId: string,
-  sessionId: string,
-  issuedAt: number,
-  expiresIn: number
+function assertSignedTtl(
+  t: ExecutionContext,
+  signed: { token: string; expiresAt: Date },
+  expectedTtl: number
 ) {
-  return jwt.sign(
-    { sid: sessionId, typ: 'user_session', iat: issuedAt },
-    currentJwtKey(crypto),
-    {
-      algorithm: 'HS256',
-      audience: 'affine-client',
-      expiresIn,
-      issuer: 'affine',
-      subject: userId,
-    }
-  );
+  const ttlMs = signed.expiresAt.getTime() - Date.now();
+  t.true(ttlMs > (expectedTtl - 5) * 1000);
+  t.true(ttlMs <= (expectedTtl + 1) * 1000);
+
+  const payload = jwt.decode(signed.token);
+  t.truthy(payload);
+  t.true(typeof payload !== 'string');
+  if (!payload || typeof payload === 'string') return;
+  t.is(typeof payload.iat, 'number');
+  t.is(typeof payload.exp, 'number');
+  if (typeof payload.iat !== 'number' || typeof payload.exp !== 'number') {
+    return;
+  }
+  t.is(payload.exp - payload.iat, expectedTtl);
 }
 
 test.serial('should sign and verify a user session jwt', async t => {
@@ -107,21 +107,13 @@ test.serial('should sign and verify a user session jwt', async t => {
   t.true(signed.expiresAt.getTime() > Date.now());
 });
 
-test.serial(
-  'should default jwt session ttl to application session ttl',
-  async t => {
-    const signed = t.context.jwtSession.sign(
-      t.context.user.id,
-      t.context.sessionId
-    );
+test.serial('should use application session ttl for jwt expiration', async t => {
+  const defaultSigned = t.context.jwtSession.sign(
+    t.context.user.id,
+    t.context.sessionId
+  );
+  assertSignedTtl(t, defaultSigned, DEFAULT_SESSION_TTL);
 
-    const ttlMs = signed.expiresAt.getTime() - Date.now();
-    t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
-    t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
-  }
-);
-
-test.serial('should use configured application session ttl', async t => {
   const ttl = 120;
   t.context.config.override({
     auth: {
@@ -131,37 +123,29 @@ test.serial('should use configured application session ttl', async t => {
     },
   });
 
-  const signed = t.context.jwtSession.sign(
+  const configuredSigned = t.context.jwtSession.sign(
     t.context.user.id,
     t.context.sessionId
   );
-
-  const ttlMs = signed.expiresAt.getTime() - Date.now();
-  t.true(ttlMs > (ttl - 5) * 1000);
-  t.true(ttlMs <= (ttl + 1) * 1000);
+  assertSignedTtl(t, configuredSigned, ttl);
 });
-
-test.serial(
-  'should reject legacy jwt when embedded expiration has elapsed',
-  async t => {
-    const issuedAt =
-      Math.floor(Date.now() / 1000) - LEGACY_JWT_SESSION_TTL - 60;
-    const token = signJwtSessionWithIssuedAt(
-      t.context.crypto,
-      t.context.user.id,
-      t.context.sessionId,
-      issuedAt,
-      LEGACY_JWT_SESSION_TTL
-    );
-
-    await t.throwsAsync(() => t.context.jwtSession.verify(token), {
-      message: 'You must sign in first to access this resource.',
-    });
-  }
-);
 
 test.serial('should reject invalid jwt cases', async t => {
   const cases: Array<{ name: string; token: string }> = [
+    {
+      name: 'expired token',
+      token: jwt.sign(
+        { sid: t.context.sessionId, typ: 'user_session' },
+        currentJwtKey(t.context.crypto),
+        {
+          algorithm: 'HS256',
+          audience: 'affine-client',
+          expiresIn: -1,
+          issuer: 'affine',
+          subject: t.context.user.id,
+        }
+      ),
+    },
     {
       name: 'wrong signature',
       token: jwt.sign(

--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -204,6 +204,21 @@ test.serial(
   }
 );
 
+test.serial('should reject jwt when issued-at is in the future', async t => {
+  const issuedAt = Math.floor(Date.now() / 1000) + 60;
+  const token = signJwtSessionWithIssuedAt(
+    t.context.crypto,
+    t.context.user.id,
+    t.context.sessionId,
+    issuedAt,
+    DEFAULT_SESSION_TTL
+  );
+
+  await t.throwsAsync(() => t.context.jwtSession.verify(token), {
+    message: 'You must sign in first to access this resource.',
+  });
+});
+
 test.serial('should reject invalid jwt cases', async t => {
   const cases: Array<{ name: string; token: string }> = [
     {

--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -108,99 +108,114 @@ test.serial('should sign and verify a user session jwt', async t => {
   t.true(signed.expiresAt.getTime() > Date.now());
 });
 
-test.serial('should default jwt session ttl to application session ttl', async t => {
-  const signed = t.context.jwtSession.sign(
-    t.context.user.id,
-    t.context.sessionId
-  );
+test.serial(
+  'should default jwt session ttl to application session ttl',
+  async t => {
+    const signed = t.context.jwtSession.sign(
+      t.context.user.id,
+      t.context.sessionId
+    );
 
-  const ttlMs = signed.expiresAt.getTime() - Date.now();
-  t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
-  t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
-});
+    const ttlMs = signed.expiresAt.getTime() - Date.now();
+    t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
+    t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
+  }
+);
 
-test.serial('should use configured jwt session ttl when it is shorter than session ttl', async t => {
-  t.context.config.override({
-    auth: {
-      session: {
-        jwtTtl: 120,
+test.serial(
+  'should use configured jwt session ttl when it is shorter than session ttl',
+  async t => {
+    t.context.config.override({
+      auth: {
+        session: {
+          jwtTtl: 120,
+        },
       },
-    },
-  });
+    });
 
-  const signed = t.context.jwtSession.sign(
-    t.context.user.id,
-    t.context.sessionId
-  );
+    const signed = t.context.jwtSession.sign(
+      t.context.user.id,
+      t.context.sessionId
+    );
 
-  const ttlMs = signed.expiresAt.getTime() - Date.now();
-  t.true(ttlMs > 115 * 1000);
-  t.true(ttlMs <= 121 * 1000);
-});
+    const ttlMs = signed.expiresAt.getTime() - Date.now();
+    t.true(ttlMs > 115 * 1000);
+    t.true(ttlMs <= 121 * 1000);
+  }
+);
 
-test.serial('should cap configured jwt session ttl to application session ttl', async t => {
-  t.context.config.override({
-    auth: {
-      session: {
-        jwtTtl: DEFAULT_SESSION_TTL * 2,
+test.serial(
+  'should cap configured jwt session ttl to application session ttl',
+  async t => {
+    t.context.config.override({
+      auth: {
+        session: {
+          jwtTtl: DEFAULT_SESSION_TTL * 2,
+        },
       },
-    },
-  });
+    });
 
-  const signed = t.context.jwtSession.sign(
-    t.context.user.id,
-    t.context.sessionId
-  );
+    const signed = t.context.jwtSession.sign(
+      t.context.user.id,
+      t.context.sessionId
+    );
 
-  const ttlMs = signed.expiresAt.getTime() - Date.now();
-  t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
-  t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
-});
+    const ttlMs = signed.expiresAt.getTime() - Date.now();
+    t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
+    t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
+  }
+);
 
-test.serial('should accept legacy expired jwt when token iat is inside configured ttl', async t => {
-  const issuedAt =
-    Math.floor(Date.now() / 1000) - LEGACY_JWT_SESSION_TTL - 60;
-  const token = signJwtSessionWithIssuedAt(
-    t.context.crypto,
-    t.context.user.id,
-    t.context.sessionId,
-    issuedAt,
-    LEGACY_JWT_SESSION_TTL
-  );
+test.serial(
+  'should accept legacy expired jwt when token iat is inside configured ttl',
+  async t => {
+    const issuedAt =
+      Math.floor(Date.now() / 1000) - LEGACY_JWT_SESSION_TTL - 60;
+    const token = signJwtSessionWithIssuedAt(
+      t.context.crypto,
+      t.context.user.id,
+      t.context.sessionId,
+      issuedAt,
+      LEGACY_JWT_SESSION_TTL
+    );
 
-  const session = await t.context.jwtSession.verify(token);
+    const session = await t.context.jwtSession.verify(token);
 
-  t.is(session.user.id, t.context.user.id);
-  t.is(session.sessionId, t.context.sessionId);
-});
+    t.is(session.user.id, t.context.user.id);
+    t.is(session.sessionId, t.context.sessionId);
+  }
+);
 
-test.serial('should reject jwt when configured ttl has elapsed even if embedded exp is later', async t => {
-  const issuedAt = Math.floor(Date.now() / 1000) - DEFAULT_SESSION_TTL - 60;
-  const token = signJwtSessionWithIssuedAt(
-    t.context.crypto,
-    t.context.user.id,
-    t.context.sessionId,
-    issuedAt,
-    DEFAULT_SESSION_TTL + 120
-  );
+test.serial(
+  'should reject jwt when configured ttl has elapsed even if embedded exp is later',
+  async t => {
+    const issuedAt = Math.floor(Date.now() / 1000) - DEFAULT_SESSION_TTL - 60;
+    const token = signJwtSessionWithIssuedAt(
+      t.context.crypto,
+      t.context.user.id,
+      t.context.sessionId,
+      issuedAt,
+      DEFAULT_SESSION_TTL + 120
+    );
 
-  await t.throwsAsync(() => t.context.jwtSession.verify(token), {
-    message: 'You must sign in first to access this resource.',
-  });
-});
+    await t.throwsAsync(() => t.context.jwtSession.verify(token), {
+      message: 'You must sign in first to access this resource.',
+    });
+  }
+);
 
 test.serial('should reject invalid jwt cases', async t => {
   const cases: Array<{ name: string; token: string }> = [
     {
-      name: 'expired token',
+      name: 'missing issued-at token',
       token: jwt.sign(
         { sid: t.context.sessionId, typ: 'user_session' },
         currentJwtKey(t.context.crypto),
         {
           algorithm: 'HS256',
           audience: 'affine-client',
-          expiresIn: -1,
           issuer: 'affine',
+          noTimestamp: true,
           subject: t.context.user.id,
         }
       ),
@@ -270,34 +285,37 @@ test.serial('should reject invalid jwt cases', async t => {
   }
 });
 
-test.serial('should reject jwt when its user session is missing or expired', async t => {
-  const signed = t.context.jwtSession.sign(
-    t.context.user.id,
-    t.context.sessionId
-  );
+test.serial(
+  'should reject jwt when its user session is missing or expired',
+  async t => {
+    const signed = t.context.jwtSession.sign(
+      t.context.user.id,
+      t.context.sessionId
+    );
 
-  await t.context.auth.signOut(t.context.sessionId, t.context.user.id);
+    await t.context.auth.signOut(t.context.sessionId, t.context.user.id);
 
-  await t.throwsAsync(() => t.context.jwtSession.verify(signed.token), {
-    message: 'You must sign in first to access this resource.',
-  });
+    await t.throwsAsync(() => t.context.jwtSession.verify(signed.token), {
+      message: 'You must sign in first to access this resource.',
+    });
 
-  const refreshed = await t.context.auth.createUserSession(t.context.user.id);
-  const expired = t.context.jwtSession.sign(
-    t.context.user.id,
-    refreshed.sessionId
-  );
-  await t.context.db.userSession.updateMany({
-    where: {
-      userId: t.context.user.id,
-      sessionId: refreshed.sessionId,
-    },
-    data: {
-      expiresAt: new Date(Date.now() - 1000),
-    },
-  });
+    const refreshed = await t.context.auth.createUserSession(t.context.user.id);
+    const expired = t.context.jwtSession.sign(
+      t.context.user.id,
+      refreshed.sessionId
+    );
+    await t.context.db.userSession.updateMany({
+      where: {
+        userId: t.context.user.id,
+        sessionId: refreshed.sessionId,
+      },
+      data: {
+        expiresAt: new Date(Date.now() - 1000),
+      },
+    });
 
-  await t.throwsAsync(() => t.context.jwtSession.verify(expired.token), {
-    message: 'You must sign in first to access this resource.',
-  });
-});
+    await t.throwsAsync(() => t.context.jwtSession.verify(expired.token), {
+      message: 'You must sign in first to access this resource.',
+    });
+  }
+);

--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -167,7 +167,7 @@ test.serial(
 );
 
 test.serial(
-  'should accept legacy expired jwt when token iat is inside configured ttl',
+  'should reject legacy jwt when embedded expiration has elapsed',
   async t => {
     const issuedAt =
       Math.floor(Date.now() / 1000) - LEGACY_JWT_SESSION_TTL - 60;
@@ -179,25 +179,6 @@ test.serial(
       LEGACY_JWT_SESSION_TTL
     );
 
-    const session = await t.context.jwtSession.verify(token);
-
-    t.is(session.user.id, t.context.user.id);
-    t.is(session.sessionId, t.context.sessionId);
-  }
-);
-
-test.serial(
-  'should reject jwt when configured ttl has elapsed even if embedded exp is later',
-  async t => {
-    const issuedAt = Math.floor(Date.now() / 1000) - DEFAULT_SESSION_TTL - 60;
-    const token = signJwtSessionWithIssuedAt(
-      t.context.crypto,
-      t.context.user.id,
-      t.context.sessionId,
-      issuedAt,
-      DEFAULT_SESSION_TTL + 120
-    );
-
     await t.throwsAsync(() => t.context.jwtSession.verify(token), {
       message: 'You must sign in first to access this resource.',
     });
@@ -206,20 +187,6 @@ test.serial(
 
 test.serial('should reject invalid jwt cases', async t => {
   const cases: Array<{ name: string; token: string }> = [
-    {
-      name: 'missing issued-at token',
-      token: jwt.sign(
-        { sid: t.context.sessionId, typ: 'user_session' },
-        currentJwtKey(t.context.crypto),
-        {
-          algorithm: 'HS256',
-          audience: 'affine-client',
-          issuer: 'affine',
-          noTimestamp: true,
-          subject: t.context.user.id,
-        }
-      ),
-    },
     {
       name: 'wrong signature',
       token: jwt.sign(

--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -62,7 +62,6 @@ function resetAuthSessionConfig(config: ConfigFactory) {
       session: {
         ttl: DEFAULT_SESSION_TTL,
         ttr: DEFAULT_SESSION_TTR,
-        jwtTtl: undefined,
       },
     },
   });
@@ -122,49 +121,25 @@ test.serial(
   }
 );
 
-test.serial(
-  'should use configured jwt session ttl when it is shorter than session ttl',
-  async t => {
-    t.context.config.override({
-      auth: {
-        session: {
-          jwtTtl: 120,
-        },
+test.serial('should use configured application session ttl', async t => {
+  const ttl = 120;
+  t.context.config.override({
+    auth: {
+      session: {
+        ttl,
       },
-    });
+    },
+  });
 
-    const signed = t.context.jwtSession.sign(
-      t.context.user.id,
-      t.context.sessionId
-    );
+  const signed = t.context.jwtSession.sign(
+    t.context.user.id,
+    t.context.sessionId
+  );
 
-    const ttlMs = signed.expiresAt.getTime() - Date.now();
-    t.true(ttlMs > 115 * 1000);
-    t.true(ttlMs <= 121 * 1000);
-  }
-);
-
-test.serial(
-  'should cap configured jwt session ttl to application session ttl',
-  async t => {
-    t.context.config.override({
-      auth: {
-        session: {
-          jwtTtl: DEFAULT_SESSION_TTL * 2,
-        },
-      },
-    });
-
-    const signed = t.context.jwtSession.sign(
-      t.context.user.id,
-      t.context.sessionId
-    );
-
-    const ttlMs = signed.expiresAt.getTime() - Date.now();
-    t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
-    t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
-  }
-);
+  const ttlMs = signed.expiresAt.getTime() - Date.now();
+  t.true(ttlMs > (ttl - 5) * 1000);
+  t.true(ttlMs <= (ttl + 1) * 1000);
+});
 
 test.serial(
   'should reject legacy jwt when embedded expiration has elapsed',

--- a/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
+++ b/packages/backend/server/src/__tests__/auth/jwt-session.spec.ts
@@ -2,6 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import ava, { TestFn } from 'ava';
 import jwt from 'jsonwebtoken';
 
+import { ConfigFactory } from '../../base';
 import { CryptoHelper } from '../../base/helpers';
 import {
   AuthModule,
@@ -17,6 +18,7 @@ const test = ava as TestFn<{
   auth: AuthService;
   jwtSession: JwtSessionService;
   crypto: CryptoHelper;
+  config: ConfigFactory;
   models: Models;
   db: PrismaClient;
   user: CurrentUser;
@@ -32,12 +34,14 @@ test.before(async t => {
   t.context.auth = app.get(AuthService);
   t.context.jwtSession = app.get(JwtSessionService);
   t.context.crypto = app.get(CryptoHelper);
+  t.context.config = app.get(ConfigFactory);
   t.context.models = app.get(Models);
   t.context.db = app.get(PrismaClient);
 });
 
 test.beforeEach(async t => {
   await t.context.app.initTestingDB();
+  resetAuthSessionConfig(t.context.config);
 
   t.context.user = await t.context.auth.signUp('u1@affine.pro', '1');
   const session = await t.context.auth.createUserSession(t.context.user.id);
@@ -48,6 +52,22 @@ test.after.always(async t => {
   await t.context.app.close();
 });
 
+const DEFAULT_SESSION_TTL = 60 * 60 * 24 * 15;
+const DEFAULT_SESSION_TTR = 60 * 60 * 24 * 7;
+const LEGACY_JWT_SESSION_TTL = 15 * 60;
+
+function resetAuthSessionConfig(config: ConfigFactory) {
+  config.override({
+    auth: {
+      session: {
+        ttl: DEFAULT_SESSION_TTL,
+        ttr: DEFAULT_SESSION_TTR,
+        jwtTtl: undefined,
+      },
+    },
+  });
+}
+
 function currentJwtKey(crypto: CryptoHelper) {
   return Buffer.concat([
     Buffer.from('affine:user-session-jwt:v1:'),
@@ -55,7 +75,27 @@ function currentJwtKey(crypto: CryptoHelper) {
   ]);
 }
 
-test('should sign and verify a user session jwt', async t => {
+function signJwtSessionWithIssuedAt(
+  crypto: CryptoHelper,
+  userId: string,
+  sessionId: string,
+  issuedAt: number,
+  expiresIn: number
+) {
+  return jwt.sign(
+    { sid: sessionId, typ: 'user_session', iat: issuedAt },
+    currentJwtKey(crypto),
+    {
+      algorithm: 'HS256',
+      audience: 'affine-client',
+      expiresIn,
+      issuer: 'affine',
+      subject: userId,
+    }
+  );
+}
+
+test.serial('should sign and verify a user session jwt', async t => {
   const signed = t.context.jwtSession.sign(
     t.context.user.id,
     t.context.sessionId
@@ -68,7 +108,88 @@ test('should sign and verify a user session jwt', async t => {
   t.true(signed.expiresAt.getTime() > Date.now());
 });
 
-test('should reject invalid jwt cases', async t => {
+test.serial('should default jwt session ttl to application session ttl', async t => {
+  const signed = t.context.jwtSession.sign(
+    t.context.user.id,
+    t.context.sessionId
+  );
+
+  const ttlMs = signed.expiresAt.getTime() - Date.now();
+  t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
+  t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
+});
+
+test.serial('should use configured jwt session ttl when it is shorter than session ttl', async t => {
+  t.context.config.override({
+    auth: {
+      session: {
+        jwtTtl: 120,
+      },
+    },
+  });
+
+  const signed = t.context.jwtSession.sign(
+    t.context.user.id,
+    t.context.sessionId
+  );
+
+  const ttlMs = signed.expiresAt.getTime() - Date.now();
+  t.true(ttlMs > 115 * 1000);
+  t.true(ttlMs <= 121 * 1000);
+});
+
+test.serial('should cap configured jwt session ttl to application session ttl', async t => {
+  t.context.config.override({
+    auth: {
+      session: {
+        jwtTtl: DEFAULT_SESSION_TTL * 2,
+      },
+    },
+  });
+
+  const signed = t.context.jwtSession.sign(
+    t.context.user.id,
+    t.context.sessionId
+  );
+
+  const ttlMs = signed.expiresAt.getTime() - Date.now();
+  t.true(ttlMs > (DEFAULT_SESSION_TTL - 5) * 1000);
+  t.true(ttlMs <= (DEFAULT_SESSION_TTL + 1) * 1000);
+});
+
+test.serial('should accept legacy expired jwt when token iat is inside configured ttl', async t => {
+  const issuedAt =
+    Math.floor(Date.now() / 1000) - LEGACY_JWT_SESSION_TTL - 60;
+  const token = signJwtSessionWithIssuedAt(
+    t.context.crypto,
+    t.context.user.id,
+    t.context.sessionId,
+    issuedAt,
+    LEGACY_JWT_SESSION_TTL
+  );
+
+  const session = await t.context.jwtSession.verify(token);
+
+  t.is(session.user.id, t.context.user.id);
+  t.is(session.sessionId, t.context.sessionId);
+});
+
+test.serial('should reject jwt when configured ttl has elapsed even if embedded exp is later', async t => {
+  const issuedAt = Math.floor(Date.now() / 1000) - DEFAULT_SESSION_TTL - 60;
+  const token = signJwtSessionWithIssuedAt(
+    t.context.crypto,
+    t.context.user.id,
+    t.context.sessionId,
+    issuedAt,
+    DEFAULT_SESSION_TTL + 120
+  );
+
+  await t.throwsAsync(() => t.context.jwtSession.verify(token), {
+    message: 'You must sign in first to access this resource.',
+  });
+});
+
+test.serial('should reject invalid jwt cases', async t => {
   const cases: Array<{ name: string; token: string }> = [
     {
       name: 'expired token',
@@ -149,7 +270,7 @@ test('should reject invalid jwt cases', async t => {
   }
 });
 
-test('should reject jwt when its user session is missing or expired', async t => {
+test.serial('should reject jwt when its user session is missing or expired', async t => {
   const signed = t.context.jwtSession.sign(
     t.context.user.id,
     t.context.sessionId

--- a/packages/backend/server/src/core/auth/config.ts
+++ b/packages/backend/server/src/core/auth/config.ts
@@ -6,7 +6,6 @@ export interface AuthConfig {
   session: {
     ttl: number;
     ttr: number;
-    jwtTtl?: number;
   };
   allowSignup: boolean;
   allowSignupForOauth: boolean;
@@ -91,11 +90,6 @@ defineModuleConfig('auth', {
   'session.ttl': {
     desc: 'Application auth expiration time in seconds.',
     default: 60 * 60 * 24 * 15, // 15 days
-  },
-  'session.jwtTtl': {
-    desc: 'JWT-backed native session expiration time in seconds. Defaults to auth.session.ttl.',
-    default: undefined,
-    shape: z.number().int().positive().optional(),
   },
   'session.ttr': {
     desc: 'Application auth time to refresh in seconds.',

--- a/packages/backend/server/src/core/auth/config.ts
+++ b/packages/backend/server/src/core/auth/config.ts
@@ -6,6 +6,7 @@ export interface AuthConfig {
   session: {
     ttl: number;
     ttr: number;
+    jwtTtl?: number;
   };
   allowSignup: boolean;
   allowSignupForOauth: boolean;
@@ -90,6 +91,11 @@ defineModuleConfig('auth', {
   'session.ttl': {
     desc: 'Application auth expiration time in seconds.',
     default: 60 * 60 * 24 * 15, // 15 days
+  },
+  'session.jwtTtl': {
+    desc: 'JWT-backed native session expiration time in seconds. Defaults to auth.session.ttl.',
+    default: undefined,
+    shape: z.number().int().positive().optional(),
   },
   'session.ttr': {
     desc: 'Application auth time to refresh in seconds.',

--- a/packages/backend/server/src/core/auth/jwt-session.ts
+++ b/packages/backend/server/src/core/auth/jwt-session.ts
@@ -9,6 +9,7 @@ import type { CurrentUser, Session } from './session';
 const JWT_SESSION_TYPE = 'user_session';
 const JWT_SESSION_ISSUER = 'affine';
 const JWT_SESSION_AUDIENCE = 'affine-client';
+const JWT_SESSION_CLOCK_SKEW_SECONDS = 30;
 
 export interface SignedJwtSession {
   token: string;
@@ -73,7 +74,19 @@ export class JwtSessionService {
   }
 
   private assertWithinConfiguredTtl(payload: UserSessionJwtPayload) {
-    if (typeof payload.iat !== 'number') throw new AuthenticationRequired();
+    if (
+      typeof payload.iat !== 'number' ||
+      !Number.isFinite(payload.iat) ||
+      !Number.isSafeInteger(payload.iat)
+    ) {
+      throw new AuthenticationRequired();
+    }
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    if (payload.iat > nowSeconds + JWT_SESSION_CLOCK_SKEW_SECONDS) {
+      throw new AuthenticationRequired();
+    }
+
     if (payload.iat * 1000 + this.ttl * 1000 <= Date.now()) {
       throw new AuthenticationRequired();
     }

--- a/packages/backend/server/src/core/auth/jwt-session.ts
+++ b/packages/backend/server/src/core/auth/jwt-session.ts
@@ -9,7 +9,6 @@ import type { CurrentUser, Session } from './session';
 const JWT_SESSION_TYPE = 'user_session';
 const JWT_SESSION_ISSUER = 'affine';
 const JWT_SESSION_AUDIENCE = 'affine-client';
-const JWT_SESSION_CLOCK_SKEW_SECONDS = 30;
 
 export interface SignedJwtSession {
   token: string;
@@ -20,6 +19,7 @@ interface UserSessionJwtPayload extends JwtPayload {
   sub: string;
   sid: string;
   typ: typeof JWT_SESSION_TYPE;
+  iat: number;
 }
 
 function isUserSessionJwtPayload(
@@ -29,7 +29,9 @@ function isUserSessionJwtPayload(
     typeof payload !== 'string' &&
     typeof payload.sub === 'string' &&
     typeof payload.sid === 'string' &&
-    payload.typ === JWT_SESSION_TYPE
+    payload.typ === JWT_SESSION_TYPE &&
+    typeof payload.iat === 'number' &&
+    Number.isFinite(payload.iat)
   );
 }
 
@@ -73,25 +75,6 @@ export class JwtSessionService {
     return { token, expiresAt };
   }
 
-  private assertWithinConfiguredTtl(payload: UserSessionJwtPayload) {
-    if (
-      typeof payload.iat !== 'number' ||
-      !Number.isFinite(payload.iat) ||
-      !Number.isSafeInteger(payload.iat)
-    ) {
-      throw new AuthenticationRequired();
-    }
-
-    const nowSeconds = Math.floor(Date.now() / 1000);
-    if (payload.iat > nowSeconds + JWT_SESSION_CLOCK_SKEW_SECONDS) {
-      throw new AuthenticationRequired();
-    }
-
-    if (payload.iat * 1000 + this.ttl * 1000 <= Date.now()) {
-      throw new AuthenticationRequired();
-    }
-  }
-
   async verify(token: string): Promise<Session> {
     let payload: string | JwtPayload;
     try {
@@ -100,13 +83,13 @@ export class JwtSessionService {
         audience: JWT_SESSION_AUDIENCE,
         ignoreExpiration: true,
         issuer: JWT_SESSION_ISSUER,
+        maxAge: this.ttl,
       });
     } catch {
       throw new AuthenticationRequired();
     }
 
     if (!isUserSessionJwtPayload(payload)) throw new AuthenticationRequired();
-    this.assertWithinConfiguredTtl(payload);
     const userSession = await this.models.session
       .findUserSessionsBySessionId(payload.sid)
       .then(sessions => sessions.find(s => s.userId === payload.sub));

--- a/packages/backend/server/src/core/auth/jwt-session.ts
+++ b/packages/backend/server/src/core/auth/jwt-session.ts
@@ -19,7 +19,6 @@ interface UserSessionJwtPayload extends JwtPayload {
   sub: string;
   sid: string;
   typ: typeof JWT_SESSION_TYPE;
-  iat: number;
 }
 
 function isUserSessionJwtPayload(
@@ -29,9 +28,7 @@ function isUserSessionJwtPayload(
     typeof payload !== 'string' &&
     typeof payload.sub === 'string' &&
     typeof payload.sid === 'string' &&
-    payload.typ === JWT_SESSION_TYPE &&
-    typeof payload.iat === 'number' &&
-    Number.isFinite(payload.iat)
+    payload.typ === JWT_SESSION_TYPE
   );
 }
 
@@ -43,11 +40,11 @@ export class JwtSessionService {
     private readonly config: Config
   ) {}
 
-  private get ttl() {
-    return Math.min(
-      this.config.auth.session.jwtTtl ?? this.config.auth.session.ttl,
-      this.config.auth.session.ttl
-    );
+  private get effectiveJwtTtl() {
+    const sessionTtl = this.config.auth.session.ttl;
+    const jwtTtl = this.config.auth.session.jwtTtl ?? sessionTtl;
+
+    return Math.min(jwtTtl, sessionTtl);
   }
 
   private get currentKey() {
@@ -58,7 +55,7 @@ export class JwtSessionService {
   }
 
   sign(userId: string, sessionId: string): SignedJwtSession {
-    const ttl = this.ttl;
+    const ttl = this.effectiveJwtTtl;
     const expiresAt = new Date(Date.now() + ttl * 1000);
     const token = jwt.sign(
       { sid: sessionId, typ: JWT_SESSION_TYPE },
@@ -81,9 +78,7 @@ export class JwtSessionService {
       payload = jwt.verify(token, this.currentKey, {
         algorithms: ['HS256'],
         audience: JWT_SESSION_AUDIENCE,
-        ignoreExpiration: true,
         issuer: JWT_SESSION_ISSUER,
-        maxAge: this.ttl,
       });
     } catch {
       throw new AuthenticationRequired();

--- a/packages/backend/server/src/core/auth/jwt-session.ts
+++ b/packages/backend/server/src/core/auth/jwt-session.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import jwt, { type JwtPayload } from 'jsonwebtoken';
 
-import { AuthenticationRequired, CryptoHelper } from '../../base';
+import { AuthenticationRequired, Config, CryptoHelper } from '../../base';
 import { Models } from '../../models';
 import { sessionUser } from './service';
 import type { CurrentUser, Session } from './session';
@@ -9,7 +9,6 @@ import type { CurrentUser, Session } from './session';
 const JWT_SESSION_TYPE = 'user_session';
 const JWT_SESSION_ISSUER = 'affine';
 const JWT_SESSION_AUDIENCE = 'affine-client';
-const JWT_SESSION_TTL = 15 * 60;
 
 export interface SignedJwtSession {
   token: string;
@@ -37,8 +36,16 @@ function isUserSessionJwtPayload(
 export class JwtSessionService {
   constructor(
     private readonly crypto: CryptoHelper,
-    private readonly models: Models
+    private readonly models: Models,
+    private readonly config: Config
   ) {}
+
+  private get ttl() {
+    return Math.min(
+      this.config.auth.session.jwtTtl ?? this.config.auth.session.ttl,
+      this.config.auth.session.ttl
+    );
+  }
 
   private get currentKey() {
     return Buffer.concat([
@@ -48,14 +55,15 @@ export class JwtSessionService {
   }
 
   sign(userId: string, sessionId: string): SignedJwtSession {
-    const expiresAt = new Date(Date.now() + JWT_SESSION_TTL * 1000);
+    const ttl = this.ttl;
+    const expiresAt = new Date(Date.now() + ttl * 1000);
     const token = jwt.sign(
       { sid: sessionId, typ: JWT_SESSION_TYPE },
       this.currentKey,
       {
         algorithm: 'HS256',
         audience: JWT_SESSION_AUDIENCE,
-        expiresIn: JWT_SESSION_TTL,
+        expiresIn: ttl,
         issuer: JWT_SESSION_ISSUER,
         subject: userId,
       }
@@ -64,12 +72,20 @@ export class JwtSessionService {
     return { token, expiresAt };
   }
 
+  private assertWithinConfiguredTtl(payload: UserSessionJwtPayload) {
+    if (typeof payload.iat !== 'number') throw new AuthenticationRequired();
+    if (payload.iat * 1000 + this.ttl * 1000 <= Date.now()) {
+      throw new AuthenticationRequired();
+    }
+  }
+
   async verify(token: string): Promise<Session> {
     let payload: string | JwtPayload;
     try {
       payload = jwt.verify(token, this.currentKey, {
         algorithms: ['HS256'],
         audience: JWT_SESSION_AUDIENCE,
+        ignoreExpiration: true,
         issuer: JWT_SESSION_ISSUER,
       });
     } catch {
@@ -77,6 +93,7 @@ export class JwtSessionService {
     }
 
     if (!isUserSessionJwtPayload(payload)) throw new AuthenticationRequired();
+    this.assertWithinConfiguredTtl(payload);
     const userSession = await this.models.session
       .findUserSessionsBySessionId(payload.sid)
       .then(sessions => sessions.find(s => s.userId === payload.sub));

--- a/packages/backend/server/src/core/auth/jwt-session.ts
+++ b/packages/backend/server/src/core/auth/jwt-session.ts
@@ -40,13 +40,6 @@ export class JwtSessionService {
     private readonly config: Config
   ) {}
 
-  private get effectiveJwtTtl() {
-    const sessionTtl = this.config.auth.session.ttl;
-    const jwtTtl = this.config.auth.session.jwtTtl ?? sessionTtl;
-
-    return Math.min(jwtTtl, sessionTtl);
-  }
-
   private get currentKey() {
     return Buffer.concat([
       Buffer.from('affine:user-session-jwt:v1:'),
@@ -55,7 +48,7 @@ export class JwtSessionService {
   }
 
   sign(userId: string, sessionId: string): SignedJwtSession {
-    const ttl = this.effectiveJwtTtl;
+    const ttl = this.config.auth.session.ttl;
     const expiresAt = new Date(Date.now() + ttl * 1000);
     const token = jwt.sign(
       { sid: sessionId, typ: JWT_SESSION_TYPE },


### PR DESCRIPTION
## Summary

This is a backend-only workaround for native/mobile sessions expiring much earlier than the normal AFFiNE auth session.

Native JWT-backed sessions now use the existing `auth.session.ttl` instead of the hard-coded 15-minute TTL.

No database migration, no new config, and no mobile client changes are required.

## Background / Investigation

PR #15060 introduced native session exchange and JWT-backed native sessions for mobile/desktop clients.

Relevant code introduced there:

- `packages/backend/server/src/core/auth/session-issuer.ts`
  - Native clients no longer receive normal auth cookies.
  - `SessionIssuer` clears cookies for native clients and returns a native session exchange code instead.

- `packages/backend/server/src/core/auth/native-exchange.ts`
  - Native clients exchange the one-time code for a JWT-backed session token.

- `packages/backend/server/src/core/auth/jwt-session.ts`
  - The JWT session implementation was introduced with:
    - `const JWT_SESSION_TTL = 15 * 60`
    - `expiresIn: JWT_SESSION_TTL`
    - normal `jwt.verify(...)` expiration enforcement

That means a native/mobile client that does not reconnect and exchange/sign in again within 15 minutes can lose backend auth even though the DB-backed AFFiNE user session is still valid for the normal app session TTL, currently 15 days by default.

Web does not hit this path because web keeps using the normal cookie-backed session issued by `AuthService`, whose expiration is based on `auth.session.ttl`.

## Related Issues / PRs Checked

- Source PR: #15060
  - Introduced native session exchange, JWT-backed sessions, native token storage, and websocket JWT support.
  - This PR appears to be the source of the hard-coded 15-minute native JWT TTL behavior.

I did not find a public issue that directly reports "native JWT expires after 15 minutes".

## What Changed

- Removed the hard-coded 15-minute native JWT TTL.
- Updated `JwtSessionService.sign()` to issue native JWTs with `auth.session.ttl`.
- Kept `JwtSessionService.verify()` on normal JWT expiration verification, so existing JWTs that already expired under the previous 15-minute `exp` need to be refreshed by signing in again.
- Kept the existing DB-backed session lookup:
  - sign-out still revokes the native JWT by deleting the backing session
  - expired/deleted DB sessions still reject the JWT

## Why This Is A Workaround

A more complete long-term design would add a true refresh-token flow for native clients, likely with persisted refresh tokens, rotation/revocation semantics, and database changes.

This PR intentionally avoids that larger design. It restores the expected mobile login lifetime for newly issued native JWTs by aligning native JWT lifetime with the existing app session lifetime, while preserving the current native exchange model, Keychain/Keystore storage, and revoke-by-session behavior.

## Compatibility

- Backend only
- No DB schema change
- No mobile app change
- No new config
- Existing native JWTs that already expired under the old 15-minute `exp` will still require signing in again.
- Newly issued native JWTs use `auth.session.ttl`.

## Verification

Latest verification after removing the extra native JWT TTL config:

- JWT session tests: 4 passed
- `yarn typecheck`: passed
- `lint-staged`: passed via `corepack yarn`
- `lint:ox`: passed via `corepack yarn`

Earlier broader checks on this branch also passed selected auth tests and the websocket JWT auth subset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session login tokens now follow the configured session lifetime, so expiration behavior can be adjusted through app settings.

* **Bug Fixes**
  * Improved consistency between token expiration and session expiry checks.
  * Added coverage for cases where a session is missing, expired, or the session lifetime changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->