### PR TITLE
feat: add Render Blueprint for one-click self-host

### DIFF
--- a/.render/Dockerfile
+++ b/.render/Dockerfile
@@ -1,8 +1,8 @@
-# Wraps the published AFFiNE image with a start script that runs migrations
-# before the server. Nothing is compiled here.
+# syntax=docker/dockerfile:1.7
+
+# Adds a start script to the published AFFiNE image. Nothing is compiled here.
 FROM ghcr.io/toeverything/affine:stable
 
-COPY start.sh /usr/local/bin/render-start.sh
-RUN chmod +x /usr/local/bin/render-start.sh
+COPY --chmod=0755 start.sh /usr/local/bin/render-start.sh
 
 CMD ["/usr/local/bin/render-start.sh"]

--- a/.render/Dockerfile
+++ b/.render/Dockerfile
@@ -1,0 +1,8 @@
+# Wraps the published AFFiNE image with a start script that runs migrations
+# before the server. Nothing is compiled here.
+FROM ghcr.io/toeverything/affine:stable
+
+COPY start.sh /usr/local/bin/render-start.sh
+RUN chmod +x /usr/local/bin/render-start.sh
+
+CMD ["/usr/local/bin/render-start.sh"]

--- a/.render/start.sh
+++ b/.render/start.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-set -e
+set -eu
 
-# Set the public hostname from the one Render assigns, unless it is already set
-# (a custom domain, for example).
-export AFFINE_SERVER_HOST="${AFFINE_SERVER_HOST:-$RENDER_EXTERNAL_HOSTNAME}"
+# Use the hostname Render assigns, unless AFFINE_SERVER_HOST is already set to a
+# custom domain.
+export AFFINE_SERVER_HOST="${AFFINE_SERVER_HOST:-${RENDER_EXTERNAL_HOSTNAME:-localhost}}"
 
 # Generates the server private key on first boot, then runs the Prisma and data
 # migrations. Safe to run on every boot.

--- a/.render/start.sh
+++ b/.render/start.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Set the public hostname from the one Render assigns, unless it is already set
+# (a custom domain, for example).
+export AFFINE_SERVER_HOST="${AFFINE_SERVER_HOST:-$RENDER_EXTERNAL_HOSTNAME}"
+
+# Generates the server private key on first boot, then runs the Prisma and data
+# migrations. Safe to run on every boot.
+node ./scripts/self-host-predeploy.js
+
+exec node ./dist/main.js

--- a/README.md
+++ b/README.md
@@ -176,25 +176,11 @@ We would like to express our gratitude to all the individuals who have already c
 
 Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiNE. Our team is diligently updating to the latest version. For more information on how to self-host AFFiNE, please refer to our [documentation](https://docs.affine.pro/self-host-affine).
 
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/AFFiNE/tree/feat/render-deploy)
+
 [![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
 
 [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
-
-### Render
-
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/AFFiNE/tree/feat/render-deploy)
-
-The [`render.yaml`](./render.yaml) Blueprint runs the prebuilt `ghcr.io/toeverything/affine:stable` image and provisions the two services it depends on: PostgreSQL and Key Value (Redis). AFFiNE itself is not compiled from this repo. [`.render/Dockerfile`](./.render/Dockerfile) only adds a start script to the published image, so the deploy takes a few minutes.
-
-The Blueprint creates:
-
-- A web service running the AFFiNE image, with a 10 GB disk mounted at `/root/.affine` for uploaded blobs and the generated server private key.
-- A PostgreSQL 16 database. AFFiNE migrations enable the `pgvector` extension, which Render's PostgreSQL supports.
-- A Key Value instance with `noeviction`, reachable only over the private network.
-
-Migrations run on every boot, before the server starts. Open the service URL after the first deploy to create the admin account.
-
-The default plans cost about $25/month. Free instance types are not an option here because the disk requires a paid instance, and the server needs more than 512 MB of memory. To use a custom domain, add it in the Dashboard and set `AFFINE_SERVER_HOST` to that domain. For email invites and password resets, add the `MAILER_*` variables described in the [self-host docs](https://docs.affine.pro/self-host-affine).
 
 ## Feature Request
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiN
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/AFFiNE/tree/feat/render-deploy)
 
-The [`render.yaml`](./render.yaml) Blueprint runs the prebuilt `ghcr.io/toeverything/affine:stable` image and provisions the two services it depends on: PostgreSQL and Key Value (Redis). Nothing is built from this repo, so the deploy takes a few minutes.
+The [`render.yaml`](./render.yaml) Blueprint runs the prebuilt `ghcr.io/toeverything/affine:stable` image and provisions the two services it depends on: PostgreSQL and Key Value (Redis). AFFiNE itself is not compiled from this repo. [`.render/Dockerfile`](./.render/Dockerfile) only adds a start script to the published image, so the deploy takes a few minutes.
 
 The Blueprint creates:
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,22 @@ Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiN
 
 [![Run on ClawCloud](https://raw.githubusercontent.com/ClawCloud/Run-Template/refs/heads/main/Run-on-ClawCloud.svg)](https://template.run.claw.cloud/?openapp=system-fastdeploy%3FtemplateName%3Daffine)
 
+### Render
+
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/AFFiNE/tree/feat/render-deploy)
+
+The [`render.yaml`](./render.yaml) Blueprint runs the prebuilt `ghcr.io/toeverything/affine:stable` image and provisions the two services it depends on: PostgreSQL and Key Value (Redis). Nothing is built from this repo, so the deploy takes a few minutes.
+
+The Blueprint creates:
+
+- A web service running the AFFiNE image, with a 10 GB disk mounted at `/root/.affine` for uploaded blobs and the generated server private key.
+- A PostgreSQL 16 database. AFFiNE migrations enable the `pgvector` extension, which Render's PostgreSQL supports.
+- A Key Value instance with `noeviction`, reachable only over the private network.
+
+Migrations run on every boot, before the server starts. Open the service URL after the first deploy to create the admin account.
+
+The default plans cost about $25/month. Free instance types are not an option here because the disk requires a paid instance, and the server needs more than 512 MB of memory. To use a custom domain, add it in the Dashboard and set `AFFINE_SERVER_HOST` to that domain. For email invites and password resets, add the `MAILER_*` variables described in the [self-host docs](https://docs.affine.pro/self-host-affine).
+
 ## Feature Request
 
 For feature requests, please see [discussions](https://github.com/toeverything/AFFiNE/discussions/categories/ideas).

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ We would like to express our gratitude to all the individuals who have already c
 
 Begin with Docker to deploy your own feature-rich, unrestricted version of AFFiNE. Our team is diligently updating to the latest version. For more information on how to self-host AFFiNE, please refer to our [documentation](https://docs.affine.pro/self-host-affine).
 
-[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/Ho1yShif/AFFiNE/tree/feat/render-deploy)
+[![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/toeverything/AFFiNE)
 
 [![Run on Sealos](https://sealos.io/Deploy-on-Sealos.svg)](https://sealos.io/products/app-store/affine)
 

--- a/render.yaml
+++ b/render.yaml
@@ -1,4 +1,4 @@
-version: "1"
+version: '1'
 
 projects:
   - name: affine
@@ -48,5 +48,5 @@ projects:
         databases:
           - name: affine-postgres
             plan: basic-256mb
-            postgresMajorVersion: "16"
+            postgresMajorVersion: '16'
             ipAllowList: [] # internal connections only

--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     # Runs Prisma + data migrations and generates the server private key on boot,
     # then starts the server. AFFINE_SERVER_HOST is set from the service's own
     # hostname unless you override it (e.g. for a custom domain).
-    dockerCommand: 'sh -c "export AFFINE_SERVER_HOST=${AFFINE_SERVER_HOST:-$RENDER_EXTERNAL_HOSTNAME} && node ./scripts/self-host-predeploy.js && node ./dist/main.js"'
+    dockerCommand: 'export AFFINE_SERVER_HOST=${AFFINE_SERVER_HOST:-$RENDER_EXTERNAL_HOSTNAME}; node ./scripts/self-host-predeploy.js && node ./dist/main.js'
     healthCheckPath: /info
     disk:
       # Uploaded blobs (~/.affine/storage) and the generated private key

--- a/render.yaml
+++ b/render.yaml
@@ -3,9 +3,7 @@ services:
     name: affine
     runtime: docker
     plan: standard
-    # The Dockerfile only adds a start script to
-    # ghcr.io/toeverything/affine:stable. The script runs migrations, then the
-    # server.
+    # The Dockerfile adds a start script to ghcr.io/toeverything/affine:stable. It runs migrations and the server
     dockerfilePath: ./.render/Dockerfile
     dockerContext: ./.render
     healthCheckPath: /info
@@ -44,4 +42,4 @@ services:
 databases:
   - name: affine-postgres
     plan: basic-256mb
-    postgresMajorVersion: '16'
+    postgresMajorVersion: "16"

--- a/render.yaml
+++ b/render.yaml
@@ -49,3 +49,4 @@ projects:
           - name: affine-postgres
             plan: basic-256mb
             postgresMajorVersion: "16"
+            ipAllowList: [] # internal connections only

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,48 @@
+services:
+  - type: web
+    name: affine
+    runtime: image
+    plan: standard
+    image:
+      url: ghcr.io/toeverything/affine:stable
+    # Runs Prisma + data migrations and generates the server private key on boot,
+    # then starts the server. AFFINE_SERVER_HOST is set from the service's own
+    # hostname unless you override it (e.g. for a custom domain).
+    dockerCommand: 'sh -c "export AFFINE_SERVER_HOST=${AFFINE_SERVER_HOST:-$RENDER_EXTERNAL_HOSTNAME} && node ./scripts/self-host-predeploy.js && node ./dist/main.js"'
+    healthCheckPath: /info
+    disk:
+      # Uploaded blobs (~/.affine/storage) and the generated private key
+      # (~/.affine/config/private.key) must survive restarts.
+      name: affine-data
+      mountPath: /root/.affine
+      sizeGB: 10
+    envVars:
+      - key: AFFINE_SERVER_PORT
+        value: 10000
+      - key: AFFINE_SERVER_HTTPS
+        value: true
+      - key: DATABASE_URL
+        fromDatabase:
+          name: affine-postgres
+          property: connectionString
+      - key: REDIS_SERVER_HOST
+        fromService:
+          name: affine-keyvalue
+          type: keyvalue
+          property: host
+      - key: REDIS_SERVER_PORT
+        fromService:
+          name: affine-keyvalue
+          type: keyvalue
+          property: port
+
+  - type: keyvalue
+    name: affine-keyvalue
+    plan: starter
+    maxmemoryPolicy: noeviction
+    ipAllowList: [] # internal connections only
+
+databases:
+  - name: affine-postgres
+    plan: basic-256mb
+    postgresMajorVersion: '16'

--- a/render.yaml
+++ b/render.yaml
@@ -3,8 +3,9 @@ services:
     name: affine
     runtime: docker
     plan: standard
-    # A three-line Dockerfile over ghcr.io/toeverything/affine:stable that adds a
-    # start script. The script runs migrations, then the server.
+    # The Dockerfile only adds a start script to
+    # ghcr.io/toeverything/affine:stable. The script runs migrations, then the
+    # server.
     dockerfilePath: ./.render/Dockerfile
     dockerContext: ./.render
     healthCheckPath: /info

--- a/render.yaml
+++ b/render.yaml
@@ -1,14 +1,12 @@
 services:
   - type: web
     name: affine
-    runtime: image
+    runtime: docker
     plan: standard
-    image:
-      url: ghcr.io/toeverything/affine:stable
-    # Runs Prisma + data migrations and generates the server private key on boot,
-    # then starts the server. AFFINE_SERVER_HOST is set from the service's own
-    # hostname unless you override it (e.g. for a custom domain).
-    dockerCommand: 'export AFFINE_SERVER_HOST=${AFFINE_SERVER_HOST:-$RENDER_EXTERNAL_HOSTNAME}; node ./scripts/self-host-predeploy.js && node ./dist/main.js'
+    # A three-line Dockerfile over ghcr.io/toeverything/affine:stable that adds a
+    # start script. The script runs migrations, then the server.
+    dockerfilePath: ./.render/Dockerfile
+    dockerContext: ./.render
     healthCheckPath: /info
     disk:
       # Uploaded blobs (~/.affine/storage) and the generated private key

--- a/render.yaml
+++ b/render.yaml
@@ -1,45 +1,51 @@
-services:
-  - type: web
-    name: affine
-    runtime: docker
-    plan: standard
-    # The Dockerfile adds a start script to ghcr.io/toeverything/affine:stable. It runs migrations and the server
-    dockerfilePath: ./.render/Dockerfile
-    dockerContext: ./.render
-    healthCheckPath: /info
-    disk:
-      # Uploaded blobs (~/.affine/storage) and the generated private key
-      # (~/.affine/config/private.key) must survive restarts.
-      name: affine-data
-      mountPath: /root/.affine
-      sizeGB: 10
-    envVars:
-      - key: AFFINE_SERVER_PORT
-        value: 10000
-      - key: AFFINE_SERVER_HTTPS
-        value: true
-      - key: DATABASE_URL
-        fromDatabase:
-          name: affine-postgres
-          property: connectionString
-      - key: REDIS_SERVER_HOST
-        fromService:
-          name: affine-keyvalue
-          type: keyvalue
-          property: host
-      - key: REDIS_SERVER_PORT
-        fromService:
-          name: affine-keyvalue
-          type: keyvalue
-          property: port
+version: "1"
 
-  - type: keyvalue
-    name: affine-keyvalue
-    plan: starter
-    maxmemoryPolicy: noeviction
-    ipAllowList: [] # internal connections only
+projects:
+  - name: affine
+    environments:
+      - name: production
+        services:
+          - type: web
+            name: affine
+            runtime: docker
+            plan: standard
+            # The Dockerfile adds a start script to ghcr.io/toeverything/affine:stable. It runs migrations and the server
+            dockerfilePath: ./.render/Dockerfile
+            dockerContext: ./.render
+            healthCheckPath: /info
+            disk:
+              # Uploaded blobs (~/.affine/storage) and the generated private key
+              # (~/.affine/config/private.key) must survive restarts.
+              name: affine-data
+              mountPath: /root/.affine
+              sizeGB: 10
+            envVars:
+              - key: AFFINE_SERVER_PORT
+                value: 10000
+              - key: AFFINE_SERVER_HTTPS
+                value: true
+              - key: DATABASE_URL
+                fromDatabase:
+                  name: affine-postgres
+                  property: connectionString
+              - key: REDIS_SERVER_HOST
+                fromService:
+                  name: affine-keyvalue
+                  type: keyvalue
+                  property: host
+              - key: REDIS_SERVER_PORT
+                fromService:
+                  name: affine-keyvalue
+                  type: keyvalue
+                  property: port
 
-databases:
-  - name: affine-postgres
-    plan: basic-256mb
-    postgresMajorVersion: "16"
+          - type: keyvalue
+            name: affine-keyvalue
+            plan: starter
+            maxmemoryPolicy: noeviction
+            ipAllowList: [] # internal connections only
+
+        databases:
+          - name: affine-postgres
+            plan: basic-256mb
+            postgresMajorVersion: "16"


### PR DESCRIPTION
Adds one-click deploy to [Render](https://render.com) for self-hosters. The change is additive: a root `render.yaml`, two small files under `.render/`, and one button in the existing Self-Host section of the README.

### What it does

- The web service runs the published `ghcr.io/toeverything/affine:stable` image, so nothing in this repo is compiled. `.render/Dockerfile` adds a single layer to that image: a start script that sets `AFFINE_SERVER_HOST` from the hostname Render assigns, runs `scripts/self-host-predeploy.js`, then starts the server.
- The Blueprint also creates PostgreSQL 16 and a Key Value (Redis) instance, wired through `DATABASE_URL`, `REDIS_SERVER_HOST`, and `REDIS_SERVER_PORT`. A 10 GB disk is mounted at `/root/.affine` so uploaded blobs and the generated private key survive restarts.
- No secrets are committed, and the Blueprint prompts for none. Optional settings such as `MAILER_*` can be added in the Render Dashboard after the deploy.

### Testing

Deployed from this branch. The Prisma and data migrations applied on first boot, and `/info` returns `AFFiNE 0.27.3 Server` with `"type":"selfhosted"`.

Reviewers can deploy this exact branch before merging:

https://render.com/deploy?repo=https://github.com/Ho1yShif/AFFiNE/tree/feat/render-deploy

### Note on the button

The README button only works once this PR merges. It points at `https://github.com/toeverything/AFFiNE`, and Render reads `render.yaml` from the default branch, so the Blueprint has to be on `canary` first.

Blueprint spec: https://render.com/docs/blueprint-spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment support for hosting AFFiNE on Render.
  * Configured persistent storage, health checks, PostgreSQL, and Redis services.
  * Added automated startup setup for server keys and database migrations.
* **Documentation**
  * Added a Render deployment badge and link to the self-hosting documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->