### PR TITLE
fix(editor): kanban data refresh

### DIFF
--- a/blocksuite/affine/data-view/src/__tests__/kanban.unit.spec.ts
+++ b/blocksuite/affine/data-view/src/__tests__/kanban.unit.spec.ts
@@ -300,10 +300,14 @@ const createGroupTraitHarness = (options?: {
     return cell;
   };
 
+  const isLocked$ = signal(false);
   const view = {
     data$,
     rows$: signal(rows.map(createTestRow)),
-    isLocked$: signal(false),
+    isLocked$,
+    lockRows: vi.fn((locked: boolean) => {
+      isLocked$.value = locked;
+    }),
     manager: {
       dataSource: asDataSource(dataSource),
     },
@@ -348,6 +352,7 @@ const createGroupTraitHarness = (options?: {
     groupTrait: new GroupTrait(groupBy$, view as never, ops),
     ops,
     cells,
+    view,
   };
 };
 
@@ -382,7 +387,7 @@ describe('kanban', () => {
     });
 
     it('preserves manual group order when updating card sort', () => {
-      const { groupTrait, ops, cells } = createGroupTraitHarness({
+      const { groupTrait, ops, cells, view } = createGroupTraitHarness({
         groupProperties: [
           {
             key: 'false',
@@ -402,8 +407,21 @@ describe('kanban', () => {
         },
       });
 
+      expect(
+        groupTrait.groupsDataList$.value
+          ?.find(group => group.key === 'true')
+          ?.rows.map(row => row.rowId)
+      ).toEqual(['row-2']);
+      view.lockRows(true);
+
       groupTrait.moveCardTo('row-1', 'false', 'true', 'end');
 
+      expect(view.lockRows).toHaveBeenLastCalledWith(false);
+      expect(
+        groupTrait.groupsDataList$.value
+          ?.find(group => group.key === 'true')
+          ?.rows.map(row => row.rowId)
+      ).toEqual(['row-2', 'row-1']);
       expect(ops.changeRowSort).toHaveBeenCalledWith(
         ['false', 'true'],
         'true',

--- a/blocksuite/affine/data-view/src/core/group-by/trait.ts
+++ b/blocksuite/affine/data-view/src/core/group-by/trait.ts
@@ -353,6 +353,7 @@ export class GroupTrait {
   }
 
   addToGroup(rowId: string, key: string) {
+    this.view.lockRows(false);
     const groupMap = this.groupDataMap$.value;
     const groupInfo = this.groupInfo$.value;
     if (!groupMap || !groupInfo) {
@@ -448,6 +449,7 @@ export class GroupTrait {
     toGroupKey: string,
     position: InsertToPosition
   ) {
+    this.view.lockRows(false);
     const groupMap = this.groupDataMap$.value;
     if (!groupMap) {
       return;
@@ -490,6 +492,7 @@ export class GroupTrait {
   }
 
   moveGroupTo(groupKey: string, position: InsertToPosition) {
+    this.view.lockRows(false);
     const groups = this.groupsDataListAll$.value;
     if (!groups) {
       return;
@@ -506,6 +509,7 @@ export class GroupTrait {
   }
 
   removeFromGroup(rowId: string, key: string) {
+    this.view.lockRows(false);
     const groupMap = this.groupDataMap$.value;
     if (!groupMap) {
       return;
@@ -524,6 +528,7 @@ export class GroupTrait {
   }
 
   updateValue(rows: string[], value: unknown) {
+    this.view.lockRows(false);
     const propertyId = this.property$.value?.id;
     if (!propertyId) {
       return;


### PR DESCRIPTION
fix #15281


#### PR Dependency Tree


* **PR #15321** 👈

This tree was auto-generated by [Charcoal](https://github.com/danerwilliams/charcoal)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved row handling during group and card updates to prevent rows from remaining locked.
  * Preserved manual card ordering when moving cards or updating group values.
  * Added coverage to verify row unlocking behavior during card moves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->