### PR TITLE
feat(editor): support fullscreen Mermaid preview

### DIFF
--- a/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/mermaid-preview.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/mermaid-preview.ts
@@ -63,6 +63,16 @@ export class MermaidPreview extends SignalWatcher(
       cursor: grab;
     }
 
+    .mermaid-preview-container:fullscreen {
+      box-sizing: border-box;
+      width: 100%;
+      height: 100%;
+      min-height: 0;
+      border: 0;
+      border-radius: 0;
+      padding: 32px;
+    }
+
     .mermaid-preview-container:active {
       cursor: grabbing;
     }
@@ -284,10 +294,25 @@ export class MermaidPreview extends SignalWatcher(
     this._updateTransform();
   }
 
+  private _toggleFullscreen() {
+    const action =
+      document.fullscreenElement === this.container
+        ? document.exitFullscreen()
+        : this.container.requestFullscreen();
+
+    action.catch(error => {
+      console.error('Failed to toggle Mermaid preview fullscreen:', error);
+    });
+  }
+
   private _updateTransform() {
     // trigger re-render to update transform
     this.requestUpdate();
   }
+
+  private readonly _handleControlsMouseDown = (event: MouseEvent) => {
+    event.stopPropagation();
+  };
 
   private readonly _handleMouseDown = (event: MouseEvent) => {
     if (event.button !== 0) return; // only handle left click
@@ -491,11 +516,15 @@ export class MermaidPreview extends SignalWatcher(
                     ? html`<div .innerHTML=${this.svgContent}></div>`
                     : nothing}
                 </div>
-                <div class="mermaid-controls">
+                <div
+                  class="mermaid-controls"
+                  @mousedown=${this._handleControlsMouseDown}
+                >
                   <button
                     class="mermaid-control-button"
                     @click=${this._zoomIn}
                     title="Zoom in"
+                    aria-label="Zoom in"
                   >
                     +
                   </button>
@@ -503,6 +532,7 @@ export class MermaidPreview extends SignalWatcher(
                     class="mermaid-control-button"
                     @click=${this._zoomOut}
                     title="Zoom out"
+                    aria-label="Zoom out"
                   >
                     −
                   </button>
@@ -510,8 +540,17 @@ export class MermaidPreview extends SignalWatcher(
                     class="mermaid-control-button"
                     @click=${this._resetTransform}
                     title="Reset view"
+                    aria-label="Reset view"
                   >
                     ⟳
+                  </button>
+                  <button
+                    class="mermaid-control-button"
+                    @click=${this._toggleFullscreen}
+                    title="Toggle fullscreen"
+                    aria-label="Toggle fullscreen"
+                  >
+                    ⛶
                   </button>
                 </div>
                 <div class="mermaid-scale-info">

--- a/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/mermaid-preview.ts
+++ b/packages/frontend/core/src/blocksuite/view-extensions/code-block-preview/mermaid-preview.ts
@@ -310,10 +310,6 @@ export class MermaidPreview extends SignalWatcher(
     this.requestUpdate();
   }
 
-  private readonly _handleControlsMouseDown = (event: MouseEvent) => {
-    event.stopPropagation();
-  };
-
   private readonly _handleMouseDown = (event: MouseEvent) => {
     if (event.button !== 0) return; // only handle left click
     this.isDragging = true;
@@ -516,15 +512,11 @@ export class MermaidPreview extends SignalWatcher(
                     ? html`<div .innerHTML=${this.svgContent}></div>`
                     : nothing}
                 </div>
-                <div
-                  class="mermaid-controls"
-                  @mousedown=${this._handleControlsMouseDown}
-                >
+                <div class="mermaid-controls">
                   <button
                     class="mermaid-control-button"
                     @click=${this._zoomIn}
                     title="Zoom in"
-                    aria-label="Zoom in"
                   >
                     +
                   </button>
@@ -532,7 +524,6 @@ export class MermaidPreview extends SignalWatcher(
                     class="mermaid-control-button"
                     @click=${this._zoomOut}
                     title="Zoom out"
-                    aria-label="Zoom out"
                   >
                     −
                   </button>
@@ -540,7 +531,6 @@ export class MermaidPreview extends SignalWatcher(
                     class="mermaid-control-button"
                     @click=${this._resetTransform}
                     title="Reset view"
-                    aria-label="Reset view"
                   >
                     ⟳
                   </button>
@@ -548,7 +538,6 @@ export class MermaidPreview extends SignalWatcher(
                     class="mermaid-control-button"
                     @click=${this._toggleFullscreen}
                     title="Toggle fullscreen"
-                    aria-label="Toggle fullscreen"
                   >
                     ⛶
                   </button>

--- a/tests/affine-local/e2e/blocksuite/code/crud.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/code/crud.spec.ts
@@ -46,6 +46,9 @@ test.describe('Code Block Preview', () => {
   test('enable mermaid preview', async ({ page }) => {
     const code = page.locator('affine-code');
     const mermaidSvg = page.locator('mermaid-preview .mermaid-preview-svg svg');
+    const mermaidContainer = page.locator(
+      'mermaid-preview .mermaid-preview-container'
+    );
 
     await openHomePage(page);
     await createNewPage(page);
@@ -60,6 +63,21 @@ test.describe('Code Block Preview', () => {
     });
     await page.getByText('Preview').click();
     await expect(mermaidSvg).toBeVisible();
+
+    await mermaidContainer.evaluate(element => {
+      Object.defineProperty(element, 'requestFullscreen', {
+        configurable: true,
+        value: async () => {
+          element.setAttribute('data-fullscreen-requested', 'true');
+        },
+      });
+    });
+
+    await page.getByRole('button', { name: 'Toggle fullscreen' }).click();
+    await expect(mermaidContainer).toHaveAttribute(
+      'data-fullscreen-requested',
+      'true'
+    );
   });
 
   test('enable typst preview', async ({ page }) => {

--- a/tests/affine-local/e2e/blocksuite/code/crud.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/code/crud.spec.ts
@@ -73,7 +73,7 @@ test.describe('Code Block Preview', () => {
       });
     });
 
-    await page.getByRole('button', { name: 'Toggle fullscreen' }).click();
+    await mermaidContainer.locator('[title="Toggle fullscreen"]').click();
     await expect(mermaidContainer).toHaveAttribute(
       'data-fullscreen-requested',
       'true'


### PR DESCRIPTION
## Summary

- add a fullscreen control to Mermaid previews
- use the browser Fullscreen API to enter and exit fullscreen
- add fullscreen-specific layout styles
- add E2E coverage for the fullscreen request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a fullscreen toggle for Mermaid diagram previews.
  * Mermaid previews now expand to fill the screen and can be exited through the same control.

* **Tests**
  * Added end-to-end coverage verifying fullscreen activation for Mermaid previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->