### PR TITLE
docs: fix typo independant -> independent

### DIFF
--- a/blocksuite/docs-site/guide/inline.md
+++ b/blocksuite/docs-site/guide/inline.md
@@ -1,6 +1,6 @@
 # `@blocksuite/inline`
 
-This package is a minimal rich text component for inline editing. It uses an external [`Y.Text`](https://docs.yjs.dev/api/shared-types/y.text) as it source of truth. Every `inlineEditor` instance attaches to an independant `Y.Text`, so rich text content in different block nodes can be splitted into different inline editors, making complex content conveniently composable. This significantly reduces the complexity required to implement traditional rich text editing features.
+This package is a minimal rich text component for inline editing. It uses an external [`Y.Text`](https://docs.yjs.dev/api/shared-types/y.text) as it source of truth. Every `inlineEditor` instance attaches to an independent `Y.Text`, so rich text content in different block nodes can be splitted into different inline editors, making complex content conveniently composable. This significantly reduces the complexity required to implement traditional rich text editing features.
 
 ![flat-inlines](../images/flat-inlines.png)
 


### PR DESCRIPTION
Corrects the misspelling `independant` -> `independent` in `blocksuite/docs-site/guide/inline.md`.

Documentation only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a spelling error in the introductory description of the inline package guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->