### PR TITLE
feat(blocksuite): per-block automatic text direction (dir=auto)

### DIFF
--- a/blocksuite/affine/blocks/list/src/list-block.ts
+++ b/blocksuite/affine/blocks/list/src/list-block.ts
@@ -157,7 +157,7 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
     const children = html`<div
       class="affine-block-children-container"
       style=${styleMap({
-        paddingLeft: `${BLOCK_CHILDREN_CONTAINER_PADDING_LEFT}px`,
+        paddingInlineStart: `${BLOCK_CHILDREN_CONTAINER_PADDING_LEFT}px`,
         display: collapsed ? 'none' : undefined,
       })}
     >
@@ -165,7 +165,11 @@ export class ListBlockComponent extends CaptionedBlockComponent<ListBlockModel> 
     </div>`;
 
     return html`
-      <div class=${'affine-list-block-container'} style="${textAlignStyle}">
+      <div
+        class=${'affine-list-block-container'}
+        dir="auto"
+        style="${textAlignStyle}"
+      >
         <div
           class=${classMap({
             'affine-list-rich-text-wrapper': true,

--- a/blocksuite/affine/blocks/list/src/styles.ts
+++ b/blocksuite/affine/blocks/list/src/styles.ts
@@ -12,7 +12,7 @@ export const listPrefix = css`
   .affine-list-block__numbered {
     min-width: 22px;
     height: 24px;
-    margin-left: 2px;
+    margin-inline-start: 2px;
   }
 
   .affine-list-block__todo-prefix {

--- a/blocksuite/affine/blocks/paragraph/src/paragraph-block.ts
+++ b/blocksuite/affine/blocks/paragraph/src/paragraph-block.ts
@@ -273,7 +273,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
     const children = html`<div
       class="affine-block-children-container"
       style=${styleMap({
-        paddingLeft: `${BLOCK_CHILDREN_CONTAINER_PADDING_LEFT}px`,
+        paddingInlineStart: `${BLOCK_CHILDREN_CONTAINER_PADDING_LEFT}px`,
         display: collapsed ? 'none' : undefined,
       })}
     >
@@ -294,6 +294,7 @@ export class ParagraphBlockComponent extends CaptionedBlockComponent<ParagraphBl
           'affine-paragraph-block-container': true,
           'highlight-comment': this.isCommentHighlighted,
         })}
+        dir="auto"
         style="${textAlignStyle}"
         data-has-collapsed-siblings="${collapsedSiblings.length > 0}"
       >

--- a/blocksuite/affine/blocks/paragraph/src/styles.ts
+++ b/blocksuite/affine/blocks/paragraph/src/styles.ts
@@ -110,7 +110,7 @@ export const paragraphBlockStyles = css`
 
   .quote {
     line-height: 26px;
-    padding-left: 17px;
+    padding-inline-start: 17px;
     margin-top: var(--affine-paragraph-space);
     padding-top: 10px;
     padding-bottom: 10px;
@@ -123,7 +123,7 @@ export const paragraphBlockStyles = css`
     margin-top: 10px;
     margin-bottom: 10px;
     position: absolute;
-    left: 0;
+    inset-inline-start: 0;
     top: 0;
     background: var(--affine-quote-color);
     border-radius: 18px;
@@ -136,7 +136,7 @@ export const paragraphBlockStyles = css`
     overflow-x: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    left: 0;
+    inset-inline-start: 0;
     bottom: 0;
     pointer-events: none;
     color: var(--affine-black-30);


### PR DESCRIPTION
## What

Adds `dir="auto"` to the paragraph and list block containers so each block's direction follows its own content (first strong character), and converts the handful of physical CSS properties in those blocks (quote bar, placeholder, list marker, child indentation) to logical ones so they mirror per block.

Part of #8966. Companion to #15214 (independent — can land in any order).

## Behavior

A document can freely mix directions: an Arabic paragraph right-aligns with its quote bar/list marker on the right, while English blocks stay exactly as today. No change at all for LTR-only documents.

## Notes for reviewers

- The attribute goes on the block **container**, not the rich-text contenteditable. The HTML auto-directionality algorithm skips descendants that carry their own `dir` attribute — `dir="auto"` on the contenteditable would hide the text from the container's computation (only the placeholder would count, always resolving LTR), and it would also flip rich-text hosts that must stay LTR, like code blocks. Both approaches were tested at runtime; only the container placement behaves correctly.
- Known follow-ups deliberately not in this change: `enableAutoScrollHorizontally` in rich-text.ts assumes LTR overflow (affects only `wrapText: false` hosts), and the heading collapse icon `translateX(-48px)` needs a `:dir(rtl)` override.

## Testing

- `yarn typecheck` passes; clipboard/adapter snapshots untouched (adapters not modified).
- Playwright against the dev server: English paragraph computes `direction: ltr`, Arabic paragraph computes `direction: rtl`, code blocks unaffected; verified visually in both English and Arabic UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved list and paragraph layout support for both left-to-right and right-to-left text directions.
  * Updated indentation, numbering, quote styling, and placeholders to adapt automatically to the writing direction.
  * Added automatic text-direction handling for paragraph content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->