### PR TITLE
feat(core): add Radix DirectionProvider for RTL support

### DIFF
--- a/packages/frontend/core/package.json
+++ b/packages/frontend/core/package.json
@@ -40,6 +40,7 @@
     "@preact/signals-core": "^1.8.0",
     "@radix-ui/react-collapsible": "^1.1.2",
     "@radix-ui/react-dialog": "^1.1.3",
+    "@radix-ui/react-direction": "1.1.1",
     "@radix-ui/react-popover": "^1.1.3",
     "@radix-ui/react-scroll-area": "^1.2.2",
     "@radix-ui/react-slot": "^1.1.1",

--- a/packages/frontend/core/src/components/context/index.tsx
+++ b/packages/frontend/core/src/components/context/index.tsx
@@ -1,5 +1,6 @@
 import { ConfirmModalProvider, PromptModalProvider } from '@affine/component';
 import { ProviderComposer } from '@affine/component/provider-composer';
+import { DirectionProvider } from '@affine/core/components/direction-provider';
 import { ThemeProvider } from '@affine/core/components/theme-provider';
 import type { createStore } from 'jotai';
 import { Provider } from 'jotai';
@@ -21,6 +22,7 @@ export function AffineContext(props: AffineContextProps) {
           [
             <Provider key="JotaiProvider" store={props.store} />,
             <ThemeProvider key="ThemeProvider" />,
+            <DirectionProvider key="DirectionProvider" />,
             <ConfirmModalProvider key="ConfirmModalProvider" />,
             <PromptModalProvider key="PromptModalProvider" />,
           ].filter(Boolean),

--- a/packages/frontend/core/src/components/direction-provider/index.tsx
+++ b/packages/frontend/core/src/components/direction-provider/index.tsx
@@ -1,0 +1,22 @@
+import { I18nService } from '@affine/core/modules/i18n';
+import { DirectionProvider as RadixDirectionProvider } from '@radix-ui/react-direction';
+import { useLiveData, useService } from '@toeverything/infra';
+import type { PropsWithChildren } from 'react';
+
+/**
+ * Provides the current text direction to all Radix UI primitives.
+ *
+ * Radix components read direction from React context, not from the
+ * document `dir` attribute, so without this provider every dropdown,
+ * popover and menu renders LTR even when an RTL language is active.
+ */
+export const DirectionProvider = ({ children }: PropsWithChildren) => {
+  const i18n = useService(I18nService).i18n;
+  const language = useLiveData(i18n.currentLanguage$);
+
+  return (
+    <RadixDirectionProvider dir={language?.rtl ? 'rtl' : 'ltr'}>
+      {children}
+    </RadixDirectionProvider>
+  );
+};

--- a/packages/frontend/core/src/modules/i18n/entities/i18n.spec.ts
+++ b/packages/frontend/core/src/modules/i18n/entities/i18n.spec.ts
@@ -1,0 +1,23 @@
+/** @vitest-environment happy-dom */
+import { describe, expect, test } from 'vitest';
+
+import { mapLanguageInfo } from './i18n';
+
+describe('mapLanguageInfo', () => {
+  test('marks RTL languages', () => {
+    expect(mapLanguageInfo('ar').rtl).toBe(true);
+    expect(mapLanguageInfo('fa').rtl).toBe(true);
+    expect(mapLanguageInfo('ur').rtl).toBe(true);
+  });
+
+  test('marks LTR languages', () => {
+    expect(mapLanguageInfo('en').rtl).toBe(false);
+    expect(mapLanguageInfo('fr').rtl).toBe(false);
+  });
+
+  test('defaults to English when language is undefined', () => {
+    const info = mapLanguageInfo();
+    expect(info.key).toBe('en');
+    expect(info.rtl).toBe(false);
+  });
+});

--- a/packages/frontend/core/src/modules/i18n/entities/i18n.ts
+++ b/packages/frontend/core/src/modules/i18n/entities/i18n.ts
@@ -16,11 +16,12 @@ export type LanguageInfo = {
   name: string;
   originalName: string;
   completeness: number;
+  rtl: boolean;
 };
 
 const logger = new DebugLogger('i18n');
 
-function mapLanguageInfo(language: Language = 'en'): LanguageInfo {
+export function mapLanguageInfo(language: Language = 'en'): LanguageInfo {
   const languageInfo = SUPPORTED_LANGUAGES[language];
 
   return {
@@ -28,6 +29,7 @@ function mapLanguageInfo(language: Language = 'en'): LanguageInfo {
     name: languageInfo.name,
     originalName: languageInfo.originalName,
     completeness: i18nCompletenesses[language],
+    rtl: languageInfo.rtl ?? false,
   };
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,6 +407,7 @@ __metadata:
     "@preact/signals-core": "npm:^1.8.0"
     "@radix-ui/react-collapsible": "npm:^1.1.2"
     "@radix-ui/react-dialog": "npm:^1.1.3"
+    "@radix-ui/react-direction": "npm:1.1.1"
     "@radix-ui/react-popover": "npm:^1.1.3"
     "@radix-ui/react-scroll-area": "npm:^1.2.2"
     "@radix-ui/react-slot": "npm:^1.1.1"


### PR DESCRIPTION
## What

Mounts a `DirectionProvider` in `AffineContext` that feeds the current language's text direction to all Radix UI primitives. Adds an `rtl` flag to `LanguageInfo` (from `SUPPORTED_LANGUAGES`), with a colocated unit test.

Part of #8966.

## Why

Radix primitives read direction from React context, not from the document `dir` attribute. Since #14624, `document.documentElement.dir` correctly flips to `rtl` for Arabic/Persian/Urdu — but every Radix dropdown, popover and menu still hard-renders LTR internally.

## Notes for reviewers

- `@radix-ui/react-direction` is pinned to the exact version the other Radix primitives resolve (`1.1.1`), not a caret range. A caret range resolves to a newer duplicate module copy, which means a different React context object — the primitives would silently ignore the provider. Verified at runtime both ways.
- Portaled Radix content preserves React context, so portaled popovers inherit direction too.

## Testing

- `yarn typecheck`, `yarn vitest run packages/frontend/core/src/modules/i18n` (3 tests) pass.
- Verified in the running web app (Playwright + manual): with language set to العربية, the workspace selector popover and menus render `dir="rtl"`; English UI unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic right-to-left layout support for languages such as Arabic, Persian, and Urdu.
  * Interface direction now updates with the selected language across supported UI components.

* **Tests**
  * Added coverage confirming correct direction settings for right-to-left, left-to-right, and default English languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->