### PR TITLE
fix(editor): correct markdown export of database blocks

### DIFF
--- a/blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts
@@ -2483,12 +2483,6 @@ hhh
         },
         columns: [
           {
-            type: 'title',
-            name: 'Title',
-            data: {},
-            id: 'block:2VfUaitjf9',
-          },
-          {
             type: 'select',
             name: 'Status',
             data: {
@@ -2517,6 +2511,12 @@ hhh
             name: 'Date',
             data: {},
             id: 'block:5cglrBmAr3',
+          },
+          {
+            type: 'title',
+            name: 'Title',
+            data: {},
+            id: 'block:2VfUaitjf9',
           },
           {
             type: 'number',
@@ -2610,10 +2610,10 @@ hhh
     };
 
     const md = `\
-| Title  | Status      | Date       | Number | Progress | MultiSelect | RichText                    | Link               | Checkbox |
-| ------ | ----------- | ---------- | ------ | -------- | ----------- | --------------------------- | ------------------ | -------- |
-| Task 1 | TODO        | 2023-12-15 | 1      | 65       | test1,test2 | [test2](https://google.com) | https://google.com | True     |
-| Task 2 | In Progress | 2023-12-20 |        |          |             | test1                       |                    |          |
+| Title | Status | Date | Number | Progress | MultiSelect | RichText | Link | Checkbox |
+| - | - | - | - | - | - | - | - | - |
+| Task 1 | TODO | 2023-12-15 | 1 | 65 | test1,test2 | [test2](https://google.com) | https://google.com | True |
+| Task 2 | In Progress | 2023-12-20 | | | | test1 | | |
 `;
     const mdAdapter = new MarkdownAdapter(createJob(), provider);
     const target = await mdAdapter.fromBlockSnapshot({
@@ -2847,13 +2847,13 @@ hhh
 
 &#x20;   bbb
 
-[untitled](https://example.com/4T5ObMgEIMII-4Bexyta1?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456\\&databaseId=deadbeef\\&databaseRowId=123)
+[untitled](https://example.com/4T5ObMgEIMII-4Bexyta1?mode=page&blockIds=abc%2C123&elementIds=def%2C456&databaseId=deadbeef&databaseRowId=123)
 
 &#x20;   ccc
 
 &#x20;       ddd
 
-&#x20;       eee[test](https://example.com/deadbeef?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456\\&databaseId=deadbeef\\&databaseRowId=123)[](https://example.com/foobar)
+&#x20;       eee[test](https://example.com/deadbeef?mode=page&blockIds=abc%2C123&elementIds=def%2C456&databaseId=deadbeef&databaseRowId=123)[](https://example.com/foobar)
 
 &#x20;       fff
 
@@ -5101,7 +5101,7 @@ aaa
 
 &#x20;       ddd
 
-&#x20;       eee[test](https://example.com/deadbeef?mode=page\\&blockIds=abc%2C123\\&elementIds=def%2C456)[](https://example.com/foobar)
+&#x20;       eee[test](https://example.com/deadbeef?mode=page&blockIds=abc%2C123&elementIds=def%2C456)[](https://example.com/foobar)
 
 &#x20;       fff
 

--- a/blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts
+++ b/blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts
@@ -2622,6 +2622,114 @@ hhh
     expect(target.file).toBe(md);
   });
 
+  test('table without a title column', async () => {
+    // A link cell that exists with no value stringifies to undefined,
+    // which is not a throw, and a row can hold a real newline. Neither
+    // used to survive the export.
+    const blockSnapshot: BlockSnapshot = {
+      type: 'block',
+      id: 'block:8Wb7CSJ9Qe',
+      flavour: 'affine:database',
+      props: {
+        cells: {
+          'block:P_-Wg7Rg9O': {
+            'block:U8lPD59MkF': {
+              columnId: 'block:U8lPD59MkF',
+              value: undefined,
+            },
+          },
+        },
+        columns: [
+          {
+            type: 'link',
+            name: 'Link',
+            data: {},
+            id: 'block:U8lPD59MkF',
+          },
+        ],
+      },
+      children: [
+        {
+          type: 'block',
+          id: 'block:P_-Wg7Rg9O',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'first\nsecond',
+                },
+              ],
+            },
+          },
+          children: [],
+        },
+      ],
+    };
+
+    const md = `\
+| Title | Link |
+| - | - |
+| first second | |
+`;
+    const mdAdapter = new MarkdownAdapter(createJob(), provider);
+    const target = await mdAdapter.fromBlockSnapshot({
+      snapshot: blockSnapshot,
+    });
+    expect(target.file).toBe(md);
+  });
+
+  test('table keeps a blank title column name', async () => {
+    const blockSnapshot: BlockSnapshot = {
+      type: 'block',
+      id: 'block:8Wb7CSJ9Qe',
+      flavour: 'affine:database',
+      props: {
+        cells: {},
+        columns: [
+          {
+            type: 'title',
+            name: '',
+            data: {},
+            id: 'block:2VfUaitjf9',
+          },
+        ],
+      },
+      children: [
+        {
+          type: 'block',
+          id: 'block:P_-Wg7Rg9O',
+          flavour: 'affine:paragraph',
+          props: {
+            type: 'text',
+            text: {
+              '$blocksuite:internal:text$': true,
+              delta: [
+                {
+                  insert: 'Task 1',
+                },
+              ],
+            },
+          },
+          children: [],
+        },
+      ],
+    };
+
+    const md = `\
+| |
+| - |
+| Task 1 |
+`;
+    const mdAdapter = new MarkdownAdapter(createJob(), provider);
+    const target = await mdAdapter.fromBlockSnapshot({
+      snapshot: blockSnapshot,
+    });
+    expect(target.file).toBe(md);
+  });
+
   test('reference', async () => {
     const blockSnapshot: BlockSnapshot = {
       type: 'block',

--- a/blocksuite/affine/blocks/database/src/adapters/utils.ts
+++ b/blocksuite/affine/blocks/database/src/adapters/utils.ts
@@ -67,7 +67,7 @@ export const processTable = (
     headers: [
       {
         ...(titleColumn ?? { id: 'title', type: 'title', data: {} }),
-        name: titleColumn?.name || 'Title',
+        name: titleColumn?.name ?? 'Title',
       } as ColumnDataType,
       ...valueColumns,
     ],

--- a/blocksuite/affine/blocks/database/src/adapters/utils.ts
+++ b/blocksuite/affine/blocks/database/src/adapters/utils.ts
@@ -58,8 +58,19 @@ export const processTable = (
   children: BlockSnapshot[] = [],
   cells: SerializedCells = {}
 ): Table => {
+  // Every row is built as [row title, ...non-title columns], so the headers
+  // must use that same order. Passing the raw columns array put each name
+  // above the wrong column whenever the title column was not first.
+  const titleColumn = columns.find(col => col.type === 'title');
+  const valueColumns = columns.filter(col => col.type !== 'title');
   const table: Table = {
-    headers: columns,
+    headers: [
+      {
+        ...(titleColumn ?? { id: 'title', type: 'title', data: {} }),
+        name: titleColumn?.name || 'Title',
+      } as ColumnDataType,
+      ...valueColumns,
+    ],
     rows: [],
   };
   children.forEach(v => {
@@ -77,12 +88,9 @@ export const processTable = (
       });
     }
 
-    columns.forEach(col => {
+    valueColumns.forEach(col => {
       const property = databaseBlockModels[col.type];
       const cell = cells[v.id]?.[col.id];
-      if (col.type === 'title') {
-        return;
-      }
       if (!cell || !property) {
         row.cells.push({
           value: '',
@@ -94,10 +102,14 @@ export const processTable = (
         if (isDelta(cell.value)) {
           value = cell.value;
         } else {
-          value = property.config.rawValue.toString({
-            value: cell.value,
-            data: col.data,
-          });
+          // An empty cell can stringify to undefined, which is not a throw,
+          // so the catch below does not cover it. Every adapter then reads
+          // value.delta and fails, and the whole export aborts.
+          value =
+            property.config.rawValue.toString({
+              value: cell.value,
+              data: col.data,
+            }) ?? '';
         }
       } catch {
         value = '';

--- a/blocksuite/affine/shared/package.json
+++ b/blocksuite/affine/shared/package.json
@@ -32,6 +32,7 @@
     "mdast-util-gfm-strikethrough": "^2.0.0",
     "mdast-util-gfm-table": "^2.0.0",
     "mdast-util-gfm-task-list-item": "^2.0.0",
+    "mdast-util-to-markdown": "^2.1.2",
     "micromark-extension-gfm-autolink-literal": "^2.1.0",
     "micromark-extension-gfm-footnote": "^2.1.0",
     "micromark-extension-gfm-strikethrough": "^2.1.0",

--- a/blocksuite/affine/shared/src/__tests__/adapters/markdown/link-destination.unit.spec.ts
+++ b/blocksuite/affine/shared/src/__tests__/adapters/markdown/link-destination.unit.spec.ts
@@ -1,0 +1,177 @@
+import type { Root } from 'mdast';
+import remarkParse from 'remark-parse';
+import remarkStringify from 'remark-stringify';
+import { unified } from 'unified';
+import { visit } from 'unist-util-visit';
+import { describe, expect, test } from 'vitest';
+
+import {
+  flattenTableCellNewlines,
+  remarkGfm,
+} from '../../../adapters/markdown/gfm';
+import { linkDestinationHandlers } from '../../../adapters/markdown/link-destination';
+
+function toMarkdown(tree: Root) {
+  return unified()
+    .use(remarkGfm)
+    .use(remarkStringify, {
+      resourceLink: true,
+      handlers: linkDestinationHandlers,
+    })
+    .stringify(tree);
+}
+
+function parse(markdown: string): Root {
+  const processor = unified().use(remarkParse).use(remarkGfm);
+  return processor.runSync(processor.parse(markdown)) as Root;
+}
+
+function paragraph(children: unknown[]): Root {
+  return {
+    type: 'root',
+    children: [{ type: 'paragraph', children }],
+  } as Root;
+}
+
+function link(url: string): Root {
+  return paragraph([
+    { type: 'link', url, children: [{ type: 'text', value: 'label' }] },
+  ]);
+}
+
+function firstUrl(markdown: string) {
+  let url: string | undefined;
+  visit(parse(markdown), ['link', 'image'], node => {
+    url ??= (node as unknown as { url: string }).url;
+  });
+  return url;
+}
+
+describe('link destinations survive a round trip', () => {
+  const urls = [
+    'https://www.figma.com/design/AbC123/Spec?node-id=42-7&t=xY9zQ-4&m=dev',
+    'https://example.com/?x=1&copy;=2',
+    'https://example.com/?x=1&amp;y=2',
+    'https://example.com/?a=1&#169;=2',
+    'https://example.com/?a=1&#x2764;=2',
+    'https://example.com/(foo)?a=1&b=2',
+    'https://example.com/a_(b)?a=1&copy;=2',
+  ];
+
+  for (const url of urls) {
+    test(url, () => {
+      expect(firstUrl(toMarkdown(link(url)))).toBe(url);
+    });
+
+    test(`image ${url}`, () => {
+      const tree = paragraph([{ type: 'image', url, alt: 'alt' }]);
+      expect(firstUrl(toMarkdown(tree))).toBe(url);
+    });
+  }
+
+  test('a query parameter loses its backslash', () => {
+    const url =
+      'https://www.figma.com/design/AbC123/Spec?node-id=42-7&t=xY9zQ-4';
+    expect(toMarkdown(link(url))).toContain(`&t=xY9zQ-4`);
+    expect(toMarkdown(link(url))).not.toContain('\\&');
+  });
+
+  test('a character reference keeps its backslash', () => {
+    expect(toMarkdown(link('https://example.com/?x=1&copy;=2'))).toContain(
+      '\\&copy;'
+    );
+  });
+
+  test('a title is left alone', () => {
+    const tree = paragraph([
+      {
+        type: 'link',
+        url: 'https://example.com/?a=1&b=2',
+        title: 'a & b',
+        children: [{ type: 'text', value: 'label' }],
+      },
+    ]);
+    expect(toMarkdown(tree).trim()).toBe(
+      '[label](https://example.com/?a=1&b=2 "a & b")'
+    );
+  });
+});
+
+describe('literal entities outside a destination are preserved', () => {
+  test('body text', () => {
+    const markdown = toMarkdown(
+      paragraph([{ type: 'text', value: 'a &#xA; b' }])
+    );
+    expect(firstText(markdown)).toBe('a &#xA; b');
+  });
+
+  test('inline code', () => {
+    const markdown = toMarkdown(
+      paragraph([{ type: 'inlineCode', value: 'a &#xA; b' }])
+    );
+    expect(markdown.trim()).toBe('`a &#xA; b`');
+  });
+
+  test('fenced code', () => {
+    const tree = {
+      type: 'root',
+      children: [{ type: 'code', lang: 'text', value: 'a &#xA; b' }],
+    } as Root;
+    expect(toMarkdown(tree).trim()).toBe('```text\na &#xA; b\n```');
+  });
+
+  test('link shaped text inside code keeps its escapes', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'code',
+          lang: 'text',
+          value: '[label](https://example.com/?a=1\\&b=2)',
+        },
+      ],
+    } as Root;
+    expect(toMarkdown(tree)).toContain('\\&b=2');
+  });
+});
+
+function firstText(markdown: string) {
+  let value: string | undefined;
+  visit(parse(markdown), 'text', node => {
+    value ??= (node as unknown as { value: string }).value;
+  });
+  return value;
+}
+
+describe('table cells', () => {
+  function cell(children: unknown[]) {
+    return {
+      type: 'root',
+      children: [
+        {
+          type: 'table',
+          align: [null],
+          children: [
+            { type: 'tableRow', children: [{ type: 'tableCell', children }] },
+          ],
+        },
+      ],
+    } as Root;
+  }
+
+  test('a real newline becomes a space, not an entity', () => {
+    const tree = cell([{ type: 'text', value: 'first\nsecond' }]);
+    flattenTableCellNewlines(tree);
+    const markdown = toMarkdown(tree);
+
+    expect(markdown).toContain('first second');
+    expect(markdown).not.toContain('&#xA;');
+  });
+
+  test('code in a cell keeps its own text', () => {
+    const tree = cell([{ type: 'inlineCode', value: 'a &#xA; b' }]);
+    flattenTableCellNewlines(tree);
+
+    expect(toMarkdown(tree)).toContain('a &#xA; b');
+  });
+});

--- a/blocksuite/affine/shared/src/adapters/markdown/gfm.ts
+++ b/blocksuite/affine/shared/src/adapters/markdown/gfm.ts
@@ -5,6 +5,7 @@ Copyright (c) 2020 Titus Wormer <tituswormer@gmail.com>
 
 mdast-util-gfm-autolink-literal is from markdown only.
 */
+import type { Nodes, Root } from 'mdast';
 import { gfmAutolinkLiteralFromMarkdown } from 'mdast-util-gfm-autolink-literal';
 import {
   gfmFootnoteFromMarkdown,
@@ -26,6 +27,7 @@ import { gfmTable } from 'micromark-extension-gfm-table';
 import { gfmTaskListItem } from 'micromark-extension-gfm-task-list-item';
 import { combineExtensions } from 'micromark-util-combine-extensions';
 import type { Processor } from 'unified';
+import { visit } from 'unist-util-visit';
 
 export function gfm() {
   return combineExtensions([
@@ -76,4 +78,26 @@ export function remarkGfm(this: Processor) {
   micromarkExtensions.push(gfm());
   fromMarkdownExtensions.push(gfmFromMarkdown());
   toMarkdownExtensions.push(gfmToMarkdown());
+}
+
+// A table cell cannot hold a newline. The serializer writes a character
+// reference for one, which reads as &#xA; in the exported table, so the
+// newline becomes a space first. Code and raw HTML keep their own text.
+const KEEPS_ITS_TEXT = new Set(['code', 'html', 'inlineCode']);
+
+function flattenText(node: Nodes) {
+  if (KEEPS_ITS_TEXT.has(node.type)) return;
+  if (node.type === 'text') {
+    node.value = node.value.replace(/\r?\n/g, ' ');
+    return;
+  }
+  if ('children' in node) {
+    for (const child of node.children) flattenText(child);
+  }
+}
+
+export function flattenTableCellNewlines(tree: Root) {
+  visit(tree, 'tableCell', cell => {
+    flattenText(cell);
+  });
 }

--- a/blocksuite/affine/shared/src/adapters/markdown/gfm.ts
+++ b/blocksuite/affine/shared/src/adapters/markdown/gfm.ts
@@ -51,7 +51,10 @@ function gfmToMarkdown() {
   return {
     extensions: [
       gfmStrikethroughToMarkdown(),
-      gfmTableToMarkdown(),
+      // Do not pad cells out to the widest value in the column. One long
+      // cell made every row that wide, which turned a small table into
+      // hundreds of columns of trailing spaces.
+      gfmTableToMarkdown({ tablePipeAlign: false }),
       gfmTaskListItemToMarkdown(),
       gfmFootnoteToMarkdown(),
     ],

--- a/blocksuite/affine/shared/src/adapters/markdown/link-destination.ts
+++ b/blocksuite/affine/shared/src/adapters/markdown/link-destination.ts
@@ -1,0 +1,35 @@
+import type { Image, Link } from 'mdast';
+import { defaultHandlers, type Handlers } from 'mdast-util-to-markdown';
+
+// The serializer escapes every & that a letter or # follows, which puts a
+// backslash in front of most query parameters. Only an & that completes a
+// character reference has to stay escaped, and the shape is tested rather
+// than the list of entity names, so an unknown name keeps its backslash.
+const CHARACTER_REFERENCE =
+  /^&(?:[a-zA-Z][a-zA-Z0-9]*|#\d+|#[xX][0-9a-fA-F]+);/;
+
+// The destination and its optional title, at the end of one link or image.
+const DESTINATION =
+  /\]\((<[^<>]*>|(?:\\.|[^\s()])*)((?:\s+(?:"[^"]*"|'[^']*'|\([^()]*\)))?\))$/;
+
+function unescapeAmpersands(destination: string) {
+  return destination.replace(/\\&/g, (match, offset: number) =>
+    CHARACTER_REFERENCE.test(`&${destination.slice(offset + 2)}`) ? match : '&'
+  );
+}
+
+function readableDestination(serialized: string) {
+  return serialized.replace(
+    DESTINATION,
+    (_, destination: string, tail: string) =>
+      `](${unescapeAmpersands(destination)}${tail}`
+  );
+}
+
+// Applied per node, so a link shaped string inside code keeps its escapes.
+export const linkDestinationHandlers: Partial<Handlers> = {
+  image: (node: Image, parent, state, info) =>
+    readableDestination(defaultHandlers.image(node, parent, state, info)),
+  link: (node: Link, parent, state, info) =>
+    readableDestination(defaultHandlers.link(node, parent, state, info)),
+};

--- a/blocksuite/affine/shared/src/adapters/markdown/markdown.ts
+++ b/blocksuite/affine/shared/src/adapters/markdown/markdown.ts
@@ -41,7 +41,8 @@ import {
   MarkdownASTToDeltaMatcherIdentifier,
   MarkdownDeltaConverter,
 } from './delta-converter';
-import { remarkGfm } from './gfm';
+import { flattenTableCellNewlines, remarkGfm } from './gfm';
+import { linkDestinationHandlers } from './link-destination';
 import { MarkdownPreprocessorManager } from './preprocessor';
 import { remarkCallout } from './remark-plugins/remark-callout';
 import type { Markdown, MarkdownAST } from './type';
@@ -212,28 +213,16 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
   }
 
   private _astToMarkdown(ast: Root) {
-    return (
-      unified()
-        .use(remarkGfm)
-        .use(remarkStringify, {
-          resourceLink: true,
-        })
-        .use(remarkMath)
-        .stringify(ast)
-        .replace(/&#x20;\n/g, ' \n')
-        // A table cell cannot hold a newline, so the serializer emits a
-        // character reference for it. Leave a space rather than the entity.
-        .replace(/&#xA;/g, ' ')
-        // The serializer escapes & in a link destination because it can start
-        // a character reference. That puts \& in every query string and the
-        // link breaks when a reader copies it out. A bare & in a destination
-        // parses back as itself, so unescaping it is safe. Only destinations
-        // are touched, so a literal \& in body text stays escaped.
-        .replace(
-          /(\]\()([^()\s]+)/g,
-          (_, prefix, destination) => prefix + destination.replace(/\\&/g, '&')
-        )
-    );
+    flattenTableCellNewlines(ast);
+    return unified()
+      .use(remarkGfm)
+      .use(remarkStringify, {
+        resourceLink: true,
+        handlers: linkDestinationHandlers,
+      })
+      .use(remarkMath)
+      .stringify(ast)
+      .replace(/&#x20;\n/g, ' \n');
   }
 
   private _markdownToAst(markdown: Markdown) {

--- a/blocksuite/affine/shared/src/adapters/markdown/markdown.ts
+++ b/blocksuite/affine/shared/src/adapters/markdown/markdown.ts
@@ -212,14 +212,28 @@ export class MarkdownAdapter extends BaseAdapter<Markdown> {
   }
 
   private _astToMarkdown(ast: Root) {
-    return unified()
-      .use(remarkGfm)
-      .use(remarkStringify, {
-        resourceLink: true,
-      })
-      .use(remarkMath)
-      .stringify(ast)
-      .replace(/&#x20;\n/g, ' \n');
+    return (
+      unified()
+        .use(remarkGfm)
+        .use(remarkStringify, {
+          resourceLink: true,
+        })
+        .use(remarkMath)
+        .stringify(ast)
+        .replace(/&#x20;\n/g, ' \n')
+        // A table cell cannot hold a newline, so the serializer emits a
+        // character reference for it. Leave a space rather than the entity.
+        .replace(/&#xA;/g, ' ')
+        // The serializer escapes & in a link destination because it can start
+        // a character reference. That puts \& in every query string and the
+        // link breaks when a reader copies it out. A bare & in a destination
+        // parses back as itself, so unescaping it is safe. Only destinations
+        // are touched, so a literal \& in body text stays escaped.
+        .replace(
+          /(\]\()([^()\s]+)/g,
+          (_, prefix, destination) => prefix + destination.replace(/\\&/g, '&')
+        )
+    );
   }
 
   private _markdownToAst(markdown: Markdown) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2886,6 +2886,7 @@ __metadata:
     mdast-util-gfm-strikethrough: "npm:^2.0.0"
     mdast-util-gfm-table: "npm:^2.0.0"
     mdast-util-gfm-task-list-item: "npm:^2.0.0"
+    mdast-util-to-markdown: "npm:^2.1.2"
     micromark-extension-gfm-autolink-literal: "npm:^2.1.0"
     micromark-extension-gfm-footnote: "npm:^2.1.0"
     micromark-extension-gfm-strikethrough: "npm:^2.1.0"
@@ -27947,7 +27948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mdast-util-to-markdown@npm:^2.0.0, mdast-util-to-markdown@npm:^2.1.0":
+"mdast-util-to-markdown@npm:^2.0.0, mdast-util-to-markdown@npm:^2.1.0, mdast-util-to-markdown@npm:^2.1.2":
   version: 2.1.2
   resolution: "mdast-util-to-markdown@npm:2.1.2"
   dependencies:


### PR DESCRIPTION
## What

Exporting a doc that holds a database block produces markdown that is wrong in three ways. This fixes all three, plus two smaller output defects that come from the same path.

### 1. The header row can sit above the wrong columns

A row is built as `[row title, ...non-title columns]`, but `processTable` passed the raw `columns` array as the headers. When the title column is not first, every name sits above the wrong column. A database with no title column produces a header row one cell short of every data row.

The headers are now built in the same order the rows are, with the title first.

### 2. An empty cell aborts the export of the whole document

`property.config.rawValue.toString(...)` can return `undefined`. That value went through unchanged, the adapters then read `value.delta` on it and threw, and the export of the entire document failed — not just the table.

The existing `try`/`catch` does not cover this, because a plain `undefined` return is not a throw. A `?? ''` inside the `try` handles it.

### 3. One long cell makes every row that wide

`gfmTableToMarkdown()` pads every cell out to the widest value in its column. A single long cell, such as a URL, turns a small table into hundreds of columns of trailing spaces. `tablePipeAlign: false` stops the padding; the output still parses as the same table.

### 4 and 5. Serializer output in `_astToMarkdown`

- A table cell cannot hold a newline, so the serializer emits `&#xA;`. That entity now becomes a space.
- The serializer escapes `&` in a link destination because it can start a character reference. That puts `\&` in every query string, and the link breaks when a reader copies it out. A bare `&` in a destination parses back as itself, so unescaping is safe. Only destinations are touched, so a literal `\&` in body text stays escaped.

## Tests

`blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts` — the `snapshot to markdown > table` fixture now puts the title column third instead of first. The expected markdown does not change, because a row always starts with the title. Without the header fix that test fails:

```
- | Title | Status | Date | Number | ...
+ | Status | Date | Title | Number | ...
```

The expected table and the expected reference links were updated for the padding and escaping changes.

Run locally on this branch:

```
vitest --run blocksuite/affine/all/src/__tests__/adapters/markdown.unit.spec.ts   75 passed
vitest --run blocksuite/affine/all/src/__tests__/adapters/plain-text.unit.spec.ts 14 passed
vitest --run blocksuite/affine/all/src/__tests__/adapters/html.unit.spec.ts       40 passed
vitest --run blocksuite/affine/all/src/__tests__/adapters/notion-html.unit.spec.ts 17 passed
tsc -b blocksuite/affine/blocks/database/tsconfig.json   ok
tsc -b blocksuite/affine/shared/tsconfig.json            ok
oxfmt --check, oxlint --deny-warnings                    clean
```

## How it was found

A self-hosted 0.26.2 instance could not export any doc containing a database block. The three fixes were applied to a 0.26.2 build first and confirmed against the real document, then rebased onto `canary`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Markdown table import and export by placing title columns first and providing a default title when needed.
  - Prevented missing table values from producing invalid serialized content.
  - Corrected handling of newlines in table cells and ampersands in linked-page URLs.
  - Preserved literal entities and escaping consistently across links, images, and code content.
- **Improvements**
  - Simplified exported table formatting by removing automatic column padding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->