### PR TITLE
ci: upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -181,7 +181,7 @@ jobs:
           extra-flags: workspaces focus @affine/monorepo @affine-tools/cli @affine/android
           electron-install: false
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'
@@ -261,7 +261,7 @@ jobs:
           extra-flags: workspaces focus @affine/monorepo @affine-tools/cli @affine/android
           electron-install: false
 
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/release-mobile.yml
+++ b/.github/workflows/release-mobile.yml
@@ -197,7 +197,7 @@ jobs:
           token_format: 'access_token'
           project_id: '${{ secrets.GCP_PROJECT_ID }}'
           access_token_scopes: 'https://www.googleapis.com/auth/androidpublisher'
-      - uses: actions/setup-java@v5
+      - uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
## Description

Upgrade all active workflow references from `actions/setup-java@v5` to `actions/setup-java@v6`.

## Checklist

- [ ] I have signed the [AFFiNE Contributor License Agreement](https://cla-assistant.io/toeverything/AFFiNE) — required before merge; the `license/cla` check must be green ([how it works](https://github.com/toeverything/AFFiNE/blob/canary/docs/BUILDING.md#sign-the-cla-first))
- [x] The PR targets the `canary` branch and its title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests are added or updated where it makes sense
- [ ] `yarn lint` and `yarn typecheck` pass locally

Tests were not run (workflow-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build, test, and release automation to use the latest Java setup action.
  * Android builds continue using Java 21 and existing Gradle caching settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->