### PR TITLE
fix: learn more typo

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/license/self-host-team-plan.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/license/self-host-team-plan.tsx
@@ -70,7 +70,7 @@ export const SelfHostTeamPlan = () => {
 
       <div className={styles.leanMoreButtonContainer}>
         <Button onClick={handleClick}>
-          {t['com.affine.settings.workspace.license.lean-more']()}
+          {t['com.affine.settings.workspace.license.learn-more']()}
         </Button>
       </div>
     </div>

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -6626,9 +6626,9 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.settings.workspace.license.benefit.team.g6"](): string;
     /**
-      * `Lean more`
+      * `Learn more`
       */
-    ["com.affine.settings.workspace.license.lean-more"](): string;
+    ["com.affine.settings.workspace.license.learn-more"](): string;
     /**
       * `Selfhosted workspace`
       */

--- a/packages/frontend/i18n/src/resources/ar.json
+++ b/packages/frontend/i18n/src/resources/ar.json
@@ -1836,7 +1836,7 @@
   "com.affine.settings.workspace.license.deactivate-modal.title": "هل تؤكد التعطيل؟",
   "com.affine.settings.workspace.license.deactivate-success": "تم إلغاء تفعيل الترخيص بنجاح.",
   "com.affine.settings.workspace.license.description": "إدارة معلومات الترخيص والفواتير لمساحة العمل الفريقية ذاتية الاستضافة.",
-  "com.affine.settings.workspace.license.lean-more": "تعرّف على المزيد",
+  "com.affine.settings.workspace.license.learn-more": "تعرّف على المزيد",
   "com.affine.settings.workspace.license.self-host": "مساحة العمل ذات الاستضافة الذاتية",
   "com.affine.settings.workspace.license.self-host-team": "مساحة الفريق ذات الاستضافة الذاتية",
   "com.affine.settings.workspace.license.self-host-team.deactivate-license": "إلغاء التفعيل",

--- a/packages/frontend/i18n/src/resources/ca.json
+++ b/packages/frontend/i18n/src/resources/ca.json
@@ -1658,7 +1658,7 @@
   "com.affine.settings.workspace.license.deactivate-modal.title": "Confirmar desactivació?",
   "com.affine.settings.workspace.license.deactivate-success": "Llicència desactivada exitosament.",
   "com.affine.settings.workspace.license.description": "Administrar la informació de la llicència i les factures per a l'espai de treball de l'equip autoallotjat.",
-  "com.affine.settings.workspace.license.lean-more": "Més informació",
+  "com.affine.settings.workspace.license.learn-more": "Més informació",
   "com.affine.settings.workspace.license.self-host": "Espai de treball autoallotjat",
   "com.affine.settings.workspace.license.self-host-team": "Espai de treball d'equip autoallotjat",
   "com.affine.settings.workspace.license.self-host-team.deactivate-license": "Desactivar",

--- a/packages/frontend/i18n/src/resources/de.json
+++ b/packages/frontend/i18n/src/resources/de.json
@@ -1651,7 +1651,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Unbegrenzte Teammitglieder (10+ Plätze)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Mehrere Admin-Rollen",
   "com.affine.settings.workspace.license.benefit.team.g6": "Vorrangiger Kundensupport",
-  "com.affine.settings.workspace.license.lean-more": "Mehr erfahren",
+  "com.affine.settings.workspace.license.learn-more": "Mehr erfahren",
   "com.affine.settings.workspace.license.self-host": "Selbst gehosteter Workspace",
   "com.affine.settings.workspace.license.self-host-team": "Selbst gehosteter Team-Workspace",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Diese Lizenz läuft am {{expirationDate}} ab, mit {{leftDays}} verbleibenden Tagen.",

--- a/packages/frontend/i18n/src/resources/el-GR.json
+++ b/packages/frontend/i18n/src/resources/el-GR.json
@@ -1472,7 +1472,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Απεριόριστα μέλη ομάδας (10+ θέσεις)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Πολλαπλοί ρόλοι διαχειριστών",
   "com.affine.settings.workspace.license.benefit.team.g6": "Προτεραιότητα υποστήριξης πελατών",
-  "com.affine.settings.workspace.license.lean-more": "Μάθετε περισσότερα",
+  "com.affine.settings.workspace.license.learn-more": "Μάθετε περισσότερα",
   "com.affine.settings.workspace.license.self-host": "Αυτοδιαχειριζόμενος χώρος εργασίας",
   "com.affine.settings.workspace.license.self-host-team": "Αυτοδιαχειριζόμενος χώρος εργασίας ομάδας",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Η άδεια αυτή θα λήξει στις {{expirationDate}}, με {{leftDays}} ημέρες να απομένουν.",

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -1651,7 +1651,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Unlimited team members (10+ seats)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Multiple admin roles",
   "com.affine.settings.workspace.license.benefit.team.g6": "Priority customer support",
-  "com.affine.settings.workspace.license.lean-more": "Lean more",
+  "com.affine.settings.workspace.license.learn-more": "Learn more",
   "com.affine.settings.workspace.license.self-host": "Selfhosted workspace",
   "com.affine.settings.workspace.license.self-host-team": "Self-host Team Workspace",
   "com.affine.settings.workspace.license.self-host-team.team.description": "This license will expire on {{expirationDate}}, with {{leftDays}} days remaining.",

--- a/packages/frontend/i18n/src/resources/es.json
+++ b/packages/frontend/i18n/src/resources/es.json
@@ -1474,7 +1474,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Miembros de equipo ilimitados (10+ asientos)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Roles de administrador múltiples",
   "com.affine.settings.workspace.license.benefit.team.g6": "Soporte prioritario al cliente",
-  "com.affine.settings.workspace.license.lean-more": "Más información",
+  "com.affine.settings.workspace.license.learn-more": "Más información",
   "com.affine.settings.workspace.license.self-host": "Espacio de trabajo autohospedado",
   "com.affine.settings.workspace.license.self-host-team": "Espacio de trabajo de equipo autohospedado",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Esta licencia vencerá el {{expirationDate}}, con {{leftDays}} días restantes.",

--- a/packages/frontend/i18n/src/resources/fa.json
+++ b/packages/frontend/i18n/src/resources/fa.json
@@ -1472,7 +1472,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "اعضای تیم نامحدود (10+ صندلی)",
   "com.affine.settings.workspace.license.benefit.team.g5": "نقش‌های مدیریتی متعدد",
   "com.affine.settings.workspace.license.benefit.team.g6": "پشتیبانی مشتری اولویت‌دار",
-  "com.affine.settings.workspace.license.lean-more": "بیشتر بیاموزید",
+  "com.affine.settings.workspace.license.learn-more": "بیشتر بیاموزید",
   "com.affine.settings.workspace.license.self-host": "فضای کاری خود میزبان",
   "com.affine.settings.workspace.license.self-host-team": "فضای کاری تیم خود میزبان",
   "com.affine.settings.workspace.license.self-host-team.team.description": "این مجوز در تاریخ {{expirationDate}} منقضی می‌شود و {{leftDays}} روز باقی مانده است.",

--- a/packages/frontend/i18n/src/resources/fr.json
+++ b/packages/frontend/i18n/src/resources/fr.json
@@ -1495,7 +1495,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Membres d'équipe illimités (10+ places)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Plusieurs rôles d'administrateur",
   "com.affine.settings.workspace.license.benefit.team.g6": "Support client prioritaire",
-  "com.affine.settings.workspace.license.lean-more": "En savoir plus",
+  "com.affine.settings.workspace.license.learn-more": "En savoir plus",
   "com.affine.settings.workspace.license.self-host": "Espace de travail auto-hébergé",
   "com.affine.settings.workspace.license.self-host-team": "Espace de travail d'équipe auto-hébergé",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Cette licence expirera le {{expirationDate}}, avec {{leftDays}} jours restants.",

--- a/packages/frontend/i18n/src/resources/it.json
+++ b/packages/frontend/i18n/src/resources/it.json
@@ -1495,7 +1495,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Membri del team illimitati (10+ posti)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Ruoli amministrativi multipli",
   "com.affine.settings.workspace.license.benefit.team.g6": "Supporto clienti prioritario",
-  "com.affine.settings.workspace.license.lean-more": "Maggiori informazioni",
+  "com.affine.settings.workspace.license.learn-more": "Maggiori informazioni",
   "com.affine.settings.workspace.license.self-host": "Spazio di lavoro autogestito",
   "com.affine.settings.workspace.license.self-host-team": "Spazio di lavoro del team autogestito",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Questa licenza scadrà il {{expirationDate}}, con {{leftDays}} giorni rimanenti.",

--- a/packages/frontend/i18n/src/resources/ja.json
+++ b/packages/frontend/i18n/src/resources/ja.json
@@ -1472,7 +1472,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "無制限のチームメンバー(10+席)",
   "com.affine.settings.workspace.license.benefit.team.g5": "複数の管理者役割",
   "com.affine.settings.workspace.license.benefit.team.g6": "優先カスタマーサポート",
-  "com.affine.settings.workspace.license.lean-more": "詳細を知る",
+  "com.affine.settings.workspace.license.learn-more": "詳細を知る",
   "com.affine.settings.workspace.license.self-host": "セルフホスト型ワークスペース",
   "com.affine.settings.workspace.license.self-host-team": "セルフホスト型チームワークスペース",
   "com.affine.settings.workspace.license.self-host-team.team.description": "このライセンスは{{expirationDate}}に失効し、あと{{leftDays}}日残っています。",

--- a/packages/frontend/i18n/src/resources/kk.json
+++ b/packages/frontend/i18n/src/resources/kk.json
@@ -1612,7 +1612,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Шексіз команда мүшелері (10+ орын)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Бірнеше әкімші",
   "com.affine.settings.workspace.license.benefit.team.g6": "Басымдылықпен тұтынушыларды қолдау",
-  "com.affine.settings.workspace.license.lean-more": "Толығырақ біл",
+  "com.affine.settings.workspace.license.learn-more": "Толығырақ біл",
   "com.affine.settings.workspace.license.self-host": "Self-hosted жұмыс кеңістігі",
   "com.affine.settings.workspace.license.self-host-team": "Self-host командалық жұмыс кеңістігі",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Бұл лицензияның мерзімі {{expirationDate}} күні аяқталады, {{leftDays}} күн қалды.",

--- a/packages/frontend/i18n/src/resources/ko.json
+++ b/packages/frontend/i18n/src/resources/ko.json
@@ -1482,7 +1482,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "무제한 팀 멤버(10개 이상의 좌석)",
   "com.affine.settings.workspace.license.benefit.team.g5": "다중 관리자 역할",
   "com.affine.settings.workspace.license.benefit.team.g6": "우선순위 고객 지원",
-  "com.affine.settings.workspace.license.lean-more": "자세히 알아보기",
+  "com.affine.settings.workspace.license.learn-more": "자세히 알아보기",
   "com.affine.settings.workspace.license.self-host": "Self-Host 워크스페이스",
   "com.affine.settings.workspace.license.self-host-team": "Self-Host 팀 워크스페이스",
   "com.affine.settings.workspace.license.self-host-team.team.description": "이 라이선스는 {{expirationDate}}에 만료되며, {{leftDays}}일 남았습니다.",

--- a/packages/frontend/i18n/src/resources/nb-NO.json
+++ b/packages/frontend/i18n/src/resources/nb-NO.json
@@ -953,7 +953,7 @@
   "com.affine.settings.workspace.license.self-host-team.replace-license.upload": "Last opp lisensfil",
   "com.affine.settings.workspace.license.self-host-team.replace-license.title": "Erstatt lisensfil",
   "com.affine.settings.workspace.license.self-host-team.deactivate-license": "Deaktivér",
-  "com.affine.settings.workspace.license.lean-more": "Lær mer",
+  "com.affine.settings.workspace.license.learn-more": "Lær mer",
   "com.affine.settings.workspace.license.deactivate-modal.title": "Bekrefte deaktivering?",
   "com.affine.settings.workspace.license.activate-modal.title": "Aktivér lisens",
   "com.affine.settings.workspace.license": "Lisens",

--- a/packages/frontend/i18n/src/resources/pl.json
+++ b/packages/frontend/i18n/src/resources/pl.json
@@ -1495,7 +1495,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Nieograniczona liczba członków zespołu (10+ miejsc)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Wiele ról administracyjnych",
   "com.affine.settings.workspace.license.benefit.team.g6": "Priorytetowa obsługa klienta",
-  "com.affine.settings.workspace.license.lean-more": "Dowiedz się więcej",
+  "com.affine.settings.workspace.license.learn-more": "Dowiedz się więcej",
   "com.affine.settings.workspace.license.self-host": "Środowisko pracy na własnym serwerze",
   "com.affine.settings.workspace.license.self-host-team": "Zespół na własnym serwerze",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Ta licencja wygaśnie {{expirationDate}}, pozostało {{leftDays}} dni.",

--- a/packages/frontend/i18n/src/resources/pt-BR.json
+++ b/packages/frontend/i18n/src/resources/pt-BR.json
@@ -1472,7 +1472,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Membros de equipe ilimitados (10+ assentos)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Vários papéis de administrador",
   "com.affine.settings.workspace.license.benefit.team.g6": "Suporte prioritário ao cliente",
-  "com.affine.settings.workspace.license.lean-more": "Saiba mais",
+  "com.affine.settings.workspace.license.learn-more": "Saiba mais",
   "com.affine.settings.workspace.license.self-host": "Espaço de Trabalho Auto-Hospedado",
   "com.affine.settings.workspace.license.self-host-team": "Espaço de Trabalho de Equipe Auto-Hospedado",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Esta licença expirará em {{expirationDate}}, com {{leftDays}} dias restantes.",

--- a/packages/frontend/i18n/src/resources/ru.json
+++ b/packages/frontend/i18n/src/resources/ru.json
@@ -1511,7 +1511,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Неограниченное количество участников команды (10+ мест)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Несколько администраторов",
   "com.affine.settings.workspace.license.benefit.team.g6": "Приоритетная поддержка клиентов",
-  "com.affine.settings.workspace.license.lean-more": "Узнать больше",
+  "com.affine.settings.workspace.license.learn-more": "Узнать больше",
   "com.affine.settings.workspace.license.self-host": "Рабочее пространство self-host",
   "com.affine.settings.workspace.license.self-host-team": "Рабочее пространство для self-host размещения",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Эта лицензия истекает {{expirationDate}}, осталось {{leftDays}} дней.",

--- a/packages/frontend/i18n/src/resources/sv-SE.json
+++ b/packages/frontend/i18n/src/resources/sv-SE.json
@@ -1476,7 +1476,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Obegränsat antal teammedlemmar (10+ platser)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Flera administratörsroller",
   "com.affine.settings.workspace.license.benefit.team.g6": "Prioriterad kundsupport",
-  "com.affine.settings.workspace.license.lean-more": "Läs mer",
+  "com.affine.settings.workspace.license.learn-more": "Läs mer",
   "com.affine.settings.workspace.license.self-host": "Självhostad arbetsyta",
   "com.affine.settings.workspace.license.self-host-team": "Självhostad teamarbetsyta",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Denna licens går ut den {{expirationDate}}, med {{leftDays}} dagar kvar.",

--- a/packages/frontend/i18n/src/resources/tr.json
+++ b/packages/frontend/i18n/src/resources/tr.json
@@ -1612,7 +1612,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Sınırsız ekip üyesi (10+ koltuk)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Çoklu yönetici rolleri",
   "com.affine.settings.workspace.license.benefit.team.g6": "Öncelikli müşteri desteği",
-  "com.affine.settings.workspace.license.lean-more": "Daha fazla bilgi edinin",
+  "com.affine.settings.workspace.license.learn-more": "Daha fazla bilgi edinin",
   "com.affine.settings.workspace.license.self-host": "Kendi kendine barındırılan çalışma alanı",
   "com.affine.settings.workspace.license.self-host-team": "Kendi Kendine Barındırılan Ekip Çalışma Alanı",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Bu lisansın süresi {{expirationDate}} tarihinde sona erecek ve {{leftDays}} gün kalacak.",

--- a/packages/frontend/i18n/src/resources/uk.json
+++ b/packages/frontend/i18n/src/resources/uk.json
@@ -1472,7 +1472,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "Необмежена кількість учасників команди (10+ місць)",
   "com.affine.settings.workspace.license.benefit.team.g5": "Кілька ролей адміністратора",
   "com.affine.settings.workspace.license.benefit.team.g6": "Пріоритетна підтримка клієнтів",
-  "com.affine.settings.workspace.license.lean-more": "Дізнатися більше",
+  "com.affine.settings.workspace.license.learn-more": "Дізнатися більше",
   "com.affine.settings.workspace.license.self-host": "Самостійне робоче середовище",
   "com.affine.settings.workspace.license.self-host-team": "Командний робочий простір з самостійним хостингом",
   "com.affine.settings.workspace.license.self-host-team.team.description": "Ця ліцензія закінчиться {{expirationDate}}, залишилось {{leftDays}} днів.",

--- a/packages/frontend/i18n/src/resources/ur.json
+++ b/packages/frontend/i18n/src/resources/ur.json
@@ -1927,7 +1927,7 @@
   "com.affine.settings.workspace.license.deactivate-modal.title": "غیر فعال ہونے کی تصدیق کریں؟",
   "com.affine.settings.workspace.license.deactivate-success": "لائسنس کامیابی سے غیر فعال ہو گیا۔",
   "com.affine.settings.workspace.license.description": "خود میزبان ٹیم ورک اسپیس کے لیے لائسنس کی معلومات اور رسیدوں کا نظم کریں۔",
-  "com.affine.settings.workspace.license.lean-more": "مزید جھکاؤ",
+  "com.affine.settings.workspace.license.learn-more": "مزید جھکاؤ",
   "com.affine.settings.workspace.license.self-host": "سیلف ہوسٹڈ ورک اسپیس",
   "com.affine.settings.workspace.license.self-host-team": "خود میزبان ٹیم ورک اسپیس",
   "com.affine.settings.workspace.license.self-host-team.deactivate-license": "غیر فعال کریں۔",

--- a/packages/frontend/i18n/src/resources/zh-Hans.json
+++ b/packages/frontend/i18n/src/resources/zh-Hans.json
@@ -1651,7 +1651,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "无限团队成员（10+席位）",
   "com.affine.settings.workspace.license.benefit.team.g5": "多个管理员",
   "com.affine.settings.workspace.license.benefit.team.g6": "优先客户支持",
-  "com.affine.settings.workspace.license.lean-more": "了解更多",
+  "com.affine.settings.workspace.license.learn-more": "了解更多",
   "com.affine.settings.workspace.license.self-host": "自托管工作区",
   "com.affine.settings.workspace.license.self-host-team": "自托管团队工作区",
   "com.affine.settings.workspace.license.self-host-team.team.description": "该许可证将于 {{expirationDate}} 到期，剩余 {{leftDays}} 天。",

--- a/packages/frontend/i18n/src/resources/zh-Hant.json
+++ b/packages/frontend/i18n/src/resources/zh-Hant.json
@@ -1512,7 +1512,7 @@
   "com.affine.settings.workspace.license.benefit.team.g4": "無限團隊成員（10+席位）",
   "com.affine.settings.workspace.license.benefit.team.g5": "多個管理員",
   "com.affine.settings.workspace.license.benefit.team.g6": "優先客戶支持",
-  "com.affine.settings.workspace.license.lean-more": "了解更多",
+  "com.affine.settings.workspace.license.learn-more": "了解更多",
   "com.affine.settings.workspace.license.self-host": "自托管工作區",
   "com.affine.settings.workspace.license.self-host-team": "自托管團隊工作區",
   "com.affine.settings.workspace.license.self-host-team.team.description": "該許可證將於 {{expirationDate}} 到期，剩餘 {{leftDays}} 天。",


### PR DESCRIPTION
Fixing "Learn More" typo. Adjusted the variables as well to keep things consistent.
<img width="608" height="347" alt="image" src="https://github.com/user-attachments/assets/7b1ba7ad-de99-421a-af9f-be6bfb009fba" />
