### PR TITLE
feat(editor): add callout to "Turn into" menu

### DIFF
--- a/blocksuite/affine/blocks/note/src/commands/block-type.ts
+++ b/blocksuite/affine/blocks/note/src/commands/block-type.ts
@@ -121,6 +121,84 @@ export const updateBlockType: Command<
     }
     return next({ updatedBlocks: [newModel] });
   };
+  const transformToCallout: Command<{}, { updatedBlocks: BlockModel[] }> = (
+    _,
+    next
+  ) => {
+    if (flavour !== 'affine:callout') return;
+    // When flavour IS 'affine:callout', this command MUST always be terminal
+    // (always call next, never fall through). The generic transformModel branch
+    // that follows unconditionally deletes the source block even when addBlock
+    // fails a schema check — falling through would cause data loss.
+
+    const calloutModels: BlockModel[] = [];
+    const paragraphModels: BlockModel[] = [];
+
+    blockModels.forEach(model => {
+      if (
+        !matchModels(model, [
+          ParagraphBlockModel,
+          ListBlockModel,
+          CodeBlockModel,
+        ])
+      ) {
+        return;
+      }
+
+      const parent = doc.getParent(model);
+      if (!parent) return;
+
+      // [P1a] Callout cannot be nested inside another Callout — skip silently.
+      // We still call next() at the end so the chain does NOT fall through to
+      // the generic transformModel branch (which would delete the source block).
+      if (parent.flavour === 'affine:callout') return;
+
+      const index = parent.children.indexOf(model);
+      const textContent = model.text?.clone();
+
+      // Callout is a hub block — its text lives in a child paragraph,
+      // not in its own text prop, so we create the callout first,
+      // then add a paragraph inside it carrying the original text.
+      const calloutId = doc.addBlock('affine:callout', {}, parent, index);
+      if (!calloutId) return;
+
+      const calloutModel = doc.getModelById(calloutId);
+      if (!calloutModel) return;
+
+      const paragraphId = doc.addBlock(
+        'affine:paragraph',
+        { text: textContent },
+        calloutModel
+      );
+
+      const paragraphModel = paragraphId
+        ? doc.getModelById(paragraphId)
+        : null;
+
+      // [P1b] Re-parent nested children (e.g. indented list items) to the new
+      // paragraph so they remain reachable after the source block is removed.
+      if (paragraphModel && model.children.length > 0) {
+        doc.deleteBlock(model, { bringChildrenTo: paragraphModel });
+      } else {
+        doc.deleteBlock(model, { deleteChildren: false });
+      }
+
+      calloutModels.push(calloutModel);
+      if (paragraphModel) {
+        paragraphModels.push(paragraphModel);
+      }
+    });
+
+    // Always terminal for 'affine:callout' — never fall through to
+    // genericTransform. If no blocks were converted (e.g. all were inside an
+    // existing Callout and skipped), we still call next with empty arrays.
+    const updatedBlocks =
+      paragraphModels.length > 0 ? paragraphModels : calloutModels;
+    return next({ updatedBlocks, calloutModels } as {
+      updatedBlocks: BlockModel[];
+      calloutModels: BlockModel[];
+    });
+  };
   const transformToLatex: Command<{}, { updatedBlocks: BlockModel[] }> = (
     _,
     next
@@ -206,8 +284,16 @@ export const updateBlockType: Command<
     if (blockSelections.length === 0) {
       return false;
     }
+
+    // [P2] For Callout conversions, select the Callout container rather than
+    // the inner paragraph so that an immediate Delete removes the whole block.
+    const calloutModels = (ctx as { calloutModels?: BlockModel[] })
+      .calloutModels;
+    const targetModels =
+      calloutModels && calloutModels.length > 0 ? calloutModels : updatedBlocks;
+
     requestAnimationFrame(() => {
-      const selections = updatedBlocks.map(model => {
+      const selections = targetModels.map(model => {
         return selectionManager.create(BlockSelection, {
           blockId: model.id,
         });
@@ -249,6 +335,7 @@ export const updateBlockType: Command<
     .try<{ updatedBlocks: BlockModel[] }>(chain => [
       chain.pipe(mergeToCode),
       chain.pipe(appendDivider),
+      chain.pipe(transformToCallout),
       chain.pipe(transformToLatex),
       chain.pipe((_, next) => {
         const newModels: BlockModel[] = [];

--- a/blocksuite/affine/blocks/root/src/configs/toolbar.ts
+++ b/blocksuite/affine/blocks/root/src/configs/toolbar.ts
@@ -106,6 +106,14 @@ const conversionsActionGroup = {
         .run();
     };
 
+    // Hide "Callout" from the menu when every selected block is already a
+    // direct child of a Callout — the schema forbids nested Callouts and the
+    // command layer would silently no-op, which is confusing to the user.
+    const allInsideCallout = selectedModels.every(model => {
+      const parent = model.store.getParent(model);
+      return parent?.flavour === 'affine:callout';
+    });
+
     return {
       content: html`
         <editor-menu-button
@@ -121,7 +129,11 @@ const conversionsActionGroup = {
         >
           <div data-size="large" data-orientation="vertical">
             ${repeat(
-              textConversionConfigs.filter(c => c.flavour !== 'affine:divider'),
+              textConversionConfigs.filter(
+                c =>
+                  c.flavour !== 'affine:divider' &&
+                  !(allInsideCallout && c.flavour === 'affine:callout')
+              ),
               item => item.name,
               ({ flavour, type, name, icon }) => html`
                 <editor-menu-action

--- a/blocksuite/affine/rich-text/src/conversion.ts
+++ b/blocksuite/affine/rich-text/src/conversion.ts
@@ -13,7 +13,7 @@ import {
   QuoteIcon,
   TextIcon,
 } from '@blocksuite/affine-components/icons';
-import { TeXIcon } from '@blocksuite/icons/lit';
+import { FontIcon, TeXIcon } from '@blocksuite/icons/lit';
 import type { TemplateResult } from 'lit';
 
 /**
@@ -136,6 +136,15 @@ export const textConversionConfigs: TextConversionConfig[] = [
     description: 'Add a blockquote for emphasis.',
     hotkey: null,
     icon: QuoteIcon,
+  },
+  {
+    flavour: 'affine:callout',
+    type: undefined,
+    name: 'Callout',
+    description: 'Let your words stand out.',
+    hotkey: null,
+    icon: FontIcon(),
+    searchAlias: ['callout'],
   },
   {
     flavour: 'affine:divider',

--- a/tests/affine-local/e2e/blocksuite/callout/callout.spec.ts
+++ b/tests/affine-local/e2e/blocksuite/callout/callout.spec.ts
@@ -3,7 +3,11 @@ import {
   pressArrowUp,
   pressBackspace,
   pressEnter,
+  pressEscape,
+  pressTab,
+  undoByKeyboard,
 } from '@affine-test/kit/utils/keyboard';
+import { locateToolbar } from '@affine-test/kit/utils/editor';
 import { openHomePage } from '@affine-test/kit/utils/load-page';
 import {
   clickNewPageButton,
@@ -11,6 +15,27 @@ import {
   waitForEmptyEditor,
 } from '@affine-test/kit/utils/page-logic';
 import { expect, test } from '@playwright/test';
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+async function redoByKeyboard(page: Parameters<typeof undoByKeyboard>[0]) {
+  const isMac = process.platform === 'darwin';
+  await page.keyboard.press(isMac ? 'Meta+Shift+Z' : 'Control+Shift+Z');
+}
+
+/** Select all text in the current focused block and open the Turn-into menu */
+async function openTurnIntoMenu(page: Parameters<typeof undoByKeyboard>[0]) {
+  await page.keyboard.press('Control+A');
+  const toolbar = locateToolbar(page);
+  await toolbar.getByLabel('Conversions').click();
+  return toolbar;
+}
+
+/** Convert the currently-selected content to Callout via the toolbar */
+async function convertToCallout(page: Parameters<typeof undoByKeyboard>[0]) {
+  const toolbar = await openTurnIntoMenu(page);
+  await toolbar.getByLabel('Callout').click();
+}
 
 test.beforeEach(async ({ page }) => {
   await openHomePage(page);
@@ -73,4 +98,140 @@ test('press backspace in callout block', async ({ page }) => {
   await pressBackspace(page);
   await expect(paragraph).toHaveCount(1);
   await expect(callout).toHaveCount(0);
+});
+
+// ─── Turn into → Callout regression tests ──────────────────────────────────
+
+test('turn into callout: plain paragraph preserves text and creates callout', async ({
+  page,
+}) => {
+  await type(page, 'hello world');
+  await convertToCallout(page);
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(1);
+
+  const innerParagraph = page.locator('affine-callout affine-paragraph');
+  await expect(innerParagraph).toHaveCount(1);
+  await expect(innerParagraph.locator('v-line')).toHaveText('hello world');
+});
+
+test('turn into callout: nested list items remain reachable after conversion', async ({
+  page,
+}) => {
+  // Build:  - parent item
+  //           - child item  (indented via Tab)
+  await type(page, '- parent item');
+  await pressEnter(page);
+  await pressTab(page);
+  await type(page, 'child item');
+
+  // Navigate back to parent and convert it
+  await pressArrowUp(page);
+  await convertToCallout(page);
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(1);
+
+  // Both "parent item" text and "child item" must be visible inside the callout
+  await expect(callout).toContainText('parent item');
+  await expect(callout).toContainText('child item');
+});
+
+test('turn into callout: content inside existing callout is NOT converted (no data loss)', async ({
+  page,
+}) => {
+  // Create a callout with some text
+  await type(page, '/callout\ninner text');
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(1);
+
+  // Select the inner paragraph and try to convert to callout again
+  const innerParagraph = page.locator('affine-callout affine-paragraph');
+  await innerParagraph.click();
+  await page.keyboard.press('Control+A');
+
+  const toolbar = locateToolbar(page);
+  await toolbar.getByLabel('Conversions').click();
+
+  // The Callout option must NOT appear in the menu (hidden for nested context)
+  await expect(toolbar.getByLabel('Callout')).toHaveCount(0);
+
+  // The inner paragraph still exists and its text is intact
+  await pressEscape(page);
+  await expect(innerParagraph).toContainText('inner text');
+  await expect(callout).toHaveCount(1);
+});
+
+test('turn into callout: delete after conversion removes the whole callout', async ({
+  page,
+}) => {
+  await type(page, 'delete me');
+
+  // Use keyboard shortcut path to trigger conversion so we can check
+  // BlockSelection behavior afterwards
+  await convertToCallout(page);
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(1);
+
+  // Press Escape to exit text editing → BlockSelection on the callout
+  await pressEscape(page);
+  await page.keyboard.press('Backspace');
+
+  // The entire callout (not just the inner paragraph) should be gone
+  await expect(callout).toHaveCount(0);
+});
+
+test('turn into callout: undo restores original paragraph with correct text', async ({
+  page,
+}) => {
+  await type(page, 'undo me');
+  await convertToCallout(page);
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(1);
+
+  await undoByKeyboard(page);
+
+  await expect(callout).toHaveCount(0);
+  const paragraph = page.locator('affine-note > affine-paragraph');
+  await expect(paragraph).toContainText('undo me');
+});
+
+test('turn into callout: redo restores the callout after undo', async ({
+  page,
+}) => {
+  await type(page, 'redo me');
+  await convertToCallout(page);
+  await undoByKeyboard(page);
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(0);
+
+  await redoByKeyboard(page);
+  await expect(callout).toHaveCount(1);
+  await expect(callout).toContainText('redo me');
+});
+
+test('turn into callout: rich-text formatting is preserved after conversion', async ({
+  page,
+}) => {
+  // Type text and bold part of it
+  await type(page, 'plain ');
+  await page.keyboard.press('Control+B');
+  await type(page, 'bold');
+  await page.keyboard.press('Control+B');
+
+  await convertToCallout(page);
+
+  const callout = page.locator('affine-callout');
+  await expect(callout).toHaveCount(1);
+
+  // The bold span must still be inside the callout
+  const boldSpan = callout.locator('v-element[data-v-type="text"] span').filter({
+    hasText: 'bold',
+  });
+  await expect(boldSpan).toHaveCount(1);
 });


### PR DESCRIPTION
## Summary

Closes #13954

The "Turn into" menu was missing the Callout option. Users had no way to convert an existing paragraph/list/code block into a Callout directly from the slash menu or context toolbar.

## Root Cause

`textConversionConfigs` in `rich-text/src/conversion.ts` had no entry for `affine:callout`, so the option never appeared in the menu.

Additionally, Callout is a **hub block** — its text lives in a child paragraph, not in its own `text` prop. This means the generic `transformModel` path would silently fail, requiring a dedicated conversion handler.

## Changes

- `blocksuite/affine/rich-text/src/conversion.ts` — add callout entry to `textConversionConfigs`
- `blocksuite/affine/blocks/note/src/commands/block-type.ts` — add `transformToCallout` command that:
  1. Creates a new `affine:callout` block at the original position
  2. Moves the original text into a child `affine:paragraph` inside the callout
  3. Deletes the original block

## Before / After

| Before | After |
|--------|-------|
| "Turn into" menu had no Callout option | Callout appears in "Turn into" menu |
| Selecting any block → Turn into showed: Heading, Text, Quote, Divider… | Now also shows: **Callout** |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Convert selected paragraphs, lists, and code blocks into callouts while preserving text and nested content.
  * Added callout recognition and icon display in rich-text conversion.
  * Conversion results now distinguish between selected blocks and text.
* **Bug Fixes**
  * Prevented invalid, nested, or incompatible callout conversions.
  * The conversion menu now hides Callout when unavailable.
  * Preserved original blocks when conversion fails.
  * Improved undo and redo behavior for callout conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->