### PR TITLE
Fix issue 12806

### DIFF
--- a/blocksuite/framework/std/src/__tests__/inline/event-composition.unit.spec.ts
+++ b/blocksuite/framework/std/src/__tests__/inline/event-composition.unit.spec.ts
@@ -1,0 +1,121 @@
+import type * as BlocksuiteGlobalEnv from '@blocksuite/global/env';
+import { expect, test, vi } from 'vitest';
+import * as Y from 'yjs';
+
+vi.mock('@blocksuite/global/env', async importOriginal => {
+  const actual = await importOriginal<typeof BlocksuiteGlobalEnv>();
+  return { ...actual, IS_ANDROID: true };
+});
+
+import { effects } from '../../effects.js';
+import { InlineEditor } from '../../inline/index.js';
+
+effects();
+
+async function setupInlineEditor(text: string) {
+  const yDoc = new Y.Doc();
+  const yText = yDoc.getText('text');
+  yText.insert(0, text);
+
+  const editor = new InlineEditor(yText);
+  const root = document.createElement('div');
+  const outside = document.createElement('div');
+  outside.textContent = 'outside';
+
+  document.body.append(root, outside);
+  editor.mount(root);
+  await editor.waitForUpdate();
+
+  return { editor, root, outside };
+}
+
+function setNativeSelection(range: Range) {
+  const selection = document.getSelection();
+  if (!selection) {
+    throw new Error('Selection is not available');
+  }
+  selection.removeAllRanges();
+  selection.addRange(range);
+}
+
+function clearNativeSelection() {
+  const selection = document.getSelection();
+  selection?.removeAllRanges();
+}
+
+async function teardownInlineEditor(
+  ctx: Awaited<ReturnType<typeof setupInlineEditor>>
+) {
+  clearNativeSelection();
+  ctx.editor.unmount();
+  ctx.root.remove();
+  ctx.outside.remove();
+}
+
+// Regression test for https://github.com/toeverything/AFFiNE/issues/12806:
+// on Android, committing an IME composition with space used to duplicate the
+// composed word because `_isComposing` was cleared before awaiting the
+// post-composition rerender, letting the space-commit `beforeinput` race in
+// and get processed as ordinary (non-composing) input.
+test('compositionend race: a beforeinput arriving mid-await does not duplicate the composed word', async () => {
+  const ctx = await setupInlineEditor('');
+  try {
+    const es = ctx.editor.eventService as any;
+
+    const collapsedRange = ctx.editor.toDomRange({ index: 0, length: 0 });
+    expect(collapsedRange).not.toBeNull();
+    setNativeSelection(collapsedRange!);
+
+    es._onCompositionStart({ data: '' } as CompositionEvent);
+    expect(es.isComposing).toBe(true);
+
+    // A composing keystroke, as the IME builds up "Hi".
+    const composingEvent = {
+      inputType: 'insertCompositionText',
+      data: 'H',
+      dataTransfer: null,
+      isComposing: true,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [],
+    } as unknown as InputEvent;
+    await es._onBeforeInput(composingEvent);
+    expect(ctx.editor.yTextString).toBe('');
+
+    // Commit the composition ("Hi"), but don't await it yet: an async
+    // function runs synchronously up to its first `await`, so this call
+    // captures the composition range and suspends at
+    // `await this.editor.waitForUpdate()` with `_isComposing` still `true`.
+    const compositionEndEvent = {
+      data: 'Hi',
+      preventDefault: vi.fn(),
+    } as unknown as CompositionEvent;
+    const compositionEndPromise = es._onCompositionEnd(compositionEndEvent);
+
+    // While still suspended, the browser fires the space-commit `beforeinput`
+    // that used to race in and duplicate the word.
+    const spaceEvent = {
+      inputType: 'insertText',
+      data: ' ',
+      dataTransfer: null,
+      isComposing: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [],
+    } as unknown as InputEvent;
+    await es._onBeforeInput(spaceEvent);
+
+    // Ignored: still treated as composing, so it must not mutate the doc.
+    expect(spaceEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(ctx.editor.yTextString).toBe('');
+
+    await compositionEndPromise;
+
+    // The composed word lands exactly once (not "HiHi"), and composing state
+    // is only cleared once composition handling has fully settled.
+    expect(ctx.editor.yTextString).toBe('Hi');
+    expect(es.isComposing).toBe(false);
+  } finally {
+    await teardownInlineEditor(ctx);
+  }
+});

--- a/blocksuite/framework/std/src/__tests__/inline/event-composition.unit.spec.ts
+++ b/blocksuite/framework/std/src/__tests__/inline/event-composition.unit.spec.ts
@@ -119,3 +119,63 @@ test('compositionend race: a beforeinput arriving mid-await does not duplicate t
     await teardownInlineEditor(ctx);
   }
 });
+
+// Regression test for https://github.com/toeverything/AFFiNE/issues/14033:
+// on Android, backspacing already-synced text right as an IME composition
+// span settles used to make the deleted word "come back". The old
+// `_onBeforeInput` guard returned early without calling `preventDefault()`,
+// so the browser still performed the native DOM deletion while the model
+// never learned about it; the next model-driven rerender (e.g. from
+// `_onCompositionEnd`) then repainted the DOM from the still-unchanged
+// model, undoing the visible deletion.
+test('compositionend race: a racing delete beforeinput is ignored, not silently undone', async () => {
+  const ctx = await setupInlineEditor('Hi');
+  try {
+    const es = ctx.editor.eventService as any;
+
+    const collapsedRange = ctx.editor.toDomRange({ index: 2, length: 0 });
+    expect(collapsedRange).not.toBeNull();
+    setNativeSelection(collapsedRange!);
+
+    // GBoard commonly wraps already-committed text in a composition span
+    // (e.g. for suggestions) even though the user isn't actively typing, so
+    // this composition contributes no new characters of its own (`data: ''`).
+    es._onCompositionStart({ data: '' } as CompositionEvent);
+    expect(es.isComposing).toBe(true);
+
+    // End the (empty) composition, but don't await it yet: this suspends at
+    // `await this.editor.waitForUpdate()` with `_isComposing` still `true`.
+    const compositionEndEvent = {
+      data: '',
+      preventDefault: vi.fn(),
+    } as unknown as CompositionEvent;
+    const compositionEndPromise = es._onCompositionEnd(compositionEndEvent);
+
+    // While still suspended, the user backspaces — the delete `beforeinput`
+    // races in during the same window the space-commit did above.
+    const deleteEvent = {
+      inputType: 'deleteContentBackward',
+      data: null,
+      dataTransfer: null,
+      isComposing: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      getTargetRanges: () => [],
+    } as unknown as InputEvent;
+    await es._onBeforeInput(deleteEvent);
+
+    // Ignored: still treated as composing, so it must not mutate the doc
+    // (neither the model nor, via preventDefault, the native DOM).
+    expect(deleteEvent.preventDefault).toHaveBeenCalledOnce();
+    expect(ctx.editor.yTextString).toBe('Hi');
+
+    await compositionEndPromise;
+
+    // Nothing was deleted, and nothing "came back": the text is simply
+    // untouched throughout.
+    expect(ctx.editor.yTextString).toBe('Hi');
+    expect(es.isComposing).toBe(false);
+  } finally {
+    await teardownInlineEditor(ctx);
+  }
+});

--- a/blocksuite/framework/std/src/inline/services/event.ts
+++ b/blocksuite/framework/std/src/inline/services/event.ts
@@ -109,13 +109,19 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
       if (otherRoot && otherRoot !== rootElement) return;
     }
 
-    if (this._isComposing) {
+    if (this._isComposing || event.isComposing) {
       if (IS_ANDROID && event.inputType === 'insertCompositionText') {
         const compositionInlineRange = this.editor.toInlineRange(range);
         if (compositionInlineRange) {
           this._compositionInlineRange = compositionInlineRange;
         }
       }
+      // Prevent the native DOM mutation for input we're deferring to
+      // composition handling — otherwise the browser applies it directly to
+      // the contenteditable DOM and `rerenderWholeEditor()` in
+      // `_onCompositionEnd` silently wipes it instead of the model ever
+      // seeing it.
+      event.preventDefault();
       return;
     }
 
@@ -363,47 +369,57 @@ export class EventService<TextAttributes extends BaseTextAttributes> {
   };
 
   private readonly _onCompositionEnd = async (event: CompositionEvent) => {
-    this._isComposing = false;
-    if (!this.editor.rootElement || !this.editor.rootElement.isConnected) {
-      return;
-    }
-
-    const range = this.editor.rangeService.getNativeRange();
-    if (
-      this.editor.isReadonly ||
-      !range ||
-      !this._isRangeCompletelyInRoot(range)
-    )
-      return;
-
-    this.editor.rerenderWholeEditor();
-    await this.editor.waitForUpdate();
-
+    // Captured synchronously, before the `await` below, so a `beforeinput`
+    // racing this handler can't see a stale/cleared value.
     const inlineRange = this._compositionInlineRange;
-    if (!inlineRange) return;
+    try {
+      if (!this.editor.rootElement || !this.editor.rootElement.isConnected) {
+        return;
+      }
 
-    event.preventDefault();
+      const range = this.editor.rangeService.getNativeRange();
+      if (
+        this.editor.isReadonly ||
+        !range ||
+        !this._isRangeCompletelyInRoot(range)
+      ) {
+        return;
+      }
 
-    const ctx: CompositionEndHookCtx<TextAttributes> = {
-      inlineEditor: this.editor,
-      raw: event,
-      inlineRange,
-      data: event.data,
-      attributes: {} as TextAttributes,
-    };
-    this.editor.hooks.compositionEnd?.(ctx);
+      this.editor.rerenderWholeEditor();
+      await this.editor.waitForUpdate();
 
-    const { inlineRange: newInlineRange, data: newData } = ctx;
-    if (newData && newData.length > 0) {
-      this.editor.insertText(newInlineRange, newData, ctx.attributes);
-      this.editor.setInlineRange({
-        index: newInlineRange.index + newData.length,
-        length: 0,
-      });
+      if (!inlineRange) return;
+
+      event.preventDefault();
+
+      const ctx: CompositionEndHookCtx<TextAttributes> = {
+        inlineEditor: this.editor,
+        raw: event,
+        inlineRange,
+        data: event.data,
+        attributes: {} as TextAttributes,
+      };
+      this.editor.hooks.compositionEnd?.(ctx);
+
+      const { inlineRange: newInlineRange, data: newData } = ctx;
+      if (newData && newData.length > 0) {
+        this.editor.insertText(newInlineRange, newData, ctx.attributes);
+        this.editor.setInlineRange({
+          index: newInlineRange.index + newData.length,
+          length: 0,
+        });
+      }
+
+      this.editor.slots.inputting.next(event.data ?? '');
+      this._finishAndroidComposingSession(false);
+    } finally {
+      // Deferred until composition handling (including the rerender/await
+      // above) fully completes, so a `beforeinput` arriving in that window
+      // is still treated as composing and ignored instead of racing in and
+      // duplicating the just-committed text.
+      this._isComposing = false;
     }
-
-    this.editor.slots.inputting.next(event.data ?? '');
-    this._finishAndroidComposingSession(false);
   };
 
   private readonly _onCompositionStart = (event: CompositionEvent) => {


### PR DESCRIPTION
The PR addresses an issue on Android (particularly Edge/Chromium browsers) where pressing the spacebar to commit a predictive text word causes the word to duplicate (e.g., 'Hi' becomes 'HiHi ').

The root cause was an asynchronous race condition within the event service:
1. `_onCompositionEnd` eagerly set `_isComposing = false` before yielding to `await this.editor.waitForUpdate()`.
2. The browser immediately dispatched a `beforeinput` event for the space key.
3. Because `_isComposing` was already false, the `_onBeforeInput` handler incorrectly processed this event and inserted the text into the CRDT.
4. When `waitForUpdate()` resolved, `_onCompositionEnd` resumed and inserted the text *again*, resulting in the duplication.

Fixes:
- Hardened `_onBeforeInput` to strictly ignore events that are inherently part of the composition cycle by checking `(this._isComposing || event.isComposing)`.
- Deferred toggling `this._isComposing = false` until the absolute end of the `_onCompositionEnd` handler (safely wrapped in a `finally` block), closing the window where rogue `beforeinput` events could be misprocessed during the CRDT reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flexible row and column layouts for arranging content.
  * Added slash-menu actions for creating two- to five-column layouts.
  * Added support for adding and editing content within layout columns.
  * Added consistent spacing, sizing, and directional styling for layout containers.

* **Bug Fixes**
  * Improved text composition handling during input and editing.
  * Reduced unexpected changes when composition ends during selection or editor state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->