### PR TITLE
feat(server): add Dub affiliate attribution to Stripe Checkout

### DIFF
--- a/.docker/selfhost/schema.json
+++ b/.docker/selfhost/schema.json
@@ -1613,6 +1613,16 @@
           "description": "Whether enable lifetime price and allow user to pay for it.\n@default true",
           "default": true
         },
+        "dubAffiliateEnabled": {
+          "type": "boolean",
+          "description": "Whether to attribute eligible Stripe customers to Dub affiliates.\n@default false",
+          "default": false
+        },
+        "dubAffiliateExcludedPromotionCodes": {
+          "type": "array",
+          "description": "Promotion codes that must not also receive Dub attribution.\n@default []",
+          "default": []
+        },
         "stripe": {
           "type": "object",
           "description": "Stripe sdk options and credentials\n@default {\"apiKey\":\"\",\"webhookKey\":\"\"}\n@link https://docs.stripe.com/api",

--- a/packages/backend/server/src/__tests__/mutex.spec.ts
+++ b/packages/backend/server/src/__tests__/mutex.spec.ts
@@ -79,3 +79,13 @@ test('should be able to acquire lock parallel', async t => {
     'should be able to acquire lock parallel'
   );
 });
+
+test('tryAcquire should only attempt to acquire the lock once', async t => {
+  const { locker } = t.context;
+  const lock = Sinon.stub(locker, 'lock').rejects(new Error('contended'));
+  t.teardown(() => lock.restore());
+  const mutex = new Mutex(locker);
+
+  t.is(await mutex.tryAcquire(`${lockerPrefix}4`), undefined);
+  t.is(lock.callCount, 1);
+});

--- a/packages/backend/server/src/__tests__/mutex.spec.ts
+++ b/packages/backend/server/src/__tests__/mutex.spec.ts
@@ -4,7 +4,7 @@ import { TestingModule } from '@nestjs/testing';
 import ava, { TestFn } from 'ava';
 import Sinon from 'sinon';
 
-import { Locker, Mutex } from '../base/mutex';
+import { Locker, LockUnavailableError, Mutex } from '../base/mutex';
 import { SessionRedis } from '../base/redis';
 import { createTestingModule, sleep } from './utils';
 
@@ -82,10 +82,24 @@ test('should be able to acquire lock parallel', async t => {
 
 test('tryAcquire should only attempt to acquire the lock once', async t => {
   const { locker } = t.context;
-  const lock = Sinon.stub(locker, 'lock').rejects(new Error('contended'));
+  const lock = Sinon.stub(locker, 'lock').rejects(
+    new LockUnavailableError('contended')
+  );
   t.teardown(() => lock.restore());
   const mutex = new Mutex(locker);
 
   t.is(await mutex.tryAcquire(`${lockerPrefix}4`), undefined);
+  t.is(lock.callCount, 1);
+});
+
+test('tryAcquire should expose infrastructure errors to the caller', async t => {
+  const { locker } = t.context;
+  const lock = Sinon.stub(locker, 'lock').rejects(new Error('redis offline'));
+  t.teardown(() => lock.restore());
+  const mutex = new Mutex(locker);
+
+  await t.throwsAsync(mutex.tryAcquire(`${lockerPrefix}5`), {
+    message: 'redis offline',
+  });
   t.is(lock.callCount, 1);
 });

--- a/packages/backend/server/src/__tests__/payment/config.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/config.spec.ts
@@ -1,0 +1,36 @@
+import '../../plugins/payment/config';
+
+import test from 'ava';
+
+import { ConfigFactory } from '../../base';
+
+test('Dub affiliate runtime config defaults are isolated between factories', t => {
+  const first = new ConfigFactory();
+
+  t.false(first.config.payment.dubAffiliateEnabled);
+  t.deepEqual(first.config.payment.dubAffiliateExcludedPromotionCodes, []);
+
+  first.config.payment.dubAffiliateExcludedPromotionCodes.push('legacy-code');
+
+  const second = new ConfigFactory();
+  t.false(second.config.payment.dubAffiliateEnabled);
+  t.deepEqual(second.config.payment.dubAffiliateExcludedPromotionCodes, []);
+});
+
+test('Dub affiliate runtime config can be overridden without sharing state', t => {
+  const first = new ConfigFactory({
+    payment: {
+      dubAffiliateEnabled: true,
+      dubAffiliateExcludedPromotionCodes: ['legacy-code'],
+    },
+  });
+
+  t.true(first.config.payment.dubAffiliateEnabled);
+  t.deepEqual(first.config.payment.dubAffiliateExcludedPromotionCodes, [
+    'legacy-code',
+  ]);
+
+  const second = new ConfigFactory();
+  t.false(second.config.payment.dubAffiliateEnabled);
+  t.deepEqual(second.config.payment.dubAffiliateExcludedPromotionCodes, []);
+});

--- a/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
@@ -1,0 +1,554 @@
+import test from 'ava';
+import Sinon from 'sinon';
+import Stripe from 'stripe';
+
+import { Config, Lock, Mutex } from '../../base';
+import {
+  type DubAffiliatePrepareInput,
+  DubAffiliateService,
+} from '../../plugins/payment/dub-affiliate';
+
+type StripeStubs = {
+  customers: {
+    retrieve: Sinon.SinonStub;
+    update: Sinon.SinonStub;
+  };
+  subscriptions: { list: Sinon.SinonStub };
+  invoices: { list: Sinon.SinonStub };
+  charges: { list: Sinon.SinonStub };
+};
+
+type Harness = {
+  config: Config;
+  stripe: StripeStubs;
+  mutex: { tryAcquire: Sinon.SinonStub };
+  service: DubAffiliateService;
+  releases: () => number;
+};
+
+const input: DubAffiliatePrepareInput = {
+  stripeCustomerId: 'cus_test',
+  affineUserId: 'user_test',
+  dubClickId: 'click_123-ABC',
+  plan: 'pro',
+};
+
+const emptyList = <T>(data: readonly T[] = [], hasMore = false) => ({
+  object: 'list' as const,
+  data: [...data],
+  has_more: hasMore,
+  url: '/v1/test',
+});
+
+function createHarness(options?: {
+  enabled?: boolean;
+  excludedPromotionCodes?: string[];
+  customer?: Record<string, unknown>;
+  subscriptions?: readonly unknown[];
+  invoices?: readonly unknown[];
+  charges?: readonly unknown[];
+  chargesHasMore?: boolean;
+}): Harness {
+  let releaseCount = 0;
+  const stripe: StripeStubs = {
+    customers: {
+      retrieve: Sinon.stub().resolves(
+        options?.customer ?? {
+          id: input.stripeCustomerId,
+          deleted: false,
+          metadata: {},
+        }
+      ),
+      update: Sinon.stub().resolves({
+        id: input.stripeCustomerId,
+        deleted: false,
+        metadata: {},
+      }),
+    },
+    subscriptions: {
+      list: Sinon.stub().resolves(emptyList(options?.subscriptions ?? [])),
+    },
+    invoices: {
+      list: Sinon.stub().resolves(emptyList(options?.invoices ?? [])),
+    },
+    charges: {
+      list: Sinon.stub().resolves(
+        emptyList(options?.charges ?? [], options?.chargesHasMore)
+      ),
+    },
+  };
+  const mutex = {
+    tryAcquire: Sinon.stub().resolves(
+      new Lock(async () => {
+        releaseCount += 1;
+      })
+    ),
+  };
+  const config = {
+    payment: {
+      dubAffiliateEnabled: options?.enabled ?? true,
+      dubAffiliateExcludedPromotionCodes: options?.excludedPromotionCodes ?? [],
+    },
+  } as Config;
+
+  return {
+    config,
+    stripe,
+    mutex,
+    service: new DubAffiliateService(
+      stripe as unknown as Stripe,
+      config,
+      mutex as unknown as Mutex
+    ),
+    releases: () => releaseCount,
+  };
+}
+
+function totalStripeCalls(stripe: StripeStubs) {
+  return (
+    stripe.customers.retrieve.callCount +
+    stripe.customers.update.callCount +
+    stripe.subscriptions.list.callCount +
+    stripe.invoices.list.callCount +
+    stripe.charges.list.callCount
+  );
+}
+
+test.afterEach.always(() => {
+  Sinon.restore();
+});
+
+test('skips before locking or Stripe calls when disabled', async t => {
+  const h = createHarness({ enabled: false });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'disabled',
+  });
+  t.is(h.mutex.tryAcquire.callCount, 0);
+  t.is(totalStripeCalls(h.stripe), 0);
+});
+
+for (const [name, dubClickId, reason] of [
+  ['missing', undefined, 'missing'],
+  ['invalid', 'contains spaces', 'invalid'],
+  ['too long', 'a'.repeat(256), 'invalid'],
+] as const) {
+  test(`skips ${name} click id before locking or Stripe calls`, async t => {
+    const h = createHarness();
+
+    t.deepEqual(await h.service.prepareCheckout({ ...input, dubClickId }), {
+      status: 'skipped',
+      reason,
+    });
+    t.is(h.mutex.tryAcquire.callCount, 0);
+    t.is(totalStripeCalls(h.stripe), 0);
+  });
+}
+
+test('skips normalized excluded promotion code before lock and Stripe', async t => {
+  const h = createHarness({ excludedPromotionCodes: ['  Legacy-Code  '] });
+
+  t.deepEqual(
+    await h.service.prepareCheckout({
+      ...input,
+      promotionCode: ' LEGACY-code ',
+    }),
+    { status: 'skipped', reason: 'legacy_promotion_code' }
+  );
+  t.is(h.mutex.tryAcquire.callCount, 0);
+  t.is(totalStripeCalls(h.stripe), 0);
+});
+
+test('attributes an eligible customer with bounded Stripe requests', async t => {
+  const h = createHarness();
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'attributed',
+    sessionMetadata: { dubCustomerExternalId: input.affineUserId },
+  });
+
+  t.deepEqual(h.stripe.customers.retrieve.firstCall.args, [
+    input.stripeCustomerId,
+    { timeout: 1000, maxNetworkRetries: 0 },
+  ]);
+  t.deepEqual(h.stripe.subscriptions.list.firstCall.args, [
+    { customer: input.stripeCustomerId, status: 'all', limit: 1 },
+    { timeout: 1000, maxNetworkRetries: 0 },
+  ]);
+  t.deepEqual(h.stripe.invoices.list.firstCall.args, [
+    { customer: input.stripeCustomerId, limit: 1 },
+    { timeout: 1000, maxNetworkRetries: 0 },
+  ]);
+  t.deepEqual(h.stripe.charges.list.firstCall.args, [
+    { customer: input.stripeCustomerId, limit: 10 },
+    { timeout: 1000, maxNetworkRetries: 0 },
+  ]);
+  t.deepEqual(
+    h.stripe.customers.update.firstCall.args[0],
+    input.stripeCustomerId
+  );
+  t.deepEqual(h.stripe.customers.update.firstCall.args[1], {
+    metadata: {
+      dubCustomerExternalId: input.affineUserId,
+      dubClickId: input.dubClickId,
+    },
+  });
+  t.deepEqual(h.stripe.customers.update.firstCall.args[2], {
+    timeout: 1500,
+    maxNetworkRetries: 0,
+    idempotencyKey: h.stripe.customers.update.firstCall.args[2].idempotencyKey,
+  });
+  t.regex(
+    h.stripe.customers.update.firstCall.args[2].idempotencyKey,
+    /^dub-affiliate:v1:[a-f0-9]{64}$/
+  );
+  t.is(h.releases(), 1);
+});
+
+test('uses a hashed customer lock key without exposing identifiers', async t => {
+  const h = createHarness();
+
+  await h.service.prepareCheckout(input);
+
+  const key = h.mutex.tryAcquire.firstCall.args[0] as string;
+  t.regex(key, /^dub-affiliate:customer:[a-f0-9]{64}$/);
+  t.false(key.includes(input.stripeCustomerId));
+  t.false(key.includes(input.affineUserId));
+  t.false(key.includes(input.dubClickId!));
+});
+
+test('keeps an existing click for the matching owner', async t => {
+  const h = createHarness({
+    customer: {
+      id: input.stripeCustomerId,
+      deleted: false,
+      metadata: {
+        dubCustomerExternalId: input.affineUserId,
+        dubClickId: 'first_click',
+      },
+    },
+  });
+
+  t.deepEqual(
+    await h.service.prepareCheckout({ ...input, dubClickId: 'second_click' }),
+    {
+      status: 'existing_owner',
+      sessionMetadata: { dubCustomerExternalId: input.affineUserId },
+    }
+  );
+  t.is(h.stripe.customers.update.callCount, 0);
+  t.is(h.releases(), 1);
+});
+
+test('fails open on conflicting ownership without overwriting metadata', async t => {
+  const h = createHarness({
+    customer: {
+      id: input.stripeCustomerId,
+      deleted: false,
+      metadata: {
+        dubCustomerExternalId: 'different_user',
+        dubClickId: 'first_click',
+      },
+    },
+  });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'conflict',
+  });
+  t.is(h.stripe.customers.update.callCount, 0);
+  t.is(h.releases(), 1);
+});
+
+test('treats non-empty malformed ownership metadata as a conflict', async t => {
+  const h = createHarness({
+    customer: {
+      id: input.stripeCustomerId,
+      deleted: false,
+      metadata: {
+        dubCustomerExternalId: ` ${input.affineUserId} `,
+        dubClickId: 'first_click',
+      },
+    },
+  });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'conflict',
+  });
+  t.is(h.stripe.customers.update.callCount, 0);
+  t.is(h.releases(), 1);
+});
+
+test('fails open for an existing click with missing ownership metadata', async t => {
+  const h = createHarness({
+    customer: {
+      id: input.stripeCustomerId,
+      deleted: false,
+      metadata: { dubClickId: 'first_click' },
+    },
+  });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'incomplete_metadata',
+  });
+  t.is(h.stripe.customers.update.callCount, 0);
+  t.is(h.releases(), 1);
+});
+
+for (const existingClickId of ['   ', 'invalid click value']) {
+  test(`does not overwrite existing malformed click metadata: ${JSON.stringify(existingClickId)}`, async t => {
+    const h = createHarness({
+      customer: {
+        id: input.stripeCustomerId,
+        deleted: false,
+        metadata: { dubClickId: existingClickId },
+      },
+    });
+
+    t.deepEqual(await h.service.prepareCheckout(input), {
+      status: 'skipped',
+      reason: 'incomplete_metadata',
+    });
+    t.is(h.stripe.customers.update.callCount, 0);
+    t.is(h.releases(), 1);
+  });
+}
+
+for (const [name, options] of [
+  ['subscription', { subscriptions: [{ id: 'sub_1' }] }],
+  ['invoice', { invoices: [{ id: 'in_1' }] }],
+  ['succeeded charge', { charges: [{ id: 'ch_1', status: 'succeeded' }] }],
+  [
+    'paid and refunded charge',
+    { charges: [{ id: 'ch_1', paid: true, refunded: true }] },
+  ],
+  [
+    'paid and uncaptured charge',
+    { charges: [{ id: 'ch_1', paid: true, captured: false }] },
+  ],
+] as const) {
+  test(`rejects prior billing from ${name}`, async t => {
+    const h = createHarness(options);
+
+    t.deepEqual(await h.service.prepareCheckout(input), {
+      status: 'skipped',
+      reason: 'prior_billing',
+    });
+    t.is(h.stripe.customers.update.callCount, 0);
+    t.is(h.releases(), 1);
+  });
+}
+
+test('allows only failed or pending charges when history is complete', async t => {
+  const h = createHarness({
+    charges: [
+      { id: 'ch_failed', paid: false, status: 'failed' },
+      { id: 'ch_pending', paid: false, status: 'pending' },
+    ],
+  });
+
+  t.is((await h.service.prepareCheckout(input)).status, 'attributed');
+  t.is(h.stripe.customers.update.callCount, 1);
+});
+
+test('fails closed when incomplete charge history has no visible success', async t => {
+  const h = createHarness({
+    charges: [{ id: 'ch_failed', paid: false, status: 'failed' }],
+    chargesHasMore: true,
+  });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'ambiguous_charge_history',
+  });
+  t.is(h.stripe.customers.update.callCount, 0);
+});
+
+test('skips a deleted customer', async t => {
+  const h = createHarness({
+    customer: { id: input.stripeCustomerId, deleted: true },
+  });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'deleted_customer',
+  });
+  t.is(h.stripe.customers.update.callCount, 0);
+  t.is(h.releases(), 1);
+});
+
+test('reuses known subscriptions without listing them again', async t => {
+  const h = createHarness();
+
+  t.deepEqual(
+    await h.service.prepareCheckout({ ...input, knownSubscriptions: [] }),
+    {
+      status: 'attributed',
+      sessionMetadata: { dubCustomerExternalId: input.affineUserId },
+    }
+  );
+  t.is(h.stripe.subscriptions.list.callCount, 0);
+  t.is(h.stripe.customers.update.callCount, 1);
+});
+
+test('known subscriptions still trigger prior billing without a list call', async t => {
+  const h = createHarness();
+
+  t.deepEqual(
+    await h.service.prepareCheckout({
+      ...input,
+      knownSubscriptions: [{ id: 'sub_known' } as Stripe.Subscription],
+    }),
+    { status: 'skipped', reason: 'prior_billing' }
+  );
+  t.is(h.stripe.subscriptions.list.callCount, 0);
+  t.is(h.stripe.customers.update.callCount, 0);
+});
+
+test('lock contention fails open without Stripe calls', async t => {
+  const h = createHarness();
+  h.mutex.tryAcquire.resolves(undefined);
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'lock_contention',
+  });
+  t.is(h.mutex.tryAcquire.callCount, 1);
+  t.is(totalStripeCalls(h.stripe), 0);
+});
+
+test('lock errors fail open without Stripe calls', async t => {
+  const h = createHarness();
+  h.mutex.tryAcquire.rejects(new Error('redis unavailable'));
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'stripe_error',
+  });
+  t.is(totalStripeCalls(h.stripe), 0);
+});
+
+for (const operation of [
+  'retrieve',
+  'subscriptions',
+  'invoices',
+  'charges',
+  'update',
+] as const) {
+  test(`${operation} Stripe errors fail open and release the lock`, async t => {
+    const h = createHarness();
+    const stub =
+      operation === 'retrieve'
+        ? h.stripe.customers.retrieve
+        : operation === 'subscriptions'
+          ? h.stripe.subscriptions.list
+          : operation === 'invoices'
+            ? h.stripe.invoices.list
+            : operation === 'charges'
+              ? h.stripe.charges.list
+              : h.stripe.customers.update;
+    stub.rejects(new Error('stripe unavailable'));
+
+    t.deepEqual(await h.service.prepareCheckout(input), {
+      status: 'skipped',
+      reason: 'stripe_error',
+    });
+    t.is(h.releases(), 1);
+  });
+}
+
+test('Stripe timeouts fail open as ambiguous without an unhandled rejection', async t => {
+  const h = createHarness();
+  h.stripe.customers.update.rejects(
+    Object.assign(new Error('Request timed out'), { code: 'ETIMEDOUT' })
+  );
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'ambiguous_timeout',
+  });
+  t.is(h.releases(), 1);
+});
+
+test('read timeouts fail open as ordinary Stripe errors', async t => {
+  const h = createHarness();
+  h.stripe.customers.retrieve.rejects(
+    Object.assign(new Error('Request timed out'), { code: 'ETIMEDOUT' })
+  );
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'stripe_error',
+  });
+  t.is(h.releases(), 1);
+});
+
+test('uses a stable idempotency key for the same attribution input', async t => {
+  const first = createHarness();
+  const second = createHarness();
+
+  await first.service.prepareCheckout(input);
+  await second.service.prepareCheckout(input);
+
+  t.is(
+    first.stripe.customers.update.firstCall.args[2].idempotencyKey,
+    second.stripe.customers.update.firstCall.args[2].idempotencyKey
+  );
+});
+
+test('concurrent clicks update at most once and do not overwrite the owner', async t => {
+  let locked = false;
+  let releaseFirstUpdate!: () => void;
+  let signalFirstUpdate!: () => void;
+  const firstUpdateStarted = new Promise<void>(resolve => {
+    signalFirstUpdate = resolve;
+  });
+  const permitFirstUpdate = new Promise<void>(resolve => {
+    releaseFirstUpdate = resolve;
+  });
+  const customer = {
+    id: input.stripeCustomerId,
+    deleted: false,
+    metadata: {} as Record<string, string>,
+  };
+  const h = createHarness({ customer });
+  h.mutex.tryAcquire.callsFake(async () => {
+    if (locked) return undefined;
+    locked = true;
+    return new Lock(async () => {
+      locked = false;
+    });
+  });
+  h.stripe.customers.retrieve.callsFake(async () => ({
+    ...customer,
+    metadata: { ...customer.metadata },
+  }));
+  h.stripe.customers.update.callsFake(async (_id, params) => {
+    signalFirstUpdate();
+    await permitFirstUpdate;
+    customer.metadata = { ...params.metadata };
+    return customer;
+  });
+
+  const first = h.service.prepareCheckout({
+    ...input,
+    dubClickId: 'click_one',
+  });
+  await firstUpdateStarted;
+  const second = await h.service.prepareCheckout({
+    ...input,
+    dubClickId: 'click_two',
+  });
+  releaseFirstUpdate();
+
+  t.deepEqual(second, { status: 'skipped', reason: 'lock_contention' });
+  t.is((await first).status, 'attributed');
+  t.is(h.stripe.customers.update.callCount, 1);
+  t.deepEqual(customer.metadata, {
+    dubCustomerExternalId: input.affineUserId,
+    dubClickId: 'click_one',
+  });
+});

--- a/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
@@ -2,7 +2,7 @@ import test from 'ava';
 import Sinon from 'sinon';
 import Stripe from 'stripe';
 
-import { Config, Lock, Mutex } from '../../base';
+import { Config, Lock, metrics, Mutex } from '../../base';
 import {
   type DubAffiliatePrepareInput,
   DubAffiliateService,
@@ -146,6 +146,40 @@ for (const [name, dubClickId, reason] of [
     t.is(totalStripeCalls(h.stripe), 0);
   });
 }
+
+test('records prepare duration only after a lock attempt', async t => {
+  const record = Sinon.stub(
+    metrics.payment.histogram('dub_affiliate_prepare_duration_ms'),
+    'record'
+  );
+
+  const disabled = createHarness({ enabled: false });
+  await disabled.service.prepareCheckout(input);
+  const missing = createHarness();
+  await missing.service.prepareCheckout({ ...input, dubClickId: undefined });
+  const invalid = createHarness();
+  await invalid.service.prepareCheckout({ ...input, dubClickId: 'bad id' });
+  const legacy = createHarness({ excludedPromotionCodes: ['legacy'] });
+  await legacy.service.prepareCheckout({ ...input, promotionCode: 'legacy' });
+  t.is(record.callCount, 0);
+
+  const contended = createHarness();
+  contended.mutex.tryAcquire.resolves(undefined);
+  await contended.service.prepareCheckout(input);
+  t.is(record.callCount, 1);
+  t.like(record.lastCall.args[1], { outcome: 'lock_contention', plan: 'pro' });
+
+  const errored = createHarness();
+  errored.mutex.tryAcquire.rejects(new Error('redis unavailable'));
+  await errored.service.prepareCheckout(input);
+  t.is(record.callCount, 2);
+  t.like(record.lastCall.args[1], { outcome: 'lock_error', plan: 'pro' });
+
+  const attributed = createHarness();
+  await attributed.service.prepareCheckout(input);
+  t.is(record.callCount, 3);
+  t.like(record.lastCall.args[1], { outcome: 'attributed', plan: 'pro' });
+});
 
 test('skips normalized excluded promotion code before lock and Stripe', async t => {
   const h = createHarness({ excludedPromotionCodes: ['  Legacy-Code  '] });
@@ -444,8 +478,10 @@ test('lock errors fail open without Stripe calls', async t => {
 
   t.deepEqual(await h.service.prepareCheckout(input), {
     status: 'skipped',
-    reason: 'stripe_error',
+    reason: 'lock_error',
   });
+  t.is(h.mutex.tryAcquire.callCount, 1);
+  t.is(h.releases(), 0);
   t.is(totalStripeCalls(h.stripe), 0);
 });
 

--- a/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
@@ -282,6 +282,23 @@ test('treats non-empty malformed ownership metadata as a conflict', async t => {
   t.is(h.releases(), 1);
 });
 
+test('does not replace a whitespace-only existing external owner', async t => {
+  const h = createHarness({
+    customer: {
+      id: input.stripeCustomerId,
+      deleted: false,
+      metadata: { dubCustomerExternalId: '   ' },
+    },
+  });
+
+  t.deepEqual(await h.service.prepareCheckout(input), {
+    status: 'skipped',
+    reason: 'conflict',
+  });
+  t.is(h.stripe.customers.update.callCount, 0);
+  t.is(h.releases(), 1);
+});
+
 test('fails open for an existing click with missing ownership metadata', async t => {
   const h = createHarness({
     customer: {

--- a/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/dub-affiliate.spec.ts
@@ -7,6 +7,7 @@ import {
   type DubAffiliatePrepareInput,
   DubAffiliateService,
 } from '../../plugins/payment/dub-affiliate';
+import { StripeFactory } from '../../plugins/payment/stripe';
 
 type StripeStubs = {
   customers: {
@@ -96,7 +97,7 @@ function createHarness(options?: {
     stripe,
     mutex,
     service: new DubAffiliateService(
-      stripe as unknown as Stripe,
+      { stripe } as unknown as StripeFactory,
       config,
       mutex as unknown as Mutex
     ),

--- a/packages/backend/server/src/__tests__/payment/resolver-integration.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/resolver-integration.spec.ts
@@ -1,0 +1,279 @@
+import '../../plugins/payment';
+
+import { PrismaClient } from '@prisma/client';
+import ava, { TestFn } from 'ava';
+import Sinon from 'sinon';
+import Stripe from 'stripe';
+
+import { AppModule } from '../../app.module';
+import { EventBus } from '../../base';
+import { ConfigFactory, ConfigModule } from '../../base/config';
+import { StripeFactory } from '../../plugins/payment/stripe';
+import {
+  SubscriptionPlan,
+  SubscriptionRecurring,
+} from '../../plugins/payment/types';
+import { createTestingApp, TestingApp } from '../utils';
+
+const CREATE_CHECKOUT_SESSION = `
+  mutation CreateCheckoutSession($input: CreateCheckoutSessionInput!) {
+    createCheckoutSession(input: $input)
+  }
+`;
+
+const PRO_YEARLY = `${SubscriptionPlan.Pro}_${SubscriptionRecurring.Yearly}`;
+const SELFHOST_YEARLY = `${SubscriptionPlan.SelfHostedTeam}_${SubscriptionRecurring.Yearly}`;
+
+const PRICES: Record<string, Stripe.Price> = {
+  [PRO_YEARLY]: {
+    id: PRO_YEARLY,
+    object: 'price',
+    active: true,
+    billing_scheme: 'per_unit',
+    created: 0,
+    currency: 'usd',
+    custom_unit_amount: null,
+    livemode: false,
+    lookup_key: PRO_YEARLY,
+    metadata: {},
+    nickname: null,
+    product: 'prod_pro',
+    recurring: {
+      aggregate_usage: null,
+      interval: 'year',
+      interval_count: 1,
+      meter: null,
+      trial_period_days: null,
+      usage_type: 'licensed',
+    },
+    tax_behavior: 'unspecified',
+    tiers_mode: null,
+    transform_quantity: null,
+    type: 'recurring',
+    unit_amount: 8100,
+    unit_amount_decimal: '8100',
+  },
+  [SELFHOST_YEARLY]: {
+    id: SELFHOST_YEARLY,
+    object: 'price',
+    active: true,
+    billing_scheme: 'per_unit',
+    created: 0,
+    currency: 'usd',
+    custom_unit_amount: null,
+    livemode: false,
+    lookup_key: SELFHOST_YEARLY,
+    metadata: {},
+    nickname: null,
+    product: 'prod_selfhost',
+    recurring: {
+      aggregate_usage: null,
+      interval: 'year',
+      interval_count: 1,
+      meter: null,
+      trial_period_days: null,
+      usage_type: 'licensed',
+    },
+    tax_behavior: 'unspecified',
+    tiers_mode: null,
+    transform_quantity: null,
+    type: 'recurring',
+    unit_amount: 12000,
+    unit_amount_decimal: '12000',
+  },
+};
+
+type StripeStubs = {
+  customers: Sinon.SinonStubbedInstance<Stripe.CustomersResource>;
+  prices: Sinon.SinonStubbedInstance<Stripe.PricesResource>;
+  subscriptions: Sinon.SinonStubbedInstance<Stripe.SubscriptionsResource>;
+  charges: Sinon.SinonStubbedInstance<Stripe.ChargesResource>;
+  invoices: Sinon.SinonStubbedInstance<Stripe.InvoicesResource>;
+  checkout: {
+    sessions: Sinon.SinonStubbedInstance<Stripe.Checkout.SessionsResource>;
+  };
+};
+
+const test = ava as TestFn<{
+  app: TestingApp;
+  stripe: StripeStubs;
+}>;
+
+test.before(async t => {
+  const app = await createTestingApp({
+    imports: [
+      ConfigModule.override({
+        payment: {
+          enabled: true,
+          showLifetimePrice: true,
+          stripe: {
+            apiKey: '1',
+            webhookKey: '1',
+          },
+        },
+      }),
+      AppModule,
+    ],
+    tapModule: module => {
+      module
+        .overrideProvider(EventBus)
+        .useValue(Sinon.createStubInstance(EventBus));
+    },
+  });
+
+  const stripeFactory = app.get(StripeFactory);
+  await stripeFactory.onConfigInit();
+  const stripe = stripeFactory.stripe;
+
+  t.context = {
+    app,
+    stripe: {
+      customers: Sinon.stub(stripe.customers),
+      prices: Sinon.stub(stripe.prices),
+      subscriptions: Sinon.stub(stripe.subscriptions),
+      charges: Sinon.stub(stripe.charges),
+      invoices: Sinon.stub(stripe.invoices),
+      checkout: {
+        sessions: Sinon.stub(stripe.checkout.sessions),
+      },
+    },
+  };
+});
+
+test.beforeEach(async t => {
+  const { app, stripe } = t.context;
+  await app.initTestingDB();
+  app.get(ConfigFactory).override({
+    payment: {
+      showLifetimePrice: true,
+      dubAffiliateEnabled: true,
+      dubAffiliateExcludedPromotionCodes: [],
+      revenuecat: { enabled: false },
+    },
+  });
+
+  Sinon.reset();
+
+  // @ts-expect-error Stripe list fixture only needs data consumed by checkout.
+  stripe.prices.list.callsFake((params: Stripe.PriceListParams) =>
+    Promise.resolve({
+      data: (params.lookup_keys ?? []).map(key => PRICES[key]),
+    })
+  );
+  // @ts-expect-error Complete fields consumed by the payment managers.
+  stripe.subscriptions.list.resolves({ data: [] });
+  stripe.customers.retrieve.resolves({
+    id: 'cus_graphql',
+    object: 'customer',
+    deleted: false,
+    metadata: {},
+  } as any);
+  stripe.customers.update.resolves({
+    id: 'cus_graphql',
+    object: 'customer',
+    deleted: false,
+    metadata: {},
+  } as any);
+  // @ts-expect-error Complete fields consumed by DubAffiliateService.
+  stripe.charges.list.resolves({ data: [], has_more: false });
+  // @ts-expect-error Complete fields consumed by DubAffiliateService.
+  stripe.invoices.list.resolves({ data: [], has_more: false });
+  stripe.checkout.sessions.create.resolves({
+    id: 'cs_graphql',
+    object: 'checkout.session',
+    url: 'https://checkout.stripe.test/cs_graphql',
+  } as any);
+});
+
+test.after.always(async t => {
+  await t.context.app.close();
+});
+
+test('Web Pro GraphQL checkout reaches Dub Customer update and Checkout metadata', async t => {
+  const { app, stripe } = t.context;
+  const user = await app.signup();
+  await app.get(PrismaClient).userStripeCustomer.create({
+    data: { userId: user.id, stripeCustomerId: 'cus_graphql' },
+  });
+  app.withCookies({ dub_id: 'click_graphql_web' });
+
+  const result = await app.gql<{ createCheckoutSession: string }>(
+    CREATE_CHECKOUT_SESSION,
+    {
+      input: {
+        plan: 'Pro',
+        recurring: 'Yearly',
+        successCallbackLink: '/settings',
+      },
+    }
+  );
+
+  t.is(result.createCheckoutSession, 'https://checkout.stripe.test/cs_graphql');
+  t.like(stripe.customers.update.firstCall.args[1], {
+    metadata: {
+      dubClickId: 'click_graphql_web',
+      dubCustomerExternalId: user.id,
+    },
+  });
+  const checkout = stripe.checkout.sessions.create.getCall(0)!
+    .args[0] as Stripe.Checkout.SessionCreateParams;
+  t.like(checkout, {
+    customer: 'cus_graphql',
+    metadata: { dubCustomerExternalId: user.id },
+  });
+});
+
+test('native Pro GraphQL checkout reaches the manager without Dub attribution', async t => {
+  const { app, stripe } = t.context;
+  const user = await app.signup();
+  await app.get(PrismaClient).userStripeCustomer.create({
+    data: { userId: user.id, stripeCustomerId: 'cus_graphql' },
+  });
+  app.withCookies({ dub_id: 'click_graphql_native' });
+
+  const response = await app
+    .POST('/graphql')
+    .set('x-operation-name', 'CreateCheckoutSession')
+    .set('x-affine-client-kind', 'native')
+    .send({
+      query: CREATE_CHECKOUT_SESSION,
+      variables: {
+        input: {
+          plan: 'Pro',
+          recurring: 'Yearly',
+          successCallbackLink: '/settings',
+        },
+      },
+    });
+
+  t.is(response.status, 200);
+  t.falsy(response.body.errors);
+  t.false(stripe.customers.update.called);
+  const checkout = stripe.checkout.sessions.create.getCall(0)!
+    .args[0] as Stripe.Checkout.SessionCreateParams;
+  t.false('metadata' in checkout);
+});
+
+test('public SelfHostedTeam GraphQL checkout uses its manager without Dub attribution', async t => {
+  const { app, stripe } = t.context;
+  app.withCookies({ dub_id: 'click_graphql_selfhosted' });
+
+  const result = await app.gql<{ createCheckoutSession: string }>(
+    CREATE_CHECKOUT_SESSION,
+    {
+      input: {
+        plan: 'SelfHostedTeam',
+        recurring: 'Yearly',
+        successCallbackLink: '/selfhosted',
+        args: { quantity: 12 },
+      },
+    }
+  );
+
+  t.is(result.createCheckoutSession, 'https://checkout.stripe.test/cs_graphql');
+  t.false(stripe.customers.update.called);
+  const checkout = stripe.checkout.sessions.create.getCall(0)!
+    .args[0] as Stripe.Checkout.SessionCreateParams;
+  t.false('customer' in checkout);
+  t.false('metadata' in checkout);
+});

--- a/packages/backend/server/src/__tests__/payment/resolver.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/resolver.spec.ts
@@ -1,0 +1,171 @@
+import ava, { TestFn } from 'ava';
+import Sinon from 'sinon';
+
+import { AppModule } from '../../app.module';
+import { SubscriptionService } from '../../plugins/payment/service';
+import {
+  SubscriptionPlan,
+  SubscriptionRecurring,
+} from '../../plugins/payment/types';
+import { createTestingApp, TestingApp } from '../utils';
+
+const CREATE_CHECKOUT_SESSION = `
+  mutation CreateCheckoutSession($input: CreateCheckoutSessionInput!) {
+    createCheckoutSession(input: $input)
+  }
+`;
+
+type CheckoutInput = {
+  plan: 'Pro' | 'Team' | 'SelfHostedTeam';
+  recurring: 'Monthly' | 'Yearly';
+  successCallbackLink: string;
+  args?: { workspaceId?: string; quantity?: number };
+};
+
+const test = ava as TestFn<{
+  app: TestingApp;
+  checkout: Sinon.SinonStub;
+}>;
+
+test.before(async t => {
+  const checkout = Sinon.stub().resolves({
+    url: 'https://checkout.stripe.test/session',
+  });
+  const app = await createTestingApp({
+    imports: [AppModule],
+    tapModule: module => {
+      module.overrideProvider(SubscriptionService).useValue({ checkout });
+    },
+  });
+
+  t.context = { app, checkout };
+});
+
+test.beforeEach(async t => {
+  await t.context.app.initTestingDB();
+  t.context.checkout.resetHistory();
+});
+
+test.after.always(async t => {
+  await t.context.app.close();
+});
+
+async function checkoutWithGql(app: TestingApp, input: CheckoutInput) {
+  return app.gql<{ createCheckoutSession: string }>(CREATE_CHECKOUT_SESSION, {
+    input,
+  });
+}
+
+test('passes the Dub cookie through authenticated Web Pro GraphQL checkout', async t => {
+  const { app, checkout } = t.context;
+  const user = await app.signup();
+  app.withCookies({ dub_id: 'click_web' });
+
+  const result = await checkoutWithGql(app, {
+    plan: 'Pro',
+    recurring: 'Yearly',
+    successCallbackLink: '/settings',
+  });
+
+  t.is(result.createCheckoutSession, 'https://checkout.stripe.test/session');
+  t.true(checkout.calledOnce);
+  t.deepEqual(checkout.firstCall.args[0], {
+    plan: SubscriptionPlan.Pro,
+    recurring: SubscriptionRecurring.Yearly,
+    successCallbackLink: '/settings',
+  });
+  t.like(checkout.firstCall.args[1].user, {
+    id: user.id,
+    email: user.email,
+  });
+  t.is(checkout.firstCall.args[1].dubClickId, 'click_web');
+});
+
+test('excludes the Dub cookie from authenticated native GraphQL checkout', async t => {
+  const { app, checkout } = t.context;
+  const user = await app.signup();
+  app.withCookies({ dub_id: 'click_native' });
+
+  const response = await app
+    .POST('/graphql')
+    .set('x-operation-name', 'CreateCheckoutSession')
+    .set('x-affine-client-kind', 'native')
+    .send({
+      query: CREATE_CHECKOUT_SESSION,
+      variables: {
+        input: {
+          plan: 'Pro',
+          recurring: 'Yearly',
+          successCallbackLink: '/settings',
+        },
+      },
+    });
+
+  t.is(response.status, 200);
+  t.falsy(response.body.errors);
+  t.is(
+    response.body.data.createCheckoutSession,
+    'https://checkout.stripe.test/session'
+  );
+  t.true(checkout.calledOnce);
+  t.like(checkout.firstCall.args[1].user, {
+    id: user.id,
+    email: user.email,
+  });
+  t.is(checkout.firstCall.args[1].dubClickId, undefined);
+});
+
+test('does not add Dub data to public SelfHostedTeam GraphQL checkout args', async t => {
+  const { app, checkout } = t.context;
+  app.withCookies({ dub_id: 'click_selfhosted' });
+
+  const result = await checkoutWithGql(app, {
+    plan: 'SelfHostedTeam',
+    recurring: 'Yearly',
+    successCallbackLink: '/selfhosted',
+    args: { quantity: 12 },
+  });
+
+  t.is(result.createCheckoutSession, 'https://checkout.stripe.test/session');
+  t.deepEqual(checkout.firstCall.args[1], {
+    plan: SubscriptionPlan.SelfHostedTeam,
+    quantity: 12,
+    user: undefined,
+  });
+  t.false('dubClickId' in checkout.firstCall.args[1]);
+});
+
+test('preserves workspaceId and passes the Dub cookie for Web Team checkout', async t => {
+  const { app, checkout } = t.context;
+  const user = await app.signup();
+  app.withCookies({ dub_id: 'click_team' });
+
+  const result = await checkoutWithGql(app, {
+    plan: 'Team',
+    recurring: 'Monthly',
+    successCallbackLink: '/workspace',
+    args: { workspaceId: 'workspace_test' },
+  });
+
+  t.is(result.createCheckoutSession, 'https://checkout.stripe.test/session');
+  t.like(checkout.firstCall.args[1].user, {
+    id: user.id,
+    email: user.email,
+  });
+  t.is(checkout.firstCall.args[1].workspaceId, 'workspace_test');
+  t.is(checkout.firstCall.args[1].dubClickId, 'click_team');
+});
+
+test('keeps Web checkout attribution empty when no Dub cookie exists', async t => {
+  const { app, checkout } = t.context;
+  await app.signup();
+
+  await checkoutWithGql(app, {
+    plan: 'Pro',
+    recurring: 'Monthly',
+    successCallbackLink: '/settings',
+  });
+
+  t.true(checkout.calledOnce);
+  t.is(checkout.firstCall.args[1].dubClickId, undefined);
+});

--- a/packages/backend/server/src/__tests__/payment/service.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/service.spec.ts
@@ -6,12 +6,14 @@ import Sinon from 'sinon';
 import Stripe from 'stripe';
 
 import { AppModule } from '../../app.module';
-import { EventBus } from '../../base';
+import { EventBus, Lock, Mutex } from '../../base';
 import { ConfigFactory, ConfigModule } from '../../base/config';
 import { CurrentUser } from '../../core/auth';
 import { AuthService } from '../../core/auth/service';
 import { EntitlementService } from '../../core/entitlement';
+import { Models } from '../../models';
 import { SubscriptionCronJobs } from '../../plugins/payment/cron';
+import { DubAffiliateService } from '../../plugins/payment/dub-affiliate';
 import { SelfhostTeamSubscriptionManager } from '../../plugins/payment/manager';
 import { RevenueCatService } from '../../plugins/payment/revenuecat';
 import { SubscriptionService } from '../../plugins/payment/service';
@@ -221,6 +223,8 @@ test.beforeEach(async t => {
   app.get(ConfigFactory).override({
     payment: {
       showLifetimePrice: true,
+      dubAffiliateEnabled: false,
+      dubAffiliateExcludedPromotionCodes: [],
       revenuecat: {
         enabled: false,
       },
@@ -722,6 +726,221 @@ test('should apply user coupon for checking out', async t => {
     price: PRO_MONTHLY,
     coupon: 'coupon_1',
   });
+});
+
+test('should add Dub attribution to eligible Pro checkout without listing subscriptions twice', async t => {
+  const { app, service, stripe, u1 } = t.context;
+  app.get(ConfigFactory).override({
+    payment: { dubAffiliateEnabled: true },
+  });
+  stripe.customers.retrieve.resolves({
+    id: 'cus_1',
+    deleted: false,
+    metadata: {},
+  } as any);
+  stripe.customers.update.resolves({ id: 'cus_1' } as any);
+  const tryAcquire = Sinon.stub(app.get(Mutex), 'tryAcquire').resolves(
+    new Lock(async () => {})
+  );
+  t.teardown(() => tryAcquire.restore());
+
+  await service.checkout(
+    {
+      plan: SubscriptionPlan.Pro,
+      recurring: SubscriptionRecurring.Yearly,
+      successCallbackLink: '/settings',
+    },
+    { user: u1, dubClickId: 'click_pro' }
+  );
+
+  t.is(stripe.subscriptions.list.callCount, 1);
+  t.like(stripe.customers.update.firstCall.args[1], {
+    metadata: {
+      dubCustomerExternalId: u1.id,
+      dubClickId: 'click_pro',
+    },
+  });
+  t.deepEqual(getLastCheckoutParams(stripe.checkout.sessions.create), {
+    customer: 'cus_1',
+    line_items: [{ price: PRO_YEARLY, quantity: 1 }],
+    mode: 'subscription',
+    subscription_data: undefined,
+    allow_promotion_codes: true,
+    success_url: 'http://localhost:3010/settings',
+    metadata: { dubCustomerExternalId: u1.id },
+  });
+});
+
+test('should preserve AI trial parameters when adding Dub metadata', async t => {
+  const { app, service, stripe, u1 } = t.context;
+  app.get(ConfigFactory).override({
+    payment: { dubAffiliateEnabled: true },
+  });
+  stripe.customers.retrieve.resolves({
+    id: 'cus_1',
+    deleted: false,
+    metadata: {},
+  } as any);
+  stripe.customers.update.resolves({ id: 'cus_1' } as any);
+  const tryAcquire = Sinon.stub(app.get(Mutex), 'tryAcquire').resolves(
+    new Lock(async () => {})
+  );
+  t.teardown(() => tryAcquire.restore());
+  const prepareCheckout = Sinon.spy(
+    app.get(DubAffiliateService),
+    'prepareCheckout'
+  );
+  t.teardown(() => prepareCheckout.restore());
+  t.is(
+    (app.get(DubAffiliateService) as unknown as { mutex: Mutex }).mutex,
+    app.get(Mutex)
+  );
+
+  await service.checkout(
+    {
+      plan: SubscriptionPlan.AI,
+      recurring: SubscriptionRecurring.Yearly,
+      successCallbackLink: '',
+    },
+    { user: u1, dubClickId: 'click_ai' }
+  );
+
+  t.is(prepareCheckout.callCount, 1);
+  t.deepEqual(await prepareCheckout.firstCall.returnValue, {
+    status: 'attributed',
+    sessionMetadata: { dubCustomerExternalId: u1.id },
+  });
+  t.like(getLastCheckoutParams(stripe.checkout.sessions.create), {
+    mode: 'subscription',
+    subscription_data: { trial_period_days: 7 },
+    metadata: { dubCustomerExternalId: u1.id },
+  });
+});
+
+test('should preserve Lifetime payment parameters when adding Dub metadata', async t => {
+  const { app, service, stripe, u1 } = t.context;
+  app.get(ConfigFactory).override({
+    payment: { dubAffiliateEnabled: true },
+  });
+  stripe.customers.retrieve.resolves({
+    id: 'cus_1',
+    deleted: false,
+    metadata: {},
+  } as any);
+  stripe.customers.update.resolves({ id: 'cus_1' } as any);
+  const tryAcquire = Sinon.stub(app.get(Mutex), 'tryAcquire').resolves(
+    new Lock(async () => {})
+  );
+  t.teardown(() => tryAcquire.restore());
+
+  await service.checkout(
+    {
+      plan: SubscriptionPlan.Pro,
+      recurring: SubscriptionRecurring.Lifetime,
+      successCallbackLink: '',
+    },
+    { user: u1, dubClickId: 'click_lifetime' }
+  );
+
+  t.like(getLastCheckoutParams(stripe.checkout.sessions.create), {
+    mode: 'payment',
+    invoice_creation: { enabled: true },
+    metadata: { dubCustomerExternalId: u1.id },
+  });
+});
+
+test('should preserve Team seats and workspace metadata when adding Dub metadata', async t => {
+  const { app, service, stripe, u1 } = t.context;
+  app.get(ConfigFactory).override({
+    payment: { dubAffiliateEnabled: true },
+  });
+  stripe.customers.retrieve.resolves({
+    id: 'cus_1',
+    deleted: false,
+    metadata: {},
+  } as any);
+  stripe.customers.update.resolves({ id: 'cus_1' } as any);
+  const tryAcquire = Sinon.stub(app.get(Mutex), 'tryAcquire').resolves(
+    new Lock(async () => {})
+  );
+  t.teardown(() => tryAcquire.restore());
+  const count = Sinon.stub(app.get(Models).workspaceUser, 'count').resolves(3);
+  t.teardown(() => count.restore());
+
+  await service.checkout(
+    {
+      plan: SubscriptionPlan.Team,
+      recurring: SubscriptionRecurring.Monthly,
+      successCallbackLink: '',
+    },
+    { user: u1, workspaceId: 'ws_1', dubClickId: 'click_team' }
+  );
+
+  t.like(getLastCheckoutParams(stripe.checkout.sessions.create), {
+    line_items: [{ price: TEAM_MONTHLY, quantity: 3 }],
+    subscription_data: { metadata: { workspaceId: 'ws_1' } },
+    metadata: { dubCustomerExternalId: u1.id },
+  });
+});
+
+for (const [name, enabled, dubClickId] of [
+  ['disabled', false, 'click_disabled'],
+  ['missing click', true, undefined],
+] as const) {
+  test(`should omit Dub metadata and attribution Stripe calls when ${name}`, async t => {
+    const { app, service, stripe, u1 } = t.context;
+    app.get(ConfigFactory).override({
+      payment: { dubAffiliateEnabled: enabled },
+    });
+
+    await service.checkout(
+      {
+        plan: SubscriptionPlan.Pro,
+        recurring: SubscriptionRecurring.Monthly,
+        successCallbackLink: '',
+      },
+      { user: u1, dubClickId }
+    );
+
+    const checkout = getLastCheckoutParams(stripe.checkout.sessions.create);
+    t.false('metadata' in checkout);
+    t.is(stripe.customers.retrieve.callCount, 0);
+    t.is(stripe.customers.update.callCount, 0);
+    t.is(stripe.invoices.list.callCount, 0);
+    t.is(stripe.charges.list.callCount, 0);
+    t.is(stripe.subscriptions.list.callCount, 1);
+  });
+}
+
+test('should keep the coupon path and skip Dub for an excluded FirstPromoter code', async t => {
+  const { app, service, stripe, u1 } = t.context;
+  app.get(ConfigFactory).override({
+    payment: {
+      dubAffiliateEnabled: true,
+      dubAffiliateExcludedPromotionCodes: [' legacy-code '],
+    },
+  });
+  stripe.promotionCodes.list.resolves({
+    data: [{ coupon: { id: 'coupon_legacy' } }],
+  } as any);
+
+  await service.checkout(
+    {
+      plan: SubscriptionPlan.Pro,
+      recurring: SubscriptionRecurring.Monthly,
+      successCallbackLink: '',
+      coupon: 'LEGACY-CODE',
+    },
+    { user: u1, dubClickId: 'click_legacy' }
+  );
+
+  const checkout = getLastCheckoutParams(stripe.checkout.sessions.create);
+  t.deepEqual(checkout.discounts, [{ coupon: 'coupon_legacy' }]);
+  t.false('metadata' in checkout);
+  t.is(stripe.customers.retrieve.callCount, 0);
+  t.is(stripe.customers.update.callCount, 0);
+  t.is(stripe.invoices.list.callCount, 0);
+  t.is(stripe.charges.list.callCount, 0);
 });
 
 // =============== subscriptions ===============

--- a/packages/backend/server/src/__tests__/payment/service.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/service.spec.ts
@@ -144,6 +144,7 @@ const test = ava as TestFn<{
     prices: Sinon.SinonStubbedInstance<Stripe.PricesResource>;
     subscriptions: Sinon.SinonStubbedInstance<Stripe.SubscriptionsResource>;
     subscriptionSchedules: Sinon.SinonStubbedInstance<Stripe.SubscriptionSchedulesResource>;
+    charges: Sinon.SinonStubbedInstance<Stripe.ChargesResource>;
     checkout: {
       sessions: Sinon.SinonStubbedInstance<Stripe.Checkout.SessionsResource>;
     };
@@ -201,6 +202,7 @@ test.before(async t => {
     prices: Sinon.stub(stripe.prices),
     subscriptions: Sinon.stub(stripe.subscriptions),
     subscriptionSchedules: Sinon.stub(stripe.subscriptionSchedules),
+    charges: Sinon.stub(stripe.charges),
     invoices: Sinon.stub(stripe.invoices),
     checkout: {
       sessions: Sinon.stub(stripe.checkout.sessions),
@@ -254,11 +256,23 @@ test.beforeEach(async t => {
   // @ts-expect-error stub
   stripe.subscriptions.list.resolves({ data: [] });
   // @ts-expect-error stub
+  stripe.charges.list.resolves({ data: [], has_more: false });
+  // @ts-expect-error stub
+  stripe.invoices.list.resolves({ data: [], has_more: false });
+  // @ts-expect-error stub
   stripe.checkout.sessions.create.resolves({ id: 'cs_1' });
 });
 
 test.after.always(async t => {
   await t.context.app.close();
+});
+
+test('should initialize empty Stripe billing history test doubles', async t => {
+  const charges = await t.context.stripe.charges.list({ customer: 'cus_1' });
+  const invoices = await t.context.stripe.invoices.list({ customer: 'cus_1' });
+
+  t.deepEqual(charges, { data: [], has_more: false });
+  t.deepEqual(invoices, { data: [], has_more: false });
 });
 
 // ============== prices ==============

--- a/packages/backend/server/src/__tests__/utils/testing-app.spec.ts
+++ b/packages/backend/server/src/__tests__/utils/testing-app.spec.ts
@@ -1,0 +1,74 @@
+import { Controller, Get, Req } from '@nestjs/common';
+import test from 'ava';
+import type { Request } from 'express';
+
+import { AuthModule, AuthService } from '../../core/auth';
+import { Public } from '../../core/auth/guard';
+import { createTestingApp, type TestingApp } from './testing-app';
+
+@Public()
+@Controller('/testing-app')
+class TestingAppController {
+  @Get('/cookies')
+  cookies(@Req() request: Request) {
+    const rawCookieHeaderCount = request.rawHeaders.reduce(
+      (count, header, index) =>
+        index % 2 === 0 && header.toLowerCase() === 'cookie'
+          ? count + 1
+          : count,
+      0
+    );
+
+    return {
+      cookie: request.headers.cookie ?? '',
+      rawCookieHeaderCount,
+    };
+  }
+}
+
+let app: TestingApp;
+
+test.before(async () => {
+  app = await createTestingApp({
+    imports: [AuthModule],
+    controllers: [TestingAppController],
+  });
+});
+
+test.beforeEach(async () => {
+  await app.initTestingDB();
+});
+
+test.after.always(async () => {
+  await app.close();
+});
+
+test('withCookies merges auth and additional cookies into one header', async t => {
+  const user = await app.signup();
+
+  app.withCookies({ dub_id: 'click_123' });
+
+  const response = await app.GET('/testing-app/cookies').expect(200);
+  const cookies = Object.fromEntries(
+    response.body.cookie.split('; ').map((cookie: string) => cookie.split('='))
+  );
+
+  t.truthy(cookies[AuthService.sessionCookieName]);
+  t.is(cookies[AuthService.userCookieName], user.id);
+  t.truthy(cookies[AuthService.csrfCookieName]);
+  t.is(cookies.dub_id, 'click_123');
+  t.is(response.body.rawCookieHeaderCount, 1);
+});
+
+test('clearAuth also clears additional cookies', async t => {
+  await app.signup();
+  app.withCookies({ dub_id: 'click_123' });
+
+  app.clearAuth();
+
+  const response = await app.GET('/testing-app/cookies').expect(200);
+
+  t.false(response.body.cookie.includes('dub_id='));
+  t.false(response.body.cookie.includes(`${AuthService.csrfCookieName}=`));
+  t.is(response.body.rawCookieHeaderCount, 1);
+});

--- a/packages/backend/server/src/__tests__/utils/testing-app.ts
+++ b/packages/backend/server/src/__tests__/utils/testing-app.ts
@@ -99,6 +99,7 @@ export class TestingApp extends ApplyType<INestApplication>() {
   private currentUserCookie: string | null = null;
   private csrfCookie: string | null = null;
   private readonly userCookies: Set<string> = new Set();
+  private readonly additionalCookies = new Map<string, string>();
 
   readonly create!: ReturnType<typeof createFactory>;
   readonly mails!: MockMailer;
@@ -119,6 +120,15 @@ export class TestingApp extends ApplyType<INestApplication>() {
     this.currentUserCookie = null;
     this.csrfCookie = null;
     this.userCookies.clear();
+    this.additionalCookies.clear();
+  }
+
+  withCookies(cookies: Readonly<Record<string, string>>) {
+    for (const [name, value] of Object.entries(cookies)) {
+      this.additionalCookies.set(name, value);
+    }
+
+    return this;
   }
 
   url() {
@@ -133,17 +143,23 @@ export class TestingApp extends ApplyType<INestApplication>() {
     method: 'options' | 'get' | 'post' | 'put' | 'delete' | 'patch',
     path: string
   ): supertest.Test {
-    const cookies = [
-      `${AuthService.sessionCookieName}=${this.sessionCookie ?? ''}`,
-      `${AuthService.userCookieName}=${this.currentUserCookie ?? ''}`,
-    ];
+    const cookies = new Map([
+      [AuthService.sessionCookieName, this.sessionCookie ?? ''],
+      [AuthService.userCookieName, this.currentUserCookie ?? ''],
+    ]);
     if (this.csrfCookie) {
-      cookies.push(`${AuthService.csrfCookieName}=${this.csrfCookie}`);
+      cookies.set(AuthService.csrfCookieName, this.csrfCookie);
+    }
+    for (const [name, value] of this.additionalCookies) {
+      cookies.set(name, value);
     }
 
     const req = supertest(this.getHttpServer())
       [method](path)
-      .set('Cookie', cookies);
+      .set(
+        'Cookie',
+        Array.from(cookies, ([name, value]) => `${name}=${value}`).join('; ')
+      );
 
     if (this.csrfCookie) {
       req.set('x-affine-csrf-token', this.csrfCookie);

--- a/packages/backend/server/src/__tests__/utils/testing-app.ts
+++ b/packages/backend/server/src/__tests__/utils/testing-app.ts
@@ -158,7 +158,7 @@ export class TestingApp extends ApplyType<INestApplication>() {
       [method](path)
       .set(
         'Cookie',
-        Array.from(cookies, ([name, value]) => `${name}=${value}`).join('; ')
+        Array.from(cookies, ([name, value]) => `${name}=${value}`)
       );
 
     if (this.csrfCookie) {

--- a/packages/backend/server/src/base/metrics/metrics.ts
+++ b/packages/backend/server/src/base/metrics/metrics.ts
@@ -63,6 +63,7 @@ export type KnownMetricScopes =
   | 'storage'
   | 'process'
   | 'permission'
+  | 'payment'
   | 'search'
   | 'workspace';
 

--- a/packages/backend/server/src/base/mutex/index.ts
+++ b/packages/backend/server/src/base/mutex/index.ts
@@ -1,6 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 
-import { Locker } from './locker';
+import { Locker, LockUnavailableError } from './locker';
 import { Mutex, RequestMutex } from './mutex';
 
 @Global()
@@ -10,5 +10,5 @@ import { Mutex, RequestMutex } from './mutex';
 })
 export class MutexModule {}
 
-export { Locker, Mutex, RequestMutex };
+export { Locker, LockUnavailableError, Mutex, RequestMutex };
 export { Lock } from './lock';

--- a/packages/backend/server/src/base/mutex/locker.ts
+++ b/packages/backend/server/src/base/mutex/locker.ts
@@ -4,6 +4,8 @@ import { Command } from 'ioredis';
 import { SessionRedis } from '../redis';
 import { Lock } from './lock';
 
+export class LockUnavailableError extends Error {}
+
 // === atomic mutex lock ===
 // acquire lock
 // return 1 if lock is acquired
@@ -62,6 +64,8 @@ export class Locker {
       });
     }
 
-    throw new Error(`Failed to acquire lock for resource [${key}]`);
+    throw new LockUnavailableError(
+      `Failed to acquire lock for resource [${key}]`
+    );
   }
 }

--- a/packages/backend/server/src/base/mutex/mutex.ts
+++ b/packages/backend/server/src/base/mutex/mutex.ts
@@ -20,6 +20,23 @@ export class Mutex {
   constructor(protected readonly locker: Locker) {}
 
   /**
+   * Attempt to lock a resource once, without the retries used by {@link acquire}.
+   *
+   * This is intended for best-effort work that must not delay the caller when
+   * another request already owns the lock.
+   */
+  async tryAcquire(
+    key: string,
+    owner: string = `${this.clusterIdentifier}:${nanoid()}`
+  ) {
+    try {
+      return await this.locker.lock(owner, key);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * lock an resource and return a lock guard, which will release the lock when disposed
    *
    * if the lock is not available, it will retry for [MUTEX_RETRY] times

--- a/packages/backend/server/src/base/mutex/mutex.ts
+++ b/packages/backend/server/src/base/mutex/mutex.ts
@@ -7,7 +7,7 @@ import { nanoid } from 'nanoid';
 
 import { GraphqlContext } from '../graphql';
 import { retryable } from '../utils/promise';
-import { Locker } from './locker';
+import { Locker, LockUnavailableError } from './locker';
 
 export const MUTEX_RETRY = 5;
 export const MUTEX_WAIT = 100;
@@ -31,8 +31,11 @@ export class Mutex {
   ) {
     try {
       return await this.locker.lock(owner, key);
-    } catch {
-      return undefined;
+    } catch (error) {
+      if (error instanceof LockUnavailableError) {
+        return undefined;
+      }
+      throw error;
     }
   }
 

--- a/packages/backend/server/src/plugins/payment/config.ts
+++ b/packages/backend/server/src/plugins/payment/config.ts
@@ -1,4 +1,5 @@
 import type { Stripe } from 'stripe';
+import { z } from 'zod';
 
 import { defineModuleConfig } from '../../base';
 
@@ -20,6 +21,8 @@ export interface PaymentStartupConfig {
 
 export interface PaymentRuntimeConfig {
   showLifetimePrice: boolean;
+  dubAffiliateEnabled: boolean;
+  dubAffiliateExcludedPromotionCodes: string[];
 }
 
 declare global {
@@ -27,6 +30,8 @@ declare global {
     payment: {
       enabled: boolean;
       showLifetimePrice: boolean;
+      dubAffiliateEnabled: boolean;
+      dubAffiliateExcludedPromotionCodes: ConfigItem<string[]>;
       stripe: ConfigItem<
         {
           /** Preferred place for Stripe API key */
@@ -61,6 +66,15 @@ defineModuleConfig('payment', {
   showLifetimePrice: {
     desc: 'Whether enable lifetime price and allow user to pay for it.',
     default: true,
+  },
+  dubAffiliateEnabled: {
+    desc: 'Whether to attribute eligible Stripe customers to Dub affiliates.',
+    default: false,
+  },
+  dubAffiliateExcludedPromotionCodes: {
+    desc: 'Promotion codes that must not also receive Dub attribution.',
+    default: [],
+    shape: z.array(z.string()),
   },
   stripe: {
     desc: 'Stripe sdk options and credentials',

--- a/packages/backend/server/src/plugins/payment/dub-affiliate.ts
+++ b/packages/backend/server/src/plugins/payment/dub-affiliate.ts
@@ -231,7 +231,7 @@ export class DubAffiliateService {
       const existingClickId = customer.metadata.dubClickId;
 
       if (
-        isNonEmpty(existingExternalId) &&
+        isRawNonEmpty(existingExternalId) &&
         existingExternalId !== input.affineUserId
       ) {
         return finish({ status: 'skipped', reason: 'conflict' });
@@ -307,13 +307,8 @@ export class DubAffiliateService {
       });
       return finish({ status: 'skipped', reason });
     } finally {
-      try {
-        await lock.release();
-      } catch {
-        // The production Lock currently swallows release failures. Keep this
-        // boundary fail-open for alternate implementations and test doubles.
-        lockErrorCounter.add(1, { operation: 'release' });
-      }
+      // Lock.release already retries and logs failures without rejecting.
+      await lock.release();
     }
   }
 

--- a/packages/backend/server/src/plugins/payment/dub-affiliate.ts
+++ b/packages/backend/server/src/plugins/payment/dub-affiliate.ts
@@ -24,6 +24,7 @@ export type DubAffiliateSkipReason =
   | 'invalid'
   | 'legacy_promotion_code'
   | 'lock_contention'
+  | 'lock_error'
   | 'deleted_customer'
   | 'conflict'
   | 'incomplete_metadata'
@@ -140,10 +141,15 @@ export class DubAffiliateService {
   ): Promise<DubAffiliatePrepareResult> {
     const startedAt = performance.now();
     const plan = input.plan ?? 'unknown';
+    // Pre-lock skips do no work worth timing; recording them would flood the
+    // histogram with ~0ms samples and hide the real attribution latency.
+    let lockAttempted = false;
     const finish = (result: DubAffiliatePrepareResult) => {
       const attributes = { outcome: outcome(result), plan };
       prepareCounter.add(1, attributes);
-      prepareDuration.record(performance.now() - startedAt, attributes);
+      if (lockAttempted) {
+        prepareDuration.record(performance.now() - startedAt, attributes);
+      }
       return result;
     };
 
@@ -173,13 +179,14 @@ export class DubAffiliateService {
     }
 
     let lock: Lock | undefined;
+    lockAttempted = true;
     try {
       lock = await this.mutex.tryAcquire(
         `dub-affiliate:customer:${hash(input.stripeCustomerId)}`
       );
     } catch {
       lockErrorCounter.add(1, { operation: 'acquire' });
-      return finish({ status: 'skipped', reason: 'stripe_error' });
+      return finish({ status: 'skipped', reason: 'lock_error' });
     }
 
     if (!lock) {

--- a/packages/backend/server/src/plugins/payment/dub-affiliate.ts
+++ b/packages/backend/server/src/plugins/payment/dub-affiliate.ts
@@ -1,0 +1,325 @@
+import { createHash } from 'node:crypto';
+
+import { Injectable } from '@nestjs/common';
+import Stripe from 'stripe';
+
+import { Config, Lock, metrics, Mutex } from '../../base';
+
+const DUB_CLICK_ID_PATTERN = /^[A-Za-z0-9_-]{1,255}$/;
+const STRIPE_READ_OPTIONS = {
+  timeout: 1000,
+  maxNetworkRetries: 0,
+} satisfies Stripe.RequestOptions;
+const STRIPE_UPDATE_OPTIONS = {
+  timeout: 1500,
+  maxNetworkRetries: 0,
+} satisfies Stripe.RequestOptions;
+
+export type DubAffiliatePlan = 'pro' | 'ai' | 'team' | 'lifetime' | 'unknown';
+
+export type DubAffiliateSkipReason =
+  | 'disabled'
+  | 'missing'
+  | 'invalid'
+  | 'legacy_promotion_code'
+  | 'lock_contention'
+  | 'deleted_customer'
+  | 'conflict'
+  | 'incomplete_metadata'
+  | 'prior_billing'
+  | 'ambiguous_charge_history'
+  | 'stripe_error'
+  | 'ambiguous_timeout';
+
+export type DubAffiliatePrepareInput = {
+  stripeCustomerId: string;
+  affineUserId: string;
+  dubClickId?: string;
+  promotionCode?: string;
+  knownSubscriptions?: readonly Stripe.Subscription[];
+  plan?: DubAffiliatePlan;
+};
+
+type DubSessionMetadata = {
+  dubCustomerExternalId: string;
+};
+
+export type DubAffiliatePrepareResult =
+  | {
+      status: 'attributed' | 'existing_owner';
+      sessionMetadata: DubSessionMetadata;
+    }
+  | { status: 'skipped'; reason: DubAffiliateSkipReason };
+
+type StripeOperation =
+  | 'customer_retrieve'
+  | 'subscriptions_list'
+  | 'invoices_list'
+  | 'charges_list'
+  | 'customer_update';
+
+class StripeOperationError extends Error {
+  constructor(
+    readonly operation: StripeOperation,
+    readonly originalError: unknown
+  ) {
+    super(`Dub affiliate Stripe operation failed: ${operation}`);
+  }
+}
+
+const prepareCounter = metrics.payment.counter('dub_affiliate_prepare_total');
+const prepareDuration = metrics.payment.histogram(
+  'dub_affiliate_prepare_duration_ms'
+);
+const stripeErrorCounter = metrics.payment.counter(
+  'dub_affiliate_stripe_error_total'
+);
+const lockContentionCounter = metrics.payment.counter(
+  'dub_affiliate_lock_contention_total'
+);
+const lockErrorCounter = metrics.payment.counter(
+  'dub_affiliate_lock_error_total'
+);
+
+function hash(value: string) {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function normalizePromotionCode(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function isNonEmpty(value: string | undefined): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isRawNonEmpty(value: string | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function stringProperty(value: unknown, property: string) {
+  if (!value || typeof value !== 'object') {
+    return '';
+  }
+
+  const candidate = Reflect.get(value, property);
+  return typeof candidate === 'string' ? candidate : '';
+}
+
+function isAmbiguousTimeout(error: unknown) {
+  const code = stringProperty(error, 'code').toUpperCase();
+  const type = stringProperty(error, 'type');
+  const message = stringProperty(error, 'message');
+
+  return (
+    ['ETIMEDOUT', 'ESOCKETTIMEDOUT', 'ECONNRESET', 'EPIPE'].includes(code) ||
+    type === 'StripeConnectionError' ||
+    /timed?\s*out|timeout/i.test(message)
+  );
+}
+
+function outcome(result: DubAffiliatePrepareResult) {
+  return result.status === 'skipped' ? result.reason : result.status;
+}
+
+@Injectable()
+export class DubAffiliateService {
+  constructor(
+    private readonly stripe: Stripe,
+    private readonly config: Config,
+    private readonly mutex: Mutex
+  ) {}
+
+  async prepareCheckout(
+    input: DubAffiliatePrepareInput
+  ): Promise<DubAffiliatePrepareResult> {
+    const startedAt = performance.now();
+    const plan = input.plan ?? 'unknown';
+    const finish = (result: DubAffiliatePrepareResult) => {
+      const attributes = { outcome: outcome(result), plan };
+      prepareCounter.add(1, attributes);
+      prepareDuration.record(performance.now() - startedAt, attributes);
+      return result;
+    };
+
+    if (!this.config.payment.dubAffiliateEnabled) {
+      return finish({ status: 'skipped', reason: 'disabled' });
+    }
+
+    if (!input.dubClickId) {
+      return finish({ status: 'skipped', reason: 'missing' });
+    }
+
+    const dubClickId = input.dubClickId.trim();
+    if (!DUB_CLICK_ID_PATTERN.test(dubClickId)) {
+      return finish({ status: 'skipped', reason: 'invalid' });
+    }
+
+    const promotionCode = input.promotionCode
+      ? normalizePromotionCode(input.promotionCode)
+      : undefined;
+    const excludedPromotionCodes = new Set(
+      this.config.payment.dubAffiliateExcludedPromotionCodes
+        .map(normalizePromotionCode)
+        .filter(Boolean)
+    );
+    if (promotionCode && excludedPromotionCodes.has(promotionCode)) {
+      return finish({ status: 'skipped', reason: 'legacy_promotion_code' });
+    }
+
+    let lock: Lock | undefined;
+    try {
+      lock = await this.mutex.tryAcquire(
+        `dub-affiliate:customer:${hash(input.stripeCustomerId)}`
+      );
+    } catch {
+      lockErrorCounter.add(1, { operation: 'acquire' });
+      return finish({ status: 'skipped', reason: 'stripe_error' });
+    }
+
+    if (!lock) {
+      lockContentionCounter.add(1);
+      return finish({ status: 'skipped', reason: 'lock_contention' });
+    }
+
+    try {
+      const subscriptionsPromise = input.knownSubscriptions
+        ? Promise.resolve({ data: input.knownSubscriptions })
+        : this.stripeCall('subscriptions_list', () =>
+            this.stripe.subscriptions.list(
+              {
+                customer: input.stripeCustomerId,
+                status: 'all',
+                limit: 1,
+              },
+              STRIPE_READ_OPTIONS
+            )
+          );
+
+      const [customer, subscriptions, invoices, charges] = await Promise.all([
+        this.stripeCall('customer_retrieve', () =>
+          this.stripe.customers.retrieve(
+            input.stripeCustomerId,
+            STRIPE_READ_OPTIONS
+          )
+        ),
+        subscriptionsPromise,
+        this.stripeCall('invoices_list', () =>
+          this.stripe.invoices.list(
+            { customer: input.stripeCustomerId, limit: 1 },
+            STRIPE_READ_OPTIONS
+          )
+        ),
+        this.stripeCall('charges_list', () =>
+          this.stripe.charges.list(
+            { customer: input.stripeCustomerId, limit: 10 },
+            STRIPE_READ_OPTIONS
+          )
+        ),
+      ]);
+
+      if (customer.deleted) {
+        return finish({ status: 'skipped', reason: 'deleted_customer' });
+      }
+
+      const existingExternalId = customer.metadata.dubCustomerExternalId;
+      const existingClickId = customer.metadata.dubClickId;
+
+      if (
+        isNonEmpty(existingExternalId) &&
+        existingExternalId !== input.affineUserId
+      ) {
+        return finish({ status: 'skipped', reason: 'conflict' });
+      }
+
+      if (isRawNonEmpty(existingClickId)) {
+        if (isNonEmpty(existingExternalId)) {
+          return finish({
+            status: 'existing_owner',
+            sessionMetadata: {
+              dubCustomerExternalId: input.affineUserId,
+            },
+          });
+        }
+
+        return finish({ status: 'skipped', reason: 'incomplete_metadata' });
+      }
+
+      const hasSuccessfulCharge = charges.data.some(
+        charge => charge.paid === true || charge.status === 'succeeded'
+      );
+      if (
+        subscriptions.data.length > 0 ||
+        invoices.data.length > 0 ||
+        hasSuccessfulCharge
+      ) {
+        return finish({ status: 'skipped', reason: 'prior_billing' });
+      }
+
+      if (charges.has_more) {
+        return finish({
+          status: 'skipped',
+          reason: 'ambiguous_charge_history',
+        });
+      }
+
+      await this.stripeCall('customer_update', () =>
+        this.stripe.customers.update(
+          input.stripeCustomerId,
+          {
+            metadata: {
+              dubCustomerExternalId: input.affineUserId,
+              dubClickId,
+            },
+          },
+          {
+            ...STRIPE_UPDATE_OPTIONS,
+            idempotencyKey: `dub-affiliate:v1:${hash(
+              [input.stripeCustomerId, input.affineUserId, dubClickId].join(
+                '\0'
+              )
+            )}`,
+          }
+        )
+      );
+
+      return finish({
+        status: 'attributed',
+        sessionMetadata: { dubCustomerExternalId: input.affineUserId },
+      });
+    } catch (error) {
+      const stripeError =
+        error instanceof StripeOperationError ? error : undefined;
+      const originalError = stripeError?.originalError ?? error;
+      const reason =
+        stripeError?.operation === 'customer_update' &&
+        isAmbiguousTimeout(originalError)
+          ? 'ambiguous_timeout'
+          : 'stripe_error';
+      stripeErrorCounter.add(1, {
+        error: reason,
+        operation: stripeError?.operation ?? 'unknown',
+      });
+      return finish({ status: 'skipped', reason });
+    } finally {
+      try {
+        await lock.release();
+      } catch {
+        // The production Lock currently swallows release failures. Keep this
+        // boundary fail-open for alternate implementations and test doubles.
+        lockErrorCounter.add(1, { operation: 'release' });
+      }
+    }
+  }
+
+  private async stripeCall<T>(
+    operation: StripeOperation,
+    call: () => PromiseLike<T>
+  ): Promise<T> {
+    try {
+      return await call();
+    } catch (error) {
+      throw new StripeOperationError(operation, error);
+    }
+  }
+}

--- a/packages/backend/server/src/plugins/payment/dub-affiliate.ts
+++ b/packages/backend/server/src/plugins/payment/dub-affiliate.ts
@@ -4,6 +4,7 @@ import { Injectable } from '@nestjs/common';
 import Stripe from 'stripe';
 
 import { Config, Lock, metrics, Mutex } from '../../base';
+import { StripeFactory } from './stripe';
 
 const DUB_CLICK_ID_PATTERN = /^[A-Za-z0-9_-]{1,255}$/;
 const STRIPE_READ_OPTIONS = {
@@ -125,10 +126,14 @@ function outcome(result: DubAffiliatePrepareResult) {
 @Injectable()
 export class DubAffiliateService {
   constructor(
-    private readonly stripe: Stripe,
+    private readonly stripeProvider: StripeFactory,
     private readonly config: Config,
     private readonly mutex: Mutex
   ) {}
+
+  private get stripe() {
+    return this.stripeProvider.stripe;
+  }
 
   async prepareCheckout(
     input: DubAffiliatePrepareInput

--- a/packages/backend/server/src/plugins/payment/index.ts
+++ b/packages/backend/server/src/plugins/payment/index.ts
@@ -12,6 +12,7 @@ import { UserModule } from '../../core/user';
 import { WorkspaceModule } from '../../core/workspaces';
 import { StripeWebhookController } from './controller';
 import { SubscriptionCronJobs } from './cron';
+import { DubAffiliateService } from './dub-affiliate';
 import { PaymentEventHandlers } from './event';
 import { LicenseController } from './license/controller';
 import {
@@ -59,6 +60,7 @@ import { StripeWebhook } from './webhook';
     SubscriptionCronJobs,
     WorkspaceSubscriptionResolver,
     PaymentEventHandlers,
+    DubAffiliateService,
   ],
   controllers: [
     StripeWebhookController,

--- a/packages/backend/server/src/plugins/payment/manager/user.ts
+++ b/packages/backend/server/src/plugins/payment/manager/user.ts
@@ -22,6 +22,7 @@ import {
   URLHelper,
 } from '../../../base';
 import { EntitlementService } from '../../../core/entitlement';
+import { DubAffiliateService } from '../dub-affiliate';
 import { resolveProductMapping, RevenueCatService } from '../revenuecat';
 import { StripeFactory } from '../stripe';
 import {
@@ -52,6 +53,7 @@ export const UserSubscriptionCheckoutArgs = z.object({
     id: z.string(),
     email: z.string(),
   }),
+  dubClickId: z.string().optional(),
 });
 
 @Injectable()
@@ -66,7 +68,8 @@ export class UserSubscriptionManager extends SubscriptionManager {
     private readonly url: URLHelper,
     private readonly mutex: Mutex,
     private readonly entitlement: EntitlementService,
-    private readonly revenueCat: RevenueCatService
+    private readonly revenueCat: RevenueCatService,
+    private readonly dubAffiliate: DubAffiliateService
   ) {
     super(stripeProvider, db);
   }
@@ -89,7 +92,7 @@ export class UserSubscriptionManager extends SubscriptionManager {
   async checkout(
     lookupKey: LookupKey,
     params: z.infer<typeof CheckoutParams>,
-    { user }: z.infer<typeof UserSubscriptionCheckoutArgs>
+    { user, dubClickId }: z.infer<typeof UserSubscriptionCheckoutArgs>
   ) {
     if (
       (lookupKey.plan !== SubscriptionPlan.Pro &&
@@ -171,6 +174,23 @@ export class UserSubscriptionManager extends SubscriptionManager {
             subscription_data: subscriptionData,
           };
 
+    const dubAttribution = await this.dubAffiliate.prepareCheckout({
+      stripeCustomerId: customer.stripeCustomerId,
+      affineUserId: user.id,
+      dubClickId,
+      promotionCode: params.coupon ?? undefined,
+      knownSubscriptions: stripeSubscriptions.data,
+      plan:
+        lookupKey.recurring === SubscriptionRecurring.Lifetime
+          ? 'lifetime'
+          : lookupKey.plan,
+    });
+    const dubMetadata =
+      dubAttribution.status === 'attributed' ||
+      dubAttribution.status === 'existing_owner'
+        ? { metadata: dubAttribution.sessionMetadata }
+        : {};
+
     const session = await this.stripe.checkout.sessions.create({
       customer: customer.stripeCustomerId,
       line_items: [
@@ -181,6 +201,7 @@ export class UserSubscriptionManager extends SubscriptionManager {
       ],
       ...mode,
       ...discounts,
+      ...dubMetadata,
       success_url: this.url.safeLink(params.successCallbackLink || '/'),
     });
 

--- a/packages/backend/server/src/plugins/payment/manager/workspace.ts
+++ b/packages/backend/server/src/plugins/payment/manager/workspace.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../base';
 import { EntitlementService } from '../../../core/entitlement';
 import { Models } from '../../../models';
+import { DubAffiliateService } from '../dub-affiliate';
 import { StripeFactory } from '../stripe';
 import {
   KnownStripeInvoice,
@@ -43,6 +44,7 @@ export const WorkspaceSubscriptionCheckoutArgs = z.object({
     id: z.string(),
     email: z.string(),
   }),
+  dubClickId: z.string().optional(),
 });
 
 @Injectable()
@@ -53,7 +55,8 @@ export class WorkspaceSubscriptionManager extends SubscriptionManager {
     private readonly url: URLHelper,
     private readonly event: EventBus,
     private readonly models: Models,
-    private readonly entitlement: EntitlementService
+    private readonly entitlement: EntitlementService,
+    private readonly dubAffiliate: DubAffiliateService
   ) {
     super(stripeProvider, db);
   }
@@ -108,6 +111,19 @@ export class WorkspaceSubscriptionManager extends SubscriptionManager {
 
     const count = await this.models.workspaceUser.count(args.workspaceId);
 
+    const dubAttribution = await this.dubAffiliate.prepareCheckout({
+      stripeCustomerId: customer.stripeCustomerId,
+      affineUserId: args.user.id,
+      dubClickId: args.dubClickId,
+      promotionCode: params.coupon ?? undefined,
+      plan: 'team',
+    });
+    const dubMetadata =
+      dubAttribution.status === 'attributed' ||
+      dubAttribution.status === 'existing_owner'
+        ? { metadata: dubAttribution.sessionMetadata }
+        : {};
+
     return this.stripe.checkout.sessions.create({
       customer: customer.stripeCustomerId,
       line_items: [
@@ -123,6 +139,7 @@ export class WorkspaceSubscriptionManager extends SubscriptionManager {
         },
       },
       ...discounts,
+      ...dubMetadata,
       success_url: this.url.safeLink(params.successCallbackLink || '/'),
     });
   }

--- a/packages/backend/server/src/plugins/payment/resolver.ts
+++ b/packages/backend/server/src/plugins/payment/resolver.ts
@@ -1,6 +1,7 @@
 import { Headers } from '@nestjs/common';
 import {
   Args,
+  Context,
   Field,
   InputType,
   Int,
@@ -23,10 +24,13 @@ import {
   AccessDenied,
   AuthenticationRequired,
   FailedToCheckout,
+  getRequestCookie,
+  getRequestHeader,
   InvalidSubscriptionParameters,
   Throttle,
   WorkspaceIdRequiredToUpdateTeamSubscription,
 } from '../../base';
+import type { GraphqlContext } from '../../base/graphql';
 import { CurrentUser, Public } from '../../core/auth';
 import { EntitlementService } from '../../core/entitlement';
 import { PermissionAccess } from '../../core/permission';
@@ -283,9 +287,15 @@ export class SubscriptionResolver {
   async createCheckoutSession(
     @CurrentUser() user: CurrentUser | null,
     @Args({ name: 'input', type: () => CreateCheckoutSessionInput })
-    input: CreateCheckoutSessionInput
+    input: CreateCheckoutSessionInput,
+    @Context() context: GraphqlContext
   ) {
     let session: Stripe.Checkout.Session;
+    const clientKind = getRequestHeader(context.req, 'x-affine-client-kind');
+    const dubClickId =
+      input.plan !== SubscriptionPlan.SelfHostedTeam && clientKind !== 'native'
+        ? getRequestCookie(context.req, 'dub_id')
+        : undefined;
 
     if (input.plan === SubscriptionPlan.SelfHostedTeam) {
       session = await this.service.checkout(input, {
@@ -302,6 +312,7 @@ export class SubscriptionResolver {
         plan: input.plan as any,
         user,
         workspaceId: input.args?.workspaceId,
+        dubClickId,
       });
     }
 

--- a/packages/frontend/admin/src/config.json
+++ b/packages/frontend/admin/src/config.json
@@ -450,6 +450,14 @@
       "type": "Boolean",
       "desc": "Whether enable lifetime price and allow user to pay for it."
     },
+    "dubAffiliateEnabled": {
+      "type": "Boolean",
+      "desc": "Whether to attribute eligible Stripe customers to Dub affiliates."
+    },
+    "dubAffiliateExcludedPromotionCodes": {
+      "type": "Array",
+      "desc": "Promotion codes that must not also receive Dub attribution."
+    },
     "stripe": {
       "type": "Object",
       "desc": "Stripe sdk options and credentials",


### PR DESCRIPTION
## Summary

- pass a validated Dub click identifier from authenticated Web GraphQL checkout into the existing Pro, AI, Team, and Believer/Lifetime Stripe Checkout paths
- assign eligible new Web Stripe customers a stable `dubCustomerExternalId` and `dubClickId`, and mirror the external customer ID into Checkout Session metadata
- exclude native, RevenueCat/IAP, self-hosted, existing-billing, conflicting-owner, invalid-click, and configured legacy promotion-code paths
- add bounded Stripe history checks, per-customer locking, stable idempotency, fail-open behavior, and finite-label metrics for rollout monitoring

## Phase 1 program contract

- Cloud, AI, and Team: 30% recurring commission for up to 12 months, configured in Dub
- AFFiNE Believer (Lifetime) Plan: included as a one-time 30% commission, with no recurring commission
- AI free trials do not create commission until an eligible positive-amount payment is recorded by the Stripe/Dub integration
- only new Web Stripe customers are eligible; mobile IAP, self-hosted, enterprise leads, and manually invoiced transactions remain out of scope
- no manual `trackLead`/`trackSale`, new Dub webhook, direct discount, or partner promotion-code implementation is added here

## Safety and rollout controls

- `payment.dubAffiliateEnabled` defaults to `false`
- `payment.dubAffiliateExcludedPromotionCodes` supports the controlled FirstPromoter migration path
- attribution skips before Stripe calls when disabled, missing, invalid, native, self-hosted, or using an excluded legacy code
- existing billing history and ambiguous/incomplete history fail closed for attribution while checkout itself remains fail open
- existing non-empty ownership/click metadata is never guessed or overwritten
- Customer metadata updates use a stable idempotency key and execute under a hashed per-customer lock

## Shared infrastructure change (base/mutex)

- `Locker.lock()` now throws a typed `LockUnavailableError` instead of a bare `Error` when the resource is already locked; the message is unchanged and `Mutex.acquire()` behaviour (5 × 100 ms retry via `retryable`) is untouched.
- This is required so the new `Mutex.tryAcquire()` can distinguish "lock held by another request" (return `undefined`, attribution skips with `lock_contention`) from Redis/infrastructure failures (rethrown, attribution skips with `lock_error`).
- No other caller of `Locker` or `Mutex` changes; `mutex.spec.ts` covers both branches.

## Verification

- [x] 7 focused Backend specs: 101 passed / 2 pre-existing Team cancel/resume tests skipped (`dub-affiliate.spec.ts` + `config.spec.ts` re-run locally after the 2026-09-04 review fixes: 38 passed; remaining specs need Postgres/Redis and are verified by CI)
- [x] real GraphQL integration reaches Stripe Customer update and Checkout metadata for Web Pro
- [x] real GraphQL integration verifies zero Dub attribution for native Pro and public SelfHostedTeam
- [x] Cloud/Pro, AI trial, Team seats/workspace metadata, and Believer/Lifetime payment parameters covered
- [x] existing-customer, ownership-conflict, Stripe-error/timeout, concurrency, and legacy-code exclusions covered
- [x] `tsc -b packages/backend/server`: exit 0
- [x] `oxlint --deny-warnings packages/backend/server/src`: exit 0
- [x] `oxfmt --check packages/backend/server/src`: exit 0
- [x] diff check against current `origin/canary`: exit 0

## Related PR

- Website consent, cookie, provider-switch, and legal changes: toeverything/AFFiNE.pro#1066
- Pre-existing `revenuecat.spec.ts` canary failure, split out so it can merge first: #15565

## Required before merge / live rollout

- [ ] complete paired engineering/security review of this PR and AFFiNE.pro#1066
- [ ] Legal approves the Affiliate Terms and revised Cookie Policy
- [ ] complete Stripe/Dub Sandbox tests for Cloud, AI, Team, Believer, renewals, refunds, existing-customer exclusion, and FirstPromoter duplicate prevention
- [ ] disable legacy FirstPromoter promotion codes at T0 before enabling the live Dub path
- [ ] confirm Dub is configured for 30% recurring / 12 months with a 60-day payout hold and auto-approve disabled
- [ ] monitor the finite Dub attribution metrics for 48 hours after launch

## CI fixes (2026-09-03)
- title scope changed to `server` (commitlint allowlist)
- committed regenerated `.docker/selfhost/schema.json` and `packages/frontend/admin/src/config.json` from `yarn affine server genconfig`
- testing-app keeps the `Cookie` header as an array so `auth/controller.spec.ts` can filter it
- the pre-existing `revenuecat` refresh spec failure on canary (since 2026-09-01, run 33712922544) is fixed separately in #15565; this PR will be rebased once that merges, so the `revenuecat.spec.ts` job stays red here until then

## Review fixes (2026-09-04)
- Redis/lock infrastructure failures are now reported as `lock_error` instead of `stripe_error`
- `dub_affiliate_prepare_duration_ms` is recorded only after a lock attempt, so pre-lock skips no longer dilute p95/p99
- `revenuecat.spec.ts` change moved to #15565
