### PR TITLE
fix(copilot): cap embedding batch size to 64 to avoid provider limits

### DIFF
--- a/packages/backend/native/src/runtime/backend_runtime/embedding/worker.rs
+++ b/packages/backend/native/src/runtime/backend_runtime/embedding/worker.rs
@@ -16,7 +16,7 @@ const MAX_INPUT_BYTES: usize = 50 * 1024 * 1024;
 const MAX_TEXT_BYTES: usize = 64 * 1024 * 1024;
 const MAX_TOKENS: usize = 1_000_000;
 const MAX_CHUNKS: usize = 2048;
-const PROVIDER_BATCH: usize = 128;
+const PROVIDER_BATCH: usize = 64;
 
 pub(super) struct WorkerHandle {
   stop: watch::Sender<bool>,

--- a/packages/backend/server/src/plugins/copilot/runtime/capability-runtime.ts
+++ b/packages/backend/server/src/plugins/copilot/runtime/capability-runtime.ts
@@ -365,17 +365,38 @@ export class CapabilityRuntime {
     input: string | string[],
     options: CopilotEmbeddingOptions = {}
   ) {
-    const result = (await this.execute(
-      'index.embedding',
-      buildLlmEmbeddingRequest({
-        model: 'route-selected',
-        inputs: Array.isArray(input) ? input : [input],
-        dimensions: options.dimensions,
-      }),
-      {},
-      options
-    )) as { embeddings: number[][] };
-    return result.embeddings;
+    const inputs = Array.isArray(input) ? input : [input];
+    const BATCH_SIZE = 64;
+    if (inputs.length <= BATCH_SIZE) {
+      const result = (await this.execute(
+        'index.embedding',
+        buildLlmEmbeddingRequest({
+          model: 'route-selected',
+          inputs,
+          dimensions: options.dimensions,
+        }),
+        {},
+        options
+      )) as { embeddings: number[][] };
+      return result.embeddings;
+    }
+
+    const embeddings: number[][] = [];
+    for (let i = 0; i < inputs.length; i += BATCH_SIZE) {
+      const batch = inputs.slice(i, i + BATCH_SIZE);
+      const result = (await this.execute(
+        'index.embedding',
+        buildLlmEmbeddingRequest({
+          model: 'route-selected',
+          inputs: batch,
+          dimensions: options.dimensions,
+        }),
+        {},
+        options
+      )) as { embeddings: number[][] };
+      embeddings.push(...result.embeddings);
+    }
+    return embeddings;
   }
 
   async rerankConfigured(_modelId: string) {


### PR DESCRIPTION
### Summary
Google Gemini embedding API (`batchEmbedContents`) enforces a maximum limit of 100 requests per batch (`* BatchEmbedContentsRequest.requests: at most 100 requests can be in one batch`).

Previously, `PROVIDER_BATCH` in the native embedding worker was set to `128`, causing batch embed calls to fail on documents with > 100 chunks when using Gemini (or other providers with < 128 limits such as Cohere).

This PR:
1. Reduces `PROVIDER_BATCH` in the native embedding worker from 128 to 64.
2. Adds chunk batching in `CapabilityRuntime.embed` to prevent large inputs from exceeding single-batch limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Embedding requests are now processed in smaller batches of up to 64 items.
  * Larger embedding workloads are automatically split into multiple requests and combined into a single result.
  * This improves handling of large inputs and helps provide more consistent embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->