### PR TITLE
feat(mcp): add constrained database row writes

### DIFF
--- a/packages/backend/server/src/core/doc/__tests__/database-row.spec.ts
+++ b/packages/backend/server/src/core/doc/__tests__/database-row.spec.ts
@@ -1,0 +1,211 @@
+import test from 'ava';
+import * as Y from 'yjs';
+
+import { appendDatabaseRow } from '../database-row';
+
+type FixtureColumn = {
+  data?: Record<string, unknown>;
+  id: string;
+  name: string;
+  type: string;
+};
+
+function toYMap(input: Record<string, unknown>): Y.Map<unknown> {
+  const map = new Y.Map<unknown>();
+  for (const [key, value] of Object.entries(input)) {
+    if (Array.isArray(value)) {
+      const array = new Y.Array<unknown>();
+      array.push(
+        value.map(item =>
+          typeof item === 'object' && item
+            ? toYMap(item as Record<string, unknown>)
+            : item
+        )
+      );
+      map.set(key, array);
+    } else if (typeof value === 'object' && value) {
+      map.set(key, toYMap(value as Record<string, unknown>));
+    } else {
+      map.set(key, value);
+    }
+  }
+  return map;
+}
+
+function createDatabaseSnapshot(columnsInput?: FixtureColumn[]) {
+  const columnsFixture = columnsInput ?? [
+    {
+      id: 'status-col',
+      type: 'select',
+      name: 'Status',
+      data: { options: [{ id: 'todo-option', value: 'Todo' }] },
+    },
+  ];
+  const doc = new Y.Doc();
+  const blocks = doc.getMap<Y.Map<unknown>>('blocks');
+  const database = new Y.Map<unknown>();
+
+  database.set('sys:id', 'database-1');
+  database.set('sys:flavour', 'affine:database');
+  database.set('sys:version', 3);
+  database.set('sys:children', new Y.Array<string>());
+  database.set('prop:title', new Y.Text());
+  const columns = new Y.Array<unknown>();
+  columns.push(columnsFixture.map(toYMap));
+  database.set('prop:columns', columns);
+  database.set('prop:cells', new Y.Map<unknown>());
+  blocks.set('database-1', database);
+
+  return Buffer.from(Y.encodeStateAsUpdate(doc));
+}
+
+function loadSnapshot(snapshot: Buffer, update?: Buffer) {
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, snapshot);
+  if (update) {
+    Y.applyUpdate(doc, update);
+  }
+  return doc;
+}
+
+test('appendDatabaseRow creates a paragraph child with a Y.Text title', t => {
+  const snapshot = createDatabaseSnapshot();
+  const result = appendDatabaseRow(snapshot, {
+    databaseBlockId: 'database-1',
+    rowId: 'row-1',
+    title: 'Review expenses',
+  });
+
+  t.is(result.rowId, 'row-1');
+
+  const doc = loadSnapshot(snapshot, result.update);
+  const blocks = doc.getMap<Y.Map<unknown>>('blocks');
+  const database = blocks.get('database-1')!;
+  const children = database.get('sys:children') as Y.Array<string>;
+  const row = blocks.get('row-1')!;
+
+  t.deepEqual(children.toArray(), ['row-1']);
+  t.is(row.get('sys:id'), 'row-1');
+  t.is(row.get('sys:flavour'), 'affine:paragraph');
+  t.is(row.get('sys:version'), 1);
+  t.is(row.get('prop:type'), 'text');
+  t.is((row.get('prop:text') as Y.Text).toString(), 'Review expenses');
+  t.false(row.get('prop:collapsed') as boolean);
+});
+
+test('appendDatabaseRow writes a validated select cell from Yjs column metadata', t => {
+  const snapshot = createDatabaseSnapshot();
+  const result = appendDatabaseRow(snapshot, {
+    databaseBlockId: 'database-1',
+    rowId: 'row-1',
+    title: 'Review expenses',
+    cells: { 'status-col': 'todo-option' },
+  });
+
+  const doc = loadSnapshot(snapshot, result.update);
+  const database = doc.getMap<Y.Map<unknown>>('blocks').get('database-1')!;
+  const cell = (database.get('prop:cells') as Y.Map<Y.Map<Y.Map<unknown>>>)
+    .get('row-1')!
+    .get('status-col')!;
+
+  t.is(cell.get('columnId'), 'status-col');
+  t.is(cell.get('value'), 'todo-option');
+});
+
+test('appendDatabaseRow rejects an unknown database column', t => {
+  const error = t.throws(() =>
+    appendDatabaseRow(createDatabaseSnapshot(), {
+      databaseBlockId: 'database-1',
+      rowId: 'row-1',
+      title: 'Review expenses',
+      cells: { missing: 'value' },
+    })
+  );
+
+  t.is(error?.message, 'Database column missing not found');
+});
+
+test('appendDatabaseRow rejects an invalid select option', t => {
+  const error = t.throws(() =>
+    appendDatabaseRow(createDatabaseSnapshot(), {
+      databaseBlockId: 'database-1',
+      rowId: 'row-1',
+      title: 'Review expenses',
+      cells: { 'status-col': 'not-configured' },
+    })
+  );
+
+  t.is(
+    error?.message,
+    'Database column status-col requires a configured select option'
+  );
+});
+
+test('appendDatabaseRow validates primitive column types', t => {
+  const snapshot = createDatabaseSnapshot([
+    { id: 'amount-col', type: 'number', name: 'Amount' },
+    { id: 'date-col', type: 'date', name: 'Date' },
+    { id: 'done-col', type: 'checkbox', name: 'Done' },
+  ]);
+  const result = appendDatabaseRow(snapshot, {
+    databaseBlockId: 'database-1',
+    rowId: 'row-1',
+    title: 'Expense',
+    cells: { 'amount-col': 42, 'date-col': 1780000000000, 'done-col': false },
+  });
+
+  const doc = loadSnapshot(snapshot, result.update);
+  const cells = doc
+    .getMap<Y.Map<unknown>>('blocks')
+    .get('database-1')!
+    .get('prop:cells') as Y.Map<Y.Map<Y.Map<unknown>>>;
+
+  t.is(cells.get('row-1')!.get('amount-col')!.get('value'), 42);
+  t.is(cells.get('row-1')!.get('date-col')!.get('value'), 1780000000000);
+  t.is(cells.get('row-1')!.get('done-col')!.get('value'), false);
+});
+
+test('appendDatabaseRow rejects non-finite number and date values', t => {
+  const snapshot = createDatabaseSnapshot([
+    { id: 'amount-col', type: 'number', name: 'Amount' },
+    { id: 'date-col', type: 'date', name: 'Date' },
+  ]);
+
+  const numberError = t.throws(() =>
+    appendDatabaseRow(snapshot, {
+      databaseBlockId: 'database-1',
+      rowId: 'row-number',
+      title: 'Invalid amount',
+      cells: { 'amount-col': Infinity },
+    })
+  );
+  const dateError = t.throws(() =>
+    appendDatabaseRow(snapshot, {
+      databaseBlockId: 'database-1',
+      rowId: 'row-date',
+      title: 'Invalid date',
+      cells: { 'date-col': Number.NaN },
+    })
+  );
+
+  t.is(
+    numberError?.message,
+    'Database column amount-col requires a finite number'
+  );
+  t.is(
+    dateError?.message,
+    'Database column date-col requires a finite date timestamp'
+  );
+});
+
+test('appendDatabaseRow rejects a missing database block', t => {
+  const error = t.throws(() =>
+    appendDatabaseRow(createDatabaseSnapshot(), {
+      databaseBlockId: 'missing',
+      rowId: 'row-1',
+      title: 'Review expenses',
+    })
+  );
+
+  t.is(error?.message, 'Database block missing not found');
+});

--- a/packages/backend/server/src/core/doc/database-row.ts
+++ b/packages/backend/server/src/core/doc/database-row.ts
@@ -1,0 +1,227 @@
+import * as Y from 'yjs';
+
+export type AppendDatabaseRowInput = {
+  databaseBlockId: string;
+  rowId: string;
+  title: string;
+  cells?: Record<string, string | number | boolean>;
+};
+
+export type AppendDatabaseRowResult = {
+  rowId: string;
+  update: Buffer;
+};
+
+function assertSafeIdentifier(value: string, field: string): void {
+  if (!value || ['__proto__', 'constructor', 'prototype'].includes(value)) {
+    throw new Error(`Invalid ${field}`);
+  }
+}
+
+function getDatabaseBlock(
+  blocks: Y.Map<Y.Map<unknown>>,
+  databaseBlockId: string
+): Y.Map<unknown> {
+  const database = blocks.get(databaseBlockId);
+  if (!database) {
+    throw new Error(`Database block ${databaseBlockId} not found`);
+  }
+  if (!(database instanceof Y.Map)) {
+    throw new Error(`Database block ${databaseBlockId} has invalid shape`);
+  }
+  if (database.get('sys:flavour') !== 'affine:database') {
+    throw new Error(`Block ${databaseBlockId} is not an AFFiNE database`);
+  }
+  if (!(database.get('sys:children') instanceof Y.Array)) {
+    throw new Error(`Database block ${databaseBlockId} has invalid children`);
+  }
+  return database;
+}
+
+type ColumnSnapshot = {
+  id: string;
+  type: string;
+  optionIds: Set<string>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readStringField(
+  source: Y.Map<unknown> | Record<string, unknown>,
+  key: string
+): string | undefined {
+  const value = source instanceof Y.Map ? source.get(key) : source[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+function readOptions(
+  source: Y.Map<unknown> | Record<string, unknown>
+): Set<string> {
+  const data = source instanceof Y.Map ? source.get('data') : source.data;
+  const rawOptions =
+    data instanceof Y.Map
+      ? data.get('options')
+      : isRecord(data)
+        ? data.options
+        : undefined;
+  const options =
+    rawOptions instanceof Y.Array
+      ? rawOptions.toArray()
+      : Array.isArray(rawOptions)
+        ? rawOptions
+        : [];
+  const ids = new Set<string>();
+  for (const option of options) {
+    if (option instanceof Y.Map) {
+      const id = option.get('id');
+      if (typeof id === 'string' && id) ids.add(id);
+    } else if (isRecord(option) && typeof option.id === 'string' && option.id) {
+      ids.add(option.id);
+    }
+  }
+  return ids;
+}
+
+function readColumnSnapshot(candidate: unknown): ColumnSnapshot | undefined {
+  if (!(candidate instanceof Y.Map) && !isRecord(candidate)) {
+    return undefined;
+  }
+  const id = readStringField(candidate, 'id');
+  const type = readStringField(candidate, 'type');
+  if (!id || !type) {
+    return undefined;
+  }
+  return { id, type, optionIds: readOptions(candidate) };
+}
+
+function validateCells(
+  database: Y.Map<unknown>,
+  cells: Record<string, string | number | boolean>
+): void {
+  const columns = database.get('prop:columns');
+  if (!(columns instanceof Y.Array)) {
+    throw new Error('Database block has invalid columns');
+  }
+
+  for (const [columnId, value] of Object.entries(cells)) {
+    assertSafeIdentifier(columnId, 'column id');
+    const column = columns
+      .toArray()
+      .map(readColumnSnapshot)
+      .find(candidate => candidate?.id === columnId);
+    if (!column) {
+      throw new Error(`Database column ${columnId} not found`);
+    }
+
+    switch (column.type) {
+      case 'number':
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          throw new Error(
+            `Database column ${columnId} requires a finite number`
+          );
+        }
+        break;
+      case 'date':
+        if (typeof value !== 'number' || !Number.isFinite(value)) {
+          throw new Error(
+            `Database column ${columnId} requires a finite date timestamp`
+          );
+        }
+        break;
+      case 'checkbox':
+        if (typeof value !== 'boolean') {
+          throw new Error(`Database column ${columnId} requires a boolean`);
+        }
+        break;
+      case 'select': {
+        if (
+          typeof value !== 'string' ||
+          !value ||
+          !column.optionIds.has(value)
+        ) {
+          throw new Error(
+            `Database column ${columnId} requires a configured select option`
+          );
+        }
+        break;
+      }
+      default:
+        throw new Error(
+          `Database column ${columnId} type ${String(column.type)} is not supported`
+        );
+    }
+  }
+}
+
+function writeCells(
+  database: Y.Map<unknown>,
+  rowId: string,
+  cells: Record<string, string | number | boolean>
+): void {
+  if (!Object.keys(cells).length) {
+    return;
+  }
+
+  const databaseCells = database.get('prop:cells');
+  if (!(databaseCells instanceof Y.Map)) {
+    throw new Error('Database block has invalid cells');
+  }
+
+  const rowCells = new Y.Map<unknown>();
+  for (const [columnId, value] of Object.entries(cells)) {
+    const cell = new Y.Map<unknown>();
+    cell.set('columnId', columnId);
+    cell.set('value', value);
+    rowCells.set(columnId, cell);
+  }
+  databaseCells.set(rowId, rowCells);
+}
+
+export function appendDatabaseRow(
+  snapshot: Buffer,
+  input: AppendDatabaseRowInput
+): AppendDatabaseRowResult {
+  assertSafeIdentifier(input.databaseBlockId, 'database block id');
+  assertSafeIdentifier(input.rowId, 'row id');
+  if (!input.title.trim()) {
+    throw new Error('Row title must not be empty');
+  }
+
+  const doc = new Y.Doc();
+  Y.applyUpdate(doc, snapshot);
+  const stateVector = Y.encodeStateVector(doc);
+  const blocks = doc.getMap<Y.Map<unknown>>('blocks');
+  const database = getDatabaseBlock(blocks, input.databaseBlockId);
+
+  if (blocks.has(input.rowId)) {
+    throw new Error(`Row ${input.rowId} already exists`);
+  }
+
+  const cells = input.cells ?? {};
+  validateCells(database, cells);
+
+  doc.transact(() => {
+    const row = new Y.Map<unknown>();
+    const title = new Y.Text();
+    title.insert(0, input.title);
+
+    row.set('sys:id', input.rowId);
+    row.set('sys:flavour', 'affine:paragraph');
+    row.set('sys:version', 1);
+    row.set('sys:children', new Y.Array<string>());
+    row.set('prop:type', 'text');
+    row.set('prop:text', title);
+    row.set('prop:collapsed', false);
+
+    blocks.set(input.rowId, row);
+    (database.get('sys:children') as Y.Array<string>).push([input.rowId]);
+    writeCells(database, input.rowId, cells);
+  });
+
+  return {
+    rowId: input.rowId,
+    update: Buffer.from(Y.encodeStateAsUpdate(doc, stateVector)),
+  };
+}

--- a/packages/backend/server/src/core/doc/writer.ts
+++ b/packages/backend/server/src/core/doc/writer.ts
@@ -11,6 +11,7 @@ import {
   updateRootDocMetaTitle,
 } from '../../native';
 import { PgWorkspaceDocStorageAdapter } from './adapters/workspace';
+import { appendDatabaseRow, type AppendDatabaseRowInput } from './database-row';
 
 export interface CreateDocResult {
   docId: string;
@@ -196,6 +197,53 @@ export class DocWriter {
     );
 
     return { success: true };
+  }
+
+  async appendDatabaseRow(
+    workspaceId: string,
+    docId: string,
+    input: Omit<AppendDatabaseRowInput, 'rowId'>,
+    editorId?: string
+  ): Promise<{ rowId: string }> {
+    const existingDoc = await this.storage.getDoc(workspaceId, docId);
+    if (!existingDoc?.bin) {
+      throw new NotFoundException(`Document ${docId} not found`);
+    }
+
+    const existingBinary = Buffer.isBuffer(existingDoc.bin)
+      ? existingDoc.bin
+      : Buffer.from(
+          existingDoc.bin.buffer,
+          existingDoc.bin.byteOffset,
+          existingDoc.bin.byteLength
+        );
+    const result = appendDatabaseRow(existingBinary, {
+      ...input,
+      rowId: nanoid(),
+    });
+
+    const timestamp = await this.storage.pushDocUpdates(
+      workspaceId,
+      docId,
+      [result.update],
+      editorId
+    );
+    this.emitDocUpdatesPushed({
+      spaceId: workspaceId,
+      docId,
+      updates: [result.update],
+      timestamp,
+      editor: editorId,
+    });
+
+    await this.updateDocProperties(
+      workspaceId,
+      docId,
+      { updatedBy: editorId },
+      editorId
+    );
+
+    return { rowId: result.rowId };
   }
 
   /**

--- a/packages/backend/server/src/plugins/copilot/mcp/provider.ts
+++ b/packages/backend/server/src/plugins/copilot/mcp/provider.ts
@@ -437,7 +437,84 @@ export class WorkspaceMcpProvider {
         },
       });
 
-      tools.push(createDocument, updateDocument, updateDocumentMeta);
+      const appendDatabaseRowTool = defineTool({
+        name: 'append_database_row',
+        title: 'Append Database Row',
+        description:
+          'Append one row to an existing AFFiNE database block. Supports title and validated primitive cells only; it cannot create schemas, attachments, relations, or delete rows.',
+        parser: z.object({
+          docId: z.string(),
+          databaseBlockId: z.string(),
+          title: z.string().min(1).max(500),
+          cells: z
+            .record(z.union([z.string(), z.number(), z.boolean()]))
+            .optional(),
+        }),
+        inputSchema: {
+          type: 'object',
+          properties: {
+            docId: {
+              type: 'string',
+              description: 'The document containing the database block',
+            },
+            databaseBlockId: {
+              type: 'string',
+              description: 'The target affine:database block ID',
+            },
+            title: { type: 'string', description: 'The new row title' },
+            cells: {
+              type: 'object',
+              description:
+                'Optional values keyed by existing database column ID. V1 only accepts validated primitive values.',
+              additionalProperties: { type: ['string', 'number', 'boolean'] },
+            },
+          },
+          required: ['docId', 'databaseBlockId', 'title'],
+          additionalProperties: false,
+        },
+        execute: async ({ docId, databaseBlockId, title, cells }, options) => {
+          const notFoundError = toolError(`Doc with id ${docId} not found.`);
+          const accessible = await this.ac
+            .user(userId)
+            .workspace(workspaceId)
+            .doc(docId)
+            .can('Doc.Update');
+          if (!accessible) return notFoundError;
+
+          const abortedBeforeWrite = abortIfNeeded(options.signal);
+          if (abortedBeforeWrite) return abortedBeforeWrite;
+
+          try {
+            const sanitizedTitle = title.replace(/[\r\n]+/g, ' ').trim();
+            if (!sanitizedTitle) throw new Error('Title cannot be empty');
+            const result = await this.writer.appendDatabaseRow(
+              workspaceId,
+              docId,
+              { databaseBlockId, title: sanitizedTitle, cells },
+              userId
+            );
+            return toolText(
+              JSON.stringify({
+                success: true,
+                docId,
+                databaseBlockId,
+                rowId: result.rowId,
+              })
+            );
+          } catch (error) {
+            return toolError(
+              `Failed to append database row: ${error instanceof Error ? error.message : 'Unknown error'}`
+            );
+          }
+        },
+      });
+
+      tools.push(
+        createDocument,
+        updateDocument,
+        updateDocumentMeta,
+        appendDatabaseRowTool
+      );
     }
 
     return {


### PR DESCRIPTION
## Summary

Adds a dev/canary-only workspace MCP tool, `append_database_row`, for appending a constrained row into an existing AFFiNE database block through the existing server-side document update path.

This is intentionally scoped as an upstreamable implementation seam, not a production-write rollout.

## What changed

- Add `packages/backend/server/src/core/doc/database-row.ts`
  - Applies existing document update data into `Y.Doc`
  - Validates the target block is an AFFiNE database
  - Appends a paragraph row under database `sys:children`
  - Writes validated primitive cells into database `prop:cells`
- Add focused AVA coverage for the generated Yjs shape and validation boundaries
- Add `DocWriter.appendDatabaseRow()` using existing storage/event paths
- Expose `append_database_row` in the MCP provider only for `READ_WRITE` credentials and dev/canary environments

## Safety boundaries

Current patch:

- Does not enable production writes
- Does not create database schemas
- Does not delete anything
- Requires existing document update permission (`Doc.Update`)
- Requires `READ_WRITE` MCP credential
- Validates actual Yjs column metadata
- Validates select/status options against option IDs
- Accepts only constrained primitive cell values
- Rejects non-finite number/date values (`Infinity`, `NaN`)

Before production enablement, this should still get follow-up policy work:

- explicit feature flag
- credential allowlists for tools/docs/database blocks/property IDs
- persistent idempotency
- persistent audit log with source/confirmation references
- rate limits / workspace allowlist if needed

## Verification

Local verification completed:

```text
corepack yarn workspace @affine/server build
→ packages/backend/server/src/index.ts compiled successfully
```

Focused helper tests:

```text
7 tests passed
```

Disposable E2E was also run against an isolated local AFFiNE stack:

```text
patched server build
→ isolated Postgres / Redis / storage
→ real Workspace
→ real READ_WRITE MCP credential
→ real MCP create_document
→ real MCP append_database_row
→ persisted CRDT stream verification
→ server restart
→ persisted row still present
```

Production AFFiNE / real workspace data was not touched.

## Notes for maintainers

The main question here is whether this server-side Yjs row-builder seam is acceptable, or whether BlockSuite should expose a shared server-safe row builder before MCP database writes are added.

If this should live somewhere other than the current copilot MCP provider, I can split/rework the provider layer while keeping the pure doc helper and tests intact.
