### PR TITLE
fix(server): share query

### DIFF
--- a/packages/backend/server/src/__tests__/models/doc.spec.ts
+++ b/packages/backend/server/src/__tests__/models/doc.spec.ts
@@ -679,6 +679,7 @@ test('should get doc info', async t => {
   t.like(docInfo, {
     workspaceId: workspace.id,
     docId,
+    public: false,
     updatedAt: new Date(snapshot.timestamp),
     creatorId: user.id,
     lastUpdaterId: user.id,
@@ -727,6 +728,7 @@ test('should paginate docs info', async t => {
   t.is(count, 3);
   t.is(docs.length, 1);
   t.is(docs[0].docId, docId1);
+  t.false(docs[0].public);
 
   [count, docs] = await t.context.doc.paginateDocInfo(workspace.id, {
     first: 1,
@@ -737,5 +739,6 @@ test('should paginate docs info', async t => {
   t.is(count, 3);
   t.is(docs.length, 1);
   t.is(docs[0].docId, docId2);
+  t.false(docs[0].public);
 });
 // #endregion

--- a/packages/backend/server/src/models/doc.ts
+++ b/packages/backend/server/src/models/doc.ts
@@ -634,7 +634,10 @@ export class DocModel extends BaseModel {
      "workspace_pages"."workspace_id" as "workspaceId",
      "workspace_pages"."page_id" as "docId",
      "workspace_pages"."mode" as "mode",
-     (dap.visibility = 'public' AND dap.public_role = 'external') as "public",
+     COALESCE(
+       dap.visibility = 'public' AND dap.public_role = 'external',
+       false
+     ) as "public",
      COALESCE(dap.member_default_role, 'manager') as "defaultRolePolicy",
      "workspace_pages"."title" as "title",
      "workspace_pages"."summary" as "summary",
@@ -694,7 +697,10 @@ export class DocModel extends BaseModel {
        "workspace_pages"."workspace_id" as "workspaceId",
        "workspace_pages"."page_id" as "docId",
        "workspace_pages"."mode" as "mode",
-       (dap.visibility = 'public' AND dap.public_role = 'external') as "public",
+       COALESCE(
+         dap.visibility = 'public' AND dap.public_role = 'external',
+         false
+       ) as "public",
        COALESCE(dap.member_default_role, 'manager') as "defaultRolePolicy",
        "snapshots"."created_at" as "createdAt",
        "snapshots"."updated_at" as "updatedAt",
@@ -761,7 +767,10 @@ export class DocModel extends BaseModel {
        "workspace_pages"."workspace_id" as "workspaceId",
        "workspace_pages"."page_id" as "docId",
        "workspace_pages"."mode" as "mode",
-       (dap.visibility = 'public' AND dap.public_role = 'external') as "public",
+       COALESCE(
+         dap.visibility = 'public' AND dap.public_role = 'external',
+         false
+       ) as "public",
        COALESCE(dap.member_default_role, 'manager') as "defaultRolePolicy",
        "workspace_pages"."title" as "title",
        "snapshots"."created_at" as "createdAt",


### PR DESCRIPTION
fix #15283



#### PR Dependency Tree


* **PR #15305** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Document metadata now consistently reports documents as not public when no applicable access policy is available.
  * Improved reliability of document visibility information across document listings and pagination.
* **Tests**
  * Added coverage verifying the `public` status in document details and paginated results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->