### PR TITLE
fix(mobile): fix iOS self-hosted login and workspace sync

### DIFF
--- a/packages/frontend/apps/ios/App/App/Plugins/Auth/AuthPlugin.swift
+++ b/packages/frontend/apps/ios/App/App/Plugins/Auth/AuthPlugin.swift
@@ -411,7 +411,15 @@ public class AuthPlugin: CAPPlugin, CAPBridgedPlugin {
         }
 
         try await self.exchangeSession(endpoint, data)
-        call.resolve(["ok": true])
+        // Return the signed-in user so the JS AuthProvider can optimistically flip
+        // the client session to `authenticated` (matching web/desktop). Without this
+        // the session only completes via a realtime-gated revalidation, which stalls
+        // on self-hosted servers and leaves the app stuck on the sign-in screen.
+        if let user = self.userFromSignInResponse(data) {
+          call.resolve(["user": user])
+        } else {
+          call.resolve(["ok": true])
+        }
       } catch {
         call.reject("Failed to sign in, \(error)", nil, error)
       }
@@ -463,6 +471,26 @@ public class AuthPlugin: CAPPlugin, CAPBridgedPlugin {
     }
 
     return code
+  }
+
+  // Extracts the SignInUserInfo fields from the /api/auth/sign-in response body
+  // (which is `{ ...sessionUser, exchangeCode }`), for the JS AuthProvider to return.
+  private func userFromSignInResponse(_ data: Data) -> [String: Any]? {
+    guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+      let id = json["id"] as? String,
+      let email = json["email"] as? String
+    else {
+      return nil
+    }
+    var user: [String: Any] = [
+      "id": id,
+      "email": email,
+      "name": json["name"] as? String ?? "",
+      "emailVerified": json["emailVerified"] as? Bool ?? false,
+    ]
+    user["hasPassword"] = (json["hasPassword"] as? Bool).map { $0 as Any } ?? NSNull()
+    user["avatarUrl"] = (json["avatarUrl"] as? String).map { $0 as Any } ?? NSNull()
+    return user
   }
 
   private func exchangeSession(_ endpoint: String, _ signInData: Data) async throws {

--- a/packages/frontend/apps/ios/src/app.tsx
+++ b/packages/frontend/apps/ios/src/app.tsx
@@ -200,10 +200,11 @@ framework.scope(ServerScope).override(AuthProvider, resolver => {
       return {};
     },
     async signInPassword(credential) {
-      await Auth.signInPassword({
+      const { user } = await Auth.signInPassword({
         endpoint,
         ...credential,
       });
+      return user;
     },
     async signInOpenAppSignInCode(code) {
       await Auth.signInOpenApp({

--- a/packages/frontend/apps/ios/src/nbstore.worker.ts
+++ b/packages/frontend/apps/ios/src/nbstore.worker.ts
@@ -18,6 +18,8 @@ import {
 import { type MessageCommunicapable, OpConsumer } from '@toeverything/infra/op';
 import { AsyncCall } from 'async-call-rpc';
 
+import { setWorkerAccessTokenProvider } from './proxy';
+
 let authTokenPort: MessagePort | undefined;
 const terminalAuthErrors = new Set([
   'ACCESS_TOKEN_INVALID',
@@ -41,6 +43,12 @@ configureSocketAuthMethod((endpoint, cb) => {
     .then(token => cb(token ? { token, tokenType: 'jwt' } : {}))
     .catch(() => cb({ error: 'AUTH_SESSION_TEMPORARILY_UNAVAILABLE' }));
 });
+
+// The shared fetch/XHR proxy (proxy.ts) can't use the Capacitor Auth plugin here (it
+// hangs in a worker), so let it obtain the access token through this worker's
+// auth-access-token-channel instead — keeping authenticated HTTP requests from the
+// worker's cloud storages (blob / indexer / static-doc) working.
+setWorkerAccessTokenProvider(getValidAccessToken);
 
 globalThis.addEventListener('message', e => {
   if (e.data.type === 'auth-access-token-channel') {

--- a/packages/frontend/apps/ios/src/plugins/auth/definitions.ts
+++ b/packages/frontend/apps/ios/src/plugins/auth/definitions.ts
@@ -17,7 +17,16 @@ export interface AuthPlugin {
     password: string;
     verifyToken?: string;
     challenge?: string;
-  }): Promise<void>;
+  }): Promise<{
+    user?: {
+      id: string;
+      email: string;
+      name: string;
+      hasPassword: boolean | null;
+      avatarUrl: string | null;
+      emailVerified: boolean;
+    };
+  }>;
   signInOpenApp(options: { endpoint: string; code: string }): Promise<void>;
   signOut(options: { endpoint: string }): Promise<void>;
   getValidAccessToken(options: {

--- a/packages/frontend/apps/ios/src/proxy.ts
+++ b/packages/frontend/apps/ios/src/proxy.ts
@@ -2,6 +2,17 @@ import { canonicalAuthEndpoint } from '@affine/mobile-shared/auth/endpoint';
 
 import { Auth } from './plugins/auth';
 
+// Capacitor plugins are only available on the main thread — calling them from a Web
+// Worker posts to a native bridge that does not exist there, so the promise hangs
+// FOREVER. The nbstore worker imports this file (via setup-worker) to patch fetch/XHR;
+// without this guard the self-hosted socket.io *polling* transport (which goes through
+// the patched XHR) hangs on the Auth plugin call, the doc-sync socket never connects
+// ("connecting timeout"), and the workspace loads forever. The worker authenticates its
+// socket via the auth-token-channel instead, so skip the plugin calls in a worker.
+const isWorkerScope =
+  typeof (globalThis as { importScripts?: unknown }).importScripts ===
+  'function';
+
 function authEndpointForUrl(url: string | URL) {
   try {
     const parsed = new URL(url, globalThis.location.origin);
@@ -30,7 +41,7 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
   }
 
   const response = await rawFetch(request);
-  if (response.status !== 401 || !origin) return response;
+  if (response.status !== 401 || !origin || isWorkerScope) return response;
   const body = await response
     .clone()
     .json()
@@ -88,7 +99,7 @@ globalThis.XMLHttpRequest = class extends rawXMLHttpRequest {
         } catch {
           return;
         }
-        if (code !== 'ACCESS_TOKEN_EXPIRED') return;
+        if (code !== 'ACCESS_TOKEN_EXPIRED' || isWorkerScope) return;
         event.stopImmediatePropagation();
         this.replaying = true;
         this.hasReplayed = true;
@@ -184,9 +195,29 @@ globalThis.XMLHttpRequest = class extends rawXMLHttpRequest {
   }
 };
 
+// In a Web Worker the Capacitor bridge is unavailable, so calling the Auth plugin would
+// hang forever. The nbstore worker registers a channel-based provider (the
+// auth-access-token-channel to the main thread) so the worker's patched fetch/XHR still
+// get a valid Bearer for its cloud HTTP storages (blob / indexer / static-doc), which have
+// no cookie fallback and would otherwise 401 on self-hosted.
+let workerAccessTokenProvider:
+  | ((endpoint: string) => Promise<string | null>)
+  | undefined;
+
+export function setWorkerAccessTokenProvider(
+  provider: (endpoint: string) => Promise<string | null>
+) {
+  workerAccessTokenProvider = provider;
+}
+
 export async function getValidAccessToken(
   endpoint: string
 ): Promise<string | null> {
+  if (isWorkerScope) {
+    return workerAccessTokenProvider
+      ? await workerAccessTokenProvider(endpoint)
+      : null;
+  }
   const { token } = await Auth.getValidAccessToken({
     endpoint: canonicalAuthEndpoint(endpoint),
   });

--- a/packages/frontend/core/src/components/sign-in/index.tsx
+++ b/packages/frontend/core/src/components/sign-in/index.tsx
@@ -1,7 +1,7 @@
 import { DefaultServerService, type Server } from '@affine/core/modules/cloud';
 import type { AuthSessionStatus } from '@affine/core/modules/cloud/entities/session';
 import { FrameworkScope, useService } from '@toeverything/infra';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { AddSelfhostedStep } from './add-selfhosted';
 import { SignInStep } from './sign-in';
@@ -29,7 +29,7 @@ export const SignInPanel = ({
   initStep,
   onAuthenticated,
 }: {
-  onAuthenticated?: (status: AuthSessionStatus) => void;
+  onAuthenticated?: (status: AuthSessionStatus, server?: Server) => void;
   onSkip: () => void;
   server?: string;
   initStep?: SignInStep | undefined;
@@ -48,6 +48,16 @@ export const SignInPanel = ({
   const step = state.step;
   const server = state.server ?? defaultServerService.server;
 
+  // Surface which server was actually signed into (the self-hosted flow picks it
+  // inside AddSelfhostedStep, so the outer panel otherwise can't know it). Optional
+  // second arg keeps existing callers (e.g. desktop) unchanged.
+  const handleAuthenticated = useCallback(
+    (status: AuthSessionStatus) => {
+      onAuthenticated?.(status, server);
+    },
+    [onAuthenticated, server]
+  );
+
   return (
     <FrameworkScope scope={server.scope}>
       {step === 'signIn' ? (
@@ -55,19 +65,19 @@ export const SignInPanel = ({
           state={state}
           changeState={setState}
           onSkip={onSkip}
-          onAuthenticated={onAuthenticated}
+          onAuthenticated={handleAuthenticated}
         />
       ) : step === 'signInWithEmail' ? (
         <SignInWithEmailStep
           state={state}
           changeState={setState}
-          onAuthenticated={onAuthenticated}
+          onAuthenticated={handleAuthenticated}
         />
       ) : step === 'signInWithPassword' ? (
         <SignInWithPasswordStep
           state={state}
           changeState={setState}
-          onAuthenticated={onAuthenticated}
+          onAuthenticated={handleAuthenticated}
         />
       ) : step === 'addSelfhosted' ? (
         <AddSelfhostedStep state={state} changeState={setState} />

--- a/packages/frontend/core/src/mobile/components/sign-in/index.tsx
+++ b/packages/frontend/core/src/mobile/components/sign-in/index.tsx
@@ -1,5 +1,9 @@
+import { useNavigateHelper } from '@affine/core/components/hooks/use-navigate-helper';
 import { SignInPanel, type SignInStep } from '@affine/core/components/sign-in';
+import { DefaultServerService, type Server } from '@affine/core/modules/cloud';
 import type { AuthSessionStatus } from '@affine/core/modules/cloud/entities/session';
+import { WorkspacesService } from '@affine/core/modules/workspace';
+import { useService } from '@toeverything/infra';
 import { useCallback } from 'react';
 
 import { MobileSignInLayout } from './layout';
@@ -13,13 +17,62 @@ export const MobileSignInPanel = ({
   server?: string;
   initStep?: SignInStep;
 }) => {
+  const workspacesService = useService(WorkspacesService);
+  const defaultServerService = useService(DefaultServerService);
+  const { jumpToPage } = useNavigateHelper();
+
   const onAuthenticated = useCallback(
-    (status: AuthSessionStatus) => {
-      if (status === 'authenticated') {
-        onClose();
+    (status: AuthSessionStatus, authedServer?: Server) => {
+      if (status !== 'authenticated') {
+        return;
       }
+
+      // On mobile the active server (globalContext.serverId) is set ONLY when a
+      // workspace layout mounts (see mobile/pages/workspace/layout.tsx). The iOS
+      // native layer reads that value via window.getCurrentServerBaseUrl(), so
+      // after a self-hosted sign-in — which authenticates the server but never
+      // opens one of its workspaces — the app stays anchored to the default cloud
+      // server. Fix: when signing into a self-hosted (non-default) server, navigate
+      // into one of its workspaces so it becomes the active server. Cloud/default
+      // sign-in keeps the previous behavior (just close).
+      if (!authedServer || authedServer.id === defaultServerService.server.id) {
+        onClose();
+        return;
+      }
+
+      const openServerWorkspace = () => {
+        const workspace = workspacesService.list.workspaces$.value.find(
+          w => w.flavour === authedServer.id
+        );
+        if (!workspace) {
+          return false;
+        }
+        jumpToPage(workspace.id, 'home');
+        onClose();
+        return true;
+      };
+
+      // Already synced → navigate immediately.
+      if (openServerWorkspace()) {
+        return;
+      }
+
+      // The freshly-signed-in server's workspace list may not have synced yet;
+      // wait briefly for a workspace to appear, then navigate. Fall back to just
+      // closing (same end-state as today) if none shows up.
+      let timer: ReturnType<typeof setTimeout>;
+      const subscription = workspacesService.list.workspaces$.subscribe(() => {
+        if (openServerWorkspace()) {
+          subscription.unsubscribe();
+          clearTimeout(timer);
+        }
+      });
+      timer = setTimeout(() => {
+        subscription.unsubscribe();
+        onClose();
+      }, 10000);
     },
-    [onClose]
+    [defaultServerService, jumpToPage, onClose, workspacesService]
   );
 
   return (


### PR DESCRIPTION
## Fix iOS self-hosted login and workspace sync

Signing into and using a **self-hosted** server from the iOS app was broken by three separate bugs. All three reproduce on a clean build against a self-hosted server and are fixed here. Cloud (AFFiNE Cloud) sign-in, web, and desktop are unaffected.

### 1. Login never completed (stuck on the sign-in screen)
The native `AuthPlugin.signInPassword` resolved `["ok": true]`, **discarding the user object** that the `/api/auth/sign-in` response already contains. The client only optimistically flips `session.status$` to `authenticated` when the `AuthProvider` returns a user (`AuthService.signInPassword` → `setCachedSignInUser`). Web/desktop return the user; iOS returned `void`, so it fell back to `session.revalidate()` → `fetchSession`, which is gated on a realtime `user.profile.get` that stalls on self-hosted (`backoffRetry({count: Infinity})`) — leaving the panel stuck and re-issuing `/session/exchange` in a loop.

**Fix:** return the user from the native sign-in (already in hand), matching web/desktop.
`AuthPlugin.swift`, `plugins/auth/definitions.ts`, `app.tsx`.

### 2. App stayed on the default Cloud server after a self-hosted sign-in
On mobile, `globalContext.serverId` (which the native layer reads via `window.getCurrentServerBaseUrl()`) is written **only** when a workspace layout mounts. Self-hosted sign-in authenticates the server but never opens one of its workspaces, so the app stayed anchored to the default cloud server.

**Fix:** on a self-hosted (non-default) sign-in, navigate into one of that server's workspaces so it becomes the active server. The signed-into `server` is threaded through `SignInPanel`'s `onAuthenticated` as an **optional** second argument — existing callers (desktop) ignore it, and cloud/default sign-in keeps the previous close-only behavior.
`components/sign-in/index.tsx`, `mobile/components/sign-in/index.tsx`.

### 3. Workspace loaded forever (docs never rendered)
`proxy.ts` patches the nbstore **worker's** `fetch`/`XMLHttpRequest` to attach a Bearer token via the Capacitor `Auth` plugin — but Capacitor plugins are **main-thread only** and the call **hangs forever in a Web Worker**. The self-hosted socket.io **polling** transport (`transports: ['polling', 'websocket']`) runs through the patched XHR, so its handshake hung (`connecting timeout`) and the doc-sync socket never connected. (Cloud uses websocket-only, which isn't patched — hence cloud worked.)

**Fix:** skip the Capacitor plugin in worker scope and source the token from the worker's existing `auth-access-token-channel` (the same mechanism it already uses for socket auth), so socket.io polling **and** the worker's HTTP storages (blob / indexer / static-doc) stay authenticated.
`proxy.ts`, `nbstore.worker.ts`.

### Testing
Verified end-to-end on a physical device (iOS 17/18, iPhone 16 Pro Max) against a self-hosted 0.27.x server behind a Cloudflare tunnel: sign-in completes, the app switches to the self-hosted server, and the workspace loads and syncs (docs + blobs).

### Compatibility
- iOS-only except the shared `SignInPanel` change, which only **adds an optional** second arg to `onAuthenticated` — desktop callers pass a `(status) => …` handler and are unaffected; TS is sound (`SignInUserInfo | void`).
- Cloud/default mobile sign-in takes the unchanged branch.

### Known minor follow-up (non-blocking)
The mobile `onAuthenticated` waits up to 10s for the self-hosted workspace list to sync via a `workspaces$` subscription + timer created outside the React lifecycle. It self-cleans on success/timeout; a future pass could move it to a `useEffect`/ref for stricter unmount cleanup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Password sign-in now returns authenticated user details when available.
  - Mobile sign-in can open the matching workspace when signing in to a different server.
  - Authentication callbacks now provide the authenticated server context.

- **Bug Fixes**
  - Improved authenticated requests from background workers by using a valid access token without relying on unavailable mobile authentication features.
  - Prevented worker requests from entering refresh flows that could hang.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->