### PR TITLE
fix(server): stop forwarding Accept-Encoding in worker link-preview/image-proxy

### DIFF
--- a/packages/backend/server/src/__tests__/worker.e2e.ts
+++ b/packages/backend/server/src/__tests__/worker.e2e.ts
@@ -403,3 +403,74 @@ test('should preview link', async t => {
     }
   }
 });
+
+test('should not forward Accept-Encoding when fetching a link-preview target', async t => {
+  const capturedHeaders: Record<string, string>[] = [];
+  const fetchSpy = stubSafeFetch(request => {
+    capturedHeaders.push(
+      (request as { headers?: Record<string, string> }).headers ?? {}
+    );
+    return {
+      body: '<html><head><meta property="og:title" content="Test" /></head></html>',
+      finalUrl: request.url,
+      headers: { 'content-type': 'text/html;charset=UTF-8' },
+    };
+  });
+
+  try {
+    const pageUrl = `http://external.com/accept-encoding-${Date.now()}`;
+    await t.context.app
+      .POST('/api/worker/link-preview')
+      .set('Origin', 'http://localhost:3010')
+      .set('Accept-Encoding', 'gzip, deflate, br')
+      .send({ url: pageUrl })
+      .expect(200);
+
+    t.true(capturedHeaders.length > 0, 'expected at least one fetch');
+    for (const headers of capturedHeaders) {
+      t.false(
+        Object.keys(headers).some(k => k.toLowerCase() === 'accept-encoding'),
+        'Accept-Encoding should not be forwarded to the fetch target'
+      );
+    }
+  } finally {
+    fetchSpy.restore();
+  }
+});
+
+test('should not forward Accept-Encoding when proxying an image', async t => {
+  const capturedHeaders: Record<string, string>[] = [];
+  const fakeBuffer = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jfJ8AAAAASUVORK5CYII=',
+    'base64'
+  );
+  const fetchSpy = stubSafeFetch(request => {
+    capturedHeaders.push(
+      (request as { headers?: Record<string, string> }).headers ?? {}
+    );
+    return {
+      body: fakeBuffer,
+      headers: { 'content-type': 'image/png' },
+    };
+  });
+
+  try {
+    const imageUrl = `http://example.com/accept-encoding-${Date.now()}.png`;
+    await t.context.app
+      .GET(`/api/worker/image-proxy?url=${imageUrl}`)
+      .set('Origin', 'http://localhost:3010')
+      .set('Accept-Encoding', 'gzip, deflate, br')
+      .send()
+      .expect(200);
+
+    t.true(capturedHeaders.length > 0, 'expected at least one fetch');
+    for (const headers of capturedHeaders) {
+      t.false(
+        Object.keys(headers).some(k => k.toLowerCase() === 'accept-encoding'),
+        'Accept-Encoding should not be forwarded to the fetch target'
+      );
+    }
+  } finally {
+    fetchSpy.restore();
+  }
+});

--- a/packages/backend/server/src/plugins/worker/utils/headers.ts
+++ b/packages/backend/server/src/plugins/worker/utils/headers.ts
@@ -33,12 +33,16 @@ export function isRefererAllowed(referer: string, allowedOrigin: OriginRules) {
 }
 
 const headerFilters = [/^Sec-/i, /^Accept/i, /^User-Agent$/i];
+const headerExcludes = [/^Accept-Encoding$/i];
 
 export function cloneHeader(source: IncomingHttpHeaders) {
   const headers: Record<string, string> = {};
 
   Object.entries(source).forEach(([key, value]) => {
-    if (headerFilters.some(filter => filter.test(key))) {
+    if (
+      headerFilters.some(filter => filter.test(key)) &&
+      !headerExcludes.some(filter => filter.test(key))
+    ) {
       if (Array.isArray(value)) {
         headers[key] = value.join(',');
       } else if (value) {


### PR DESCRIPTION
## Description

Self-hosted AFFiNE's `/api/worker/link-preview` and `/api/worker/image-proxy` endpoints forward the requesting browser's `Accept-Encoding` header to whatever URL they fetch (`cloneHeader()`), but the underlying native `safeFetch` never decompresses the response before parsing it. Sites that gzip/brotli-compress their HTML (GitHub does, for any non-trivially-sized repo page) end up handing AFFiNE compressed bytes, which the HTMLRewriter meta-tag scraper silently reads as nothing. The result: link preview cards render with no image, title, or description.

**Fix:** drop `Accept-Encoding` from the headers forwarded in `cloneHeader()`, so upstream requests are implicitly identity-encoded and the response body stays uncompressed for the parsing that follows.

**Before**
<img width="641" height="335" alt="image" src="https://github.com/user-attachments/assets/8ec8a925-6a1f-422a-9cb0-5e1687a5f75e" />

**After**
<img width="659" height="323" alt="image" src="https://github.com/user-attachments/assets/c35002b5-43c1-4f8b-a4c2-20028f1e453a" />


## Checklist

- [x] I have signed the [AFFiNE Contributor License Agreement](https://cla-assistant.io/toeverything/AFFiNE) — required before merge; the `license/cla` check must be green ([how it works](https://github.com/toeverything/AFFiNE/blob/canary/docs/BUILDING.md#sign-the-cla-first))
- [x] The PR targets the `canary` branch and its title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests are added or updated where it makes sense
- [x] `yarn lint` and `yarn typecheck` pass locally
- [x] If the PR code includes AI-generated edits, I have carefully reviewed it to ensure that the scope of the PR is consistent with what is claimed in the title and description, and that there are no redundant or invalid implementations.
- [x] I agree that maintainers may close the PR without discussion if they consider the code quality to be too low.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented `Accept-Encoding` headers from being forwarded when processing worker link-preview and image-proxy requests.
  * Improved request handling to avoid passing client compression preferences to external fetch targets.

* **Tests**
  * Added end-to-end coverage confirming that `Accept-Encoding` is excluded from forwarded requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->