### PR TITLE
fix(mobile): allow self-hosted plain-HTTP servers on Android release builds

### DIFF
--- a/packages/frontend/apps/android/App/app/build.gradle
+++ b/packages/frontend/apps/android/App/app/build.gradle
@@ -30,7 +30,6 @@ android {
         versionCode = 1
         versionName = System.getenv('VERSION_NAME') ?: 'v1.0.0-local'
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        manifestPlaceholders = [usesCleartextTraffic: "false"]
         aaptOptions {
             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
             // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
@@ -60,7 +59,6 @@ android {
         debug {
             minifyEnabled false
             debuggable true
-            manifestPlaceholders = [usesCleartextTraffic: "true"]
         }
     }
     flavorDimensions = ['chanel']

--- a/packages/frontend/apps/android/App/app/src/main/AndroidManifest.xml
+++ b/packages/frontend/apps/android/App/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:hardwareAccelerated="true"
         android:supportsRtl="true"
-        android:usesCleartextTraffic="${usesCleartextTraffic}"
+        android:usesCleartextTraffic="true"
         android:theme="@style/AppTheme">
 
         <activity

--- a/packages/frontend/apps/android/App/app/src/main/java/app/affine/pro/MainActivity.kt
+++ b/packages/frontend/apps/android/App/app/src/main/java/app/affine/pro/MainActivity.kt
@@ -137,13 +137,11 @@ class MainActivity : BridgeActivity(), AIButtonPlugin.Callback, AFFiNEThemePlugi
             isHorizontalScrollBarEnabled = false
             isVerticalScrollBarEnabled = false
             settings.apply {
-                // Debug builds may point CAP_SERVER_URL at an HTTP dev server; release builds
-                // should keep mixed content blocked.
-                mixedContentMode = if (BuildConfig.DEBUG) {
-                    WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
-                } else {
-                    WebSettings.MIXED_CONTENT_NEVER_ALLOW
-                }
+                // The only page loaded in this WebView is the bundled app at https://localhost;
+                // all other requests target the user-configured server, which for self-hosted
+                // instances may be plain HTTP. Blocking mixed content would silently break
+                // those connections (toeverything/AFFiNE#15438).
+                mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
                 setSupportZoom(false)
                 builtInZoomControls = false
                 displayZoomControls = false


### PR DESCRIPTION
PR #15118 tightened release builds to block cleartext traffic and mixed content, which broke connecting to self-hosted instances served over plain HTTP (toeverything/AFFiNE#15438): the WebView fetch to <server>/graphql fails and the app shows a generic "Network error", while browsers load the same server fine.

Restore the behavior established by #13279 and #13435:
- manifest: always allow cleartext traffic
- WebView: always allow mixed content; the only page loaded is the bundled local app, and every other request targets the user-configured server, which may be plain HTTP for self-hosted instances

Fixes #15438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Android app now allows cleartext network traffic in all build variants.
  * Web content can load mixed HTTP and HTTPS resources, including in release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->