### PR TITLE
fix(server): blob upload

### DIFF
--- a/packages/backend/server/src/__tests__/utils/blobs.ts
+++ b/packages/backend/server/src/__tests__/utils/blobs.ts
@@ -133,6 +133,7 @@ export async function createBlobUpload(
         createBlobUpload(workspaceId: $workspaceId, key: $key, size: $size, mime: $mime) {
           method
           blobKey
+          alreadyUploaded
           uploadUrl
           uploadId
           partSize

--- a/packages/backend/server/src/__tests__/workspace/blobs.e2e.ts
+++ b/packages/backend/server/src/__tests__/workspace/blobs.e2e.ts
@@ -286,6 +286,15 @@ test('should create pending blob upload with graphql fallback', async t => {
   t.truthy(record);
   t.is(record?.status, 'pending');
 
+  await createBlobUpload(
+    app,
+    workspace.id,
+    key,
+    size,
+    'application/octet-stream'
+  );
+  t.is((await blobModel.get(workspace.id, key))?.mime, mime);
+
   const listed = await listBlobs(app, workspace.id);
   t.is(listed.length, 0);
 });
@@ -317,6 +326,15 @@ test('should complete pending blob upload', async t => {
 
   const listed = await listBlobs(app, workspace.id);
   t.is(listed.length, 1);
+
+  const existing = await createBlobUpload(
+    app,
+    workspace.id,
+    key,
+    buffer.length,
+    'audio/x-m4a'
+  );
+  t.true(existing.alreadyUploaded);
 });
 
 test('should reject complete when blob key mismatched', async t => {

--- a/packages/backend/server/src/core/workspaces/resolvers/blob.ts
+++ b/packages/backend/server/src/core/workspaces/resolvers/blob.ts
@@ -215,9 +215,6 @@ export class WorkspaceBlobResolver {
       if (record.size !== size) {
         throw new BlobInvalid('Blob size mismatch');
       }
-      if (record.mime !== mime) {
-        throw new BlobInvalid('Blob mime mismatch');
-      }
 
       if (record.status === 'completed') {
         const existingMetadata = await this.storage.head(workspaceId, key);
@@ -226,8 +223,6 @@ export class WorkspaceBlobResolver {
           record = null;
         } else if (existingMetadata.contentLength !== size) {
           throw new BlobInvalid('Blob size mismatch');
-        } else if (existingMetadata.contentType !== mime) {
-          throw new BlobInvalid('Blob mime mismatch');
         } else {
           return {
             method: BlobUploadMethod.GRAPHQL,
@@ -235,6 +230,8 @@ export class WorkspaceBlobResolver {
             alreadyUploaded: true,
           };
         }
+      } else {
+        mime = record.mime;
       }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Repeated blob-upload requests now consistently recognize previously uploaded files.
  - Existing uploads preserve their original MIME metadata when requested again with a different MIME type.
  - In-progress uploads continue using the stored MIME type.
  - Completed uploads are validated by their presence and size, improving retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->