### PR TITLE
chore: add CSS logical-properties codemod and RTL contributor guide

### DIFF
--- a/docs/contributing/rtl-and-css-logical-properties.md
+++ b/docs/contributing/rtl-and-css-logical-properties.md
@@ -1,0 +1,124 @@
+# RTL support and CSS logical properties
+
+AFFiNE supports right-to-left languages (Arabic `ar`, Persian `fa`, Urdu `ur`).
+This document explains how RTL works in the codebase and the conventions new
+code must follow so layouts mirror correctly.
+
+## Architecture
+
+RTL is driven by three layers:
+
+1. **Document direction.** When the UI language changes, the i18n entity sets
+   `document.documentElement.dir` to `rtl`/`ltr` based on the `rtl` flag in
+   `SUPPORTED_LANGUAGES`
+   (`packages/frontend/core/src/modules/i18n/entities/i18n.ts`,
+   `packages/frontend/i18n/src/resources/index.ts`). CSS logical properties and
+   `:dir()` selectors pick this up automatically.
+
+2. **Radix UI direction context.** Radix primitives (dropdowns, popovers,
+   menus…) read direction from React context, _not_ from the document `dir`
+   attribute. `DirectionProvider`
+   (`packages/frontend/core/src/components/direction-provider/index.tsx`) is
+   mounted in `AffineContext` and feeds the current language's direction to
+   every Radix component, including portaled ones.
+
+3. **Per-block direction in the editor.** The BlockSuite paragraph and list
+   block containers carry `dir="auto"`, so each block's direction follows its
+   own content (first strong character). A document can freely mix Arabic and
+   English paragraphs, each aligned to its natural side, with the quote bar,
+   placeholder, list markers and child indentation mirroring per block.
+
+   Note: `dir="auto"` belongs on the block _container_, not on the rich-text
+   contenteditable inside it. The HTML auto-directionality algorithm skips
+   descendants that have their own `dir` attribute, so a `dir="auto"`
+   contenteditable would hide the text from the container's computation (the
+   container would only "see" the placeholder and always resolve LTR). It
+   would also flip rich-text hosts that must stay LTR, like code blocks.
+
+To add a new RTL language, set `rtl: true` on its entry in
+`packages/frontend/i18n/src/resources/index.ts` — everything else follows.
+
+## Convention: use CSS logical properties
+
+Physical properties (`margin-left`, `padding-right`, `left: 0`,
+`text-align: left`) do not mirror when `dir="rtl"`. New styles must use the
+logical equivalents:
+
+| Physical                                                 | Logical                                            |
+| -------------------------------------------------------- | -------------------------------------------------- |
+| `marginLeft` / `marginRight`                             | `marginInlineStart` / `marginInlineEnd`            |
+| `paddingLeft` / `paddingRight`                           | `paddingInlineStart` / `paddingInlineEnd`          |
+| `borderLeft` / `borderRight` (+ `Width`/`Style`/`Color`) | `borderInlineStart` / `borderInlineEnd` (+ suffix) |
+| `borderTopLeftRadius`                                    | `borderStartStartRadius`                           |
+| `borderTopRightRadius`                                   | `borderStartEndRadius`                             |
+| `borderBottomLeftRadius`                                 | `borderEndStartRadius`                             |
+| `borderBottomRightRadius`                                | `borderEndEndRadius`                               |
+| `left: …` / `right: …`                                   | `insetInlineStart` / `insetInlineEnd`              |
+| `textAlign: 'left'/'right'`                              | `textAlign: 'start'/'end'`                         |
+
+Cases that need judgement rather than mechanical replacement:
+
+- **`left`/`right` insets** — a decoration anchored to the text side (quote
+  bar, placeholder) should become `insetInlineStart/End`; a coordinate computed
+  in JS (floating-ui positioning, drag handles, canvas overlays) must stay
+  physical, because `getBoundingClientRect()` and pointer events are physical.
+- **`translateX(…)`** — mirrors incorrectly under RTL; add a `:dir(rtl)`
+  override with the flipped sign, or derive the sign from direction.
+- **4-value shorthands** (`padding: 1px 2px 3px 4px`) — split into
+  `paddingBlock` + `paddingInline` start/end values.
+- **Flex rows with meaningful order** — usually correct automatically, since
+  flex follows the container's direction; don't "fix" them with physical
+  margins.
+
+## Codemod
+
+`scripts/css-logical-properties-codemod.mjs` converts existing
+vanilla-extract `*.css.ts` files. It renames the mechanical cases from the
+table above and only _flags_ the judgement cases (insets, `translateX`,
+4-value shorthands) with file/line for manual review. It is idempotent —
+already-logical keys are untouched.
+
+```sh
+# dry run: report what would change
+node scripts/css-logical-properties-codemod.mjs packages/frontend/core/src/components
+
+# apply
+node scripts/css-logical-properties-codemod.mjs packages/frontend/core --write
+```
+
+Run it scoped (per package or directory) so the resulting diff stays
+reviewable.
+
+## Keeping new code clean (suggested lint guard)
+
+Once a package is fully converted, a file-scoped block in `eslint.config.mjs`
+can prevent regressions:
+
+```js
+{
+  files: ['**/*.css.ts'],
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector:
+          "PropertyDefinition, Property[key.name=/^(marginLeft|marginRight|paddingLeft|paddingRight|borderLeft|borderRight)$/]",
+        message:
+          'Use CSS logical properties (marginInlineStart, …) so styles mirror under RTL. See docs/contributing/rtl-and-css-logical-properties.md',
+      },
+    ],
+  },
+}
+```
+
+This is intentionally not enabled yet — enable it per package as the codemod
+lands there.
+
+## Known limitations (follow-up work)
+
+- Horizontal auto-scroll in `rich-text.ts` (`enableAutoScrollHorizontally`)
+  assumes LTR overflow; only affects `wrapText: false` consumers.
+- The heading collapse icon uses `translateX(-48px)` and needs a `:dir(rtl)`
+  override.
+- Edgeless canvas text has its own direction detection
+  (`isRTL()` in `blocksuite/affine/gfx/text/src/element-renderer/utils.ts`).

--- a/scripts/css-logical-properties-codemod.mjs
+++ b/scripts/css-logical-properties-codemod.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Codemod: convert physical CSS properties to logical ones in
+ * vanilla-extract style files (*.css.ts), so styles mirror correctly
+ * under RTL (dir="rtl").
+ *
+ * See docs/contributing/rtl-and-css-logical-properties.md for the
+ * conventions behind this script.
+ *
+ * Usage:
+ *   node scripts/css-logical-properties-codemod.mjs <dir-or-file>... [--write]
+ *
+ * Examples:
+ *   # dry run (default): report what would change
+ *   node scripts/css-logical-properties-codemod.mjs packages/frontend/core/src/components
+ *
+ *   # apply the changes
+ *   node scripts/css-logical-properties-codemod.mjs packages/frontend/core --write
+ *
+ * What it does:
+ *   - Renames physical property keys to their logical equivalents
+ *     (marginLeft -> marginInlineStart, borderTopLeftRadius ->
+ *     borderStartStartRadius, ...), for both camelCase identifiers and
+ *     kebab-case string keys.
+ *   - Rewrites textAlign: 'left' | 'right' to 'start' | 'end'.
+ *   - FLAGS (but never rewrites) cases that need human judgement:
+ *     bare `left`/`right` insets, translateX() transforms, and
+ *     4-value margin/padding shorthands.
+ *
+ * The transform is idempotent: logical keys are left untouched.
+ */
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { relative, resolve } from 'node:path';
+
+import ts from 'typescript';
+
+const CAMEL_RENAMES = new Map(
+  Object.entries({
+    marginLeft: 'marginInlineStart',
+    marginRight: 'marginInlineEnd',
+    paddingLeft: 'paddingInlineStart',
+    paddingRight: 'paddingInlineEnd',
+    borderLeft: 'borderInlineStart',
+    borderRight: 'borderInlineEnd',
+    borderLeftWidth: 'borderInlineStartWidth',
+    borderRightWidth: 'borderInlineEndWidth',
+    borderLeftStyle: 'borderInlineStartStyle',
+    borderRightStyle: 'borderInlineEndStyle',
+    borderLeftColor: 'borderInlineStartColor',
+    borderRightColor: 'borderInlineEndColor',
+    borderTopLeftRadius: 'borderStartStartRadius',
+    borderTopRightRadius: 'borderStartEndRadius',
+    borderBottomLeftRadius: 'borderEndStartRadius',
+    borderBottomRightRadius: 'borderEndEndRadius',
+  })
+);
+
+const camelToKebab = s => s.replace(/[A-Z]/g, c => `-${c.toLowerCase()}`);
+
+const KEBAB_RENAMES = new Map(
+  [...CAMEL_RENAMES].map(([from, to]) => [camelToKebab(from), camelToKebab(to)])
+);
+
+const TEXT_ALIGN_VALUES = new Map(
+  Object.entries({ left: 'start', right: 'end' })
+);
+
+// property keys that need human judgement: `left: 0` on an absolutely
+// positioned decoration usually wants insetInlineStart, but coordinates
+// driven by floating-ui / drag handles / viewport math must stay physical.
+const FLAG_INSETS = new Set(['left', 'right']);
+
+const args = process.argv.slice(2);
+const write = args.includes('--write');
+const targets = args.filter(a => a !== '--write');
+
+if (targets.length === 0) {
+  console.error(
+    'Usage: node scripts/css-logical-properties-codemod.mjs <dir-or-file>... [--write]'
+  );
+  process.exit(1);
+}
+
+function collectCssTsFiles(target, out) {
+  const path = resolve(target);
+  const stat = statSync(path);
+  if (stat.isDirectory()) {
+    for (const entry of readdirSync(path)) {
+      if (entry === 'node_modules' || entry === 'dist' || entry === '.git') {
+        continue;
+      }
+      collectCssTsFiles(resolve(path, entry), out);
+    }
+  } else if (path.endsWith('.css.ts')) {
+    out.push(path);
+  }
+  return out;
+}
+
+/** @returns the property name text and whether it's a string literal key */
+function propertyKey(node) {
+  if (ts.isIdentifier(node.name)) {
+    return { text: node.name.text, isString: false };
+  }
+  if (ts.isStringLiteral(node.name)) {
+    return { text: node.name.text, isString: true };
+  }
+  return null;
+}
+
+function processFile(file) {
+  const source = readFileSync(file, 'utf8');
+  const sourceFile = ts.createSourceFile(
+    file,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true
+  );
+
+  /** @type {{start: number, end: number, replacement: string}[]} */
+  const edits = [];
+  /** @type {{line: number, message: string}[]} */
+  const changes = [];
+  /** @type {{line: number, message: string}[]} */
+  const flags = [];
+
+  const lineOf = pos => sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+
+  function visit(node) {
+    if (ts.isPropertyAssignment(node)) {
+      const key = propertyKey(node);
+      if (key) {
+        const renames = key.isString ? KEBAB_RENAMES : CAMEL_RENAMES;
+        const renamed = renames.get(key.text);
+        const line = lineOf(node.getStart(sourceFile));
+
+        if (renamed) {
+          const replacement = key.isString ? `'${renamed}'` : renamed;
+          edits.push({
+            start: node.name.getStart(sourceFile),
+            end: node.name.getEnd(),
+            replacement,
+          });
+          changes.push({ line, message: `${key.text} -> ${renamed}` });
+        } else if (
+          (key.text === 'textAlign' || key.text === 'text-align') &&
+          ts.isStringLiteralLike(node.initializer) &&
+          TEXT_ALIGN_VALUES.has(node.initializer.text)
+        ) {
+          const value = TEXT_ALIGN_VALUES.get(node.initializer.text);
+          edits.push({
+            start: node.initializer.getStart(sourceFile),
+            end: node.initializer.getEnd(),
+            replacement: `'${value}'`,
+          });
+          changes.push({
+            line,
+            message: `textAlign: '${node.initializer.text}' -> '${value}'`,
+          });
+        } else if (FLAG_INSETS.has(key.text)) {
+          flags.push({
+            line,
+            message:
+              `\`${key.text}\` inset — decide manually: ` +
+              `insetInline${key.text === 'left' ? 'Start' : 'End'} if it should mirror in RTL, ` +
+              `keep physical if it is a computed/viewport coordinate`,
+          });
+        } else if (
+          (key.text === 'margin' || key.text === 'padding') &&
+          ts.isStringLiteralLike(node.initializer) &&
+          node.initializer.text.trim().split(/\s+/).length === 4
+        ) {
+          flags.push({
+            line,
+            message:
+              `4-value \`${key.text}\` shorthand — split into ` +
+              `${key.text}Block/${key.text}Inline manually`,
+          });
+        } else if (
+          ts.isStringLiteralLike(node.initializer) &&
+          node.initializer.text.includes('translateX(')
+        ) {
+          flags.push({
+            line,
+            message:
+              'translateX() — needs a sign flip under RTL (e.g. a :dir(rtl) override or a direction-aware variable)',
+          });
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+
+  if (edits.length > 0 && write) {
+    let output = source;
+    for (const edit of edits.sort((a, b) => b.start - a.start)) {
+      output =
+        output.slice(0, edit.start) + edit.replacement + output.slice(edit.end);
+    }
+    writeFileSync(file, output);
+  }
+
+  return { changes, flags };
+}
+
+const files = targets.flatMap(t => collectCssTsFiles(t, []));
+let totalChanges = 0;
+let totalFlags = 0;
+let changedFiles = 0;
+
+for (const file of files) {
+  const { changes, flags } = processFile(file);
+  if (changes.length === 0 && flags.length === 0) continue;
+
+  const rel = relative(process.cwd(), file);
+  console.log(`\n${rel}`);
+  for (const c of changes) console.log(`  L${c.line}: ${c.message}`);
+  for (const f of flags) console.log(`  L${f.line}: [FLAG] ${f.message}`);
+
+  totalChanges += changes.length;
+  totalFlags += flags.length;
+  if (changes.length > 0) changedFiles += 1;
+}
+
+console.log(
+  `\n${files.length} files scanned, ` +
+    `${totalChanges} propert${totalChanges === 1 ? 'y' : 'ies'} ` +
+    `${write ? 'rewritten' : 'to rewrite'} in ${changedFiles} files, ` +
+    `${totalFlags} flagged for manual review.`
+);
+if (!write && totalChanges > 0) {
+  console.log('Dry run — pass --write to apply.');
+}


### PR DESCRIPTION
## What

Following the guidance in #14661 — bulk changes should ship as a script plus documentation rather than a 100+ file diff — this adds:

- `scripts/css-logical-properties-codemod.mjs` — converts physical CSS properties to logical equivalents in vanilla-extract `*.css.ts` files. TypeScript-AST-based (uses the repo's own `typescript` package, no new deps), dry-run by default, `--write` to apply, scoped by directory argument, idempotent.
- `docs/contributing/rtl-and-css-logical-properties.md` — documents the RTL architecture (document `dir` ← i18n, Radix DirectionProvider from #15214, per-block `dir=auto` from #15215) and the logical-properties convention for new code.

Part of #8966. **No bulk changes are included in this PR** — the intent is that the team runs the codemod per package after merge, as suggested in #14661.

## What the codemod does

Auto-rewrites only the mechanical cases: `marginLeft/Right`, `paddingLeft/Right`, `borderLeft/Right(+Width/Style/Color)`, corner radii, `textAlign: 'left'/'right'` → `'start'/'end'` (camelCase and kebab-case keys).

Flags — but never rewrites — cases needing human judgement: bare `left`/`right` insets (decoration anchoring vs. floating-ui/viewport coordinates), `translateX(...)`, 4-value margin/padding shorthands.

Current dry run over `packages/frontend/core/src`: **235 properties to rewrite in 103 files, 237 flagged** (344 files scanned).

## Usage

```sh
node scripts/css-logical-properties-codemod.mjs packages/frontend/core/src/components   # dry run
node scripts/css-logical-properties-codemod.mjs packages/frontend/core --write          # apply
```

Verified idempotent (second run reports 0 rewrites) and that rewritten output typechecks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on right-to-left (RTL) layout support and direction handling.
  * Documented CSS logical property conventions, conversion examples, and known RTL limitations.

* **Developer Tools**
  * Added a codemod to help convert physical CSS properties to logical equivalents.
  * Supports dry runs, automatic updates, and flags cases requiring manual review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->