### PR TITLE
fix(editor): enable Shift+wheel horizontal scroll on all platforms

### DIFF
--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
@@ -356,7 +356,10 @@ export class EdgelessRootBlockComponent extends BlockComponent<
         }
         // pan
         else {
-          const simulateHorizontalScroll = IS_WINDOWS && e.shiftKey;
+          // Enable Shift+wheel horizontal scroll on Windows (no native deltaX),
+          // and on any platform when using a mouse without horizontal scroll
+          // (deltaX === 0 means no native horizontal input, e.g. external mouse on macOS/Linux).
+          const simulateHorizontalScroll = e.shiftKey && (IS_WINDOWS || e.deltaX === 0);
           const dx = simulateHorizontalScroll
             ? e.deltaY / viewport.zoom
             : e.deltaX / viewport.zoom;

--- a/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
+++ b/blocksuite/affine/blocks/root/src/edgeless/edgeless-root-block.ts
@@ -359,7 +359,8 @@ export class EdgelessRootBlockComponent extends BlockComponent<
           // Enable Shift+wheel horizontal scroll on Windows (no native deltaX),
           // and on any platform when using a mouse without horizontal scroll
           // (deltaX === 0 means no native horizontal input, e.g. external mouse on macOS/Linux).
-          const simulateHorizontalScroll = e.shiftKey && (IS_WINDOWS || e.deltaX === 0);
+          const simulateHorizontalScroll =
+            e.shiftKey && (IS_WINDOWS || e.deltaX === 0);
           const dx = simulateHorizontalScroll
             ? e.deltaY / viewport.zoom
             : e.deltaX / viewport.zoom;


### PR DESCRIPTION
Fixes #10034

Previously, Shift+wheel horizontal scroll was restricted to Windows only. Users on macOS or Linux with an external mouse (no native horizontal scroll) had no way to pan horizontally in edgeless mode.

Fix: extend the condition to also activate when deltaX === 0, which indicates no native horizontal input (e.g. external mouse). Trackpad users on macOS are unaffected since their horizontal swipe produces a non-zero deltaX.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Shift+wheel panning behavior for horizontal scrolling.
  * Horizontal scrolling now works consistently across platforms when native horizontal input is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->