### PR TITLE
fix(core): select all unused blobs across pages

### DIFF
--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx
@@ -1,0 +1,202 @@
+/** @vitest-environment happy-dom */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import type * as Infra from '@toeverything/infra';
+import type { MouseEventHandler, ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const openConfirmModal = vi.hoisted(() => vi.fn());
+const deleteBlob = vi.hoisted(() =>
+  vi.fn(async (_key: string, _permanent: boolean) => undefined)
+);
+const revalidate = vi.hoisted(() => vi.fn());
+const notifyError = vi.hoisted(() => vi.fn());
+const blobManagementServiceToken = vi.hoisted(
+  () => class BlobManagementService {}
+);
+const blobs = vi.hoisted(() =>
+  Array.from({ length: 10 }, (_, index) => ({
+    key: `blob-${index + 1}`,
+    mime: 'image/png',
+    size: 1024,
+  }))
+);
+
+vi.mock('@affine/component', () => ({
+  Button: ({
+    children,
+    disabled,
+    onClick,
+  }: {
+    children: ReactNode;
+    disabled?: boolean;
+    onClick?: MouseEventHandler<HTMLButtonElement>;
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  Checkbox: ({ checked }: { checked: boolean }) => (
+    <input type="checkbox" checked={checked} readOnly />
+  ),
+  Loading: () => <div>Loading</div>,
+  notify: { error: notifyError },
+  templateToString: (value: string) => value,
+  useConfirmModal: () => ({ openConfirmModal }),
+}));
+
+vi.mock('@affine/component/setting-components', () => ({
+  Pagination: () => <div>Pagination</div>,
+}));
+
+vi.mock('@affine/core/modules/blob-management/services', () => ({
+  BlobManagementService: blobManagementServiceToken,
+}));
+
+vi.mock('@affine/i18n', () => ({
+  useI18n: () =>
+    new Proxy(
+      {},
+      {
+        get: (_, key: string) => (args?: { count?: string }) => {
+          const translations: Record<string, string> = {
+            'com.affine.keyboardShortcuts.selectAll': 'Select all',
+            'com.affine.settings.workspace.storage.unused-blobs':
+              'Unused blobs',
+            'com.affine.settings.workspace.storage.unused-blobs.empty':
+              'No unused blobs',
+            'com.affine.settings.workspace.storage.unused-blobs.selected':
+              'Selected',
+            'com.affine.settings.workspace.storage.unused-blobs.delete.title':
+              'Delete blob files',
+            'com.affine.settings.workspace.storage.unused-blobs.delete.warning':
+              'Delete these blobs?',
+            'com.affine.settings.workspace.storage.unused-blobs.delete.failed':
+              'Delete failed',
+            Delete: 'Delete',
+            Cancel: 'Cancel',
+          };
+          return (translations[key] ?? key).replace(
+            '{{count}}',
+            String(args?.count ?? '')
+          );
+        },
+      }
+    ),
+}));
+
+vi.mock('@affine/track', () => ({
+  default: {
+    $: {
+      settingsPanel: {
+        workspace: { deleteUnusedBlob: vi.fn() },
+      },
+    },
+  },
+}));
+
+vi.mock('@blocksuite/affine/components/icons', () => ({
+  getAttachmentFileIcon: () => '<svg></svg>',
+}));
+
+vi.mock('@blocksuite/icons/rc', () => ({
+  DeleteIcon: () => <span>Delete icon</span>,
+}));
+
+vi.mock('@toeverything/infra', async importOriginal => {
+  const actual = await importOriginal<typeof Infra>();
+  const unusedBlobs = {
+    unusedBlobs$: { value: blobs },
+    isLoading$: { value: false },
+    deleteBlob,
+    revalidate,
+  };
+
+  return {
+    ...actual,
+    useLiveData: (liveData: { value: unknown }) => liveData.value,
+    useService: () => ({ unusedBlobs }),
+  };
+});
+
+import { BlobManagementPanel } from './blob-management';
+
+describe('BlobManagementPanel', () => {
+  beforeEach(() => {
+    openConfirmModal.mockReset();
+    deleteBlob.mockReset();
+    deleteBlob.mockResolvedValue(undefined);
+    revalidate.mockClear();
+    notifyError.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('selects and deletes unused blobs across every page', async () => {
+    render(<BlobManagementPanel />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('blob-preview-card')).toHaveLength(9);
+    });
+
+    fireEvent.click(screen.getAllByTestId('blob-preview-card')[0]);
+    expect(screen.getByText('1 Selected')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all (10)' }));
+    expect(screen.getByText('10 Selected')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(openConfirmModal).toHaveBeenCalledOnce();
+    expect(openConfirmModal.mock.calls[0][0].title).toBe(
+      'Delete blob files (10)'
+    );
+    expect(openConfirmModal.mock.calls[0][0].children).toBe(
+      'Delete these blobs?'
+    );
+
+    await act(async () => {
+      await openConfirmModal.mock.calls[0][0].onConfirm();
+    });
+
+    expect(deleteBlob).toHaveBeenCalledTimes(10);
+    expect(deleteBlob.mock.calls.map(call => call[0])).toEqual(
+      blobs.map(blob => blob.key)
+    );
+    expect(screen.getByText('Unused blobs (0)')).toBeTruthy();
+  });
+
+  test('keeps failed deletions selected', async () => {
+    deleteBlob.mockImplementation(async key => {
+      if (key === 'blob-3') {
+        throw new Error('Delete failed');
+      }
+    });
+    render(<BlobManagementPanel />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('blob-preview-card')).toHaveLength(9);
+    });
+
+    fireEvent.click(screen.getAllByTestId('blob-preview-card')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Select all (10)' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await act(async () => {
+      await openConfirmModal.mock.calls[0][0].onConfirm();
+    });
+
+    expect(screen.getByText('1 Selected')).toBeTruthy();
+    expect(screen.getAllByTestId('blob-preview-card')).toHaveLength(1);
+    expect(screen.getByRole('checkbox')).toHaveProperty('checked', true);
+    expect(notifyError).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx
@@ -199,4 +199,38 @@ describe('BlobManagementPanel', () => {
     expect(screen.getByRole('checkbox')).toHaveProperty('checked', true);
     expect(notifyError).toHaveBeenCalledOnce();
   });
+
+  test('disables select all while deletion is in progress', async () => {
+    let finishDeletion: (() => void) | undefined;
+    deleteBlob.mockImplementation(
+      () =>
+        new Promise<undefined>(resolve => {
+          finishDeletion = () => resolve(undefined);
+        })
+    );
+    render(<BlobManagementPanel />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('blob-preview-card')).toHaveLength(9);
+    });
+
+    fireEvent.click(screen.getAllByTestId('blob-preview-card')[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    let deletion: Promise<void> | undefined;
+    await act(async () => {
+      deletion = openConfirmModal.mock.calls[0][0].onConfirm();
+      await Promise.resolve();
+    });
+
+    const selectAll = screen.getByRole('button', { name: 'Select all (10)' });
+    expect(selectAll).toHaveProperty('disabled', true);
+    fireEvent.click(selectAll);
+    expect(screen.getByText('1 Selected')).toBeTruthy();
+
+    await act(async () => {
+      finishDeletion?.();
+      await deletion;
+    });
+  });
 });

--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   Checkbox,
   Loading,
+  notify,
   templateToString,
   useConfirmModal,
 } from '@affine/component';
@@ -75,6 +76,7 @@ const BlobCard = ({
 };
 
 const PAGE_SIZE = 9;
+const DELETE_BATCH_SIZE = 5;
 
 export const BlobManagementPanel = () => {
   const t = useI18n();
@@ -88,36 +90,55 @@ export const BlobManagementPanel = () => {
     useState<ListedBlobRecord | null>(null);
 
   const [unusedBlobs, setUnusedBlobs] = useState<ListedBlobRecord[]>([]);
+  const [selectedBlobKeys, setSelectedBlobKeys] = useState<Set<string>>(
+    () => new Set()
+  );
+  const [deleting, setDeleting] = useState(false);
   const unusedBlobsPage = useMemo(() => {
     return unusedBlobs.slice(skip, skip + PAGE_SIZE);
   }, [unusedBlobs, skip]);
 
   useEffect(() => {
     setUnusedBlobs(originalUnusedBlobs);
+    const availableBlobKeys = new Set(
+      originalUnusedBlobs.map(blob => blob.key)
+    );
+    setSelectedBlobKeys(previous => {
+      return new Set(
+        Array.from(previous).filter(key => availableBlobKeys.has(key))
+      );
+    });
   }, [originalUnusedBlobs]);
 
   useEffect(() => {
     unusedBlobsEntity.revalidate();
   }, [unusedBlobsEntity]);
 
-  const [selectedBlobs, setSelectedBlobs] = useState<ListedBlobRecord[]>([]);
-  const [deleting, setDeleting] = useState(false);
-
   const handleSelectBlob = useCallback((blob: ListedBlobRecord) => {
-    setSelectedBlobs(prev => {
-      if (prev.includes(blob)) {
-        return prev;
+    setSelectedBlobKeys(previous => {
+      if (previous.has(blob.key)) {
+        return previous;
       }
-      return [...prev, blob];
+      const next = new Set(previous);
+      next.add(blob.key);
+      return next;
     });
   }, []);
 
   const handleUnselectBlob = useCallback((blob: ListedBlobRecord) => {
-    setSelectedBlobs(prev => prev.filter(b => b.key !== blob.key));
+    setSelectedBlobKeys(previous => {
+      const next = new Set(previous);
+      next.delete(blob.key);
+      return next;
+    });
   }, []);
 
   const handleBlobClick = useCallback(
     (blob: ListedBlobRecord, event: React.MouseEvent) => {
+      if (deleting) {
+        return;
+      }
+
       const isMetaKey = event.metaKey || event.ctrlKey;
 
       if (event.shiftKey && selectionAnchor) {
@@ -132,28 +153,29 @@ export const BlobManagementPanel = () => {
           const end = Math.max(anchorIndex, currentIndex);
           const blobsToSelect = unusedBlobsPage.slice(start, end + 1);
 
-          setSelectedBlobs(prev => {
+          setSelectedBlobKeys(previous => {
             // If meta/ctrl is also pressed, add to existing selection
-            const baseSelection = isMetaKey ? prev : [];
-            const newSelection = new Set([...baseSelection, ...blobsToSelect]);
-            return Array.from(newSelection);
+            const next = isMetaKey ? new Set(previous) : new Set<string>();
+            blobsToSelect.forEach(item => next.add(item.key));
+            return next;
           });
         }
       } else {
-        if (selectedBlobs.includes(blob)) {
+        if (selectedBlobKeys.has(blob.key)) {
           handleUnselectBlob(blob);
         } else {
           handleSelectBlob(blob);
         }
-        if (selectedBlobs.length === 0) {
-          setSelectionAnchor(selectedBlobs.includes(blob) ? null : blob);
+        if (selectedBlobKeys.size === 0) {
+          setSelectionAnchor(selectedBlobKeys.has(blob.key) ? null : blob);
         }
       }
     },
     [
+      deleting,
       selectionAnchor,
       unusedBlobsPage,
-      selectedBlobs,
+      selectedBlobKeys,
       handleSelectBlob,
       handleUnselectBlob,
     ]
@@ -162,26 +184,25 @@ export const BlobManagementPanel = () => {
   const handleSelectAll = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      unusedBlobsPage.forEach(blob => handleSelectBlob(blob));
+      setSelectedBlobKeys(new Set(unusedBlobs.map(blob => blob.key)));
     },
-    [unusedBlobsPage, handleSelectBlob]
+    [unusedBlobs]
   );
 
-  const showSelectAll = !unusedBlobsPage.every(blob =>
-    selectedBlobs.includes(blob)
-  );
+  const showSelectAll = selectedBlobKeys.size < unusedBlobs.length;
 
   const { openConfirmModal } = useConfirmModal();
 
   const handleDeleteSelectedBlobs = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
-      const currentSelectedBlobs = selectedBlobs;
+      const currentSelectedBlobKeys = unusedBlobs
+        .filter(blob => selectedBlobKeys.has(blob.key))
+        .map(blob => blob.key);
       openConfirmModal({
-        title:
-          t[
-            'com.affine.settings.workspace.storage.unused-blobs.delete.title'
-          ](),
+        title: `${t[
+          'com.affine.settings.workspace.storage.unused-blobs.delete.title'
+        ]()} (${currentSelectedBlobKeys.length})`,
         children:
           t[
             'com.affine.settings.workspace.storage.unused-blobs.delete.warning'
@@ -189,12 +210,49 @@ export const BlobManagementPanel = () => {
         onConfirm: async () => {
           setDeleting(true);
           track.$.settingsPanel.workspace.deleteUnusedBlob();
-          for (const blob of currentSelectedBlobs) {
-            await unusedBlobsEntity.deleteBlob(blob.key, true);
-            handleUnselectBlob(blob);
-            setUnusedBlobs(prev => prev.filter(b => b.key !== blob.key));
+          const deletedBlobKeys = new Set<string>();
+          const failedBlobKeys = new Set<string>();
+
+          try {
+            for (
+              let index = 0;
+              index < currentSelectedBlobKeys.length;
+              index += DELETE_BATCH_SIZE
+            ) {
+              const batch = currentSelectedBlobKeys.slice(
+                index,
+                index + DELETE_BATCH_SIZE
+              );
+              const results = await Promise.allSettled(
+                batch.map(key => unusedBlobsEntity.deleteBlob(key, true))
+              );
+
+              results.forEach((result, resultIndex) => {
+                const key = batch[resultIndex];
+                if (result.status === 'fulfilled') {
+                  deletedBlobKeys.add(key);
+                } else {
+                  failedBlobKeys.add(key);
+                }
+              });
+            }
+
+            setUnusedBlobs(previous =>
+              previous.filter(blob => !deletedBlobKeys.has(blob.key))
+            );
+            setSelectedBlobKeys(failedBlobKeys);
+
+            if (failedBlobKeys.size > 0) {
+              notify.error({
+                title:
+                  t[
+                    'com.affine.settings.workspace.storage.unused-blobs.delete.failed'
+                  ](),
+              });
+            }
+          } finally {
+            setDeleting(false);
           }
-          setDeleting(false);
         },
         confirmText: t['Delete'](),
         cancelText: t['Cancel'](),
@@ -203,7 +261,7 @@ export const BlobManagementPanel = () => {
         },
       });
     },
-    [selectedBlobs, openConfirmModal, t, unusedBlobsEntity, handleUnselectBlob]
+    [selectedBlobKeys, unusedBlobs, openConfirmModal, t, unusedBlobsEntity]
   );
 
   const blobPreviewGridRef = useRef<HTMLDivElement>(null);
@@ -213,7 +271,8 @@ export const BlobManagementPanel = () => {
       const unselectBlobs = (e: MouseEvent) => {
         const target = e.target as HTMLElement;
         if (!blobPreviewGridRef.current?.contains(target)) {
-          setSelectedBlobs([]);
+          setSelectedBlobKeys(new Set());
+          setSelectionAnchor(null);
         }
       };
       document.addEventListener('click', unselectBlobs);
@@ -224,19 +283,30 @@ export const BlobManagementPanel = () => {
     return;
   }, [unusedBlobs]);
 
+  useEffect(() => {
+    const lastPageNum = Math.max(
+      0,
+      Math.ceil(unusedBlobs.length / PAGE_SIZE) - 1
+    );
+    if (pageNum > lastPageNum) {
+      setPageNum(lastPageNum);
+      setSkip(lastPageNum * PAGE_SIZE);
+    }
+  }, [pageNum, unusedBlobs.length]);
+
   const isEmpty = (unusedBlobs.length === 0 || !unusedBlobs) && !isLoading;
 
   return (
     <>
-      {selectedBlobs.length > 0 ? (
+      {selectedBlobKeys.size > 0 ? (
         <div className={styles.blobManagementControls}>
           <div className={styles.blobManagementName}>
-            {`${selectedBlobs.length} ${t['com.affine.settings.workspace.storage.unused-blobs.selected']()}`}
+            {`${selectedBlobKeys.size} ${t['com.affine.settings.workspace.storage.unused-blobs.selected']()}`}
           </div>
           <div className={styles.spacer} />
           {showSelectAll && (
             <Button onClick={handleSelectAll} variant="primary">
-              {t['com.affine.keyboardShortcuts.selectAll']()}
+              {`${t['com.affine.keyboardShortcuts.selectAll']()} (${unusedBlobs.length})`}
             </Button>
           )}
           <Button
@@ -265,7 +335,7 @@ export const BlobManagementPanel = () => {
             <>
               <div className={styles.blobPreviewGrid} ref={blobPreviewGridRef}>
                 {unusedBlobsPage.map(blob => {
-                  const selected = selectedBlobs.includes(blob);
+                  const selected = selectedBlobKeys.has(blob.key);
                   return (
                     <BlobCard
                       key={blob.key}

--- a/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.tsx
+++ b/packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.tsx
@@ -184,9 +184,12 @@ export const BlobManagementPanel = () => {
   const handleSelectAll = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation();
+      if (deleting) {
+        return;
+      }
       setSelectedBlobKeys(new Set(unusedBlobs.map(blob => blob.key)));
     },
-    [unusedBlobs]
+    [deleting, unusedBlobs]
   );
 
   const showSelectAll = selectedBlobKeys.size < unusedBlobs.length;
@@ -305,7 +308,11 @@ export const BlobManagementPanel = () => {
           </div>
           <div className={styles.spacer} />
           {showSelectAll && (
-            <Button onClick={handleSelectAll} variant="primary">
+            <Button
+              onClick={handleSelectAll}
+              variant="primary"
+              disabled={deleting}
+            >
               {`${t['com.affine.keyboardShortcuts.selectAll']()} (${unusedBlobs.length})`}
             </Button>
           )}

--- a/packages/frontend/i18n/src/i18n.gen.ts
+++ b/packages/frontend/i18n/src/i18n.gen.ts
@@ -8959,6 +8959,10 @@ export function useAFFiNEI18N(): {
       */
     ["com.affine.settings.workspace.storage.unused-blobs.delete.warning"](): string;
     /**
+      * `Some blob files could not be deleted. Failed items remain selected.`
+      */
+    ["com.affine.settings.workspace.storage.unused-blobs.delete.failed"](): string;
+    /**
       * `Join Failed`
       */
     ["com.affine.fail-to-join-workspace.title"](): string;

--- a/packages/frontend/i18n/src/resources/en.json
+++ b/packages/frontend/i18n/src/resources/en.json
@@ -2233,6 +2233,7 @@
   "com.affine.settings.workspace.storage.unused-blobs.selected": "Selected",
   "com.affine.settings.workspace.storage.unused-blobs.delete.title": "Delete blob files",
   "com.affine.settings.workspace.storage.unused-blobs.delete.warning": "Are you sure you want to delete these blob files? This action cannot be undone. Make sure you no longer need them before proceeding.",
+  "com.affine.settings.workspace.storage.unused-blobs.delete.failed": "Some blob files could not be deleted. Failed items remain selected.",
   "com.affine.fail-to-join-workspace.title": "Join Failed",
   "com.affine.invitation.account-mismatch.title": "This invitation is for another account",
   "com.affine.invitation.account-mismatch.description": "You're signed in with an account that wasn't invited. Sign in with the account that received this invitation to continue.",

--- a/packages/frontend/i18n/src/resources/zh-Hans.json
+++ b/packages/frontend/i18n/src/resources/zh-Hans.json
@@ -2114,6 +2114,7 @@
   "com.affine.settings.workspace.storage.unused-blobs.selected": "已选中",
   "com.affine.settings.workspace.storage.unused-blobs.delete.title": "删除 blob 文件",
   "com.affine.settings.workspace.storage.unused-blobs.delete.warning": "您确定要删除这些 blob 文件吗？此操作无法撤销。在继续之前，请确保您不再需要它们。",
+  "com.affine.settings.workspace.storage.unused-blobs.delete.failed": "部分 blob 文件删除失败，失败项仍保持选中。",
   "com.affine.fail-to-join-workspace.title": "加入失败",
   "com.affine.fail-to-join-workspace.description-1": "由于可用席位不足，无法加入<1/> <2>{{workspaceName}}</2>。",
   "com.affine.fail-to-join-workspace.description-2": "请联系您的工作区所有者以添加更多席位。",

--- a/packages/frontend/i18n/src/resources/zh-Hant.json
+++ b/packages/frontend/i18n/src/resources/zh-Hant.json
@@ -1982,6 +1982,7 @@
   "com.affine.settings.workspace.storage.unused-blobs.selected": "已選中",
   "com.affine.settings.workspace.storage.unused-blobs.delete.title": "刪除 blob 文件",
   "com.affine.settings.workspace.storage.unused-blobs.delete.warning": "您確定要刪除這些 blob 文件嗎？此操作無法撤銷。在繼續之前，請確保您不再需要它們。",
+  "com.affine.settings.workspace.storage.unused-blobs.delete.failed": "部分 blob 文件刪除失敗，失敗項仍保持選中。",
   "com.affine.fail-to-join-workspace.title": "加入失敗",
   "com.affine.fail-to-join-workspace.description-1": "由於可用席位不足，無法加入<1/> <2>{{workspaceName}}</2>。",
   "com.affine.fail-to-join-workspace.description-2": "請聯繫您的工作區所有者以添加更多席位。",


### PR DESCRIPTION
## Summary

- keep unused blob selection keyed across pagination
- make Select all include every unused blob, not only the current page
- delete selected blobs in bounded batches and retain failed items for retry
- keep pagination valid after deletions and report partial failures

## Tests

- `yarn vitest run packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx`
- `yarn oxfmt --check packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.tsx packages/frontend/i18n/src/i18n.gen.ts packages/frontend/i18n/src/resources/en.json packages/frontend/i18n/src/resources/zh-Hans.json packages/frontend/i18n/src/resources/zh-Hant.json`
- `yarn oxlint --deny-warnings packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.spec.tsx packages/frontend/core/src/desktop/dialogs/setting/workspace-setting/storage/blob-management.tsx packages/frontend/i18n/src/i18n.gen.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved unused blob management with multi-page selection, select-all, range selection, and a visible total selection count.
  - Deletions now process in batches and update the list and pagination automatically.
  - Failed deletions display localized notifications, while unsuccessful items remain selected for retry.

- **Bug Fixes**
  - Preserved valid selections when the blob list refreshes.
  - Prevented selection changes while deletion is in progress.

- **Tests**
  - Added coverage for multi-page deletion and failed deletion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->