### PR TITLE
Fix/issue 15435

### DIFF
--- a/packages/frontend/component/src/ui/date-picker/calendar/constants.ts
+++ b/packages/frontend/component/src/ui/date-picker/calendar/constants.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
 
-export const DATE_MIN = '1970-01-01';
+export const DATE_MIN = '1900-01-01';
 export const DATE_MAX = '2099-12-31';
 
 export const YEAR_MIN = dayjs(DATE_MIN).year();


### PR DESCRIPTION
### Description
This PR fixes a bug where the date picker inside the property panel restricted users from selecting dates prior to 1970. 

**Changes:**
- Updated the minimum date constant (`DATE_MIN`) in the date picker calendar from `1970-01-01` to `1900-01-01`. 
- This allows a broader historical range of dates to be selected, properly supporting birth dates and historical events.

### Related Issues
Fixes #15435 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Testing Done
- Verified that the property date picker allows navigation and selection of years prior to 1970.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the date picker’s supported range to include dates from January 1, 1900.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->