### PR TITLE
ci: pin elastic/elastic-github-actions to a full commit SHA

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -973,7 +973,7 @@ jobs:
           sudo sysctl -w vm.max_map_count=262144
 
       - name: Runs Elasticsearch
-        uses: elastic/elastic-github-actions/elasticsearch@master
+        uses: elastic/elastic-github-actions/elasticsearch@98431b45a60cbb6ace481778827bc8e11f12fd65 # master
         with:
           stack-version: 9.0.1
           security-enabled: false


### PR DESCRIPTION
### What
Pin `elastic/elastic-github-actions/elasticsearch@master` → `98431b4…` in `build-test.yml` (tag kept in a comment).

### Why
`@master` is a moving ref. This third-party action runs in the `server-test-elasticsearch` job, which
also hands `secrets.CODECOV_TOKEN` to a later step in the same job. If the action's `master` were moved
(compromise or an accidental change), the new code would run in that credentialed job — the class of
issue behind the 2025 `tj-actions/changed-files` incident. Pinning to a SHA removes that.

### Scope / safety
Behaviour unchanged (SHA = current tip of master). Signed-off. Per GitHub's [pin-to-SHA guidance](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflow and the pinned SHA myself.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated testing workflow to use a fixed Elasticsearch action version, improving build consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->