### PR TITLE
test(server): use relative dates in revenuecat refresh spec

### DIFF
--- a/packages/backend/server/src/__tests__/payment/revenuecat.spec.ts
+++ b/packages/backend/server/src/__tests__/payment/revenuecat.spec.ts
@@ -1113,6 +1113,9 @@ test('should not dispatch webhook event when authorization header is missing or 
 
 test('should refresh user subscriptions (empty / revenuecat / stripe-only)', async t => {
   const { subResolver, db, mockAlias, mockSubSeq } = t.context;
+  const now = Date.now();
+  const relativeDate = (days: number) =>
+    new Date(now + days * 24 * 60 * 60 * 1000);
 
   mockAlias(user.id);
   const currentUser = {
@@ -1134,8 +1137,8 @@ test('should refresh user subscriptions (empty / revenuecat / stripe-only)', asy
         identifier: 'Pro',
         isTrial: false,
         isActive: true,
-        latestPurchaseDate: new Date('2025-09-01T00:00:00.000Z'),
-        expirationDate: new Date('2026-09-01T00:00:00.000Z'),
+        latestPurchaseDate: relativeDate(-2),
+        expirationDate: relativeDate(364),
         productId: 'app.affine.pro.Annual',
         store: 'app_store',
         willRenew: true,
@@ -1147,8 +1150,8 @@ test('should refresh user subscriptions (empty / revenuecat / stripe-only)', asy
         identifier: 'AI',
         isTrial: false,
         isActive: true,
-        latestPurchaseDate: new Date('2025-09-02T00:00:00.000Z'),
-        expirationDate: new Date('2026-09-02T00:00:00.000Z'),
+        latestPurchaseDate: relativeDate(-1),
+        expirationDate: relativeDate(365),
         productId: 'app.affine.pro.ai.Annual',
         store: 'play_store',
         willRenew: true,


### PR DESCRIPTION
## Summary

- `src/__tests__/payment/revenuecat.spec.ts` › `should refresh user subscriptions (empty / revenuecat / stripe-only)` has been red on `canary` since 2026-09-01 (see run 33712922544): the mocked RevenueCat entitlements used fixed calendar dates (`expirationDate: 2026-09-01` / `2026-09-02`) that have now passed, so the entitlements are treated as expired.
- Replace the fixed dates with dates relative to `Date.now()` so the fixture cannot expire again.
- Test-only change, no runtime code touched.

## Relationship to other PRs

- Split out of #15564 so `canary` goes green independently of that PR's Legal/Sandbox gates. #15564 will be rebased onto this once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated subscription refresh test dates to be calculated relative to the current time.
  * Improved test reliability across different execution dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->