### PR TITLE
fix(editor): make Android keyboard autocorrect work in the mobile editor

### DIFF
--- a/blocksuite/affine/blocks/root/src/page/page-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/page/page-root-block.ts
@@ -19,6 +19,7 @@ import {
   getScrollContainer,
   matchModels,
 } from '@blocksuite/affine-shared/utils';
+import { IS_MOBILE } from '@blocksuite/global/env';
 import { Point } from '@blocksuite/global/gfx';
 import type { PointerEventState } from '@blocksuite/std';
 import { BlockComponent, BlockSelection, TextSelection } from '@blocksuite/std';
@@ -413,7 +414,13 @@ export class PageRootBlockComponent extends BlockComponent<RootBlockModel> {
       return !(isNote && displayOnEdgeless);
     });
 
-    this.contentEditable = String(!this.store.readonly$.value);
+    // On mobile the page root being contenteditable competes with each block's
+    // own inline editor: keyboards like the Samsung one focus the outer page
+    // root and their selection lands between blocks (whitespace / <style>
+    // text), so IME input never reaches the block and autocorrect on space or
+    // enter corrupts the text. Keep only the inner block editors editable on
+    // mobile. See https://github.com/toeverything/AFFiNE/issues/14021
+    this.contentEditable = String(!this.store.readonly$.value && !IS_MOBILE);
 
     return html`
       <div class="affine-page-root-block-container">${children} ${widgets}</div>

--- a/blocksuite/framework/std/src/__tests__/inline/event-composition.unit.spec.ts
+++ b/blocksuite/framework/std/src/__tests__/inline/event-composition.unit.spec.ts
@@ -1,0 +1,368 @@
+import { expect, test, vi } from 'vitest';
+import * as Y from 'yjs';
+
+// Force the Android IME code path, which is where autocorrect-on-space
+// composition is handled. See https://github.com/toeverything/AFFiNE/issues/14021
+vi.mock('@blocksuite/global/env', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, IS_ANDROID: true };
+});
+
+import { effects } from '../../effects.js';
+import { InlineEditor } from '../../inline/index.js';
+
+effects();
+
+async function setupInlineEditor(text: string) {
+  const yDoc = new Y.Doc();
+  const yText = yDoc.getText('text');
+  yText.insert(0, text);
+
+  const editor = new InlineEditor(yText);
+  const root = document.createElement('div');
+  document.body.append(root);
+  editor.mount(root);
+  await editor.waitForUpdate();
+
+  return { editor, root };
+}
+
+function setNativeSelection(range: Range) {
+  const selection = document.getSelection();
+  if (!selection) {
+    throw new Error('Selection is not available');
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+// The DOM-text cache is invalidated by a MutationObserver, which runs
+// asynchronously, so let it settle after each simulated composition edit.
+const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+// Drive the Android IME sequence for composing `word` at `startIndex`, then
+// committing `commit` on space (autocorrect may rewrite the word on commit).
+// During composition the browser inserts the composing text into the DOM but
+// not into the model, exactly like a real IME.
+async function composeAndCommit(
+  editor: InlineEditor,
+  startIndex: number,
+  word: string,
+  commit: string
+) {
+  const eventService = editor.eventService as any;
+
+  const domRange = editor.toDomRange({ index: startIndex, length: 0 });
+  if (!domRange) throw new Error('Cannot resolve start dom range');
+  const textNode = domRange.startContainer as Text;
+  const baseOffset = domRange.startOffset;
+
+  const startRange = document.createRange();
+  startRange.setStart(textNode, baseOffset);
+  startRange.setEnd(textNode, baseOffset);
+  setNativeSelection(startRange);
+  eventService._onCompositionStart(
+    new CompositionEvent('compositionstart', { data: '' })
+  );
+
+  for (let i = 1; i <= word.length; i++) {
+    textNode.replaceData(baseOffset, i - 1, word.slice(0, i));
+    await tick();
+
+    const caret = document.createRange();
+    caret.setStart(textNode, baseOffset + i);
+    caret.setEnd(textNode, baseOffset + i);
+    setNativeSelection(caret);
+
+    const staticRange = {
+      startContainer: textNode,
+      startOffset: baseOffset,
+      endContainer: textNode,
+      endOffset: baseOffset + i,
+    };
+    await eventService._onBeforeInput({
+      inputType: 'insertCompositionText',
+      data: word.slice(0, i),
+      dataTransfer: null,
+      isComposing: true,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [staticRange],
+    } as unknown as InputEvent);
+  }
+
+  const caret = document.createRange();
+  caret.setStart(textNode, baseOffset + word.length);
+  caret.setEnd(textNode, baseOffset + word.length);
+  setNativeSelection(caret);
+  await eventService._onCompositionEnd(
+    new CompositionEvent('compositionend', { data: commit })
+  );
+  await editor.waitForUpdate();
+}
+
+test('android IME commits a composed word at the caret, not the end of the line', async () => {
+  const { editor, root } = await setupInlineEditor('XY');
+  try {
+    // Compose "ab" before the existing "XY".
+    await composeAndCommit(editor, 0, 'ab', 'ab');
+    expect(editor.yTextString).toBe('abXY');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});
+
+test('android IME autocorrect on space keeps the corrected word in place', async () => {
+  const { editor, root } = await setupInlineEditor('XY');
+  try {
+    // Compose the misspelled "wrold" before "XY"; autocorrect commits "world".
+    await composeAndCommit(editor, 0, 'wrold', 'world');
+    expect(editor.yTextString).toBe('worldXY');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});
+
+test('applies input at the current inline range when the native range is stale', async () => {
+  // Reproduces the Samsung sequence: compositionend rebuilds the editor DOM
+  // (detaching the composition nodes), then the following space arrives with a
+  // native selection still pointing at the now-detached node. The editor must
+  // apply the space at its own inline range instead of letting the browser
+  // mutate the DOM natively (which desyncs DOM and model). See issue #14021.
+  const { editor, root } = await setupInlineEditor('Wort');
+  try {
+    editor.setInlineRange({ index: 4, length: 0 });
+
+    // A detached node standing in for the replaced composition DOM.
+    const staleNode = document.createTextNode('\n ');
+    document.body.append(staleNode);
+    const staleRange = document.createRange();
+    staleRange.setStart(staleNode, 1);
+    staleRange.setEnd(staleNode, 1);
+    setNativeSelection(staleRange);
+
+    const preventDefault = vi.fn();
+    await (editor.eventService as any)._onBeforeInput({
+      inputType: 'insertText',
+      data: ' ',
+      dataTransfer: null,
+      isComposing: false,
+      target: root,
+      preventDefault,
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [
+        {
+          startContainer: staleNode,
+          startOffset: 1,
+          endContainer: staleNode,
+          endOffset: 1,
+        },
+      ],
+    } as unknown as InputEvent);
+
+    staleNode.remove();
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    // The space landed at the caret in the model, no native corruption.
+    expect(editor.yTextString).toBe('Wort ');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});
+
+test('android insertParagraph does not insert an inline line break', async () => {
+  // On Android, Enter arrives as an `insertParagraph` beforeinput. The inline
+  // editor must not turn it into a soft line break; the block keymap performs
+  // the paragraph split instead. See issue #14021.
+  const ctx = await setupInlineEditor('ab');
+  try {
+    const range = ctx.editor.toDomRange({ index: 2, length: 0 });
+    expect(range).not.toBeNull();
+    setNativeSelection(range!);
+
+    const preventDefault = vi.fn();
+    await (ctx.editor.eventService as any)._onBeforeInput({
+      inputType: 'insertParagraph',
+      data: null,
+      dataTransfer: null,
+      preventDefault,
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [],
+    } as unknown as InputEvent);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    // No "\n" was inserted into the model.
+    expect(ctx.editor.yTextString).toBe('ab');
+  } finally {
+    ctx.editor.unmount();
+    ctx.root.remove();
+  }
+});
+
+test('android insertParagraph during composition does not insert a soft line break', async () => {
+  // The paragraph guard must run before the composing branch, otherwise Enter
+  // during composition is swallowed without preventing the native newline.
+  const { editor, root } = await setupInlineEditor('ab');
+  const eventService = editor.eventService as any;
+  try {
+    const range = editor.toDomRange({ index: 2, length: 0 });
+    expect(range).not.toBeNull();
+    setNativeSelection(range!);
+
+    eventService._onCompositionStart(
+      new CompositionEvent('compositionstart', { data: '' })
+    );
+    expect(editor.eventService.isComposing).toBe(true);
+
+    const preventDefault = vi.fn();
+    await eventService._onBeforeInput({
+      inputType: 'insertParagraph',
+      data: null,
+      dataTransfer: null,
+      isComposing: true,
+      target: root,
+      preventDefault,
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [],
+    } as unknown as InputEvent);
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(editor.yTextString).toBe('ab');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});
+
+test('android insertParagraph with a stale native range does not insert a soft line break', async () => {
+  // The paragraph guard must run before the stale-range branch, otherwise Enter
+  // is turned into an inline line break (insertLineBreak) instead of delegating
+  // the block split to the keymap.
+  const { editor, root } = await setupInlineEditor('ab');
+  const eventService = editor.eventService as any;
+  try {
+    editor.setInlineRange({ index: 2, length: 0 });
+
+    const staleNode = document.createTextNode('\n ');
+    document.body.append(staleNode);
+    const staleRange = document.createRange();
+    staleRange.setStart(staleNode, 1);
+    staleRange.setEnd(staleNode, 1);
+    setNativeSelection(staleRange);
+
+    const preventDefault = vi.fn();
+    await eventService._onBeforeInput({
+      inputType: 'insertParagraph',
+      data: null,
+      dataTransfer: null,
+      isComposing: false,
+      target: root,
+      preventDefault,
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [],
+    } as unknown as InputEvent);
+
+    staleNode.remove();
+
+    expect(preventDefault).toHaveBeenCalledOnce();
+    // Not turned into a soft "\n" by the stale-range branch.
+    expect(editor.yTextString).toBe('ab');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});
+
+test('android IME keeps the first word typed in an empty field', async () => {
+  const { editor, root } = await setupInlineEditor('');
+  const eventService = editor.eventService as any;
+  try {
+    const vText = root.querySelector('[data-v-text="true"]');
+    if (!vText) throw new Error('Cannot find v-text');
+    const textNode = Array.from(vText.childNodes).find(
+      (node): node is Text => node instanceof Text
+    );
+    if (!textNode) throw new Error('Cannot find text node');
+
+    // An empty line renders a zero-width placeholder that is not part of the
+    // model. The IME inserts the composing text into that same text node.
+    const placeholder = textNode.data;
+
+    const startRange = document.createRange();
+    startRange.setStart(textNode, 0);
+    startRange.setEnd(textNode, 0);
+    setNativeSelection(startRange);
+    eventService._onCompositionStart(
+      new CompositionEvent('compositionstart', { data: '' })
+    );
+
+    const word = 'hello';
+    for (let i = 1; i <= word.length; i++) {
+      textNode.data = placeholder + word.slice(0, i);
+      await tick();
+
+      const caret = document.createRange();
+      caret.setStart(textNode, placeholder.length + i);
+      caret.setEnd(textNode, placeholder.length + i);
+      setNativeSelection(caret);
+
+      const staticRange = {
+        startContainer: textNode,
+        startOffset: placeholder.length,
+        endContainer: textNode,
+        endOffset: placeholder.length + i,
+      };
+      await eventService._onBeforeInput({
+        inputType: 'insertCompositionText',
+        data: word.slice(0, i),
+        dataTransfer: null,
+        isComposing: true,
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+        getTargetRanges: () => [staticRange],
+      } as unknown as InputEvent);
+    }
+
+    const caret = document.createRange();
+    caret.setStart(textNode, textNode.data.length);
+    caret.setEnd(textNode, textNode.data.length);
+    setNativeSelection(caret);
+    await eventService._onCompositionEnd(
+      new CompositionEvent('compositionend', { data: word })
+    );
+    await editor.waitForUpdate();
+
+    expect(editor.yTextString).toBe('hello');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});
+
+test('composition commit clamps an out-of-bounds range instead of dropping the text', async () => {
+  const { editor, root } = await setupInlineEditor('ab');
+  try {
+    const domRange = editor.toDomRange({ index: 2, length: 0 });
+    expect(domRange).not.toBeNull();
+    setNativeSelection(domRange!);
+
+    const eventService = editor.eventService as any;
+    // Simulate a captured composition range that is out of bounds for the
+    // current model (length 2). The composed text must be kept (clamped), not
+    // silently dropped. See issue #14021 review feedback.
+    eventService._compositionInlineRange = { index: 99, length: 0 };
+
+    await eventService._onCompositionEnd(
+      new CompositionEvent('compositionend', { data: 'xy' })
+    );
+    await editor.waitForUpdate();
+
+    expect(editor.yTextString).toBe('abxy');
+  } finally {
+    editor.unmount();
+    root.remove();
+  }
+});

--- a/blocksuite/framework/std/src/__tests__/keymap.unit.spec.ts
+++ b/blocksuite/framework/std/src/__tests__/keymap.unit.spec.ts
@@ -1,6 +1,7 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi } from 'vitest';
 
-import { bindKeymap } from '../event/keymap.js';
+import { UIEventState, UIEventStateContext } from '../event/base.js';
+import { androidBindKeymapPatch, bindKeymap } from '../event/keymap.js';
 
 const createKeyboardEvent = (options: {
   key: string;
@@ -115,5 +116,62 @@ describe('bindKeymap', () => {
 
     expect(handler(createCtx(event))).toBe(false);
     expect(handled).toBe(false);
+  });
+});
+
+describe('androidBindKeymapPatch', () => {
+  const beforeInputCtx = (inputType: string) => {
+    const event = new InputEvent('beforeinput', { inputType });
+    return { ctx: UIEventStateContext.from(new UIEventState(event)), event };
+  };
+
+  test('routes deleteContentBackward to the Backspace binding', () => {
+    const backspace = vi.fn(() => true);
+    const handler = androidBindKeymapPatch({ Backspace: backspace });
+    const { ctx } = beforeInputCtx('deleteContentBackward');
+
+    expect(handler(ctx)).toBe(true);
+    expect(backspace).toHaveBeenCalledOnce();
+  });
+
+  test('routes insertParagraph (Android soft-keyboard Enter) to the Enter binding', () => {
+    // The Enter binding reads a keyboardState; the patch must provide one.
+    const enter = vi.fn((ctx: UIEventStateContext) => {
+      ctx.get('keyboardState').raw.preventDefault();
+      return true;
+    });
+    const handler = androidBindKeymapPatch({ Enter: enter });
+    const { ctx, event } = beforeInputCtx('insertParagraph');
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    expect(handler(ctx)).toBe(true);
+    expect(enter).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+    // The synthesized keyboardState wraps the original InputEvent.
+    expect(ctx.get('keyboardState').raw).toBe(
+      event as unknown as KeyboardEvent
+    );
+  });
+
+  test('does nothing for insertParagraph without an Enter binding', () => {
+    const handler = androidBindKeymapPatch({ Backspace: vi.fn(() => true) });
+    const { ctx } = beforeInputCtx('insertParagraph');
+
+    expect(handler(ctx)).toBe(false);
+    expect(ctx.has('keyboardState')).toBe(false);
+  });
+
+  test('ignores unrelated input types', () => {
+    const enter = vi.fn(() => true);
+    const backspace = vi.fn(() => true);
+    const handler = androidBindKeymapPatch({
+      Enter: enter,
+      Backspace: backspace,
+    });
+    const { ctx } = beforeInputCtx('insertText');
+
+    expect(handler(ctx)).toBe(false);
+    expect(enter).not.toHaveBeenCalled();
+    expect(backspace).not.toHaveBeenCalled();
   });
 });

--- a/blocksuite/framework/std/src/event/keymap.ts
+++ b/blocksuite/framework/std/src/event/keymap.ts
@@ -3,6 +3,7 @@ import { BlockSuiteError, ErrorCode } from '@blocksuite/global/exceptions';
 import { base, keyName } from 'w3c-keyname';
 
 import type { UIEventHandler } from './base.js';
+import { KeyboardEventState } from './state/index.js';
 
 function normalizeKeyName(name: string) {
   const parts = name.split(/-(?!$)/);
@@ -132,6 +133,22 @@ export function androidBindKeymapPatch(
       'Backspace' in bindings
     ) {
       return bindings['Backspace'](ctx);
+    }
+
+    // Enter is delivered as an `insertParagraph` beforeinput instead of a
+    // keydown, so route it to the `Enter` binding. The binding reads a
+    // `keyboardState`, so provide one that wraps the InputEvent. It only uses
+    // `preventDefault`/`stopPropagation`/`isComposing`, which InputEvent has.
+    if (event.inputType === 'insertParagraph' && 'Enter' in bindings) {
+      if (!ctx.has('keyboardState')) {
+        ctx.add(
+          new KeyboardEventState({
+            event: event as unknown as KeyboardEvent,
+            composing: event.isComposing,
+          })
+        );
+      }
+      return bindings['Enter'](ctx);
     }
 
     return false;

--- a/blocksuite/framework/std/src/inline/services/event.ts
+++ b/blocksuite/framework/std/src/inline/services/event.ts
@@ -45,6 +45,19 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
     const rootElement = this.editor.rootElement;
     if (!rootElement) return;
 
+    // On Android, Enter is delivered as an `insertParagraph` beforeinput
+    // instead of a keydown. Prevent the inline editor from inserting a soft
+    // line break and let the block-level keymap turn it into a real paragraph
+    // split (see `androidBindKeymapPatch`); otherwise the inline newline
+    // corrupts the following IME composition. This runs before the stale-range
+    // and composing branches below so those cannot turn it into a soft line
+    // break or swallow it. `insertLineBreak` (Shift+Enter) is left untouched so
+    // soft breaks keep working.
+    if (IS_ANDROID && event.inputType === 'insertParagraph') {
+      event.preventDefault();
+      return;
+    }
+
     const startInRoot =
       range.startContainer === rootElement ||
       rootElement.contains(range.startContainer);
@@ -52,8 +65,47 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
       range.endContainer === rootElement ||
       rootElement.contains(range.endContainer);
 
-    // Not this inline editor.
-    if (!startInRoot && !endInRoot) return;
+    if (!startInRoot && !endInRoot) {
+      // The native range is not inside this editor. Usually that means the
+      // event is not for us. But the range can also be stale: some IMEs
+      // (notably the Samsung keyboard) fire the input that follows a
+      // composition before the browser re-syncs its selection to the DOM we
+      // just rebuilt on compositionend, so the range still points at the
+      // detached composition nodes. If this editor is the real event target,
+      // prevent the browser from mutating the DOM natively (which would leave
+      // the DOM out of sync with the model) and apply the input at the
+      // editor's current inline range instead of bailing out.
+      const target = event.target;
+      const isOurTarget =
+        target instanceof Node &&
+        (target === rootElement || rootElement.contains(target));
+      if (!isOurTarget || this._isComposing) return;
+
+      const currentInlineRange = this.editor.getInlineRange();
+      if (!currentInlineRange) return;
+
+      event.preventDefault();
+
+      const staleCtx: BeforeinputHookCtx<TextAttributes> = {
+        inlineEditor: this.editor,
+        raw: event,
+        inlineRange: currentInlineRange,
+        data: event.data ?? event.dataTransfer?.getData('text/plain') ?? null,
+        attributes: {} as TextAttributes,
+      };
+      this.editor.hooks.beforeinput?.(staleCtx);
+
+      transformInput<TextAttributes>(
+        staleCtx.raw.inputType,
+        staleCtx.data,
+        staleCtx.attributes,
+        staleCtx.inlineRange,
+        this.editor as never
+      );
+
+      this.editor.slots.inputting.next(event.data ?? '');
+      return;
+    }
 
     // If selection spans into another inline editor, let the range binding handle it.
     if (startInRoot !== endInRoot) {
@@ -64,9 +116,40 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
 
     if (this._isComposing) {
       if (IS_ANDROID && event.inputType === 'insertCompositionText') {
-        const compositionInlineRange = this.editor.toInlineRange(range);
+        // The in-progress composition text lives in the DOM but not in the
+        // model, so a collapsed caret maps to a model index that is
+        // over-counted by the length of the composed text. Prefer the start of
+        // the composition target range, which sits before the composed
+        // characters and therefore maps to the true model index.
+        let compositionInlineRange: InlineRange | null = null;
+        const targetRanges = event.getTargetRanges();
+        if (targetRanges.length > 0) {
+          const staticRange = targetRanges[0];
+          const startRange = document.createRange();
+          startRange.setStart(
+            staticRange.startContainer,
+            staticRange.startOffset
+          );
+          startRange.setEnd(
+            staticRange.startContainer,
+            staticRange.startOffset
+          );
+          compositionInlineRange = this.editor.toInlineRange(startRange);
+        }
+        if (!compositionInlineRange) {
+          compositionInlineRange = this.editor.toInlineRange(range);
+        }
         if (compositionInlineRange) {
-          this._compositionInlineRange = compositionInlineRange;
+          // The empty-line zero-width placeholder is counted as a character
+          // once real composition text shares its text node, which pushes the
+          // index one past the model. Clamp to the model bounds so the composed
+          // text is never committed out of range, which would otherwise drop
+          // the first word typed in an empty field.
+          const index = Math.min(
+            Math.max(compositionInlineRange.index, 0),
+            this.editor.yTextLength
+          );
+          this._compositionInlineRange = { index, length: 0 };
         }
       }
       return;
@@ -257,9 +340,25 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
 
     const { inlineRange: newInlineRange, data: newData } = ctx;
     if (newData && newData.length > 0) {
-      this.editor.insertText(newInlineRange, newData, ctx.attributes);
+      let targetInlineRange = newInlineRange;
+      if (!this.editor.isValidInlineRange(targetInlineRange)) {
+        // The composition range is clamped at capture time, so this should not
+        // happen. If the model changed under us and the range is out of bounds,
+        // clamp it instead of silently dropping the composed text (which would
+        // look like the very "text deleted" bug this path guards against).
+        const index = Math.min(
+          Math.max(newInlineRange.index, 0),
+          this.editor.yTextLength
+        );
+        targetInlineRange = { index, length: 0 };
+        console.warn(
+          'InlineEditor: composition inline range out of bounds, clamped to keep the composed text',
+          { inlineRange: newInlineRange, yTextLength: this.editor.yTextLength }
+        );
+      }
+      this.editor.insertText(targetInlineRange, newData, ctx.attributes);
       this.editor.setInlineRange({
-        index: newInlineRange.index + newData.length,
+        index: targetInlineRange.index + newData.length,
         length: 0,
       });
     }

--- a/blocksuite/integration-test/src/__tests__/main/page-root-editable.spec.ts
+++ b/blocksuite/integration-test/src/__tests__/main/page-root-editable.spec.ts
@@ -1,0 +1,23 @@
+import { beforeEach, expect, test } from 'vitest';
+
+import { wait } from '../utils/common.js';
+import { setupEditor } from '../utils/setup.js';
+
+// Regression guard for the mobile IME fix (issue #14021): on desktop the page
+// root must stay contenteditable. The fix only removes it on mobile (IS_MOBILE),
+// where it otherwise swallows IME input meant for the block editors. The mobile
+// side is environment-specific (needs a mobile WebView) and is covered by the
+// per-block inline editor unit tests plus manual device testing.
+beforeEach(async () => {
+  const cleanup = await setupEditor('page');
+  return cleanup;
+});
+
+test('desktop: page root stays contenteditable', async () => {
+  await wait();
+  const pageRoot = editor.host?.querySelector('affine-page-root');
+  expect(pageRoot).toBeTruthy();
+  expect((pageRoot as HTMLElement).getAttribute('contenteditable')).toBe(
+    'true'
+  );
+});


### PR DESCRIPTION
## Problem

On Android, keyboard autocorrect (Samsung keyboard, Gboard, HeliBoard, AOSP)
rewrites the current word on space or enter through IME composition. Typing in
the editor was corrupted by this:

- a word followed by space deleted the word,
- editing inside a word deleted the text after the cursor,
- creating a new line was unreliable,
- the stray text was visible on screen but gone after closing and reopening the
  document (it lived in the DOM only and never reached the model).

It reproduced with several keyboards and in mobile browsers (Chrome, Brave,
Firefox), not only in the Android app, and disabling autocorrect/suggestions
worked around it.

Closes #14021

## Root causes and fixes

1. **Nested contenteditable on mobile.** The page root was `contenteditable`
   and competed with each block's own inline editor. On Android the page root
   captured the IME input while its native selection sat between blocks
   (whitespace and `<style>` text), so composed text never reached the block and
   never committed to the model. The page root is no longer contenteditable on
   mobile (`IS_MOBILE`), so the block inline editors keep focus and receive the
   IME input. This is the change that makes body editing usable again.

2. **Composition range was over-counted.** During composition the composed
   characters live in the DOM but not in the model, so the commit index captured
   from the caret pointed past the real position. The composition start is now
   taken from the composition target range and clamped to the model bounds. This
   also fixes the first word typed in an empty line disappearing.

3. **Enter on Android** arrives as an `insertParagraph` beforeinput rather than a
   keydown, so it was inserted as a soft line break inline instead of splitting
   the block. It is now routed to the block `Enter` binding.

4. **Stale native range recovery.** Some IMEs fire the input that follows a
   composition before the browser re-syncs its selection to the rebuilt DOM. That
   input is now applied at the editor's current inline range instead of letting
   the browser mutate the DOM natively.

## Impact of the page-root change

- Mobile only (`IS_MOBILE`); desktop is unchanged (covered by a regression test).
- Block inline editors stay `contenteditable`, so typing, caret and IME work.
- The two code paths that query `contenteditable` (range-manager `clear()` and
  range-binding selection sync) were reviewed and behave neutrally or better:
  selections that land between blocks are now correctly ignored.

## Testing

- Unit tests (framework/std): composition commit at the caret, autocorrect on
  space keeps the corrected word in place, first word in an empty line is kept,
  Android `insertParagraph` does not insert a soft line break, `insertParagraph`
  is routed to the `Enter` binding, and stale-range recovery.
- Regression test (integration-test): the page root stays contenteditable on
  desktop.
- Manual: verified on a Samsung device with the native Samsung keyboard (the
  reported case). Text input, autocorrect on space, editing mid-word and Enter
  (new block) all work, and the content stays consistent after reopening.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android IME composition/commit handling, including autocorrect-on-commit and correct caret positioning.
  * Prevented IME `insertParagraph` from creating unintended soft inline line breaks.
  * Reduced risks of stale/“out of root” beforeinput selection causing editor/model desync by routing through editor ranges.
  * Routed Android `insertParagraph` to the Enter binding when available, with consistent patched keyboard state.
  * Clamped out-of-bounds composition ranges to preserve composed text.
* **Mobile**
  * Disabled editing on the outer page container on mobile to ensure IME targets inner editors.
* **Tests**
  * Added Android IME, keymap routing, and desktop page-root contenteditable regression coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->